### PR TITLE
HIVE-21218: KafkaSerDe doesn't support topics created via Confluent

### DIFF
--- a/kafka-handler/README.md
+++ b/kafka-handler/README.md
@@ -25,6 +25,10 @@ If you want to switch serializer/deserializer classes you can use alter table.
 ```sql
 ALTER TABLE kafka_table SET TBLPROPERTIES ("kafka.serde.class"="org.apache.hadoop.hive.serde2.avro.AvroSerDe");
 ``` 
+
+If you use Confluent Avro serialzier/deserializer with schema registry you may want to remove 4 bytes from beginning that represents schema ID from registry. 
+It can be done with settings `"avro.serde.magic.bytes"="true"`. It's recommended to set `"avro.schema.url"="http://schemaregistry/SimpleDocument.avsc"`
+
 List of supported Serializer Deserializer:
 
 |Supported Serializer Deserializer|

--- a/kafka-handler/README.md
+++ b/kafka-handler/README.md
@@ -26,8 +26,8 @@ If you want to switch serializer/deserializer classes you can use alter table.
 ALTER TABLE kafka_table SET TBLPROPERTIES ("kafka.serde.class"="org.apache.hadoop.hive.serde2.avro.AvroSerDe");
 ``` 
 
-If you use Confluent Avro serialzier/deserializer with schema registry you may want to remove 4 bytes from beginning that represents schema ID from registry. 
-It can be done with settings `"avro.serde.magic.bytes"="true"`. It's recommended to set `"avro.schema.url"="http://schemaregistry/SimpleDocument.avsc"`
+If you use Confluent Avro serialzier/deserializer with schema registry you may want to remove 5 bytes from beginning that represents magic byte + schema ID from registry. 
+It can be done by setting `"avro.serde.type"="confluent"` or `"avro.serde.type"="skip"` with `"avro.serde.skip.bytes"="5"`. It's recommended to set an avro schema via `"avro.schema.url"="http://hostname/SimpleDocument.avsc"` or `"avro.schema.literal"="{"type" : "record","name" : "SimpleRecord","..."}`. If both properties are set then `avro.schema.literal` has higher priority.
 
 List of supported Serializer Deserializer:
 

--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -114,6 +114,12 @@
       <version>1.7.25</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.confluent</groupId>
+      <artifactId>kafka-streams-avro-serde</artifactId>
+      <version>4.1.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <profiles>
@@ -169,6 +175,10 @@
     <testSourceDirectory>${basedir}/src/test</testSourceDirectory>
     <plugins>
       <plugin>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro-maven-plugin</artifactId>
+      </plugin>
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
@@ -180,5 +190,28 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.avro</groupId>
+          <artifactId>avro-maven-plugin</artifactId>
+          <version>1.8.2</version>
+          <executions>
+            <execution>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>schema</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <sourceDirectory>${project.basedir}/src/resources/</sourceDirectory>
+            <!--<outputDirectory>${project.basedir}/ta/test/</outputDirectory>-->
+            <enableDecimalLogicalType>true</enableDecimalLogicalType>
+            <stringType>String</stringType>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
 </project>

--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.confluent</groupId>
       <artifactId>kafka-streams-avro-serde</artifactId>
-      <version>4.1.0</version>
+      <version>5.1.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -202,7 +202,7 @@
         <plugin>
           <groupId>org.apache.avro</groupId>
           <artifactId>avro-maven-plugin</artifactId>
-          <version>1.8.2</version>
+          <version>1.8.1</version>
           <executions>
             <execution>
               <phase>generate-sources</phase>
@@ -213,7 +213,6 @@
           </executions>
           <configuration>
             <sourceDirectory>${project.basedir}/src/resources/</sourceDirectory>
-            <!--<outputDirectory>${project.basedir}/ta/test/</outputDirectory>-->
             <enableDecimalLogicalType>true</enableDecimalLogicalType>
             <stringType>String</stringType>
           </configuration>

--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -122,6 +122,13 @@
     </dependency>
   </dependencies>
 
