### PR TITLE
HIVE-15848:count or sum distinct incorrect when hive.optimize.reducededuplication set to true

### DIFF
--- a/metastore/scripts/upgrade/mysql/hive-schema-2.2.0.mysql.sql
+++ b/metastore/scripts/upgrade/mysql/hive-schema-2.2.0.mysql.sql
@@ -799,7 +799,7 @@ CREATE TABLE IF NOT EXISTS `NOTIFICATION_LOG`
     `DB_NAME` varchar(128),
     `TBL_NAME` varchar(128),
     `MESSAGE` longtext,
-    `MESSAGE_FORMAT` varchar(16)
+    `MESSAGE_FORMAT` varchar(16),
     PRIMARY KEY (`NL_ID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplication.java
@@ -377,6 +377,13 @@ public class ReduceSinkDeDuplication extends Transform {
       if (movePartitionColTo == null) {
         return null;
       }
+      // HIVE-15848
+      // If child-RS has more than one DistinctColumn,
+      // can't make sure the second column order.
+      List<List<Integer>> childDistinctColumnIndices = cConf.getDistinctColumnIndices();
+      if (childDistinctColumnIndices != null && childDistinctColumnIndices.size() >= 2) {
+        return null;
+      }
       Integer moveNumDistKeyTo = checkNumDistributionKey(cConf.getNumDistributionKeys(),
           pConf.getNumDistributionKeys());
       return new int[] {moveKeyColTo, movePartitionColTo, moveRSOrderTo,


### PR DESCRIPTION
when I run command  'schematool -dbType mysql -initSchema -verbose'.
error:
 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') ENGINE=InnoDB DEFAULT CHARSET=latin1' at line 1