### PR TITLE
HIVE-23615: Null pointers should not be dereferenced

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -201,7 +201,7 @@ public class Commands {
         return def;
       }
       throw new IllegalArgumentException(beeLine.loc("arg-usage",
-          new Object[] {ret.length == 0 ? "" : ret[0],
+          new Object[] {ret == null || ret.length == 0 ? "" : ret[0],
               paramname}));
     }
     return ret[1];


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - Null pointers should not be dereferenced
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2259
Please let me know if you have any questions.
Kirill Vlasov
