### PR TITLE
HIVE-13745: NullPointerException when current_date is used in mapreduce

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1126,6 +1126,7 @@ public class HiveConf extends Configuration {
     HIVETESTCURRENTTIMESTAMP("hive.test.currenttimestamp", null, "current timestamp for test", false),
     HIVETESTMODEROLLBACKTXN("hive.test.rollbacktxn", false, "For testing only.  Will mark every ACID transaction aborted", false),
     HIVETESTMODEFAILCOMPACTION("hive.test.fail.compaction", false, "For testing only.  Will cause CompactorMR to fail.", false),
+    HIVE_QUERY_TIMESTAMP("hive.query.timestamp", System.currentTimeMillis(), "query execte time."),
 
     HIVEMERGEMAPFILES("hive.merge.mapfiles", true,
         "Merge small files at the end of a map-only job"),

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1638,6 +1638,7 @@ public class SessionState {
    */
   public void setupQueryCurrentTimestamp() {
     queryCurrentTimestamp = new Timestamp(System.currentTimeMillis());
+    conf.setLongVar(ConfVars.HIVE_QUERY_TIMESTAMP, queryCurrentTimestamp.getTime());
 
     // Provide a facility to set current timestamp during tests
     if (conf.getBoolVar(ConfVars.HIVE_IN_TEST)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFCurrentDate.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFCurrentDate.java
@@ -18,8 +18,12 @@
 package org.apache.hadoop.hive.ql.udf.generic;
 
 import java.sql.Date;
+import java.sql.Timestamp;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.MapredContext;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentLengthException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -39,6 +43,13 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectIn
 public class GenericUDFCurrentDate extends GenericUDF {
 
   protected DateWritable currentDate;
+  private Configuration conf;
+
+  @Override
+  public void configure(MapredContext context) {
+    super.configure(context);
+    conf = context.getJobConf();
+  }
 
   @Override
   public ObjectInspector initialize(ObjectInspector[] arguments)
@@ -50,8 +61,21 @@ public class GenericUDFCurrentDate extends GenericUDF {
     }
 
     if (currentDate == null) {
+      SessionState ss = SessionState.get();
+      Timestamp queryTimestamp;
+      if (ss == null) {
+        if (conf == null) {
+          queryTimestamp = new Timestamp(System.currentTimeMillis());
+        } else {
+          queryTimestamp = new Timestamp(
+                  HiveConf.getLongVar(conf, HiveConf.ConfVars.HIVE_QUERY_TIMESTAMP));
+        }
+      } else {
+        queryTimestamp = ss.getQueryCurrentTimestamp();
+      }
+
       Date dateVal =
-          Date.valueOf(SessionState.get().getQueryCurrentTimestamp().toString().substring(0, 10));
+              Date.valueOf(queryTimestamp.toString().substring(0, 10));
       currentDate = new DateWritable(dateVal);
     }
 

--- a/storage-api/src/java/org/apache/hadoop/hive/common/type/HiveDecimal.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/type/HiveDecimal.java
@@ -35,8 +35,8 @@ public class HiveDecimal implements Comparable<HiveDecimal> {
    * Default precision/scale when user doesn't specify in the column metadata, such as
    * decimal and decimal(8).
    */
-  public static final int USER_DEFAULT_PRECISION = 10;
-  public static final int USER_DEFAULT_SCALE = 0;
+  public static final int USER_DEFAULT_PRECISION = 38;
+  public static final int USER_DEFAULT_SCALE = 18;
 
   /**
    *  Default precision/scale when system is not able to determine them, such as in case


### PR DESCRIPTION
NullPointerException when current_date is used in mapreduce.
