### PR TITLE
HIVE-19725 : Add ability to dump non-native tables in replication metadata dump

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -751,7 +751,7 @@ public class TestReplicationScenariosAcrossInstances {
   }
 
   @Test
-  public void shouldNotCreateDirectoryForNonNativeTableInDumpDirectory() throws Throwable {
+  public void testShouldNotCreateDirectoryForNonNativeTableInDumpDirectory() throws Throwable {
     String createTableQuery =
         "CREATE TABLE custom_serdes( serde_id bigint COMMENT 'from deserializer', name string "
             + "COMMENT 'from deserializer', slib string COMMENT 'from deserializer') "
@@ -770,6 +770,33 @@ public class TestReplicationScenariosAcrossInstances {
         "custom_serdes");
     FileSystem fs = cSerdesTableDumpLocation.getFileSystem(primary.hiveConf);
     assertFalse(fs.exists(cSerdesTableDumpLocation));
+  }
+
+  @Test
+  public void testShouldDumpMetaDataForNonNativeTableIfSetMeataDataOnly() throws Throwable {
+    String tableName = testName.getMethodName() + "_table";
+    String createTableQuery =
+            "CREATE TABLE " + tableName + " ( serde_id bigint COMMENT 'from deserializer', name string "
+                    + "COMMENT 'from deserializer', slib string COMMENT 'from deserializer') "
+                    + "ROW FORMAT SERDE 'org.apache.hive.storage.jdbc.JdbcSerDe' "
+                    + "STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler' "
+                    + "WITH SERDEPROPERTIES ('serialization.format'='1') "
+                    + "TBLPROPERTIES ( "
+                    + "'hive.sql.database.type'='METASTORE', "
+                    + "'hive.sql.query'='SELECT \"SERDE_ID\", \"NAME\", \"SLIB\" FROM \"SERDES\"')";
+
+    WarehouseInstance.Tuple bootstrapTuple = primary
+            .run("use " + primaryDbName)
+            .run(createTableQuery)
+            .dump(primaryDbName, null, Collections.singletonList("'hive.repl.dump.metadata.only'='true'"));
+
+    // Bootstrap load in replica
+    replica.load(replicatedDbName, bootstrapTuple.dumpLocation)
+            .status(replicatedDbName)
+            .verifyResult(bootstrapTuple.lastReplicationId)
+            .run("use " + replicatedDbName)
+            .run("show tables")
+            .verifyResult(tableName);
   }
 
   private void verifyIfCkptSet(Map<String, String> props, String dumpDir) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
@@ -172,7 +172,8 @@ public class Utils {
       return false;
     }
 
-    if (tableHandle.isNonNative()) {
+    // if its metadata only, then dump metadata of non native tables also.
+    if (tableHandle.isNonNative() && !replicationSpec.isMetadataOnly()) {
       return false;
     }
 


### PR DESCRIPTION
if hive.repl.dump.metadata.only is set to true, allow dumping non native tables also. This will be used by DAS.

Data dump for non-native tables should never be allowed.