### PR TITLE
HIVE-20099: Fix logger for LlapServlet

### DIFF
--- a/service/src/java/org/apache/hive/http/LlapServlet.java
+++ b/service/src/java/org/apache/hive/http/LlapServlet.java
@@ -34,7 +34,7 @@ import org.apache.hadoop.hive.llap.cli.LlapStatusServiceDriver;
 @SuppressWarnings("serial")
 public class LlapServlet extends HttpServlet {
 
-  private static final Log LOG = LogFactory.getLog(JMXJsonServlet.class);
+  private static final Log LOG = LogFactory.getLog(LlapServlet.class);
 
   /**
    * Initialize this servlet.


### PR DESCRIPTION
logger should be LlapServlet, not the JMXJsonServlet, it can mislead the user while debugging UI issues. so fixing this logger

