### PR TITLE
HIVE-15191: Fix typo in conf/hive-env.sh.template

### DIFF
--- a/conf/hive-env.sh.template
+++ b/conf/hive-env.sh.template
@@ -50,5 +50,5 @@
 # Hive Configuration Directory can be controlled by:
 # export HIVE_CONF_DIR=
 
-# Folder containing extra ibraries required for hive compilation/execution can be controlled by:
+# Folder containing extra libraries required for hive compilation/execution can be controlled by:
 # export HIVE_AUX_JARS_PATH=


### PR DESCRIPTION
'Libraries', not 'ibraries'.