### PR TITLE
[HIVE-15690] Enable webhcat to run JDBC connection for Hive DDL queries

### DIFF
--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/AppConfig.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/AppConfig.java
@@ -168,6 +168,15 @@ public class AppConfig extends Configuration {
 
   public static final String XSRF_FILTER_ENABLED = "templeton.xsrf.filter.enabled";
 
+  /**
+   * JDBC connection to hive server2 for DDL/Hive queries
+   * to enable set 'templeton.ddl.mode' to 'jdbc'
+   */
+  public static final String DDL_MODE                 = "templeton.ddl.mode";
+  public static final String HIVE_KERBEROS_PRINCIPAL  = "hive.server2.kerberos.principal";
+  public static final String HIVE_KERBEROS_KEYTAB     = "hive.server2.kerberos.keytab";
+  public static final String HIVE_JDBC_URL            = "hive.jdbc.url";
+
   private static final Logger LOG = LoggerFactory.getLogger(AppConfig.class);
 
   public AppConfig() {
@@ -389,4 +398,9 @@ public class AppConfig extends Configuration {
 
   public String zkHosts()          { return get(ZooKeeperStorage.ZK_HOSTS); }
   public int zkSessionTimeout()    { return getInt(ZooKeeperStorage.ZK_SESSION_TIMEOUT, 30000); }
+
+  public String hiveKerberosPrincipal(){ return get(HIVE_KERBEROS_PRINCIPAL); }
+  public String hiveKerberosKeytab()   { return get(HIVE_KERBEROS_KEYTAB); }
+  public String hiveJdbcUrl()          { return get(HIVE_JDBC_URL); }
+  public boolean jdbcMode()            { return "jdbc".equalsIgnoreCase(get(DDL_MODE)); }
 }

--- a/hcatalog/webhcat/svr/src/test/java/org/apache/hive/hcatalog/templeton/HcatDelegatorTest.java
+++ b/hcatalog/webhcat/svr/src/test/java/org/apache/hive/hcatalog/templeton/HcatDelegatorTest.java
@@ -1,0 +1,17 @@
+package org.apache.hive.hcatalog.templeton;
+
+import junit.framework.TestCase;
+
+public class HcatDelegatorTest extends TestCase {
+    public void testGetCatalogStatementWithUse() {
+        HcatDelegator.SchemaStatement cs = HcatDelegator.getSchemaStatement("use db1; show create table x;");
+        assertEquals("db1", cs.schema);
+        assertEquals("show create table x", cs.statement);
+    }
+
+    public void testGetCatalogStatementWithoutUse() {
+        HcatDelegator.SchemaStatement cs = HcatDelegator.getSchemaStatement("show create table db1.x;");
+        assertEquals(null, cs.schema);
+        assertEquals("show create table db1.x", cs.statement);
+    }
+}


### PR DESCRIPTION
This is a change in `HcatDelegator` to run Hive DDL queries over **JDBC** connection in contrast to slow `hcat` command.

Motivation is basically speed. The way `HcatDelegator` launches new `hcat` scripts per call makes it unsuitable for interactive REST calls. 

This change speeds up /ddl queries from normally 10-20 sec down to few milliseconds. No connection pooling is in place to make the RP small but that can be added anytime. 

Also being JDBC connection, this is pretty secure and compatible with all access policies define in Hive server2. User does not have visibility over other databases (which used to be the case in `hcat` mode.)

To switch to JDBC mode simply add this configuration to **webhcat-site.xml**

```xml
<property>
      <name>templeton.ddl.mode</name>
      <value>jdbc</value>
</property>
<property>
      <name>hive.jdbc.url</name>
      <value>jdbc:hive2://server:port</value>
</property>
```

For secure environments we also need these attributes in webhcat-site.xml configuration:

```xml
    <property>
      <name>hive.server2.kerberos.keytab</name>
      <value>/etc/security/keytabs/hive.service.keytab</value>
    </property>

    <property>
      <name>hive.server2.kerberos.principal</name>
      <value>hive/_HOST@{REALM}</value>
    </property>
```

This change uses Hive DDL JSON output so that should be allowed in **hiveserver2-site.xml**

```xml
    <property>
      <name>hive.security.authorization.sqlstd.confwhitelist.append</name>
      <value>hive.ddl.output.format</value>
    </property>
```

