### PR TITLE
HIVE-16839: Fix a race condidtion during concurrent partition drops

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2440,34 +2440,41 @@ public class ObjectStore implements RawStore, Configurable {
                                 List<String> part_vals,
                                 String validWriteIds)
       throws NoSuchObjectException, MetaException {
-    openTransaction();
-    MTable table = this.getMTable(catName, dbName, tableName);
-    MPartition mpart = getMPartition(catName, dbName, tableName, part_vals);
-    Partition part = convertToPart(mpart);
-    commitTransaction();
-    if(part == null) {
-      throw new NoSuchObjectException("partition values="
+    Partition part = null;
+    boolean committed = false;
+    try {
+      openTransaction();
+      MTable table = this.getMTable(catName, dbName, tableName);
+      MPartition mpart = getMPartition(catName, dbName, tableName, part_vals);
+      part = convertToPart(mpart);
+      committed = commitTransaction();
+      if (part == null) {
+        throw new NoSuchObjectException("partition values="
           + part_vals.toString());
-    }
-    part.setValues(part_vals);
-    // If transactional table partition, check whether the current version partition
-    // statistics in the metastore comply with the client query's snapshot isolation.
-    long statsWriteId = mpart.getWriteId();
-    if (TxnUtils.isTransactionalTable(table.getParameters())) {
-      if (!areTxnStatsSupported) {
-        // Do not make persistent the following state since it is query specific (not global).
-        StatsSetupConst.setBasicStatsState(part.getParameters(), StatsSetupConst.FALSE);
-        LOG.info("Removed COLUMN_STATS_ACCURATE from Partition object's parameters.");
-      } else if (validWriteIds != null) {
-        if (isCurrentStatsValidForTheQuery(part, statsWriteId, validWriteIds, false)) {
-          part.setIsStatsCompliant(true);
-        } else {
-          part.setIsStatsCompliant(false);
+      }
+
+      part.setValues(part_vals);
+      // If transactional table partition, check whether the current version partition
+      // statistics in the metastore comply with the client query's snapshot isolation.
+      long statsWriteId = mpart.getWriteId();
+      if (TxnUtils.isTransactionalTable(table.getParameters())) {
+        if (!areTxnStatsSupported) {
           // Do not make persistent the following state since it is query specific (not global).
           StatsSetupConst.setBasicStatsState(part.getParameters(), StatsSetupConst.FALSE);
           LOG.info("Removed COLUMN_STATS_ACCURATE from Partition object's parameters.");
+        } else if (validWriteIds != null) {
+          if (isCurrentStatsValidForTheQuery(part, statsWriteId, validWriteIds, false)) {
+            part.setIsStatsCompliant(true);
+          } else {
+            part.setIsStatsCompliant(false);
+            // Do not make persistent the following state since it is query specific (not global).
+            StatsSetupConst.setBasicStatsState(part.getParameters(), StatsSetupConst.FALSE);
+            LOG.info("Removed COLUMN_STATS_ACCURATE from Partition object's parameters.");
+          }
         }
       }
+    } finally {
+      rollbackAndCleanup(committed, (Query)null);
     }
     return part;
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -85,6 +85,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BrokenBarrierException;
@@ -358,6 +359,72 @@ public class TestObjectStore {
     objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, value2);
     objectStore.dropTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
     objectStore.dropDatabase(db1.getCatalogName(), DB1);
+  }
+
+  /**
+   * Test the concurrent drop of same partition would leak transaction.
+   * https://issues.apache.org/jira/browse/HIVE-16839
+   *
+   * Note: the leak happens during a race condition, this test case tries
+   * to simulate the race condition on best effort, it have two threads trying
+   * to drop the same set of partitions
+   */
+  @Test
+  public void testConcurrentDropPartitions() throws MetaException, InvalidObjectException {
+    Database db1 = new DatabaseBuilder()
+      .setName(DB1)
+      .setDescription("description")
+      .setLocation("locationurl")
+      .build(conf);
+    objectStore.createDatabase(db1);
+    StorageDescriptor sd = createFakeSd("location");
+    HashMap<String, String> tableParams = new HashMap<>();
+    tableParams.put("EXTERNAL", "false");
+    FieldSchema partitionKey1 = new FieldSchema("Country", ColumnType.STRING_TYPE_NAME, "");
+    FieldSchema partitionKey2 = new FieldSchema("State", ColumnType.STRING_TYPE_NAME, "");
+    Table tbl1 =
+      new Table(TABLE1, DB1, "owner", 1, 2, 3, sd, Arrays.asList(partitionKey1, partitionKey2),
+        tableParams, null, null, "MANAGED_TABLE");
+    objectStore.createTable(tbl1);
+    HashMap<String, String> partitionParams = new HashMap<>();
+    partitionParams.put("PARTITION_LEVEL_PRIVILEGE", "true");
+
+    // Create some partitions
+    List<List<String>> partNames = new LinkedList<>();
+    for (char c = 'A'; c < 'Z'; c++) {
+      String name = "" + c;
+      partNames.add(Arrays.asList(name, name));
+    }
+    for (List<String> n : partNames) {
+      Partition p = new Partition(n, DB1, TABLE1, 111, 111, sd, partitionParams);
+      p.setCatName(DEFAULT_CATALOG_NAME);
+      objectStore.addPartition(p);
+    }
+
+    int numThreads = 2;
+    ExecutorService executorService = Executors.newFixedThreadPool(numThreads);
+    for (int i = 0; i < numThreads; i++) {
+      executorService.execute(
+        () -> {
+          for (List<String> p : partNames) {
+            try {
+              objectStore.dropPartition(DEFAULT_CATALOG_NAME, DB1, TABLE1, p);
+              System.out.println("Dropping partition: " + p.get(0));
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          }
+        }
+      );
+    }
+
+    executorService.shutdown();
+    try {
+      executorService.awaitTermination(30, TimeUnit.SECONDS);
+    } catch (InterruptedException ex) {
+      Assert.assertTrue("Got interrupted.", false);
+    }
+    Assert.assertTrue("Expect no active transactions.", !objectStore.isActiveTransaction());
   }
 
   /**


### PR DESCRIPTION
We have seen a leaked lock on hive metastore DB which caused all
PARTITION insertion failed on timeout waiting for lock until the
metastore service is restarted.

A transaction dump on the DB shows there is a thread that is Sleep which
potentiall holds the the lock, like:
```
  trx_id: 33603171058
                 trx_state: RUNNING
               trx_started: 2018-10-23 06:43:22
     trx_requested_lock_id: NULL
          trx_wait_started: NULL
                trx_weight: 70298
       trx_mysql_thread_id: 275402202
                 trx_query: NULL
       trx_operation_state: NULL
         trx_tables_in_use: 0
         trx_tables_locked: 0
          trx_lock_structs: 21286
     trx_lock_memory_bytes: 2881064
           trx_rows_locked: 98810
         trx_rows_modified: 49012
   trx_concurrency_tickets: 0
       trx_isolation_level: READ COMMITTED
         trx_unique_checks: 1
    trx_foreign_key_checks: 1
trx_last_foreign_key_error: NULL
 trx_adaptive_hash_latched: 0
 trx_adaptive_hash_timeout: 0
          trx_is_read_only: 0
trx_autocommit_non_locking: 0
                        ID: 275402202
                      USER: metastore_gold
                      HOST: 10.37.182.82:36684
                        DB: metastoregold
                   COMMAND: Sleep
                      TIME: 1
                     STATE:
                      INFO: NULL
                  duration: 1316
Given the HOST ip, we trace back to the hive metastore instance and found the following exceptions:

No such database row
org.datanucleus.exceptions.NucleusObjectNotFoundException: No such database row
        at org.datanucleus.store.rdbms.request.FetchRequest.execute(FetchRequest.java:357)
        at org.datanucleus.store.rdbms.RDBMSPersistenceHandler.fetchObject(RDBMSPersistenceHandler.java:324)
        at org.datanucleus.state.AbstractStateManager.loadFieldsFromDatastore(AbstractStateManager.java:1120)
        at org.datanucleus.state.JDOStateManager.loadSpecifiedFields(JDOStateManager.java:2916)
        at org.datanucleus.state.JDOStateManager.isLoaded(JDOStateManager.java:3219)
```
The problem is that the caller expects a NULL if the partition does not exist, however, the convertToPart function would throw
an exception which lead to the leak.