+  <repositories>
+    <repository>
+      <id>confluent</id>
+      <url>http://packages.confluent.io/maven/</url>
+    </repository>
+  </repositories>
+
   <profiles>
     <profile>
       <id>dev-fast-build</id>

--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
@@ -140,15 +140,31 @@ import java.util.stream.Collectors;
     }
   }
 
+  enum BytesConverterType {
+    CONFLUENT,
+    SKIP,
+    NONE;
+
+    static BytesConverterType fromString(String value) {
+      try {
+        return BytesConverterType.valueOf(value.trim().toUpperCase());
+      } catch (Exception e){
+        return NONE;
+      }
+    }
+  }
+
   BytesConverter getByteConverterForAvroDelegate(Schema schema, Properties tbl) {
-    String avroByteConverterType = tbl.getProperty(AvroSerdeUtils.AvroTableProperties.AVRO_SERDE_TYPE
-                                                         .getPropName(), "none");
+    String avroBytesConverterProperty = tbl.getProperty(AvroSerdeUtils
+                                                            .AvroTableProperties.AVRO_SERDE_TYPE
+                                                            .getPropName(), "none");
+    BytesConverterType avroByteConverterType = BytesConverterType.fromString(avroBytesConverterProperty);
     int avroSkipBytes = Integer.getInteger(tbl.getProperty(AvroSerdeUtils.AvroTableProperties.AVRO_SERDE_SKIP_BYTES
                                                          .getPropName(), "5"));
     switch ( avroByteConverterType ) {
-      case "confluent" : return new AvroSkipBytesConverter(schema, 5);
-      case "skip" : return new AvroSkipBytesConverter(schema, avroSkipBytes);
-      default : return new AvroBytesConverter(schema);
+      case CONFLUENT: return new AvroSkipBytesConverter(schema, 5);
+      case SKIP: return new AvroSkipBytesConverter(schema, avroSkipBytes);
+      default: return new AvroBytesConverter(schema);
     }
   }
 

--- a/kafka-handler/src/resources/SimpleRecord.avsc
+++ b/kafka-handler/src/resources/SimpleRecord.avsc
@@ -1,0 +1,13 @@
+{
+  "type" : "record",
+  "name" : "SimpleRecord",
+  "namespace" : "org.apache.hadoop.hive.kafka",
+  "fields" : [ {
+    "name" : "id",
+    "type" : "string"
+  }, {
+    "name" : "name",
+    "type" : "string"
+  }
+  ]
+}

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
@@ -67,4 +67,19 @@ public class AvroBytesConverterTest {
         Assert.assertNotNull(simpleRecord1Deserialized);
         Assert.assertEquals(simpleRecord1, simpleRecord1Deserialized);
     }
