### PR TITLE
HIVE-20708: Load an external table as an external table on target with the same location as  on the source

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -1517,8 +1517,13 @@ public class TestReplicationScenariosAcrossInstances {
             .run("use " + replicatedDbName)
             .run("show tables like 't3'")
             .verifyResult("t3")
+            .verifyExternalTable(replicatedDbName, "t3",
+                    primary.getTableLocation(primaryDbName, "t3"))
             .run("select id from t3 where id = 10")
-            .verifyFailure(new String[] {"10"});
+            // Since both the external tables point to the same location as they share the same
+            // file system, the data in external table on the primary is also visible through the
+            // external table on the replica.
+            .verifyResult("10");
   }
 
   @Test
@@ -1587,11 +1592,11 @@ public class TestReplicationScenariosAcrossInstances {
             .run("select id from " + extTabName2)
             .verifyResult("5")
             .verifyExternalTable(replicatedDbName, "t3",
-                    primary.getTableLocation(primaryDbName,"t3"))
+                    primary.getTableLocation(primaryDbName, "t3"))
             .verifyExternalTable(replicatedDbName, "t4",
-                    primary.getTableLocation(primaryDbName,"t4"))
+                    primary.getTableLocation(primaryDbName, "t4"))
             .verifyExternalTable(replicatedDbName, extTabName2,
-                    primary.getTableLocation(primaryDbName,extTabName2));
+                    primary.getTableLocation(primaryDbName, extTabName2));
 
     // Insert a row in the external table on primary and it should show up on replica as well
     // since both of them share the same file system and the external tables on both point to the

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -197,16 +197,14 @@ public class WarehouseInstance implements Closeable {
   }
 
   /**
-   * Delete location pointed by the given path with respect to the external table location root on
-   * DFS.
+   * Delete location pointed by the given path on DFS.
    * @param location
    * @throws IOException
    * @throws SemanticException
    */
