### PR TITLE
HIVE-19886: Logs may be directed to 2 files if --hiveconf hive.log.fi…

### DIFF
--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.hive.common.JvmPauseMonitor;
 import org.apache.hadoop.hive.common.LogUtils;
 import org.apache.hadoop.hive.common.LogUtils.LogInitializationException;
 import org.apache.hadoop.hive.common.ServerUtils;
-import org.apache.hadoop.hive.common.cli.CommonCliOptions;
 import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
@@ -1209,11 +1208,17 @@ public class HiveServer2 extends CompositeService {
         for (String propKey : confProps.stringPropertyNames()) {
           // save logging message for log4j output latter after log4j initialize properly
           debugMessage.append("Setting " + propKey + "=" + confProps.getProperty(propKey) + ";\n");
-          if (propKey.equalsIgnoreCase("hive.root.logger")) {
-            CommonCliOptions.splitAndSetLogger(propKey, confProps);
-          } else {
-            System.setProperty(propKey, confProps.getProperty(propKey));
+          if ("hive.log.file".equals(propKey) ||
+              "hive.log.dir".equals(propKey) ||
+              "hive.root.logger".equals(propKey)) {
+            throw new IllegalArgumentException("Logs will be split in two "
+                + "files if the commandline argument " + propKey + " is "
+                + "used. To prevent this use to HADOOP_CLIENT_OPTS -D"
+                + propKey + "=" + confProps.getProperty(propKey)
+                + " or use the set the value in the configuration file"
+                + " (see HIVE-19886)");
           }
+          System.setProperty(propKey, confProps.getProperty(propKey));
         }
 
         // Process --help


### PR DESCRIPTION
…le is used.

This is still dumping some logs for the metastore before the reconfiguration is done:
```
2018-06-18T16:39:17,109  INFO [main] conf.MetastoreConf: Found configuration file file:/hadoop-3.1.0/etc/hadoop/hive-site.xml
2018-06-18T16:39:17,364  INFO [main] conf.MetastoreConf: Unable to find config file hivemetastore-site.xml
2018-06-18T16:39:17,364  INFO [main] conf.MetastoreConf: Found configuration file null
2018-06-18T16:39:17,365  INFO [main] conf.MetastoreConf: Unable to find config file metastore-site.xml
2018-06-18T16:39:17,365  INFO [main] conf.MetastoreConf: Found configuration file null
```
(and that's it). Before, the loggers created before the logging configuration happened sent the logs to the wrong file forever.

It's hard to get rid of those because `MetastoreConf` is used to create the configure logging(and therefore spits logs before the configuration happens) so some refactoring would have to be done.