### PR TITLE
[HCatalog]: The column size property of rcfile header should be coded in decimal instead of octal

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
@@ -76,7 +76,7 @@ public class SpecialCases {
     if (ofclass == RCFileOutputFormat.class) {
       // RCFile specific parameter
       jobProperties.put(HiveConf.ConfVars.HIVE_RCFILE_COLUMN_NUMBER_CONF.varname,
-          Integer.toOctalString(
+          Integer.toString(
               jobInfo.getOutputSchema().getFields().size()));
     } else if (ofclass == OrcOutputFormat.class) {
       // Special cases for ORC


### PR DESCRIPTION
The column size property of rcfile header 

``` java
HiveConf.ConfVars.HIVE_RCFILE_COLUMN_NUMBER_CONF
```

should be decimal instead of octal.
