### PR TITLE
HIVE-20359: Update protobuf to v3.6.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,7 +191,7 @@
     <parquet.version>1.10.0</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.6.1</protobuf.version>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.10</slf4j.version>
     <ST4.version>4.0.4</ST4.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -81,7 +81,7 @@
     <log4j2.version>2.8.2</log4j2.version>
     <mockito-all.version>1.10.19</mockito-all.version>
     <orc.version>1.5.1</orc.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.6.1</protobuf.version>
     <sqlline.version>1.3.0</sqlline.version>
     <storage-api.version>2.7.0</storage-api.version>
 
@@ -599,7 +599,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:3.6.1</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>


### PR DESCRIPTION
The AArch64 support is released from v3.5.0 onwords. Hence
update all the pom.xml files to use the latest available prtobuf
version.
v3.6.1: https://repo.maven.apache.org/maven2/com/google/protobuf/protoc/

Signed-off-by: Naresh Bhat <naresh.bhat@linaro.org>