### PR TITLE
Update to UDFRegExpExtract

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFRegExpExtract.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFRegExpExtract.java
@@ -53,7 +53,12 @@ public class UDFRegExpExtract extends UDF {
     Matcher m = p.matcher(s);
     if (m.find()) {
       MatchResult mr = m.toMatchResult();
-      return mr.group(extractIndex);
+      try {
+        return mr.group(extractIndex);
+      }
+      catch (IndexOutOfBoundsException e){
+        return "Regex index not found";
+      }  
     }
     return "";
   }


### PR DESCRIPTION
I would like to return a clearer error message, for failed regex extract commands.