### PR TITLE
HIVE-20953: Fix testcase TestReplicationScenariosAcrossInstances#test…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -155,6 +155,88 @@ public class TestReplicationScenariosAcrossInstances {
   }
 
   @Test
+  public void testBootstrapReplLoadRetryAfterFailureForFunctions() throws Throwable {
+    String funcName1 = "f1";
+    String funcName2 = "f2";
+    WarehouseInstance.Tuple tuple = primary.run("use " + primaryDbName)
+            .run("CREATE FUNCTION " + primaryDbName + "." + funcName1 +
+                    " as 'hivemall.tools.string.StopwordUDF' " +
+                    "using jar  'ivy://io.github.myui:hivemall:0.4.0-2'")
+            .run("CREATE FUNCTION " + primaryDbName + "." + funcName2 +
+                    " as 'hivemall.tools.string.SplitWordsUDF' "+
+                    "using jar  'ivy://io.github.myui:hivemall:0.4.0-1'")
+            .dump(primaryDbName, null);
+
+    // Allow create function only on f1. Create should fail for the second function.
+    BehaviourInjection<CallerArguments, Boolean> callerVerifier
+            = new BehaviourInjection<CallerArguments, Boolean>() {
+      @Override
+      public Boolean apply(CallerArguments args) {
+        injectionPathCalled = true;
+        if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
+          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
+          return false;
+        }
+        if (args.funcName != null) {
+          LOG.warn("Verifier - Function : " + String.valueOf(args.funcName));
+          return args.funcName.equals(funcName1);
+        }
+        return true;
+      }
+    };
+    InjectableBehaviourObjectStore.setCallerVerifier(callerVerifier);
+
+    // Trigger bootstrap dump which just creates function f1 but not f2
+    List<String> withConfigs = Arrays.asList("'hive.repl.approx.max.load.tasks'='1'",
+            "'hive.in.repl.test.files.sorted'='true'");
+    try {
+      replica.loadFailure(replicatedDbName, tuple.dumpLocation, withConfigs);
+      callerVerifier.assertInjectionsPerformed(true, false);
+    } finally {
+      InjectableBehaviourObjectStore.resetCallerVerifier(); // reset the behaviour
+    }
+
+    // Verify that only f1 got loaded
+    replica.run("use " + replicatedDbName)
+            .run("repl status " + replicatedDbName)
+            .verifyResult("null")
+            .run("show functions like '" + replicatedDbName + "*'")
+            .verifyResult(replicatedDbName + "." + funcName1);
+
+    // Verify no calls to load f1 only f2.
+    callerVerifier = new BehaviourInjection<CallerArguments, Boolean>() {
+      @Override
+      public Boolean apply(CallerArguments args) {
+        injectionPathCalled = true;
+        if (!args.dbName.equalsIgnoreCase(replicatedDbName) || (args.funcName != null)) {
+          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName)
+                  + " Function : " + String.valueOf(args.funcName));
+          return args.funcName.equals(funcName2);
+        }
+        return true;
+      }
+    };
+    InjectableBehaviourObjectStore.setCallerVerifier(callerVerifier);
+
+    try {
+      // Retry with same dump with which it was already loaded should resume the bootstrap load.
+      // This time, it completes by adding just the function f2
+      replica.load(replicatedDbName, tuple.dumpLocation);
+      callerVerifier.assertInjectionsPerformed(true, false);
+    } finally {
+      InjectableBehaviourObjectStore.resetCallerVerifier(); // reset the behaviour
+    }
+
+    // Verify that both the functions are available.
+    replica.run("use " + replicatedDbName)
+            .run("repl status " + replicatedDbName)
+            .verifyResult(tuple.lastReplicationId)
+            .run("show functions like '" + replicatedDbName +"*'")
+            .verifyResults(new String[] {replicatedDbName + "." + funcName1,
+                    replicatedDbName +"." +funcName2});
+  }
+
+  @Test
   public void testDropFunctionIncrementalReplication() throws Throwable {
     primary.run("CREATE FUNCTION " + primaryDbName
         + ".testFunctionAnother as 'hivemall.tools.string.StopwordUDF' "

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcrossInstances.java
@@ -170,20 +170,20 @@ public class TestReplicationScenariosAcrossInstances {
     // Allow create function only on f1. Create should fail for the second function.
     BehaviourInjection<CallerArguments, Boolean> callerVerifier
             = new BehaviourInjection<CallerArguments, Boolean>() {
-      @Override
-      public Boolean apply(CallerArguments args) {
-        injectionPathCalled = true;
-        if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
-          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
-          return false;
-        }
-        if (args.funcName != null) {
-          LOG.warn("Verifier - Function : " + String.valueOf(args.funcName));
-          return args.funcName.equals(funcName1);
-        }
-        return true;
-      }
-    };
+              @Override
+              public Boolean apply(CallerArguments args) {
+                injectionPathCalled = true;
+                if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
+                  LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
+                  return false;
+                }
+                if (args.funcName != null) {
+                  LOG.debug("Verifier - Function: " + String.valueOf(args.funcName));
+                  return args.funcName.equals(funcName1);
+                }
+                return true;
+              }
+            };
     InjectableBehaviourObjectStore.setCallerVerifier(callerVerifier);
 
     // Trigger bootstrap dump which just creates function f1 but not f2
