### PR TITLE
[HIVE-21345][CLI] Fix the error when hive cliDriver parses sql statement h semicolon in a pair of double quote

### DIFF
--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -446,6 +446,17 @@ public class CliDriver {
         }
         break;
       case '"':
+        if (!escape) {
+          if (!inQuotes) {
+            quoteChar = c;
+            inQuotes = !inQuotes;
+          } else {
+            if (c == quoteChar) {
+              inQuotes = !inQuotes;
+            }
+          }
+        }
+        break;
       case '\'':
         if (!escape) {
           if (!inQuotes) {

--- a/cli/src/test/org/apache/hadoop/hive/cli/TestCliDriverMethods.java
+++ b/cli/src/test/org/apache/hadoop/hive/cli/TestCliDriverMethods.java
@@ -378,6 +378,11 @@ public class TestCliDriverMethods extends TestCase {
     results = CliDriver.splitSemiColon(cmd1 + ";" + cmd2 + ";");
     assertEquals(cmd1, results.get(0));
     assertEquals(cmd2, results.get(1));
+
+    // Test semicolon in double quote
+    String cmd3 = "select * from table_a where column_a not like \"%;\"";
+    assertEquals(cmd3, CliDriver.splitSemiColon(cmd3).get(0));
+    assertEquals(cmd3, CliDriver.splitSemiColon(cmd3 + ";").get(0));
   }
 
   private static void setEnv(String key, String value) throws Exception {


### PR DESCRIPTION

## What changes were proposed in this pull request?
Hive parse statement incorrectly when there is a semicolon in  a pair of double quote. 

For example:
The statement:

select * from table_a where column_a not like "%;";
Will be parsed to:

select * from table_a where column_a not like "%

In this PR, I complete the splitSemicolon method  and process the '"' correctly.
