### PR TITLE
HIVE-1360.  It has been a long-standing request for UDFs to be able to

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
@@ -164,6 +164,7 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDFLocate;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMap;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMapKeys;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMapValues;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFNamedStruct;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualOrGreaterThan;
@@ -404,6 +405,7 @@ public final class FunctionRegistry {
     registerGenericUDF("array", GenericUDFArray.class);
     registerGenericUDF("map", GenericUDFMap.class);
     registerGenericUDF("struct", GenericUDFStruct.class);
+    registerGenericUDF("named_struct", GenericUDFNamedStruct.class);
     registerGenericUDF("create_union", GenericUDFUnion.class);
 
     registerGenericUDF("case", GenericUDFCase.class);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeConstantDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeConstantDesc.java
@@ -21,6 +21,10 @@ package org.apache.hadoop.hive.ql.plan;
 import java.io.Serializable;
 
 import org.apache.hadoop.hive.serde.Constants;
+import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 
@@ -51,6 +55,19 @@ public class ExprNodeConstantDesc extends ExprNodeDesc implements Serializable {
   public Object getValue() {
     return value;
   }
+
+  @Override
+  public ConstantObjectInspector getWritableObjectInspector() {
+    PrimitiveCategory pc = ((PrimitiveTypeInfo)getTypeInfo())
+        .getPrimitiveCategory();
+    // Convert from Java to Writable
+    Object writableValue = PrimitiveObjectInspectorFactory
+        .getPrimitiveJavaObjectInspector(pc).getPrimitiveWritableObject(
+          getValue());
+    return PrimitiveObjectInspectorFactory
+        .getPrimitiveWritableConstantObjectInspector(pc, writableValue);
+  }
+
 
   @Override
   public String toString() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDesc.java
@@ -23,6 +23,8 @@ import java.util.List;
 
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 /**
  * ExprNodeDesc.
@@ -62,6 +64,11 @@ public abstract class ExprNodeDesc implements Serializable, Node {
   public String getExprString() {
     assert (false);
     return null;
+  }
+
+  public ObjectInspector getWritableObjectInspector() {
+    return TypeInfoUtils
+      .getStandardWritableObjectInspectorFromTypeInfo(typeInfo);
   }
 
   @Explain(displayName = "type")

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeGenericFuncDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeGenericFuncDesc.java
@@ -145,9 +145,7 @@ public class ExprNodeGenericFuncDesc extends ExprNodeDesc implements
       List<ExprNodeDesc> children) throws UDFArgumentException {
     ObjectInspector[] childrenOIs = new ObjectInspector[children.size()];
     for (int i = 0; i < childrenOIs.length; i++) {
-      childrenOIs[i] = TypeInfoUtils
-          .getStandardWritableObjectInspectorFromTypeInfo(children.get(i)
-          .getTypeInfo());
+      childrenOIs[i] = children.get(i).getWritableObjectInspector();
     }
 
     ObjectInspector oi = genericUDF.initialize(childrenOIs);

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFNamedStruct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFNamedStruct.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.udf.generic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentLengthException;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentTypeException;
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.WritableConstantStringObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+
+@Description(name = "named_struct",
+    value = "_FUNC_(name1, val1, name2, val2, ...) - Creates a struct with the given " +
+            "field names and values")
+public class GenericUDFNamedStruct extends GenericUDF {
+  Object[] ret;
+
+  @Override
+  public ObjectInspector initialize(ObjectInspector[] arguments)
+      throws UDFArgumentException {
+    
+    int numFields = arguments.length;
+    if (numFields % 2 == 1) {
+      throw new UDFArgumentLengthException(
+          "NAMED_STRUCT expects an even number of arguments.");
+    }
+    ret = new Object[numFields / 2];
+    
+    ArrayList<String> fname = new ArrayList<String>(numFields / 2);
+    ArrayList<ObjectInspector> retOIs = new ArrayList<ObjectInspector>(numFields / 2);
+    for (int f = 0; f < numFields; f+=2) {
+      if (!(arguments[f] instanceof WritableConstantStringObjectInspector)) {
+        throw new UDFArgumentTypeException(f, "Even arguments" + 
+            " to NAMED_STRUCT must be a constant STRING." + arguments[f].toString());
+      }
+      WritableConstantStringObjectInspector constantOI = 
+        (WritableConstantStringObjectInspector)arguments[f];
+      fname.add(constantOI.getWritableConstantValue().toString());
+      retOIs.add(arguments[f + 1]);
+    }
+    StructObjectInspector soi = 
+      ObjectInspectorFactory.getStandardStructObjectInspector(fname, retOIs);
+    return soi;
+  }
+
+  @Override
+  public Object evaluate(DeferredObject[] arguments) throws HiveException {
+    for (int i = 0; i < arguments.length / 2; i++) {
+      ret[i] = arguments[2 * i + 1].get();
+    }
+    return ret;
+  }
+
+  @Override
+  public String getDisplayString(String[] children) {
+    StringBuilder sb = new StringBuilder();
+    sb.append("named_struct(");
+    for (int i = 0; i < children.length; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(children[i]);
+    }
+    sb.append(')');
+    return sb.toString();
+  }
+}

--- a/ql/src/test/queries/clientpositive/udf_named_struct.q
+++ b/ql/src/test/queries/clientpositive/udf_named_struct.q
@@ -1,0 +1,9 @@
+DESCRIBE FUNCTION named_struct;
+DESCRIBE FUNCTION EXTENDED named_struct;
+
+EXPLAIN
+SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1;
+
+SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1;

--- a/ql/src/test/results/clientpositive/show_functions.q.out
+++ b/ql/src/test/results/clientpositive/show_functions.q.out
@@ -97,6 +97,7 @@ max
 min
 minute
 month
+named_struct
 negative
 ngrams
 not

--- a/ql/src/test/results/clientpositive/udf_named_struct.q.out
+++ b/ql/src/test/results/clientpositive/udf_named_struct.q.out
@@ -1,0 +1,63 @@
+PREHOOK: query: DESCRIBE FUNCTION named_struct
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION named_struct
+POSTHOOK: type: DESCFUNCTION
+named_struct(name1, val1, name2, val2, ...) - Creates a struct with the given field names and values
+PREHOOK: query: DESCRIBE FUNCTION EXTENDED named_struct
+PREHOOK: type: DESCFUNCTION
+POSTHOOK: query: DESCRIBE FUNCTION EXTENDED named_struct
+POSTHOOK: type: DESCFUNCTION
+named_struct(name1, val1, name2, val2, ...) - Creates a struct with the given field names and values
+PREHOOK: query: EXPLAIN
+SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1
+PREHOOK: type: QUERY
+POSTHOOK: query: EXPLAIN
+SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1
+POSTHOOK: type: QUERY
+ABSTRACT SYNTAX TREE:
+  (TOK_QUERY (TOK_FROM (TOK_TABREF (TOK_TABNAME src))) (TOK_INSERT (TOK_DESTINATION (TOK_DIR TOK_TMP_FILE)) (TOK_SELECT (TOK_SELEXPR (TOK_FUNCTION named_struct "foo" 1 "bar" 2)) (TOK_SELEXPR (. (TOK_FUNCTION named_struct "foo" 1 "bar" 2) foo))) (TOK_LIMIT 1)))
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-1
+    Map Reduce
+      Alias -> Map Operator Tree:
+        src 
+          TableScan
+            alias: src
+            Select Operator
+              expressions:
+                    expr: named_struct('foo',1,'bar',2)
+                    type: struct<foo:int,bar:int>
+                    expr: named_struct('foo',1,'bar',2).foo
+                    type: int
+              outputColumnNames: _col0, _col1
+              Limit
+                File Output Operator
+                  compressed: false
+                  GlobalTableId: 0
+                  table:
+                      input format: org.apache.hadoop.mapred.TextInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: 1
+
+
+PREHOOK: query: SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: file:/var/folders/C4/C40caRNsEM4C4yVangruonVUe7Y/-Tmp-/jonchang/hive_2011-08-11_01-02-24_658_503462155153078291/-mr-10000
+POSTHOOK: query: SELECT named_struct("foo", 1, "bar", 2), 
+       named_struct("foo", 1, "bar", 2).foo FROM src LIMIT 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: file:/var/folders/C4/C40caRNsEM4C4yVangruonVUe7Y/-Tmp-/jonchang/hive_2011-08-11_01-02-24_658_503462155153078291/-mr-10000
+{"foo":1,"bar":2}	1

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ConstantObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ConstantObjectInspector.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.serde2.objectinspector;
+
+/**
+ * ConstantObjectInspector.  This interface should be implemented by
+ * ObjectInspectors which represent constant values and can return them without
+ * an evaluation.
+ */
+public interface ConstantObjectInspector extends ObjectInspector {
+
+  Object getWritableConstantValue(); 
+
+}

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorFactory.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorFactory.java
@@ -20,10 +20,19 @@ package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
 import java.util.HashMap;
 
+import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils.PrimitiveTypeEntry;
 import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.BooleanWritable;
+import org.apache.hadoop.io.ByteWritable;
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.io.IntWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.FloatWritable;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.Text;
 
 /**
  * PrimitiveObjectInspectorFactory is the primary way to create new
@@ -134,6 +143,40 @@ public final class PrimitiveObjectInspectorFactory {
           + " for " + primitiveCategory);
     }
     return result;
+  }
+
+  /**
+   * Returns a PrimitiveWritableObjectInspector which implements ConstantObjectInspector 
+   * for the PrimitiveCategory.
+   * 
+   * @param primitiveCategory
+   * @param value
+   */
+  public static ConstantObjectInspector getPrimitiveWritableConstantObjectInspector(
+      PrimitiveCategory primitiveCategory, Object value) {
+    switch (primitiveCategory) {
+    case BOOLEAN:
+      return new WritableConstantBooleanObjectInspector((BooleanWritable)value);
+    case BYTE:
+      return new WritableConstantByteObjectInspector((ByteWritable)value);
+    case SHORT:
+      return new WritableConstantShortObjectInspector((ShortWritable)value);
+    case INT:
+      return new WritableConstantIntObjectInspector((IntWritable)value);
+    case LONG:
+      return new WritableConstantLongObjectInspector((LongWritable)value);
+    case FLOAT:
+      return new WritableConstantFloatObjectInspector((FloatWritable)value);
+    case DOUBLE:
+      return new WritableConstantDoubleObjectInspector((DoubleWritable)value);
+    case STRING:
+      return new WritableConstantStringObjectInspector((Text)value);
+    case VOID:
+      return new WritableConstantVoidObjectInspector();
+    default:
+      throw new RuntimeException("Internal error: Cannot find "
+        + "ConstantObjectInspector for " + primitiveCategory);
+    }
   }
 
   /**

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorFactory.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/PrimitiveObjectInspectorFactory.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.serde2.io.ShortWritable;
 import org.apache.hadoop.io.IntWritable;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.FloatWritable;
-import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.io.Text;
 
 /**

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantBooleanObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantBooleanObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.BooleanWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantBooleanObjectInspector is a WritableBooleanObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantBooleanObjectInspector extends
+    WritableBooleanObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private BooleanWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantBooleanObjectInspector(BooleanWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public BooleanWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantByteObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantByteObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.ByteWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantByteObjectInspector is a WritableByteObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantByteObjectInspector extends
+    WritableByteObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private ByteWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantByteObjectInspector(ByteWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public ByteWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantDoubleObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantDoubleObjectInspector.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
 
-import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 
 /**
  * A WritableConstantDoubleObjectInspector is a WritableDoubleObjectInspector

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantDoubleObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantDoubleObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.DoubleWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantDoubleObjectInspector is a WritableDoubleObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantDoubleObjectInspector extends
+    WritableDoubleObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private DoubleWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantDoubleObjectInspector(DoubleWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public DoubleWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantFloatObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantFloatObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.FloatWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantFloatObjectInspector is a WritableFloatObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantFloatObjectInspector extends
+    WritableFloatObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private FloatWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantFloatObjectInspector(FloatWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public FloatWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantIntObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantIntObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.IntWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantIntObjectInspector is a WritableIntObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantIntObjectInspector extends
+    WritableIntObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private IntWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantIntObjectInspector(IntWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public IntWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantLongObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantLongObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.LongWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantLongObjectInspector is a WritableLongObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantLongObjectInspector extends
+    WritableLongObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private LongWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantLongObjectInspector(LongWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public LongWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantShortObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantShortObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.hive.serde2.io.ShortWritable;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantShortObjectInspector is a WritableShortObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantShortObjectInspector extends
+    WritableShortObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private ShortWritable value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantShortObjectInspector(ShortWritable value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public ShortWritable getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantStringObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantStringObjectInspector.java
@@ -15,36 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+
+import org.apache.hadoop.io.Text;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantStringObjectInspector is a WritableStringObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantStringObjectInspector extends
+    WritableStringObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
+  private Text value;
 
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantStringObjectInspector(Text value) {
+    super();
+    this.value = value;
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public Text getWritableConstantValue() {
+    return value;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantVoidObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableConstantVoidObjectInspector.java
@@ -15,36 +15,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.serde2.objectinspector.primitive;
 
-package org.apache.hadoop.hive.ql.exec;
-
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.serde2.objectinspector.ConstantObjectInspector;
-import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 
 /**
- * ExprNodeConstantEvaluator.
- *
+ * A WritableConstantVoidObjectInspector is a WritableVoidObjectInspector
+ * that implements ConstantObjectInspector.
  */
-public class ExprNodeConstantEvaluator extends ExprNodeEvaluator {
+public class WritableConstantVoidObjectInspector extends
+    WritableVoidObjectInspector implements
+    ConstantObjectInspector {
 
-  protected ExprNodeConstantDesc expr;
-  transient ConstantObjectInspector writableObjectInspector;
-
-  public ExprNodeConstantEvaluator(ExprNodeConstantDesc expr) {
-    this.expr = expr;
-    writableObjectInspector = expr.getWritableObjectInspector();
+  WritableConstantVoidObjectInspector() {
+    super();
   }
 
   @Override
-  public ObjectInspector initialize(ObjectInspector rowInspector) throws HiveException {
-    return writableObjectInspector;
+  public Object getWritableConstantValue() {
+    return null;
   }
-
-  @Override
-  public Object evaluate(Object row) throws HiveException {
-    return writableObjectInspector.getWritableConstantValue();
-  }
-
 }


### PR DESCRIPTION
access parameter values.  This not only enables significant performance
improvement possibilities, it also allows for fundamentally richer
behavior, such as allowing the output type of a UDF to depend on its
inputs.

The strategy in this diff is to introduce the notion of a
ConstantObjectInspector, like a regular ObjectInspector except that it
encapsulates a constant value and knows what this constant value is.
These COIs are created through a factory method by ExprNodeConstantDesc
during plan generation hence UDFs will be able to capture these constant
values during the initialize phase.  Furthermore, because these
ConstantObjectInspectors are simply subinterfaces of ObjectInspector,
UDFs which are not "constant-aware" receive ObjectInspectors which
also implement the same interfaces they are used to, so no special
handling needs to be done for existing UDFs.

An example UDF which uses this new functionality is also included in
this diff.  NAMED_STRUCT is like STRUCT except that it also allows users
to specify the _names_ of the fields of the struct, something previously
not possible because the names of the fields must be known at compile
time.