-  public void deleteExternalLoc(String location) throws IOException, SemanticException {
-    String extLoc = extLocRoot + "/" + location;
+  public void deleteLocation(String location) throws IOException, SemanticException {
     DistributedFileSystem fs = miniDFSCluster.getFileSystem();
-    fs.delete(new Path(extLoc), true);
+    fs.delete(new Path(location), true);
   }
 
   public HiveConf getConf() {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -387,7 +387,7 @@ public class WarehouseInstance implements Closeable {
   }
 
   /**
-   * Verify that the given table is an external table with the given location
+   * Verify that the given table is an external table with the given location.
    * @return this
    * @throws IOException, Exception
    */

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadPartitions.java
@@ -103,7 +103,11 @@ public class LoadPartitions {
 
   private String location() throws MetaException, HiveException {
     Database parentDb = context.hiveDb.getDatabase(tableDesc.getDatabaseName());
-    if (!tableContext.waitOnPrecursor()) {
+    if (tableDesc.isExternal()) {
+      // For an external table, we need to use the path specified in the source table but the
+      // scheme, authority and root path of the target file system.
+      return context.warehouse.getDnsPath(tableDesc.getSourceTableLocationPath()).toString();
+    } else if (!tableContext.waitOnPrecursor()) {
       return context.warehouse.getDefaultTablePath(
           parentDb, tableDesc.getTableName(), tableDesc.isExternal()).toString();
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
@@ -208,12 +208,12 @@ public class LoadTable {
   private String location(ImportTableDesc tblDesc, Database parentDb)
       throws MetaException, SemanticException {
 
+
     if (tblDesc.tableType().equals(TableType.EXTERNAL_TABLE)) {
       // For an external table, we need to use the path specified in the source table but the
       // scheme, authority and root path of the target file system.
       return context.warehouse.getDnsPath(tblDesc.getTableLocationPath()).toString();
-    }
-    else if (!tableContext.waitOnPrecursor()) {
+    } else if (!tableContext.waitOnPrecursor()) {
       return context.warehouse.getDefaultTablePath(
           parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString();
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.table;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
@@ -206,7 +207,13 @@ public class LoadTable {
 
   private String location(ImportTableDesc tblDesc, Database parentDb)
       throws MetaException, SemanticException {
-    if (!tableContext.waitOnPrecursor()) {
+
+    if (tblDesc.tableType().equals(TableType.EXTERNAL_TABLE)) {
+      // For an external table, we need to use the path specified in the source table but the
+      // scheme, authority and root path of the target file system.
+      return context.warehouse.getDnsPath(tblDesc.getTableLocationPath()).toString();
+    }
+    else if (!tableContext.waitOnPrecursor()) {
       return context.warehouse.getDefaultTablePath(
           parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString();
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/bootstrap/load/table/LoadTable.java
@@ -18,11 +18,9 @@
 package org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.table;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
 import org.apache.hadoop.hive.metastore.api.MetaException;
-import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.ReplCopyTask;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -209,10 +207,10 @@ public class LoadTable {
       throws MetaException, SemanticException {
 
 
-    if (tblDesc.tableType().equals(TableType.EXTERNAL_TABLE)) {
+    if (tblDesc.isExternal()) {
       // For an external table, we need to use the path specified in the source table but the
       // scheme, authority and root path of the target file system.
-      return context.warehouse.getDnsPath(tblDesc.getTableLocationPath()).toString();
+      return context.warehouse.getDnsPath(tblDesc.getSourceTableLocationPath()).toString();
     } else if (!tableContext.waitOnPrecursor()) {
       return context.warehouse.getDefaultTablePath(
           parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -1060,7 +1060,12 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     if (tblDesc.getLocation() == null) {
-      if (!waitOnPrecursor){
+      if (tblDesc.tableType().equals(TableType.EXTERNAL_TABLE)) {
+        // For an external table, we need to use the path specified in the source table but the
+        // scheme, authority and root path of the target file system.
+        tblDesc.setLocation(wh.getDnsPath(tblDesc.getTableLocationPath()).toString());
+      }
+      else if (!waitOnPrecursor){
         tblDesc.setLocation(wh.getDefaultTablePath(parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString());
       } else {
         tblDesc.setLocation(

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -1064,8 +1064,7 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
         // For an external table, we need to use the path specified in the source table but the
         // scheme, authority and root path of the target file system.
         tblDesc.setLocation(wh.getDnsPath(tblDesc.getTableLocationPath()).toString());
-      }
-      else if (!waitOnPrecursor){
+      } else if (!waitOnPrecursor){
         tblDesc.setLocation(wh.getDefaultTablePath(parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString());
       } else {
         tblDesc.setLocation(

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ImportSemanticAnalyzer.java
@@ -1060,10 +1060,10 @@ public class ImportSemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     if (tblDesc.getLocation() == null) {
-      if (tblDesc.tableType().equals(TableType.EXTERNAL_TABLE)) {
+      if (tblDesc.isExternal()) {
         // For an external table, we need to use the path specified in the source table but the
         // scheme, authority and root path of the target file system.
-        tblDesc.setLocation(wh.getDnsPath(tblDesc.getTableLocationPath()).toString());
+        tblDesc.setLocation(wh.getDnsPath(tblDesc.getSourceTableLocationPath()).toString());
       } else if (!waitOnPrecursor){
         tblDesc.setLocation(wh.getDefaultTablePath(parentDb, tblDesc.getTableName(), tblDesc.isExternal()).toString());
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.parse.repl.dump.io;
 
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/TableSerializer.java
@@ -83,14 +83,6 @@ public class TableSerializer implements JsonWriter.Serializer {
                 ReplicationSpec.KEY.CURR_STATE_ID.toString(),
                 additionalPropertiesProvider.getCurrentReplicationState());
       }
-      if (isExternalTable(table)) {
-          // Replication destination will not be external - override if set
-        table.putToParameters("EXTERNAL", "FALSE");
-      }
-      if (isExternalTableType(table)) {
-          // Replication dest will not be external - override if set
-        table.setTableType(TableType.MANAGED_TABLE.toString());
-      }
     } else {
       // ReplicationSpec.KEY scopeKey = ReplicationSpec.KEY.REPL_SCOPE;
       // write(out, ",\""+ scopeKey.toString() +"\":\"" + replicationSpec.get(scopeKey) + "\"");
@@ -99,17 +91,6 @@ public class TableSerializer implements JsonWriter.Serializer {
       // regen if we do so.
     }
     return table;
-  }
-
-  private boolean isExternalTableType(org.apache.hadoop.hive.metastore.api.Table table) {
-    return table.isSetTableType()
-        && table.getTableType().equalsIgnoreCase(TableType.EXTERNAL_TABLE.toString());
-  }
-
-  private boolean isExternalTable(org.apache.hadoop.hive.metastore.api.Table table) {
-    Map<String, String> params = table.getParameters();
-    return params.containsKey("EXTERNAL")
-        && params.get("EXTERNAL").equalsIgnoreCase("TRUE");
   }
 
   private void writePartitions(JsonWriter writer, ReplicationSpec additionalPropertiesProvider)

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
@@ -60,7 +60,8 @@ public class ImportTableDesc {
       case TABLE:
         this.createTblDesc = new CreateTableDesc(dbName,
                 table.getTableName(),
-                false, // isExternal: set to false here, can be overwritten by the IMPORT stmt
+                // isExternal: can be overwritten by the IMPORT stmt
+                TableType.EXTERNAL_TABLE.equals(table.getTableType()),
                 false,
                 table.getSd().getCols(),
                 table.getPartitionKeys(),
@@ -342,11 +343,6 @@ public class ImportTableDesc {
   }
 
   public TableType tableType() {
-    if (isView()) {
-      return TableType.VIRTUAL_VIEW;
-    } else if (isMaterializedView()) {
-      return TableType.MATERIALIZED_VIEW;
-    }
     return table.getTableType();
   }
 
@@ -367,7 +363,7 @@ public class ImportTableDesc {
     }
   }
 
-  public Path getTableLocationPath() {
+  public Path getSourceTableLocationPath() {
     return table.getPath();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -346,7 +347,7 @@ public class ImportTableDesc {
     } else if (isMaterializedView()) {
       return TableType.MATERIALIZED_VIEW;
     }
-    return TableType.MANAGED_TABLE;
+    return table.getTableType();
   }
 
   public Table toTable(HiveConf conf) throws Exception {
@@ -364,5 +365,9 @@ public class ImportTableDesc {
     if (this.createTblDesc != null) {
       this.createTblDesc.setReplWriteId(replWriteId);
     }
+  }
+
+  public Path getTableLocationPath() {
+    return table.getPath();
   }
 }

--- a/ql/src/test/results/clientpositive/repl_2_exim_basic.q.out
+++ b/ql/src/test/results/clientpositive/repl_2_exim_basic.q.out
@@ -411,7 +411,7 @@ PREHOOK: Input: default@ext_t_r_imported
 POSTHOOK: query: show create table ext_t_r_imported
 POSTHOOK: type: SHOW_CREATETABLE
 POSTHOOK: Input: default@ext_t_r_imported
-CREATE TABLE `ext_t_r_imported`(
+CREATE EXTERNAL TABLE `ext_t_r_imported`(
   `emp_id` int COMMENT 'employee id')
 PARTITIONED BY ( 
   `emp_country` string, 
@@ -425,7 +425,6 @@ OUTPUTFORMAT
 LOCATION
 #### A masked pattern was here ####
 TBLPROPERTIES (
-  'EXTERNAL'='FALSE', 
   'bucketing_version'='2', 
   'discover.partitions'='true', 
   'repl.last.id'='0', 


### PR DESCRIPTION
Dump an external table as an external table.

When loading an external table set the location of the target table same as the location of source,
but relative to the file system of the target location. IOW, the scheme, authority of the target
location is same as the target file system but the path relative to the file system is same as the
source.