### PR TITLE
[HIVE-13170] Implements interface HiveOutputFormat<K,V>

### DIFF
--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/mr/HiveAccumuloTableOutputFormat.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/mr/HiveAccumuloTableOutputFormat.java
@@ -71,7 +71,7 @@ public class HiveAccumuloTableOutputFormat extends AccumuloOutputFormat implemen
     try {
       return new MyRecordWriter(job);
     } catch (AccumuloException | AccumuloSecurityException e) {
-      return null;
+      throw new IOException("Failed to acquire Accumulo DelegationToken", e);
     }
   }
 


### PR DESCRIPTION
HiveAccumuloTableOutputFormat as OutputFormat in an hive storage handler, should implement HiveOutputFormat<K,V> interface as well to ensure compatibility

ref. https://issues.apache.org/jira/browse/HIVE-13170
