### PR TITLE
HIVE-16595: fix syntax in Hplsql.g4

### DIFF
--- a/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
+++ b/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
@@ -18,7 +18,7 @@
 // HPL/SQL Procedural SQL Extension Grammar 
 grammar Hplsql;
 
-program : block ;
+program : block EOF;
 
 block : ((begin_end_block | stmt) T_GO?)+ ;               // Multiple consecutive blocks/statements
 


### PR DESCRIPTION
According to https://github.com/antlr/antlr4/issues/118, it is better to add EOF for the first rule in grammar. This can solve the potential incorrect error message issue.

Signed-off-by: Yishuang Lu <luyscmu@gmail.com>