### PR TITLE
HIVE-20785: Typo KEQ_SEQ -> KEY_SEQ

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/GetPrimaryKeysOperation.java
@@ -62,7 +62,7 @@ PK_NAME String => primary key name (may be null)
       "Table name")
   .addPrimitiveColumn("COLUMN_NAME", Type.STRING_TYPE,
       "Column name")
-  .addPrimitiveColumn("KEQ_SEQ", Type.INT_TYPE,
+  .addPrimitiveColumn("KEY_SEQ", Type.INT_TYPE,
       "Sequence number within primary key")
   .addPrimitiveColumn("PK_NAME", Type.STRING_TYPE,
       "Primary key name (may be null)");


### PR DESCRIPTION
According to the `java.sql.DatabaseMetaData` API the key should be `KEY_SEQ`.

https://docs.oracle.com/javase/8/docs/api/java/sql/DatabaseMetaData.html#getPrimaryKeys-java.lang.String-java.lang.String-java.lang.String-