### PR TITLE
HIVE-20283: Logs may be directed to 2 files if --hiveconf hive.log.fi…

### DIFF
--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -1221,9 +1221,9 @@ public class HiveServer2 extends CompositeService {
               "hive.root.logger".equals(propKey)) {
             throw new IllegalArgumentException("Logs will be split in two "
                 + "files if the commandline argument " + propKey + " is "
-                + "used. To prevent this use to HADOOP_CLIENT_OPTS -D"
+                + "used. To prevent this use HADOOP_CLIENT_OPTS=-D"
                 + propKey + "=" + confProps.getProperty(propKey)
-                + " or use the set the value in the configuration file"
+                + " or set the value in the configuration file"
                 + " (see HIVE-19886)");
           }
           System.setProperty(propKey, confProps.getProperty(propKey));

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/CommonCliOptions.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/CommonCliOptions.java
@@ -95,8 +95,13 @@ public class CommonCliOptions {
         System.err.println(
             "hiveconf: " + propKey + "=" + confProps.getProperty(propKey));
       }
-      if (propKey.equalsIgnoreCase("hive.root.logger")) {
-        splitAndSetLogger(propKey, confProps);
+      if ("hive.log.file".equals(propKey) ||
+          "hive.log.dir".equals(propKey) ||
+          "hive.root.logger".equals(propKey)) {
+        throw new IllegalArgumentException("Logs will be split in two "
+            + "files if the commandline argument " + propKey + " is "
+            + "used. Set instead the appropriate value in "
+            + "hive-log4j2.properties (see HIVE-20283)");
       } else {
         System.setProperty(propKey, confProps.getProperty(propKey));
       }


### PR DESCRIPTION
…le is used (metastore)