### PR TITLE
HIVE-16391: Add a new classifier for hive-exec to be used by Spark

### DIFF
--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -675,6 +675,34 @@
         <artifactId>maven-shade-plugin</artifactId>
         <executions>
           <execution>
+            <id>build-spark-exec-bundle</id>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <shadedArtifactAttached>true</shadedArtifactAttached>
+              <shadedClassifierName>core-spark</shadedClassifierName>
+              <artifactSet>
+                <includes>
+                  <include>org.apache.hive:hive-exec</include>
+                  <include>com.esotericsoftware.kryo:kryo</include>
+                  <include>com.google.protobuf:protobuf-java</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.esotericsoftware</pattern>
+                  <shadedPattern>org.apache.hive.com.esotericsoftware</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>com.google.protobuf</pattern>
+                  <shadedPattern>org.apache.hive.com.google.protobuf</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+          <execution>
             <id>build-exec-bundle</id>
             <phase>package</phase>
             <goals>


### PR DESCRIPTION
This fix adding a new classifier for hive-exec artifact (`core-spark`), which is specifically used for Spark. Details in [SPARK-20202](https://issues.apache.org/jira/browse/SPARK-20202). 

This is because  original hive-exec packages many transitive dependencies into shaded jar without relocation, this makes conflicts in Spark. Spark only needs to relocate protobuf and kryo jar. So here propose to add a new classifier to generate a new artifact only for Spark.

