### PR TITLE
HIVE-18338 Exposing asynchronous execution through hive-jdbc client

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -456,7 +456,7 @@ public class HiveStatement implements java.sql.Statement {
     return statusResp;
   }
 
-  TGetOperationStatusResp waitForOperationToComplete() throws SQLException {
+  public TGetOperationStatusResp waitForOperationToComplete() throws SQLException {
     TGetOperationStatusReq statusReq = new TGetOperationStatusReq(stmtHandle);
     boolean shouldGetProgressUpdate = inPlaceUpdateStream != InPlaceUpdateStream.NO_OP;
     statusReq.setGetProgressUpdate(shouldGetProgressUpdate);

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -37,7 +37,6 @@ import org.apache.hive.service.rpc.thrift.TGetOperationStatusReq;
 import org.apache.hive.service.rpc.thrift.TGetOperationStatusResp;
 import org.apache.hive.service.rpc.thrift.TGetQueryIdReq;
 import org.apache.hive.service.rpc.thrift.TOperationHandle;
-import org.apache.hive.service.rpc.thrift.TOperationState;
 import org.apache.hive.service.rpc.thrift.TSessionHandle;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -269,10 +268,7 @@ public class HiveStatement implements java.sql.Statement {
     if (!status.isHasResultSet() && !stmtHandle.isHasResultSet()) {
       return false;
     }
-    resultSet =  new HiveQueryResultSet.Builder(this).setClient(client).setSessionHandle(sessHandle)
-        .setStmtHandle(stmtHandle).setMaxRows(maxRows).setFetchSize(fetchSize)
-        .setScrollable(isScrollableResultset)
-        .build();
+    buildResultSet();
     return true;
   }
 
@@ -297,11 +293,112 @@ public class HiveStatement implements java.sql.Statement {
     if (!status.isHasResultSet()) {
       return false;
     }
+    buildResultSet();
+    return true;
+  }
+
+  /**
+   * Utility method to build result set. To be called only if the query can produce one.
+   * @throws SQLException
+   */
+  private void buildResultSet() throws SQLException {
     resultSet =
         new HiveQueryResultSet.Builder(this).setClient(client).setSessionHandle(sessHandle)
             .setStmtHandle(stmtHandle).setMaxRows(maxRows).setFetchSize(fetchSize)
             .setScrollable(isScrollableResultset).build();
+  }
+
+  /**
+   * Given an operation handle, this method tries to latch on to the execution.
+   * The operation in synchronous, hence it will wait for completion
+   *
+   * @param tOperationHandle
+   * @return true if the first result is a ResultSet object; false if it is an update count or there
+   *         are no results
+   * @throws SQLException if the latch failed
+   */
+  public boolean latchSync(TOperationHandle tOperationHandle) throws SQLException {
+    refreshStatus(new TGetOperationStatusReq(tOperationHandle));
+    stmtHandle = tOperationHandle;
+    waitForOperationToComplete();
+    if (!stmtHandle.isHasResultSet()) {
+      return false;
+    }
+    buildResultSet();
     return true;
+  }
+
+  /**
+   * Given an operation handle, this method tries to latch on to the execution
+   *
+   * @param tOperationHandle
+   * @return true if the first result is a ResultSet object; false if it is an update count or there
+   *         are no results
+   * @throws SQLException if the latch failed
+   */
+  public boolean latchAsync(TOperationHandle tOperationHandle) throws SQLException {
+    refreshStatus(new TGetOperationStatusReq(tOperationHandle));
+    stmtHandle = tOperationHandle;
+    if (!stmtHandle.isHasResultSet()) {
+      return false;
+    }
+    buildResultSet();
+    return true;
+  }
+
+  /**
+   *
+   * @param statusReq
+   * @return returns operation handle if avilable
+   * @throws SQLException
+   */
+  private TGetOperationStatusResp refreshStatus(TGetOperationStatusReq statusReq) throws SQLException {
+    TGetOperationStatusResp statusResp;
+    try {
+      /**
+       * For an async SQLOperation, GetOperationStatus will use the long polling approach It will
+       * essentially return after the HIVE_SERVER2_LONG_POLLING_TIMEOUT (a server config) expires
+       */
+      statusResp = client.GetOperationStatus(statusReq);
+      inPlaceUpdateStream.update(statusResp.getProgressUpdateResponse());
+      Utils.verifySuccessWithInfo(statusResp.getStatus());
+      if (statusResp.isSetOperationState()) {
+        switch (statusResp.getOperationState()) {
+          case CLOSED_STATE:
+          case FINISHED_STATE:
+            isOperationComplete = true;
+            isLogBeingGenerated = false;
+            break;
+          case CANCELED_STATE:
+            // 01000 -> warning
+            String errMsg = statusResp.getErrorMessage();
+            if (errMsg != null && !errMsg.isEmpty()) {
+              throw new SQLException("Query was cancelled. " + errMsg, "01000");
+            } else {
+              throw new SQLException("Query was cancelled", "01000");
+            }
+          case TIMEDOUT_STATE:
+            throw new SQLTimeoutException("Query timed out after " + queryTimeout + " seconds");
+          case ERROR_STATE:
+            // Get the error details from the underlying exception
+            throw new SQLException(statusResp.getErrorMessage(), statusResp.getSqlState(),
+                statusResp.getErrorCode());
+          case UKNOWN_STATE:
+            throw new SQLException("Unknown query", "HY000");
+          case INITIALIZED_STATE:
+          case PENDING_STATE:
+          case RUNNING_STATE:
+            break;
+        }
+      }
+    } catch (SQLException e) {
+      isLogBeingGenerated = false;
+      throw e;
+    } catch (Exception e) {
+      isLogBeingGenerated = false;
+      throw new SQLException(e.toString(), "08S01", e);
+    }
+    return statusResp;
   }
 
   private void runAsyncOnServer(String sql) throws SQLException {
@@ -370,50 +467,7 @@ public class HiveStatement implements java.sql.Statement {
 
     // Poll on the operation status, till the operation is complete
     while (!isOperationComplete) {
-      try {
-        /**
-         * For an async SQLOperation, GetOperationStatus will use the long polling approach It will
-         * essentially return after the HIVE_SERVER2_LONG_POLLING_TIMEOUT (a server config) expires
-         */
-        statusResp = client.GetOperationStatus(statusReq);
-        inPlaceUpdateStream.update(statusResp.getProgressUpdateResponse());
-        Utils.verifySuccessWithInfo(statusResp.getStatus());
-        if (statusResp.isSetOperationState()) {
-          switch (statusResp.getOperationState()) {
-          case CLOSED_STATE:
-          case FINISHED_STATE:
-            isOperationComplete = true;
-            isLogBeingGenerated = false;
-            break;
-          case CANCELED_STATE:
-            // 01000 -> warning
-            String errMsg = statusResp.getErrorMessage();
-            if (errMsg != null && !errMsg.isEmpty()) {
-              throw new SQLException("Query was cancelled. " + errMsg, "01000");
-            } else {
-              throw new SQLException("Query was cancelled", "01000");
-            }
-          case TIMEDOUT_STATE:
-            throw new SQLTimeoutException("Query timed out after " + queryTimeout + " seconds");
-          case ERROR_STATE:
-            // Get the error details from the underlying exception
-            throw new SQLException(statusResp.getErrorMessage(), statusResp.getSqlState(),
-                statusResp.getErrorCode());
-          case UKNOWN_STATE:
-            throw new SQLException("Unknown query", "HY000");
-          case INITIALIZED_STATE:
-          case PENDING_STATE:
-          case RUNNING_STATE:
-            break;
-          }
-        }
-      } catch (SQLException e) {
-        isLogBeingGenerated = false;
-        throw e;
-      } catch (Exception e) {
-        isLogBeingGenerated = false;
-        throw new SQLException(e.toString(), "08S01", e);
-      }
+      statusResp = refreshStatus(statusReq);
     }
 
     /*
@@ -648,6 +702,15 @@ public class HiveStatement implements java.sql.Statement {
     checkConnection("getQueryTimeout");
     return 0;
   }
+
+  /*
+   * Returns the operation handle involved in the statement.
+   * The operation handle can be persisted by the client to resume executions.
+   */
+  public TOperationHandle getOperationHandle() {
+    return stmtHandle;
+  }
+
 
   /*
    * (non-Javadoc)

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -329,7 +329,7 @@ public class HiveStatement implements java.sql.Statement {
   }
 
   /**
-   * Given an operation handle, this method tries to latch on to the execution
+   * Given an operation handle, this method tries to latch on to the execution.
    *
    * @param tOperationHandle
    * @return true if the first result is a ResultSet object; false if it is an update count or there
@@ -347,9 +347,10 @@ public class HiveStatement implements java.sql.Statement {
   }
 
   /**
+   * Thrift call for operation request.
    *
    * @param statusReq
-   * @return returns operation handle if avilable
+   * @return returns thrift response.
    * @throws SQLException
    */
   private TGetOperationStatusResp getStatus(TGetOperationStatusReq statusReq) throws SQLException {
@@ -389,6 +390,8 @@ public class HiveStatement implements java.sql.Statement {
         case PENDING_STATE:
         case RUNNING_STATE:
           break;
+        default:
+          throw new SQLException("Unknown state " + statusResp.getOperationState());
         }
       }
     } catch (SQLException e) {
@@ -433,7 +436,7 @@ public class HiveStatement implements java.sql.Statement {
   }
 
   /**
-   * Poll the result set status by checking if isSetHasResultSet is set
+   * Poll the result set status by checking if isSetHasResultSet is set.
    * @return
    * @throws SQLException
    */


### PR DESCRIPTION
**Problem statement**

Hive JDBC currently exposes 2 methods related to asynchronous execution
**executeAsync()** - to trigger a query execution and return immediately.
**waitForOperationToComplete()** - which waits till the current execution is complete **blocking the user thread**. 

This has one problem
- If the client process goes down, there is no way to resume queries although hive server is completely asynchronous. 

**Proposal**

If operation handle could be exposed, we can latch on to an active execution of a query.

**Code changes**

Operation handle is exposed. So client can keep a copy.
latchSync() and latchAsync() methods take an operation handle and try to latch on to the current execution in hive server if present