### PR TITLE
HIVE-18130: Update table path to storage parameters when alter a table

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -283,7 +283,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
 
     static final Logger auditLog = LoggerFactory.getLogger(
         HiveMetaStore.class.getName() + ".audit");
-    
+
     private static void logAuditEvent(String cmd) {
       if (cmd == null) {
         return;
@@ -4327,6 +4327,10 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         if (org.apache.commons.lang.StringUtils.isNotEmpty(newLocation)) {
           Path tblPath = wh.getDnsPath(new Path(newLocation));
           newTable.getSd().setLocation(tblPath.toString());
+          // Also update storage description parameters
+          if (newTable.getSd().getSerdeInfo().getParameters().containsKey("path")) {
+            newTable.getSd().getSerdeInfo().getParameters().put("path", tblPath.toString());
+          }
         }
       }
 
@@ -6810,7 +6814,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
           }
           newStatsMap.put(partName, csNew);
         }
-        
+
         Map<String, ColumnStatistics> oldStatsMap = new HashMap<>();
         Map<String, Partition> mapToPart = new HashMap<>();
         if (request.isSetNeedMerge() && request.isNeedMerge()) {


### PR DESCRIPTION
When an managed table is created by Spark, table path information is not only store in `location` field (first figure), but also in `parameters.path` fields (second figure).
<img width="445" alt="location" src="https://user-images.githubusercontent.com/1458656/33123050-466c6bdc-cf79-11e7-8b53-85ad7dc83f17.png">
<img width="677" alt="storage_parameter" src="https://user-images.githubusercontent.com/1458656/33123051-469576da-cf79-11e7-9c6c-9793a28f8389.png">

When hive alter a table, `storage parameter` is ignored. Then, spark cannot access the table anymore because spark use the parameter.

In this PR, when altering a table, the field `storageDescription.parameters.path` is also updated, if `path` key exists

