### PR TITLE
HIVE-15056: Support index shifting for struct fields

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ArrayWritableObjectInspector.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ArrayWritableObjectInspector.java
@@ -48,29 +48,29 @@ public class ArrayWritableObjectInspector extends SettableStructObjectInspector 
   private final List<StructField> fields;
   private final HashMap<String, StructFieldImpl> fieldsByName;
 
-  // Whether this OI is for the row-level schema (as opposed to nested struct fields).
+  // Whether this OI is for the column-level schema (as opposed to nested column fields).
   private final boolean isRoot;
 
   public ArrayWritableObjectInspector(final StructTypeInfo rowTypeInfo) {
     this(true, rowTypeInfo, null);
   }
 
-  public ArrayWritableObjectInspector(StructTypeInfo completeTypeInfo, StructTypeInfo prunedTypeInfo) {
-    this(true, completeTypeInfo, prunedTypeInfo);
+  public ArrayWritableObjectInspector(StructTypeInfo originalTypeInfo, StructTypeInfo prunedTypeInfo) {
+    this(true, originalTypeInfo, prunedTypeInfo);
   }
 
   public ArrayWritableObjectInspector(boolean isRoot,
-      StructTypeInfo completeTypeInfo, StructTypeInfo prunedTypeInfo) {
+      StructTypeInfo originalTypeInfo, StructTypeInfo prunedTypeInfo) {
     this.isRoot = isRoot;
-    typeInfo = completeTypeInfo;
-    fieldNames = completeTypeInfo.getAllStructFieldNames();
-    fieldInfos = completeTypeInfo.getAllStructFieldTypeInfos();
+    typeInfo = originalTypeInfo;
+    fieldNames = originalTypeInfo.getAllStructFieldNames();
+    fieldInfos = originalTypeInfo.getAllStructFieldTypeInfos();
     fields = new ArrayList<>(fieldNames.size());
     fieldsByName = new HashMap<>();
 
     for (int i = 0; i < fieldNames.size(); ++i) {
       final String name = fieldNames.get(i);
-      TypeInfo fieldInfo = fieldInfos.get(i);
+      final TypeInfo fieldInfo = fieldInfos.get(i);
 
       StructFieldImpl field;
       if (prunedTypeInfo != null && prunedTypeInfo.getAllStructFieldNames().indexOf(name) >= 0) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -180,17 +180,17 @@ public class ParquetHiveSerDe extends AbstractSerDe {
    * Given a complete struct type info and pruned paths containing selected fields
    * from the type info, return a pruned struct type info only with the selected fields.
    *
-   * For instance, if 'completeTypeInfo' is: s:struct<a:struct<b:int, c:boolean>, d:string>
+   * For instance, if 'originalTypeInfo' is: s:struct<a:struct<b:int, c:boolean>, d:string>
    *   and 'prunedPaths' is "s.a.b,s.d", then the result will be:
    *   s:struct<a:struct<b:int>, d:string>
    *
-   * @param completeTypeInfo the complete struct type info
+   * @param originalTypeInfo the complete struct type info
    * @param prunedPaths a string representing the pruned paths, separated by ','
    * @return the pruned struct type info
    */
   private StructTypeInfo pruneFromPaths(
-      StructTypeInfo completeTypeInfo, String prunedPaths) {
-    PrunedTypeInfo prunedTypeInfo = new PrunedTypeInfo(completeTypeInfo);
+      StructTypeInfo originalTypeInfo, String prunedPaths) {
+    PrunedStructTypeInfo prunedTypeInfo = new PrunedStructTypeInfo(originalTypeInfo);
 
     String[] prunedPathList = prunedPaths.split(",");
     for (String path : prunedPathList) {
@@ -200,9 +200,9 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     return prunedTypeInfo.prune();
   }
 
-  private void pruneFromSinglePath(PrunedTypeInfo prunedInfo, String path) {
+  private void pruneFromSinglePath(PrunedStructTypeInfo prunedInfo, String path) {
     Preconditions.checkArgument(prunedInfo != null,
-        "PrunedTypeInfo for path " + path + " should not be null");
+      "PrunedStructTypeInfo for path " + path + " should not be null");
 
     int index = path.indexOf('.');
     if (index < 0) {
@@ -216,12 +216,12 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     }
   }
 
-  private static class PrunedTypeInfo {
+  private static class PrunedStructTypeInfo {
     final StructTypeInfo typeInfo;
-    final Map<String, PrunedTypeInfo> children;
+    final Map<String, PrunedStructTypeInfo> children;
     final boolean[] selected;
 
-    PrunedTypeInfo(StructTypeInfo typeInfo) {
+    PrunedStructTypeInfo(StructTypeInfo typeInfo) {
       this.typeInfo = typeInfo;
       this.children = new HashMap<>();
       this.selected = new boolean[typeInfo.getAllStructFieldTypeInfos().size()];
@@ -229,7 +229,7 @@ public class ParquetHiveSerDe extends AbstractSerDe {
         TypeInfo ti = typeInfo.getAllStructFieldTypeInfos().get(i);
         if (ti.getCategory() == Category.STRUCT) {
           this.children.put(typeInfo.getAllStructFieldNames().get(i),
-              new PrunedTypeInfo((StructTypeInfo) ti));
+              new PrunedStructTypeInfo((StructTypeInfo) ti));
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/serde/ParquetHiveSerDe.java
@@ -114,13 +114,14 @@ public class ParquetHiveSerDe extends AbstractSerDe {
     // Create row related objects
     StructTypeInfo completeTypeInfo =
         (StructTypeInfo) TypeInfoFactory.getStructTypeInfo(columnNames, columnTypes);
-    String prunedColumnPaths = conf.get(ColumnProjectionUtils.READ_NESTED_COLUMN_PATH_CONF_STR);
-    if (prunedColumnPaths != null) {
-      StructTypeInfo prunedTypeInfo = pruneFromPaths(completeTypeInfo, prunedColumnPaths);
-      this.objInspector = new ArrayWritableObjectInspector(completeTypeInfo, prunedTypeInfo);
-    } else {
-      this.objInspector = new ArrayWritableObjectInspector(completeTypeInfo);
+    StructTypeInfo prunedTypeInfo = null;
+    if (conf != null) {
+      String prunedColumnPaths = conf.get(ColumnProjectionUtils.READ_NESTED_COLUMN_PATH_CONF_STR);
+      if (prunedColumnPaths != null) {
+        prunedTypeInfo = pruneFromPaths(completeTypeInfo, prunedColumnPaths);
+      }
     }
+    this.objInspector = new ArrayWritableObjectInspector(completeTypeInfo, prunedTypeInfo);
 
     // Stats part
     serializedSize = 0;

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetSerDe.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestParquetSerDe.java
@@ -19,12 +19,16 @@ import junit.framework.TestCase;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.io.ByteWritable;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
 import org.apache.hadoop.hive.serde2.io.ParquetHiveRecord;
 import org.apache.hadoop.hive.serde2.io.ShortWritable;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 import org.apache.hadoop.io.ArrayWritable;
 import org.apache.hadoop.io.BytesWritable;
@@ -79,6 +83,36 @@ public class TestParquetSerDe extends TestCase {
       e.printStackTrace();
       throw e;
     }
+  }
+
+  public void testParquetHiveSerDeComplexTypes() throws Throwable {
+    // Initialize
+    ParquetHiveSerDe serDe = new ParquetHiveSerDe();
+    Configuration conf = new Configuration();
+    Properties tblProperties = new Properties();
+
+    tblProperties.setProperty(serdeConstants.LIST_COLUMNS, "a,s");
+    tblProperties.setProperty(serdeConstants.LIST_COLUMN_TYPES, "int,struct<a:int,b:string>");
+    conf.set(ColumnProjectionUtils.READ_NESTED_COLUMN_PATH_CONF_STR, "s.b");
+
+    serDe.initialize(conf, tblProperties);
+
+    // Generate test data
+    Writable[] wb = new Writable[1];
+    wb[0] = new BytesWritable("foo".getBytes("UTF-8"));
+    Writable[] ws = new Writable[2];
+    ws[0] = null;
+    ArrayWritable awb = new ArrayWritable(Writable.class, wb);
+    ws[1] = awb;
+    ArrayWritable aws = new ArrayWritable(Writable.class, ws);
+
+    // Inspect the test data
+    StructObjectInspector soi = (StructObjectInspector) serDe.getObjectInspector();
+    StructField s = soi.getStructFieldRef("s");
+    assertEquals(awb, soi.getStructFieldData(aws, s));
+    StructObjectInspector boi = (StructObjectInspector) s.getFieldObjectInspector();
+    StructField b = boi.getStructFieldRef("b");
+    assertEquals(wb[0], boi.getStructFieldData(awb, b));
   }
 
   private void deserializeAndSerializeLazySimple(final ParquetHiveSerDe serDe, final ArrayWritable t) throws SerDeException {


### PR DESCRIPTION
In [HIVE-13873](https://issues.apache.org/jira/browse/HIVE-13873), the following case doesn't work:

```
select s.a from tbl
```

where `tbl` is of schema

```
a                       int
s                       struct<b:int,c:string>
```

This is because currently we generate a "pruned" schema (in terms of `GroupType`) for Parquet reader to scan the data. However, on the Hive side the object inspector still uses the original schema. In particular, in this case for `s.c` the data returned by Parquet reader is in index 0, but the object inspector tries to read it in index 1. Therefore, in correct result will be returned.

This patch fixes the issue by passing the necessary path information to the initialization of corresponding object inspector, so that when inspecting the data, it will use the adjusted field index.
