### PR TITLE
HIVE-21453: HPL/SQL can not SELECT Date and Timestamp type value INTO variable

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Var.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Var.java
@@ -273,6 +273,12 @@ public class Var {
     else if (type == java.sql.Types.FLOAT || type == java.sql.Types.DOUBLE) {
       cast(new Var(Double.valueOf(rs.getDouble(idx))));
     }
+    else if (type == java.sql.Types.DATE ) {
+      cast(new Var(rs.getDate(idx)));
+    }
+    else if (type == java.sql.Types.TIMESTAMP ) {
+      cast(new Var(rs.getTimestamp(idx), rsm.getScale(idx)));
+    }
     return this;
   }
   

--- a/hplsql/src/test/queries/db/select_into3.sql
+++ b/hplsql/src/test/queries/db/select_into3.sql
@@ -1,0 +1,13 @@
+declare v_date date;
+declare v_timestamp timestamp(17, 3);
+
+select
+  cast('2019-02-20 12:23:45.678' as date),
+  cast('2019-02-20 12:23:45.678' as timestamp)
+into
+  v_date,
+  v_timestamp
+from src limit 1;
+        
+print 'date: ' || v_date;
+print 'timestamp: ' || v_timestamp;

--- a/hplsql/src/test/results/db/select_into3.out.txt
+++ b/hplsql/src/test/results/db/select_into3.out.txt
@@ -1,0 +1,16 @@
+Ln:1 DECLARE v_date date
+Ln:2 DECLARE v_timestamp timestamp
+Ln:4 SELECT
+Ln:4 select
+  cast('2019-02-20 12:23:45.678' as date), cast('2019-02-20 12:23:45.678' as timestamp)
+from src LIMIT 1
+Ln:4 SELECT completed successfully
+Ln:4 SELECT INTO statement executed
+Ln:4 COLUMN: ?column?, Date
+Ln:4 SET v_date = 2019-02-20
+Ln:4 COLUMN: ?column?, Timestamp
+Ln:4 SET v_timestamp = 2019-02-20 12:23:45.678
+Ln:12 PRINT
+date: 2019-02-20
+Ln:13 PRINT
+timestamp: 2019-02-20 12:23:45.678


### PR DESCRIPTION
HPL/SQL forgot Date and Timestamp types when SELECT INTO variables before. This PR just append 6 lines code to fixed it, it also provide query and output file of test case for this feature/bug.