### PR TITLE
HIVE-16839: Fix the leak of lock during concurrent partition drop

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -1500,9 +1500,7 @@ public class ObjectStore implements RawStore, Configurable {
   @Override
   public Partition getPartition(String dbName, String tableName,
       List<String> part_vals) throws NoSuchObjectException, MetaException {
-    openTransaction();
     Partition part = convertToPart(getMPartition(dbName, tableName, part_vals));
-    commitTransaction();
     if(part == null) {
       throw new NoSuchObjectException("partition values="
           + part_vals.toString());


### PR DESCRIPTION
We have seen a leaked lock on hive metastore DB which caused all
PARTITION insertion failed on timeout waiting for lock until the
metastore service is restarted.

A transaction dump on the DB shows there is a thread that is Sleep which
potentiall holds the the lock, like:
```
  trx_id: 33603171058
                 trx_state: RUNNING
               trx_started: 2018-10-23 06:43:22
     trx_requested_lock_id: NULL
          trx_wait_started: NULL
                trx_weight: 70298
       trx_mysql_thread_id: 275402202
                 trx_query: NULL
       trx_operation_state: NULL
         trx_tables_in_use: 0
         trx_tables_locked: 0
          trx_lock_structs: 21286
     trx_lock_memory_bytes: 2881064
           trx_rows_locked: 98810
         trx_rows_modified: 49012
   trx_concurrency_tickets: 0
       trx_isolation_level: READ COMMITTED
         trx_unique_checks: 1
    trx_foreign_key_checks: 1
trx_last_foreign_key_error: NULL
 trx_adaptive_hash_latched: 0
 trx_adaptive_hash_timeout: 0
          trx_is_read_only: 0
trx_autocommit_non_locking: 0
                        ID: 275402202
                      USER: metastore_gold
                      HOST: 10.37.182.82:36684
                        DB: metastoregold
                   COMMAND: Sleep
                      TIME: 1
                     STATE:
                      INFO: NULL
                  duration: 1316
```
Given the HOST ip, we trace back to the hive metastore instance and found the following exceptions:
```2018-10-23 06:43:22,805 WARN DataNucleus.Persistence: Exception thrown by StateManager.isLoaded
No such database row
org.datanucleus.exceptions.NucleusObjectNotFoundException: No such database row
        at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:357)
        at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:324)
        at org.datanucleus.state.AbstractStateManager.loadFieldsFromDatastore(AbstractStateManager.java:1120)
        at org.datanucleus.state.JDOStateManager.loadSpecifiedFields(JDOStateManager.java:2916)
        at org.datanucleus.state.JDOStateManager.isLoaded(JDOStateManager.java:3219)
```
The problem is that the caller expects a NULL if the partition does not exist, however, the convertToPart function would throw
an exception which lead to the leak.