### PR TITLE
HIVE-14647: Typo fixes in Beeline help

### DIFF
--- a/beeline/src/main/resources/BeeLine.properties
+++ b/beeline/src/main/resources/BeeLine.properties
@@ -200,8 +200,8 @@ cmd-usage: Usage: java org.apache.hive.cli.beeline.BeeLine \n \
 \   2. Connect using simple authentication to HiveServer2 on hs.local:10000 using -n for username and -p for password\n \
 \   $ beeline -n username -p password -u jdbc:hive2://hs2.local:10012\n\n \
 \   3. Connect using Kerberos authentication with hive/localhost@mydomain.com as HiveServer2 principal\n \
-\   $ beeline -u "jdbc:hive2://hs2.local:10013/default;principal=hive/localhost@mydomain.com\n\n \
+\   $ beeline -u "jdbc:hive2://hs2.local:10013/default;principal=hive/localhost@mydomain.com"\n\n \
 \   4. Connect using SSL connection to HiveServer2 on localhost at 10000\n \
-\   $ beeline jdbc:hive2://localhost:10000/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword\n\n \
+\   $ beeline "jdbc:hive2://localhost:10000/default;ssl=true;sslTrustStore=/usr/local/truststore;trustStorePassword=mytruststorepassword"\n\n \
 \   5. Connect using LDAP authentication\n \
 \   $ beeline -u jdbc:hive2://hs2.local:10013/default <ldap-username> <ldap-password>\n \


### PR DESCRIPTION
Passing multiple arguments separated by semicolons requires to be within quotation marks.