### PR TITLE
Update TBinarySortableProtocol.java

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/thrift/TBinarySortableProtocol.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/thrift/TBinarySortableProtocol.java
@@ -662,9 +662,9 @@ public class TBinarySortableProtocol extends TProtocol implements
 
   void writeTextBytes(byte[] bytes, int start, int length) throws TException {
     writeRawBytes(nonNullByte, 0, 1);
-    int begin = 0;
+    int begin = start;
     int i = start;
-    for (; i < length; i++) {
+    for (; i < start + length; i++) {
       if (bytes[i] == 0 || bytes[i] == 1) {
         // Write the first part of the array
         if (i > begin) {


### PR DESCRIPTION
writeTextBytes doesn't respect the start parameter. It'll work only for cases where start = 0. Fixing it so that it'll work for any value of start.