### PR TITLE
fix stripe size smaller than expected

### DIFF
--- a/orc/src/java/org/apache/orc/impl/OutStream.java
+++ b/orc/src/java/org/apache/orc/impl/OutStream.java
@@ -260,13 +260,13 @@ public class OutStream extends PositionedOutputStream {
   public long getBufferSize() {
     long result = 0;
     if (current != null) {
-      result += current.capacity();
+      result += current.position();
     }
     if (compressed != null) {
-      result += compressed.capacity();
+      result += compressed.position();
     }
     if (overflow != null) {
-      result += overflow.capacity();
+      result += overflow.position();
     }
     return result;
   }


### PR DESCRIPTION
I saw there's a Jira item: https://issues.apache.org/jira/browse/HIVE-13232 moved the compressed = null out of if block. But that is not seem to be a complete fix. To calculate the right value, we cannot use all bytes that a reserved, but should use bytes are filled. Thus I change the capacity() to position().
```java  
public void flush() throws IOException {
    spill();
    if (compressed != null && compressed.position() != 0) {
      compressed.flip();
      receiver.output(compressed);
//Should move compress = null out of if block, (already been moved out in 2.1.0 code)
//otherwise its capacity will count for all following stripes even it is not used by them.
      compressed = null;
}
    uncompressedBytes = 0;
    compressedBytes = 0;
    overflow = null;
    current = null;
  }
```