### PR TITLE
HIVE-15711 :  Flaky TestEmbeddedThriftBinaryCLIService.testTaskStatus

### DIFF
--- a/service/src/test/org/apache/hive/service/cli/CLIServiceTest.java
+++ b/service/src/test/org/apache/hive/service/cli/CLIServiceTest.java
@@ -665,8 +665,8 @@ public abstract class CLIServiceTest {
       ByteArrayInputStream in = new ByteArrayInputStream(jsonTaskStatus.getBytes("UTF-8"));
       List<QueryDisplay.TaskDisplay> taskStatuses =
         mapper.readValue(in, new TypeReference<List<QueryDisplay.TaskDisplay>>(){});
-      checkTaskStatuses(taskStatuses);
       System.out.println("task statuses: " + jsonTaskStatus); // TaskDisplay doesn't have a toString, using json
+      checkTaskStatuses(taskStatuses);
       if (OperationState.CANCELED == state || state == OperationState.CLOSED
         || state == OperationState.FINISHED
         || state == OperationState.ERROR) {
@@ -693,9 +693,6 @@ public abstract class CLIServiceTest {
           assertNull(taskDisplay.getReturnValue());
           break;
         case RUNNING:
-          if (taskDisplay.getTaskType() == StageType.MAPRED || taskDisplay.getTaskType() == StageType.MAPREDLOCAL) {
-            assertNotNull(taskDisplay.getExternalHandle());
-          }
           assertNotNull(taskDisplay.getBeginTime());
           assertNull(taskDisplay.getEndTime());
           assertNotNull(taskDisplay.getElapsedTime());


### PR DESCRIPTION
The 'RUNNING' state can be set way before the job handle from MR frameworks is available to be set on the server in the taskDisplay, hence there is a possibility that we can receive jobStatus messages without the job id. Hence its not guaranteed  that it is  not null in running status hence removing this condition check. This will be checked anyways when the status is 'FINISHED'.Printing the status before validation so in case of validation failures we will know why it failed