### PR TITLE
HIVE-20979: Fix memory leak in hive streaming

### DIFF
--- a/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
+++ b/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
@@ -396,7 +396,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
     try {
       this.fs.close();
     } catch (IOException e) {
-      LOG.error("Error while closing FileSystem", e);
+      throw new StreamingIOFailure("Error while closing FileSystem", e);
     }
     if (haveError) {
       throw new StreamingIOFailure("Encountered errors while closing (see logs) " + getWatermark(partition));

--- a/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
+++ b/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
@@ -393,6 +393,11 @@ public abstract class AbstractRecordWriter implements RecordWriter {
     if (LOG.isDebugEnabled()) {
       logStats("Stats after close:");
     }
+    try {
+      this.fs.close();
+    } catch (IOException e) {
+      LOG.error("Error while closing FileSystem", e);
+    }
     if (haveError) {
       throw new StreamingIOFailure("Encountered errors while closing (see logs) " + getWatermark(partition));
     }


### PR DESCRIPTION
Fixes two memory leaks.
-In HiveStreamingConnection due to Shutdown hook not being removed.
-In AbstractRecordWriter due to FileSystem not being closed.