### PR TITLE
Use setNull when null value is passed to preparedstatement setter

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
@@ -265,7 +265,11 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
-    this.parameters.put(parameterIndex, x.toString());
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    } else {
+      this.parameters.put(parameterIndex, x.toString());
+    }
   }
 
   /*
@@ -275,8 +279,12 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
-    String str = new Scanner(x, "UTF-8").useDelimiter("\\A").next();
-    this.parameters.put(parameterIndex, str);
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    } else {
+      String str = new Scanner(x, "UTF-8").useDelimiter("\\A").next();
+      this.parameters.put(parameterIndex, str);
+    }
   }
 
   /*
@@ -445,7 +453,11 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setDate(int parameterIndex, Date x) throws SQLException {
-    this.parameters.put(parameterIndex, "'" + x.toString() + "'");
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    } else {
+      this.parameters.put(parameterIndex, "'" + x.toString() + "'");
+    }
   }
 
   /*
@@ -703,8 +715,12 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setString(int parameterIndex, String x) throws SQLException {
-     x=x.replace("'", "\\'");
-     this.parameters.put(parameterIndex,"'"+x+"'");
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    } else {
+      x=x.replace("'", "\\'");
+      this.parameters.put(parameterIndex,"'"+x+"'");
+    }
   }
 
   /*
@@ -737,7 +753,11 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
-    this.parameters.put(parameterIndex, "'" + x.toString() + "'");
+    if (x == null) {
+      setNull(parameterIndex, Types.NULL);
+    } else {
+      this.parameters.put(parameterIndex, "'" + x.toString() + "'");
+    }
   }
 
   /*


### PR DESCRIPTION
Not sure if I should open a ticket first but PreparedStatement setters are failing when a null value is passed (the setString in my case). I changed the other ones as well so they would have the same behavior.

A workaround solution is to use the setObject instead of setString but the wrong setter might be used depending on the value's type which I want to avoid.