### PR TITLE
HIVE-17077: Hive should raise StringIndexOutOfBoundsException when LPAD/RPAD len character's value is negative number

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBasePad.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBasePad.java
@@ -70,6 +70,9 @@ public abstract class GenericUDFBasePad extends GenericUDF {
       return null;
     }
     int len = lenW.get();
+    if (len < 0) {
+      return null;
+    }
     builder.setLength(0);
 
     performOp(builder, len, str.toString(), pad.toString());

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFLpad.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFLpad.java
@@ -44,6 +44,7 @@ public class TestGenericUDFLpad extends TestCase {
     runAndVerify("ｈｉ", 5, "？？", "？？？ｈｉ", udf);
     runAndVerify("ｈｉ", 1, "？？", "ｈ", udf);
     runAndVerify("hi", 3, "", null, udf);
+    runAndVerify("hi", -1, "h", null, udf);
   }
 
   private void runAndVerify(String str, int len, String pad, String expResult, GenericUDF udf)

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFRpad.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFRpad.java
@@ -42,6 +42,7 @@ public class TestGenericUDFRpad extends TestCase {
     runAndVerify("ｈｉ", 5, "？？", "ｈｉ？？？", udf);
     runAndVerify("ｈｉ", 1, "？？", "ｈ", udf);
     runAndVerify("hi", 3, "", null, udf);
+    runAndVerify("hi", -1, "h", null, udf);
   }
 
   private void runAndVerify(String str, int len, String pad, String expResult, GenericUDF udf)


### PR DESCRIPTION
[HIVE-17077] Hive should raise StringIndexOutOfBoundsException when LPAD/RPAD len character's value is negative number
- return null when len character's value is negative number

https://issues.apache.org/jira/browse/HIVE-17077