### PR TITLE
fix the import database_name.table_name from path

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -250,8 +250,8 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
 
         Task<?> t = TaskFactory.get(new DDLWork(getInputs(), getOutputs(),
             tblDesc), conf);
-        Table table = new Table(dbname, tblDesc.getTableName());
-        String currentDb = SessionState.get().getCurrentDatabase();
+        String[] dbTableName =Utilities.getDbTableName(dbname,tblDesc.getTableName());
+        Table table = new Table(dbTableName[0], dbTableName[1]);
         conf.set("import.destination.dir",
             wh.getTablePath(db.getDatabaseCurrent(),
                 tblDesc.getTableName()).toString());


### PR DESCRIPTION
detail :
use test;
create table a(id int,name string);
export table a to '/tmp/a';
drop table a;
import table test.a from '/tmp/a';
hive> import table test.a from '/tmp/a';
Failed with exception Invalid table name test.test.a
FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.exec.MoveTask

when use import database_name.table_name from ,
the tblDesc.getTableName() return database_name.table_name ,not table_name
Table table = new Table(dbname,database_name.table_name) will return the table's name is dbname.database_name.table_name
correct table name should be test.a,not   test.test.a

we can fix this:
  String[] dbTableName =Utilities.getDbTableName(dbname,tblDesc.getTableName());
   Table table = new Table(dbTableName[0], dbTableName[1]);
