### PR TITLE
HIVE-5596:hive-default.xml.template is invalid

### DIFF
--- a/conf/hive-default.xml.template
+++ b/conf/hive-default.xml.template
@@ -2003,7 +2003,7 @@
 
 <property>
   <name>hive.server2.thrift.sasl.qop</name>
-  <value>auth</auth>
+  <value>auth</value>
   <description>Sasl QOP value; Set it to one of following values to enable higher levels of
      protection for hive server2 communication with clients.
       "auth" - authentication only (default)


### PR DESCRIPTION
Fixed HIVE-5596:hive-default.xml.template is invalid.
