### PR TITLE
Update to UDFRegExpExtract with fixed pom.xml and travis file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: required
+
+language: java
+
+jdk:
+      - oraclejdk7
+
+before_install: 
+      - sudo rm /etc/mavenrc
+                - export M2_HOME=/usr/local/maven
+                              - export MAVEN_OPTS="-Dmaven.repo.local=$HOME/.m2/repository -Xmx2g -XX:MaxPermSize=256M"
+
+script:
+      - mvn install -DskipTests
+                - cd itests; mvn install -DskipTests
+
+
+cache:
+      directories:
+        - $HOME/.m2

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <activemq.version>5.5.0</activemq.version>
     <ant.version>1.9.1</ant.version>
     <antlr.version>3.4</antlr.version>
-    <apache-directory-server.version>1.5.6</apache-directory-server.version>
+    <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <apache-directory-clientapi.version>0.1</apache-directory-clientapi.version>
     <avro.version>1.7.7</avro.version>
     <bonecp.version>0.8.0.RELEASE</bonecp.version>

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFRegExpExtract.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFRegExpExtract.java
@@ -53,7 +53,12 @@ public class UDFRegExpExtract extends UDF {
     Matcher m = p.matcher(s);
     if (m.find()) {
       MatchResult mr = m.toMatchResult();
-      return mr.group(extractIndex);
+        try {
+          return mr.group(extractIndex);
+        }
+        catch (IndexOutOfBoundsException e){
+          return "Regex index not found";
+        }
     }
     return "";
   }


### PR DESCRIPTION
Slight change to RegExpExtract function in hive should be able to catch errors when thrown to inform users of their mistakes.

Added an travis file to ensure builds correctly. Named correctly now.

Updated pom file.
