### PR TITLE
There  a negative number of splits need be avoided

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
@@ -186,7 +186,8 @@ public class HiveSplitGenerator extends InputInitializer {
         if (getContext() != null) {
           totalResource = getContext().getTotalAvailableResource().getMemory();
           taskResource = getContext().getVertexTaskResource().getMemory();
-          availableSlots = totalResource / taskResource;
+          int availableSlotsDebug = totalResource / taskResource;
+          availableSlots = availableSlotsDebug < 0 ? 0 : availableSlotsDebug;
         }
 
         if (HiveConf.getLongVar(conf, HiveConf.ConfVars.MAPREDMINSPLITSIZE, 1) <= 1) {


### PR DESCRIPTION
I am facing issues when exec  insert  from select    on hive2.2-tez0.84   :
I follow the tez api source code ,but I still dont konw why here would get a a negative number
Error: Error while processing statement: FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.tez.TezTask. Vertex failed,.........java.lang.IllegalArgumentException: Illegal Capacity: -1
	at java.util.ArrayList.<init>(ArrayList.java:157)
	at org.apache.hadoop.mapred.FileInputFormat.getSplits(FileInputFormat.java:339)
	at org.apache.hadoop.hive.ql.io.HiveInputFormat.addSplitsForGroup(HiveInputFormat.java:519)
	at org.apache.hadoop.hive.ql.io.HiveInputFormat.getSplits(HiveInputFormat.java:768)
	at org.apache.hadoop.hive.ql.exec.tez.HiveSplitGenerator.initialize(HiveSplitGenerator.java:211)