@@ -208,9 +208,12 @@ public class TestReplicationScenariosAcrossInstances {
       @Override
       public Boolean apply(CallerArguments args) {
         injectionPathCalled = true;
-        if (!args.dbName.equalsIgnoreCase(replicatedDbName) || (args.funcName != null)) {
-          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName)
-                  + " Function : " + String.valueOf(args.funcName));
+        if (!args.dbName.equalsIgnoreCase(replicatedDbName)) {
+          LOG.warn("Verifier - DB: " + String.valueOf(args.dbName));
+          return false;
+        }
+        if (args.funcName != null) {
+          LOG.debug("Verifier - Function: " + String.valueOf(args.funcName));
           return args.funcName.equals(funcName2);
         }
         return true;
@@ -233,7 +236,7 @@ public class TestReplicationScenariosAcrossInstances {
             .verifyResult(tuple.lastReplicationId)
             .run("show functions like '" + replicatedDbName +"*'")
             .verifyResults(new String[] {replicatedDbName + "." + funcName1,
-                    replicatedDbName +"." +funcName2});
+                                         replicatedDbName +"." +funcName2});
   }
 
   @Test

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
@@ -206,10 +206,13 @@ public class FunctionTask extends Task<FunctionWork> {
     );
     try {
       db.createFunction(func);
-    } catch (HiveException he) {
+    } catch (Exception e) {
       // Addition to metastore failed, remove the function from the registry.
       FunctionRegistry.unregisterPermanentFunction(registeredName);
-      throw he;
+      setException(e);
+      LOG.error("Failed to add function " + createFunctionDesc.getFunctionName() +
+              " to the metastore.", e);
+      return 1;
     }
     return 0;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionTask.java
@@ -204,7 +204,13 @@ public class FunctionTask extends Task<FunctionWork> {
         org.apache.hadoop.hive.metastore.api.FunctionType.JAVA,
         resources
     );
-    db.createFunction(func);
+    try {
+      db.createFunction(func);
+    } catch (HiveException he) {
+      // Addition to metastore failed, remove the function from the registry.
+      FunctionRegistry.unregisterPermanentFunction(registeredName);
+      throw he;
+    }
     return 0;
   }
 


### PR DESCRIPTION
Fix testcase TestReplicationScenariosAcrossInstances#testBootstrapReplLoadRetryAfterFailureForPartitions to not depend upon the order in which objects get loaded.

@anishek or @maheshk114 can you please review the change?