### PR TITLE
Hive proxy system

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -405,7 +405,6 @@ public class HiveConnection implements java.sql.Connection {
 
         final Registry<ConnectionSocketFactory> registry = registryBuilder.build();
 
-
         httpClientBuilder.setConnectionManager(new BasicHttpClientConnectionManager(registry));
       }
       catch (Exception e) {
@@ -414,7 +413,7 @@ public class HiveConnection implements java.sql.Connection {
         throw new SQLException(msg, " 08S01", e);
       }
     }
-    return httpClientBuilder.build();
+    return httpClientBuilder.useSystemProperties().build();
   }
 
   private HttpHost getProxySettings() {
@@ -425,39 +424,9 @@ public class HiveConnection implements java.sql.Connection {
       return HttpHost.create(httpProxyFromEnv);
     }
 
-    String http = System.getProperty(HTTP + ".proxyHost");
-
-    if (http != null) {
-      return getProxySettings(HTTP);
-    }
-
     LOG.warn("Proxy not settings");
 
     return null;
-  }
-
-  private HttpHost getProxySettings(String protocol) {
-    if (HTTP.equalsIgnoreCase(protocol)) {
-      String host = System.getProperty(protocol + ".proxyHost", "");
-      Integer port = getPortFromProxy(protocol);
-      return new HttpHost(host, port, protocol );
-    }
-
-    LOG.warn("Proxy not settings");
-
-    return null;
-
-  }
-
-  private Integer getPortFromProxy(String protocol) {
-    String port = System.getProperty(protocol + ".proxyPort");
-    if (port != null && NumberUtils.isNumber(port)) {
-      return Integer.valueOf(port);
-    }
-
-    LOG.warn("Proxy Port not defined or not a number");
-
-    return -1;
   }
 
 


### PR DESCRIPTION
Hello,

I'm using your hive-jdbc (1.2.1) as dependency for 2 applications deployed into 2 docker containers (Java Code and Python Code).
For both containers, it runs behind a proxy system when I deploy on qualification and production environment.
For java, (-Dhttp.proxyHost=MyProxyHost -Dhttp.proxyPort=MyProxyPort)
For python, I set HTTP_PROXY=http://myproxyhost:myproxyport

And after deployed, and launched, a timeout occurs when I want to hit the hive server. I call hive by url jdbc://hive....

So after debugging your source code, I added some code (PR as requested) in order to get the proxy system (env from os or jvm configuration) and It works fine for both containers.

Is this correction acceptable or is there any other solution to hit Hive Server by using proxy ?

Python : I use jaydepbeapi and Java : Only DriverManager.getConnection("jdbc://hive2....)

Thanks a lot