### PR TITLE
Fixing array class cast exception in HiveMetaStoreClient

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -257,9 +257,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       }
 
       if (MetastoreConf.getVar(conf, ConfVars.THRIFT_URI_SELECTION).equalsIgnoreCase("RANDOM")) {
-        List uriList = Arrays.asList(metastoreUris);
+        List<URI> uriList = Arrays.asList(metastoreUris);
         Collections.shuffle(uriList);
-        metastoreUris = (URI[]) uriList.toArray();
+        metastoreUris = uriList.toArray(new URI[0]);
       }
     } catch (IllegalArgumentException e) {
       throw (e);


### PR DESCRIPTION
Java 9 made changes to `toArray()` to always return `Object[]` and this cannot be cast into any of the subtypes including `URI[]`. This raises a class cast exception on Java 9. Modified the `HiveMetaStoreClient` to use the `toArray(T[] a)` to return the `URI[]` type. This might require back ports to earlier releases if anyone is using the client in Java 9.

https://bugs.openjdk.java.net/browse/JDK-6260652
https://stackoverflow.com/questions/51372788/array-cast-java-8-vs-java-9