### PR TITLE
HIVE-17593: DataWritableWriter strip spaces for CHAR type which cause…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
@@ -453,7 +453,7 @@ public class DataWritableWriter {
 
     @Override
     public void write(Object value) {
-      String v = inspector.getPrimitiveJavaObject(value).getStrippedValue();
+      String v = inspector.getPrimitiveJavaObject(value).getPaddedValue();
       recordConsumer.addBinary(Binary.fromString(v));
     }
   }


### PR DESCRIPTION
Parquet DataWritableWriter strip tailing spaces for HiveChar type, which cause predicate push down failed to work due to ConvertAstToSearchArg constructs predicate with tailing space.  Actually, according to HiveChar definition, it should contains padded value. ParquetOutputFormat can handle tailing spaces through encoding. 