### PR TITLE
HIVE-10890 Provide implementable engine selector

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2059,6 +2059,8 @@ public class HiveConf extends Configuration {
 
     HIVE_EXECUTION_ENGINE("hive.execution.engine", "mr", new StringSet("mr", "tez", "spark"),
         "Chooses execution engine. Options are: mr (Map reduce, default), tez (hadoop 2 only), spark"),
+    HIVE_EXECUTION_ENGINE_AVAILABLE("hive.execution.engine.available", "",
+        "Comma separated list of available engines for auto selection. Regards empty value as all engines are available."),
     HIVE_EXECUTION_ENGINE_SELECTOR("hive.execution.engine.selector", null, "Chooses execution engine by EngineSelector"),
     HIVE_EXECUTION_ENGINE_SELECTOR_PARAM("hive.execution.engine.selector.param", null,
         "Parameter which will be handed over to EngineSelector"),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2059,6 +2059,9 @@ public class HiveConf extends Configuration {
 
     HIVE_EXECUTION_ENGINE("hive.execution.engine", "mr", new StringSet("mr", "tez", "spark"),
         "Chooses execution engine. Options are: mr (Map reduce, default), tez (hadoop 2 only), spark"),
+    HIVE_EXECUTION_ENGINE_SELECTOR("hive.execution.engine.selector", null, "Chooses execution engine by EngineSelector"),
+    HIVE_EXECUTION_ENGINE_SELECTOR_PARAM("hive.execution.engine.selector.param", null,
+        "Parameter which will be handed over to EngineSelector"),
     HIVE_JAR_DIRECTORY("hive.jar.directory", null,
         "This is the location hive in tez mode will look for to find a site wide \n" +
         "installed hive instance."),

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -34,13 +34,13 @@ import org.antlr.runtime.TokenRewriteStream;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.ContentSummary;
 import org.apache.hadoop.hive.ql.exec.TaskRunner;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
@@ -653,6 +653,15 @@ public class Context {
 
   public Map<String, ContentSummary> getPathToCS() {
     return pathToCS;
+  }
+
+  // for hook context, which is public
+  public Map<String, org.apache.hadoop.fs.ContentSummary> getPathToHadoopCS() {
+    Map<String, org.apache.hadoop.fs.ContentSummary> summaryMap = new HashMap<>();
+    for (Map.Entry<String, ContentSummary> entry : pathToCS.entrySet()) {
+      summaryMap.put(entry.getKey(), entry.getValue());
+    }
+    return summaryMap;
   }
 
   public Configuration getConf() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -1434,8 +1434,8 @@ public class Driver implements CommandProcessor {
       resStream = null;
 
       SessionState ss = SessionState.get();
-      HookContext hookContext = new HookContext(plan, conf, ctx.getPathToCS(), ss.getUserName(),
-          ss.getUserIpAddress(), operationId);
+      HookContext hookContext = new HookContext(plan, conf, ctx.getPathToHadoopCS(),
+          ss.getUserName(), ss.getUserIpAddress(), operationId);
       hookContext.setHookType(HookContext.HookType.PRE_EXEC_HOOK);
 
       for (Hook peh : getHooks(HiveConf.ConfVars.PREEXECHOOKS)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ContentSummary.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ContentSummary.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class ContentSummary extends org.apache.hadoop.fs.ContentSummary {
+
+  private boolean validSummary;
+
+  public ContentSummary() {}
+
+  public ContentSummary(long length, long fileCount, long directoryCount, boolean validSummary) {
+    super(length, fileCount, directoryCount);
+    this.validSummary = validSummary;
+  }
+
+  public ContentSummary(org.apache.hadoop.fs.ContentSummary summary, boolean validSummary) {
+    this(summary.getLength(), summary.getFileCount(), summary.getDirectoryCount(), validSummary);
+  }
+
+  public boolean isValidSummary() {
+    return validSummary;
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    out.writeBoolean(validSummary);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    validSummary = in.readBoolean();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/EngineSelector.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/EngineSelector.java
@@ -42,7 +42,7 @@ import java.util.Map;
 
 public interface EngineSelector {
 
-  enum Engine {TEZ, SPARK, MR}
+  enum Engine {TEZ, SPARK, MR, DEFAULT}
 
   /**
    * select engine to be used, can return null for default value
@@ -54,7 +54,7 @@ public interface EngineSelector {
    */
   Engine select(HiveConf conf, ParseContext parseContext, String param);
 
-  public static class SimpleSelect implements EngineSelector {
+  public static class SimpleSelector implements EngineSelector {
 
     static final Log LOG = LogFactory.getLog(EngineSelector.class.getName());
 
@@ -97,7 +97,7 @@ public interface EngineSelector {
       } catch (Exception e) {
         LOG.warn("Failed to select engine by exception ", e);
       }
-      return null;
+      return Engine.DEFAULT;
     }
 
     Engine evaluate(String expressions, boolean skipEval) throws Exception {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/EngineSelector.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/EngineSelector.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.optimizer.GenMapRedUtils;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.CalcitePlanner;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.ParseContext;
+import org.apache.hadoop.hive.ql.parse.ParseDriver;
+import org.apache.hadoop.hive.ql.parse.PrunedPartitionList;
+import org.apache.hadoop.hive.ql.parse.RowResolver;
+import org.apache.hadoop.hive.ql.parse.TypeCheckCtx;
+import org.apache.hadoop.hive.ql.parse.TypeCheckProcFactory;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.MapWork;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BooleanObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+
+import java.util.HashSet;
+import java.util.Map;
+
+public interface EngineSelector {
+
+  enum Engine {TEZ, SPARK, MR}
+
+  /**
+   * select engine to be used, can return null for default value
+   *
+   * @param conf
+   * @param parseContext
+   * @param param
+   * @return
+   */
+  Engine select(HiveConf conf, ParseContext parseContext, String param);
+
+  public static class SimpleSelect implements EngineSelector {
+
+    static final Log LOG = LogFactory.getLog(EngineSelector.class.getName());
+
+    @Override
+    public Engine select(HiveConf conf, ParseContext pctx, String param) {
+      Map<String, PrunedPartitionList> pruned = pctx.getPrunedPartitions();
+      Map<String, Operator<?>> topOps = pctx.getTopOps();
+
+      try {
+        long total = 0;
+        long biggest = 0;
+        for (Map.Entry<String, Operator<?>> entry : topOps.entrySet()) {
+          MapWork dummy = new MapWork();
+          String alias = entry.getKey();
+          Operator<?> operator = entry.getValue();
+          GenMapRedUtils.setMapWork(dummy, pctx, new HashSet<ReadEntity>(),
+              pruned.get(alias), operator, alias, conf, false);
+
+          ContentSummary summary = Utilities.getInputSummary(pctx.getContext(), dummy, null);
+          if (!summary.isValidSummary()) {
+            LOG.info("Cannot estimate size of " + alias);
+            total = -1;
+            break;
+          }
+          total += summary.getLength();
+          biggest = Math.max(biggest, summary.getLength());
+        }
+        // spark = $total < 10gb && $num_aliases < 4, tez
+        param = param.replaceAll("$num_aliases", String.valueOf(topOps.size()));
+        param = param.replaceAll("$total", String.valueOf(total));
+        param = param.replaceAll("$biggest", String.valueOf(biggest));
+        param = param.replaceAll("(\\d)+kb", "$1 * 1024L");
+        param = param.replaceAll("(\\d)+mb", "$1 * 1024L * 1024L");
+        param = param.replaceAll("(\\d)+gb", "$1 * 1024L * 1024L * 1024L");
+        param = param.replaceAll("(\\d)+tb", "$1 * 1024L * 1024L * 1024L * 1024L");
+
+        Engine selected = evaluate(param.trim(), total < 0);
+        LOG.info("Engine selected " + selected);
+        return selected;
+      } catch (Exception e) {
+        LOG.warn("Failed to select engine by exception ", e);
+      }
+      return null;
+    }
+
+    Engine evaluate(String expressions, boolean skipEval) throws Exception {
+      ParseDriver driver = new ParseDriver();
+      CalcitePlanner.ASTSearcher searcher = new CalcitePlanner.ASTSearcher();
+
+      TypeCheckCtx ctx = new TypeCheckCtx(new RowResolver());
+      for (String expression : expressions.split(",")) {
+        expression = expression.trim();
+        String[] split = expression.split("=");
+        if (split.length == 1) {
+          return Engine.valueOf(split[0].trim().toUpperCase());
+        }
+        if (skipEval) {
+          continue;
+        }
+        ASTNode astNode = driver.parseSelect("select " + split[1], null);
+
+        ASTNode target = (ASTNode) searcher.simpleBreadthFirstSearch(
+            astNode, HiveParser.TOK_SELEXPR).getChild(0);
+        ExprNodeDesc expr = TypeCheckProcFactory.genExprNode(target, ctx).get(target);
+        ExprNodeEvaluator evaluator = ExprNodeEvaluatorFactory.get(expr);
+        evaluator.initialize(PrimitiveObjectInspectorFactory.javaBooleanObjectInspector);
+        BooleanObjectInspector inspector = (BooleanObjectInspector) evaluator.getOutputOI();
+        if (inspector.get(evaluator.evaluate(null))) {
+          return Engine.valueOf(split[0].trim().toUpperCase());
+        }
+      }
+      return null;
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/MapRedTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/MapRedTask.java
@@ -28,7 +28,6 @@ import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
@@ -37,6 +36,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.DriverContext;
+import org.apache.hadoop.hive.ql.exec.ContentSummary;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.plan.MapWork;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkTask.java
@@ -98,7 +98,7 @@ public class SparkTask extends Task<SparkWork> {
     try {
       printConfigInfo();
       sparkSessionManager = SparkSessionManagerImpl.getInstance();
-      sparkSession = SparkUtilities.getSparkSession(conf, sparkSessionManager);
+      sparkSession = SessionState.get().getSparkSession();
 
       SparkWork sparkWork = getWork();
       sparkWork.setRequiredCounterPrefix(getCounterPrefixes());

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkUtilities.java
@@ -120,22 +120,6 @@ public class SparkUtilities {
     return master.startsWith("yarn-") || master.startsWith("local");
   }
 
-  public static SparkSession getSparkSession(HiveConf conf,
-      SparkSessionManager sparkSessionManager) throws HiveException {
-    SparkSession sparkSession = SessionState.get().getSparkSession();
-
-    // Spark configurations are updated close the existing session
-    if (conf.getSparkConfigUpdated()) {
-      sparkSessionManager.closeSession(sparkSession);
-      sparkSession =  null;
-      conf.setSparkConfigUpdated(false);
-    }
-    sparkSession = sparkSessionManager.getSession(sparkSession, conf, true);
-    SessionState.get().setSparkSession(sparkSession);
-    return sparkSession;
-  }
-
-
   public static String rddGraphToString(JavaPairRDD rdd) {
     StringBuilder sb = new StringBuilder();
     rddToString(rdd.rdd(), sb, "");

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -197,7 +197,7 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
   }
 
   public static InputFormat<WritableComparable, Writable> getInputFormatFromCache(
-    Class inputFormatClass, JobConf job) throws IOException {
+    Class inputFormatClass, Configuration job) throws IOException {
     InputFormat<WritableComparable, Writable> instance = inputFormats.get(inputFormatClass);
     if (instance == null) {
       try {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SetSparkReducerParallelism.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SetSparkReducerParallelism.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hive.ql.exec.LimitOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
-import org.apache.hadoop.hive.ql.exec.spark.SparkUtilities;
 import org.apache.hadoop.hive.ql.exec.spark.session.SparkSession;
 import org.apache.hadoop.hive.ql.exec.spark.session.SparkSessionManager;
 import org.apache.hadoop.hive.ql.exec.spark.session.SparkSessionManagerImpl;
@@ -44,6 +43,7 @@ import org.apache.hadoop.hive.ql.parse.spark.GenSparkUtils;
 import org.apache.hadoop.hive.ql.parse.spark.OptimizeSparkProcContext;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.ReduceSinkDesc;
+import org.apache.hadoop.hive.ql.session.SessionState;
 
 /**
  * SetSparkReducerParallelism determines how many reducers should
@@ -114,8 +114,7 @@ public class SetSparkReducerParallelism implements NodeProcessor {
           SparkSession sparkSession = null;
           try {
             sparkSessionManager = SparkSessionManagerImpl.getInstance();
-            sparkSession = SparkUtilities.getSparkSession(
-              context.getConf(), sparkSessionManager);
+            sparkSession = SessionState.get().getSparkSession();
             sparkMemoryAndCores = sparkSession.getMemoryAndCores();
           } catch (HiveException e) {
             throw new SemanticException("Failed to get a spark session: " + e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -567,7 +567,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
    * some token, of which only one matches, it is not guaranteed to be found. We
    * use this for simple things. Not thread-safe - reuses searchQueue.
    */
-  static class ASTSearcher {
+  public static class ASTSearcher {
     private final LinkedList<ASTNode> searchQueue = new LinkedList<ASTNode>();
 
     public ASTNode simpleBreadthFirstSearch(ASTNode ast, int... tokens) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -10217,6 +10217,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       TaskCompiler compiler = TaskCompilerFactory.getCompiler(conf, pCtx);
       compiler.init(conf, console, db);
       compiler.compile(pCtx, rootTasks, inputs, outputs);
+      compiler.initSession(SessionState.get());
       fetchTask = pCtx.getFetchTask();
     }
     LOG.info("Completed plan generation");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hive.ql.plan.LoadTableDesc;
 import org.apache.hadoop.hive.ql.plan.MoveWork;
 import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
+import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 
 import com.google.common.collect.Interner;
@@ -79,6 +80,11 @@ public abstract class TaskCompiler {
     this.conf = conf;
     this.db = db;
     this.console = console;
+  }
+
+  // called when compilation is completed.
+  // initialize something(session, for example) for the engine to execute the query.
+  public void initSession(SessionState session) {
   }
 
   @SuppressWarnings({"nls", "unchecked"})

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompilerFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompilerFactory.java
@@ -21,9 +21,15 @@ package org.apache.hadoop.hive.ql.parse;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.exec.EngineSelector;
+import org.apache.hadoop.hive.ql.exec.EngineSelector.Engine;
 import org.apache.hadoop.hive.ql.parse.spark.SparkCompiler;
 import org.apache.hive.common.util.ReflectionUtil;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
 
 /**
  * TaskCompilerFactory is a factory class to choose the appropriate
@@ -44,33 +50,52 @@ public class TaskCompilerFactory {
   public static TaskCompiler getCompiler(HiveConf conf, ParseContext parseContext) {
     EngineSelector selector = getSelector(conf);
     if (selector != null) {
-      String param = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE_SELECTOR_PARAM);
-      EngineSelector.Engine selected = selector.select(conf, parseContext, param);
-      if (selected == EngineSelector.Engine.MR) {
-        HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
+      String param = HiveConf.getVar(conf, ConfVars.HIVE_EXECUTION_ENGINE_SELECTOR_PARAM);
+      Engine selected = selector.select(conf, parseContext, param, getAvailableEngines(conf));
+      if (selected == Engine.MR) {
+        HiveConf.setVar(conf, ConfVars.HIVE_EXECUTION_ENGINE, "mr");
         return new MapReduceCompiler();
       }
-      if (selected == EngineSelector.Engine.TEZ) {
-        HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "tez");
+      if (selected == Engine.TEZ) {
+        HiveConf.setVar(conf, ConfVars.HIVE_EXECUTION_ENGINE, "tez");
         return new TezCompiler();
       }
-      if (selected == EngineSelector.Engine.SPARK) {
-        HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "spark");
+      if (selected == Engine.SPARK) {
+        HiveConf.setVar(conf, ConfVars.HIVE_EXECUTION_ENGINE, "spark");
         return new SparkCompiler();
       }
     }
 
-    if (HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
+    if (HiveConf.getVar(conf, ConfVars.HIVE_EXECUTION_ENGINE).equals("tez")) {
       return new TezCompiler();
-    } else if (HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE).equals("spark")) {
+    } else if (HiveConf.getVar(conf, ConfVars.HIVE_EXECUTION_ENGINE).equals("spark")) {
       return new SparkCompiler();
     } else {
       return new MapReduceCompiler();
     }
   }
 
+  private static EnumSet<Engine> getAvailableEngines(HiveConf conf) {
+    String available = HiveConf.getVar(conf, ConfVars.HIVE_EXECUTION_ENGINE_AVAILABLE).trim();
+    if (available.isEmpty()) {
+      return EnumSet.allOf(Engine.class);
+    }
+    List<Engine> engines = new ArrayList<Engine>();
+    for (String engine : available.split(",")) {
+      engine = engine.trim();
+      try {
+        if (!engine.isEmpty()) {
+          engines.add(Engine.valueOf(engine.toUpperCase()));
+        }
+      } catch (IllegalArgumentException e) {
+        LOG.warn("Invalid engine name '" + engine + "'.. skipping it");
+      }
+    }
+    return EnumSet.copyOf(engines);
+  }
+
   private static EngineSelector getSelector(HiveConf conf) {
-    String selector = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE_SELECTOR);
+    String selector = HiveConf.getVar(conf, ConfVars.HIVE_EXECUTION_ENGINE_SELECTOR);
     try {
       if (selector != null) {
         return (EngineSelector)ReflectionUtil.newInstance(conf.getClassByName(selector), conf);


### PR DESCRIPTION
Now hive supports three kind of engines. It would be good to have an automatic engine selector without setting explicitly engine for execution.

Added two configurations

> hive.execution.engine.selector
> hive.execution.engine.selector.param

Test implementation is included as EngineSelector$SimpleSelector, which supports simple grammar something like,

> spark = $total < 10gb && $num_aliases < 4, tez

which means if total input length is less than 10gb and number of aliases is less than 4, use spark, else tez
