### PR TITLE
HIVE-19831: Hiveserver2 should skip doAuth checks for CREATE DATABASE…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -1027,6 +1027,14 @@ public class Driver implements IDriver {
       throws HiveException, AuthorizationException {
     SessionState ss = SessionState.get();
     Hive db = sem.getDb();
+    
+    if(op.equals(HiveOperation.CREATEDATABASE)){
+      for (WriteEntity e : sem.getOutputs()) {
+        if(e.getType() == Entity.Type.DATABASE && db.databaseExists(e.getName().split(":")[1])){
+          return;
+        }
+      }
+    }
 
     Set<ReadEntity> additionalInputs = new HashSet<ReadEntity>();
     for (Entity e : sem.getInputs()) {


### PR DESCRIPTION
Hiveserver2 should skip doAuth checks for CREATE DATABASE/TABLE if database/table already exists.
the proposed change will skip the authorization check if the database is already exists.