### PR TITLE
HIVE-15929. Fix HiveDecimalWritable compatibility with Hive 2.1.

### DIFF
--- a/storage-api/src/java/org/apache/hadoop/hive/serde2/io/HiveDecimalWritable.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/serde2/io/HiveDecimalWritable.java
@@ -947,10 +947,13 @@ public final class HiveDecimalWritable extends FastHiveDecimal
     return fastHashCode();
   }
 
+  private static final byte[] EMPTY_ARRAY = new byte[0];
+
   @HiveDecimalWritableVersionV1
   public byte[] getInternalStorage() {
     if (!isSet()) {
-      throw new RuntimeException("no value set");
+      // don't break old callers that are trying to reuse storages
+      return EMPTY_ARRAY;
     }
 
     if (internalScratchLongs == null) {


### PR DESCRIPTION
This allows Hive 2.1 to work without getting an exception.