### PR TITLE
desc table Command optimize

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/DDLTask.java
@@ -3658,30 +3658,32 @@ public class DDLTask extends Task<DDLWork> implements Serializable {
         if (tbl.isPartitioned() && part == null) {
           // No partitioned specified for partitioned table, lets fetch all.
           Map<String,String> tblProps = tbl.getParameters() == null ? new HashMap<String,String>() : tbl.getParameters();
-          Map<String, Long> valueMap = new HashMap<>();
-          Map<String, Boolean> stateMap = new HashMap<>();
-          for (String stat : StatsSetupConst.SUPPORTED_STATS) {
-            valueMap.put(stat, 0L);
-            stateMap.put(stat, true);
-          }
-          PartitionIterable parts = new PartitionIterable(db, tbl, null, conf.getIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX));
-          int numParts = 0;
-          for (Partition partition : parts) {
-            Map<String, String> props = partition.getParameters();
-            Boolean state = StatsSetupConst.areBasicStatsUptoDate(props);
+          if (descTbl.isExt()) {
+            Map<String, Long> valueMap = new HashMap<>();
+            Map<String, Boolean> stateMap = new HashMap<>();
             for (String stat : StatsSetupConst.SUPPORTED_STATS) {
-              stateMap.put(stat, stateMap.get(stat) && state);
-              if (props != null && props.get(stat) != null) {
-                valueMap.put(stat, valueMap.get(stat) + Long.parseLong(props.get(stat)));
-              }
+              valueMap.put(stat, 0L);
+              stateMap.put(stat, true);
             }
-            numParts++;
+            PartitionIterable parts = new PartitionIterable(db, tbl, null, conf.getIntVar(HiveConf.ConfVars.METASTORE_BATCH_RETRIEVE_MAX));
+            int numParts = 0;
+            for (Partition partition : parts) {
+              Map<String, String> props = partition.getParameters();
+              Boolean state = StatsSetupConst.areBasicStatsUptoDate(props);
+              for (String stat : StatsSetupConst.SUPPORTED_STATS) {
+                stateMap.put(stat, stateMap.get(stat) && state);
+                if (props != null && props.get(stat) != null) {
+                  valueMap.put(stat, valueMap.get(stat) + Long.parseLong(props.get(stat)));
+                }
+              }
+              numParts++;
+            }
+            for (String stat : StatsSetupConst.SUPPORTED_STATS) {
+              StatsSetupConst.setBasicStatsState(tblProps, Boolean.toString(stateMap.get(stat)));
+              tblProps.put(stat, valueMap.get(stat).toString());
+            }
+            tblProps.put(StatsSetupConst.NUM_PARTITIONS, Integer.toString(numParts));
           }
-          for (String stat : StatsSetupConst.SUPPORTED_STATS) {
-            StatsSetupConst.setBasicStatsState(tblProps, Boolean.toString(stateMap.get(stat)));
-            tblProps.put(stat, valueMap.get(stat).toString());
-          }
-          tblProps.put(StatsSetupConst.NUM_PARTITIONS, Integer.toString(numParts));
           tbl.setParameters(tblProps);
         }
       } else {


### PR DESCRIPTION
when execute desc table {table} , and the {table} is a partitioned table which has many partitions, it will read the partitions from meta and load very slow. desc table command did not show partitions' state, so not need to load these information.