### PR TITLE
HIVE-13877 Fixed the problem with Hplsql UDF doesn't work in Hive Cli

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Udf.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Udf.java
@@ -95,6 +95,11 @@ public class Udf extends GenericUDF {
       else if (argumentsOI[i] instanceof IntObjectInspector) {
         Integer value = (Integer)((IntObjectInspector)argumentsOI[i]).getPrimitiveJavaObject(arguments[i].get());
         if (value != null) {
+          // By default, exec.currentScope is null.
+          if (exec.currentScope == null) {
+            exec.globalScope = new Scope(Scope.Type.GLOBAL);
+            exec.currentScope = exec.globalScope;
+          }
           exec.setVariable(name, new Var(new Long(value)));
         }        
       }


### PR DESCRIPTION
Hive cli will throw "Error evaluating hplsql" exception when i use the hplsql udf like "SELECT hplsql('hello[:1]', columnName) FROM tableName". So, this request exists to fix that problem.
