### PR TITLE
HIVE-16866 : existing available UDF is used in TestReplicationScenariosAcrossInstances#testDropFunctionIncrementalReplication

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -231,7 +231,7 @@ public class ReplChangeManager {
    * @param checkSum checksum of the file, can be retrieved by {@link #checksumFor(Path, FileSystem)}
    * @return Path
    */
-  static Path getCMPath(Configuration conf, String checkSum) throws IOException, MetaException {
+  static Path getCMPath(Configuration conf, String checkSum) {
     String newFileName = checkSum;
     int maxLength = conf.getInt(DFSConfigKeys.DFS_NAMENODE_MAX_COMPONENT_LENGTH_KEY,
         DFSConfigKeys.DFS_NAMENODE_MAX_COMPONENT_LENGTH_DEFAULT);


### PR DESCRIPTION
There are few javadoc changes and a method rename in repl change manager along with a few access modifiers as well. 