### PR TITLE
HIVE-12002: correct typo in HiveMetaStore INFO log

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/HiveSchemaHelper.java
+++ b/beeline/src/java/org/apache/hive/beeline/HiveSchemaHelper.java
@@ -165,7 +165,7 @@ public class HiveSchemaHelper {
   }
 
   /***
-   * Base implemenation of NestedScriptParser
+   * Base implementation of NestedScriptParser
    * abstractCommandParser.
    *
    */

--- a/hcatalog/conf/proto-hive-site.xml
+++ b/hcatalog/conf/proto-hive-site.xml
@@ -91,7 +91,7 @@
 <property>
   <name>hive.semantic.analyzer.factory.impl</name>
   <value>org.apache.hive.hcatalog.cli.HCatSemanticAnalyzerFactory</value>
-  <description>controls which SemanticAnalyzerFactory implemenation class is used by CLI</description>
+  <description>controls which SemanticAnalyzerFactory implementation class is used by CLI</description>
 </property>
 
 <property>

--- a/hcatalog/src/packages/templates/conf/hive-site.xml.template
+++ b/hcatalog/src/packages/templates/conf/hive-site.xml.template
@@ -88,7 +88,7 @@
 <property>
   <name>hive.semantic.analyzer.factory.impl</name>
   <value>org.apache.hive.hcatalog.cli.HCatSemanticAnalyzerFactory</value>
-  <description>controls which SemanticAnalyzerFactory implemenation class is used by CLI</description>
+  <description>controls which SemanticAnalyzerFactory implementation class is used by CLI</description>
 </property>
 
 <property>

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -594,7 +594,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     }
 
     private RawStore newRawStore() throws MetaException {
-      LOG.info(addPrefix("Opening raw store with implemenation class:"
+      LOG.info(addPrefix("Opening raw store with implementation class:"
           + rawStoreClassName));
       Configuration conf = getConf();
 

--- a/metastore/src/test/org/apache/hadoop/hive/metastore/AlternateFailurePreListener.java
+++ b/metastore/src/test/org/apache/hadoop/hive/metastore/AlternateFailurePreListener.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.hive.metastore.events.PreEventContext;
  *
  * AlternateFailurePreListener.
  *
- * An implemenation of MetaStorePreEventListener which fails every other time it's invoked,
+ * An implementation of MetaStorePreEventListener which fails every other time it's invoked,
  * starting with the first time.
  *
  * It also records and makes available the number of times it's been invoked.


### PR DESCRIPTION
Corrected minor typo in HiveMetaStore logging.
