### PR TITLE
Null responses for metadata getUrl() and getUserName()

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveDatabaseMetaData.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveDatabaseMetaData.java
@@ -782,11 +782,11 @@ public class HiveDatabaseMetaData implements DatabaseMetaData {
   }
 
   public String getURL() throws SQLException {
-    throw new SQLException("Method not supported");
+    return null;
   }
 
   public String getUserName() throws SQLException {
-    throw new SQLException("Method not supported");
+    return null;
   }
 
   public ResultSet getVersionColumns(String catalog, String schema, String table)


### PR DESCRIPTION
The HiveDatabaseMetaData methods getUrl() and getUserName() has been throwing SQLExceptions when called. This change will make them return null instead, which makes Hive JDBC compatible with Apache MetaModel, and probably other clients as well.
