### PR TITLE
HIVE-15585 LLAP failed to start on a host with only 1 cpu

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/LlapServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/LlapServiceDriver.java
@@ -197,7 +197,7 @@ public class LlapServiceDriver {
     final FileSystem lfs = FileSystem.getLocal(conf).getRawFileSystem();
 
     final ExecutorService executor =
-        Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors() / 2,
+        Executors.newFixedThreadPool(Math.max(1, Runtime.getRuntime().availableProcessors() / 2),
             new ThreadFactoryBuilder().setNameFormat("llap-pkg-%d").build());
     final CompletionService<Void> asyncRunner = new ExecutorCompletionService<Void>(executor);
 


### PR DESCRIPTION
LLAP failed to start on a host with only 1 cpu. The number of thread was calculated by dividing the number of cpus with 2. This resulted zero if the cpu count was 1 and caused an IllegalArgumentException upon startup. Fixed this by adding Math.max(1, cpus/2).