### PR TITLE
shuffle the metastore uris, so the request can be balanced to metastores

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -34,6 +34,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -239,6 +239,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
     if (conf.getVar(HiveConf.ConfVars.METASTOREURIS) != null) {
       String metastoreUrisString[] = conf.getVar(
           HiveConf.ConfVars.METASTOREURIS).split(",");
+      // shuffle the metastore uris, so the request can be balanced to metastores
+      Collections.shuffle(Arrays.asList(metastoreUrisString));
+      
       metastoreUris = new URI[metastoreUrisString.length];
       try {
         int i = 0;


### PR DESCRIPTION
Currently, HiveMetaStoreClient connect to the first metastore uri defaultly If we have multi metastore uris. So the client only send request to the first metastore, the metastore will be the bottleneck to process the client request.

I add the logic to shuffle metastore uris, so that the request can be balanced to all of the metastores.
