### PR TITLE
HIVE-11190: ConfVars.METASTORE_FILTER_HOOK in authorization V2 should not be hard code when the value is not default

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/HiveAuthorizerImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/HiveAuthorizerImpl.java
@@ -32,6 +32,9 @@ import org.apache.hadoop.hive.conf.HiveConf;
 @LimitedPrivate(value = { "" })
 @Evolving
 public class HiveAuthorizerImpl implements HiveAuthorizer {
+
+  public static final String METASTORE_FILTER_HOOK_V2_DEFAULT =
+      "org.apache.hadoop.hive.ql.security.authorization.plugin.AuthorizationMetaStoreFilterHook";
   HiveAccessController accessController;
   HiveAuthorizationValidator authValidator;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -756,8 +756,12 @@ public class SessionState {
     if (conf.get(CONFIG_AUTHZ_SETTINGS_APPLIED_MARKER, "").equals(Boolean.TRUE.toString())) {
       return;
     }
-    conf.setVar(ConfVars.METASTORE_FILTER_HOOK,
-        "org.apache.hadoop.hive.ql.security.authorization.plugin.AuthorizationMetaStoreFilterHook");
+    if (ConfVars.METASTORE_FILTER_HOOK.getDefaultValue().equals(
+        conf.get(ConfVars.METASTORE_FILTER_HOOK.name(),
+            ConfVars.METASTORE_FILTER_HOOK.getDefaultValue()))) {
+      conf.setVar(ConfVars.METASTORE_FILTER_HOOK,
+          HiveAuthorizerImpl.METASTORE_FILTER_HOOK_V2_DEFAULT);
+    }
 
     authorizerV2.applyAuthorizationConfigPolicy(conf);
     // update config in Hive thread local as well and init the metastore client


### PR DESCRIPTION
ConfVars.METASTORE_FILTER_HOOK in authorization V2 should not be hard code when the value is not default