### PR TITLE
fix bug when extract a list of list with list

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFJson.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFJson.java
@@ -247,8 +247,8 @@ public class UDFJson extends UDF {
             return null;
           }
           tmp_jsonList.add(((List<Object>)array).get(indexValue));
-          jsonList = tmp_jsonList;
         }
+        jsonList = tmp_jsonList;
       }
     }
     if (jsonList.isEmpty()) {


### PR DESCRIPTION
line 250 should be out of the for-loop

For example 
json = '{"h":[1, [2, 3], {"i": 0}, [{"p": 11}, {"p": 12}, {"pp": 13}]}'
get_json_object(json, '$.h[*][0]') should return back the first node(if exists)  of every childrenof '$.h'
which specifically should be 
    [2,{"p":11}] 
but hive returns only
    2

because when hive pick the node '2' out, the tmp_jsonList will change to a list only contains one node '2':
    [2]
then it was assigned to variable jsonList, in the next loop, value of i would be 2 which is greater than the size(always 1) of jsonList, then the loop broke out.