+
+    @Test
+    public void enumParseTest() {
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.CONFLUENT, KafkaSerDe.BytesConverterType.fromString("confluent"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.CONFLUENT, KafkaSerDe.BytesConverterType.fromString("conFLuent"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.CONFLUENT, KafkaSerDe.BytesConverterType.fromString("Confluent"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.CONFLUENT, KafkaSerDe.BytesConverterType.fromString("CONFLUENT"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.SKIP, KafkaSerDe.BytesConverterType.fromString("skip"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.SKIP, KafkaSerDe.BytesConverterType.fromString("sKIp"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.SKIP, KafkaSerDe.BytesConverterType.fromString("SKIP"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.NONE, KafkaSerDe.BytesConverterType.fromString("SKIP1"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.NONE, KafkaSerDe.BytesConverterType.fromString("skipper"));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.NONE, KafkaSerDe.BytesConverterType.fromString(""));
+        Assert.assertEquals(KafkaSerDe.BytesConverterType.NONE, KafkaSerDe.BytesConverterType.fromString(null));
+    }
 }

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
@@ -1,0 +1,70 @@
+package org.apache.hadoop.hive.kafka;
+
+import com.google.common.collect.Maps;
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.serde2.avro.AvroGenericRecordWritable;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Map;
+
+/**
+ * Created by Milan Baran on 1/29/19 15:03.
+ */
+public class AvroBytesConverterTest {
+
+    private static SimpleRecord simpleRecord1 = SimpleRecord.newBuilder().setId("123").setName("test").build();
+    private static byte[] simpleRecord1AsBytes;
+
+    /**
+     * Emulate confluent avro producer that add 4 magic bits (int) before value bytes. The int represents the schema ID from schema registry.
+     */
+    @BeforeClass
+    public static void setUp() {
+        Map<String,String> config = Maps.newHashMap();
+        config.put("schema.registry.url","http://localhost");
+        KafkaAvroSerializer avroSerializer = new KafkaAvroSerializer(new MockSchemaRegistryClient());
+        avroSerializer.configure(config, false);
+        simpleRecord1AsBytes = avroSerializer.serialize("temp", simpleRecord1);
+    }
+
+    /**
+     * Emulate - avro.serde.magic.bytes = false (Default)
+     */
+    @Test
+    public void convertWithAvroBytesConverter() {
+        Schema schema = SimpleRecord.getClassSchema();
+        KafkaSerDe.AvroBytesConverter conv = new KafkaSerDe.AvroBytesConverter(schema);
+        AvroGenericRecordWritable simpleRecord1Writable = conv.getWritable(simpleRecord1AsBytes);
+
+        Assert.assertNotNull(simpleRecord1Writable);
+        Assert.assertEquals(SimpleRecord.class,simpleRecord1Writable.getRecord().getClass());
+
+        SimpleRecord simpleRecord1Deserialized = (SimpleRecord) simpleRecord1Writable.getRecord();
+
+        Assert.assertNotNull(simpleRecord1Deserialized);
+        Assert.assertNotEquals(simpleRecord1, simpleRecord1Deserialized);
+    }
+
+
+    /**
+     * Emulate - avro.serde.magic.bytes = true
+     */
+    @Test
+    public void convertWithConfluentAvroBytesConverter() {
+        Schema schema = SimpleRecord.getClassSchema();
+        KafkaSerDe.ConfluentAvroBytesConverter conv = new KafkaSerDe.ConfluentAvroBytesConverter(schema);
+        AvroGenericRecordWritable simpleRecord1Writable = conv.getWritable(simpleRecord1AsBytes);
+
+        Assert.assertNotNull(simpleRecord1Writable);
+        Assert.assertEquals(SimpleRecord.class,simpleRecord1Writable.getRecord().getClass());
+
+        SimpleRecord simpleRecord1Deserialized = (SimpleRecord) simpleRecord1Writable.getRecord();
+
+        Assert.assertNotNull(simpleRecord1Deserialized);
+        Assert.assertEquals(simpleRecord1, simpleRecord1Deserialized);
+    }
+}

--- a/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
+++ b/kafka-handler/src/test/org/apache/hadoop/hive/kafka/AvroBytesConverterTest.java
@@ -12,7 +12,7 @@ import org.junit.Test;
 import java.util.Map;
 
 /**
- * Created by Milan Baran on 1/29/19 15:03.
+ * Test class for Hive Kafka Avro bytes converter.
  */
 public class AvroBytesConverterTest {
 
@@ -32,7 +32,7 @@ public class AvroBytesConverterTest {
     }
 
     /**
-     * Emulate - avro.serde.magic.bytes = false (Default)
+     * Emulate - avro.serde.type = none (Default)
      */
     @Test
     public void convertWithAvroBytesConverter() {
@@ -51,12 +51,12 @@ public class AvroBytesConverterTest {
 
 
     /**
-     * Emulate - avro.serde.magic.bytes = true
+     * Emulate - avro.serde.type = confluent
      */
     @Test
     public void convertWithConfluentAvroBytesConverter() {
         Schema schema = SimpleRecord.getClassSchema();
-        KafkaSerDe.ConfluentAvroBytesConverter conv = new KafkaSerDe.ConfluentAvroBytesConverter(schema);
+        KafkaSerDe.AvroSkipBytesConverter conv = new KafkaSerDe.AvroSkipBytesConverter(schema, 5);
         AvroGenericRecordWritable simpleRecord1Writable = conv.getWritable(simpleRecord1AsBytes);
 
         Assert.assertNotNull(simpleRecord1Writable);

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -68,7 +68,8 @@ public class AvroSerdeUtils {
     SCHEMA_NAME("avro.schema.name"),
     SCHEMA_DOC("avro.schema.doc"),
     AVRO_SERDE_SCHEMA("avro.serde.schema"),
-    AVRO_SERDE_MAGIC_BYTES("avro.serde.magic.bytes"),
+    AVRO_SERDE_TYPE("avro.serde.type"),
+    AVRO_SERDE_SKIP_BYTES("avro.serde.skip.bytes"),
     SCHEMA_RETRIEVER("avro.schema.retriever");
 
     private final String propName;
@@ -89,7 +90,6 @@ public class AvroSerdeUtils {
   @Deprecated public static final String SCHEMA_NAME = "avro.schema.name";
   @Deprecated public static final String SCHEMA_DOC = "avro.schema.doc";
   @Deprecated public static final String AVRO_SERDE_SCHEMA = AvroTableProperties.AVRO_SERDE_SCHEMA.getPropName();
-  @Deprecated public static final String AVRO_SERDE_MAGIC_BIT = AvroTableProperties.AVRO_SERDE_MAGIC_BYTES.getPropName();
   @Deprecated public static final String SCHEMA_RETRIEVER = AvroTableProperties.SCHEMA_RETRIEVER.getPropName();
 
   public static final String SCHEMA_NONE = "none";

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -68,6 +68,7 @@ public class AvroSerdeUtils {
     SCHEMA_NAME("avro.schema.name"),
     SCHEMA_DOC("avro.schema.doc"),
     AVRO_SERDE_SCHEMA("avro.serde.schema"),
+    AVRO_SERDE_MAGIC_BYTES("avro.serde.magic.bytes"),
     SCHEMA_RETRIEVER("avro.schema.retriever");
 
     private final String propName;
@@ -88,6 +89,7 @@ public class AvroSerdeUtils {
   @Deprecated public static final String SCHEMA_NAME = "avro.schema.name";
   @Deprecated public static final String SCHEMA_DOC = "avro.schema.doc";
   @Deprecated public static final String AVRO_SERDE_SCHEMA = AvroTableProperties.AVRO_SERDE_SCHEMA.getPropName();
+  @Deprecated public static final String AVRO_SERDE_MAGIC_BIT = AvroTableProperties.AVRO_SERDE_MAGIC_BYTES.getPropName();
   @Deprecated public static final String SCHEMA_RETRIEVER = AvroTableProperties.SCHEMA_RETRIEVER.getPropName();
 
   public static final String SCHEMA_NONE = "none";


### PR DESCRIPTION
Jira issue: https://issues.apache.org/jira/browse/HIVE-21218

Hive kafka handler doesn't read data stored with Confluent serializer, because it add 5 bytes at the beginning of each value that should represent schema ID in Schema registry.

`CREATE EXTERNAL TABLE kafka_table
  (`id` string )
  STORED BY 'org.apache.hadoop.hive.kafka.KafkaStorageHandler' 
  TBLPROPERTIES 
  ( 
  	"kafka.topic" = "kafka-topic", 
  	"kafka.bootstrap.servers"="kafka1:9092", 
  	"kafka.serde.class"="org.apache.hadoop.hive.serde2.avro.AvroSerDe", 
  	"avro.schema.url"="http://localhost/SimpleDocument.avsc",
  	"avro.serde.magic.bytes"="true"
 );`

In this example `"avro.serde.magic.bytes"="true"` switch **AvroBytesConverter** to **ConfluentAvroBytesConverter** which only remove 5 bytes from value byte array.

Well, this is easy fix and it works.