### PR TITLE
HIVE-21392 Fix misconfigurations of DataNucleus log in log4j.properties

### DIFF
--- a/common/src/main/resources/hive-log4j2.properties
+++ b/common/src/main/resources/hive-log4j2.properties
@@ -51,7 +51,7 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, PerfLogger, AmazonAws, ApacheHttp
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, PerfLogger, AmazonAws, ApacheHttp
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -61,12 +61,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.AmazonAws.name=com.amazonaws
 logger.AmazonAws.level = INFO

--- a/common/src/test/resources/hive-exec-log4j2-test.properties
+++ b/common/src/test/resources/hive-exec-log4j2-test.properties
@@ -42,7 +42,7 @@ appender.FA.layout.type = PatternLayout
 appender.FA.layout.pattern = %d{ISO8601} %5p [%t] %c{2}: %m%n
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -52,12 +52,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 # root logger
 rootLogger.level = ${sys:hive.log.level}

--- a/common/src/test/resources/hive-log4j2-test.properties
+++ b/common/src/test/resources/hive-log4j2-test.properties
@@ -49,7 +49,7 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -59,12 +59,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 # root logger
 rootLogger.level = ${sys:hive.log.level}

--- a/data/conf/hive-log4j2.properties
+++ b/data/conf/hive-log4j2.properties
@@ -50,7 +50,7 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange
+loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange
 
 logger.HadoopIPC.name = org.apache.hadoop.ipc
 logger.HadoopIPC.level = WARN
@@ -102,12 +102,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.Operator.name = org.apache.hadoop.hive.ql.exec.Operator
 logger.Operator.level = INFO

--- a/hcatalog/src/test/e2e/templeton/deployers/config/hive/hive-log4j2.properties
+++ b/hcatalog/src/test/e2e/templeton/deployers/config/hive/hive-log4j2.properties
@@ -49,7 +49,7 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -59,12 +59,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 # root logger
 rootLogger.level = ${sys:hive.log.level}

--- a/llap-server/src/main/resources/llap-cli-log4j2.properties
+++ b/llap-server/src/main/resources/llap-cli-log4j2.properties
@@ -58,19 +58,13 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = ZooKeeper, DataNucleus, Datastore, JPOX, HadoopConf, LlapStatusServiceDriverConsole
+loggers = ZooKeeper, DataNucleus, HadoopConf, LlapStatusServiceDriverConsole
 
 logger.ZooKeeper.name = org.apache.zookeeper
 logger.ZooKeeper.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.HadoopConf.name = org.apache.hadoop.conf.Configuration
 logger.HadoopConf.level = ERROR

--- a/llap-server/src/main/resources/llap-daemon-log4j2.properties
+++ b/llap-server/src/main/resources/llap-daemon-log4j2.properties
@@ -100,7 +100,7 @@ appender.query-routing.routes.route-mdc.file-mdc.app.layout.type = PatternLayout
 appender.query-routing.routes.route-mdc.file-mdc.app.layout.pattern = %d{ISO8601} %5p [%t (%X{fragmentId})] %c{2}: %m%n
 
 # list of all loggers
-loggers = PerfLogger, EncodedReader, NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, HistoryLogger, LlapIoImpl, LlapIoOrc, LlapIoCache, LlapIoLocking, TezSM, TezSS, TezHC, LlapDaemon
+loggers = PerfLogger, EncodedReader, NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, HistoryLogger, LlapIoImpl, LlapIoOrc, LlapIoCache, LlapIoLocking, TezSM, TezSS, TezHC, LlapDaemon
 
 logger.LlapDaemon.name = org.apache.hadoop.hive.llap.daemon.impl.LlapDaemon
 logger.LlapDaemon.level = INFO
@@ -140,12 +140,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.HistoryLogger.name = org.apache.hadoop.hive.llap.daemon.HistoryLogger
 logger.HistoryLogger.level = INFO

--- a/llap-server/src/test/resources/llap-daemon-log4j2.properties
+++ b/llap-server/src/test/resources/llap-daemon-log4j2.properties
@@ -64,7 +64,7 @@ appender.HISTORYAPPENDER.strategy.type = DefaultRolloverStrategy
 appender.HISTORYAPPENDER.strategy.max = ${sys:llap.daemon.log.maxbackupindex}
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, HistoryLogger
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, HistoryLogger
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -74,12 +74,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.HistoryLogger.name = org.apache.hadoop.hive.llap.daemon.HistoryLogger
 logger.HistoryLogger.level = INFO

--- a/ql/src/main/resources/hive-exec-log4j2.properties
+++ b/ql/src/main/resources/hive-exec-log4j2.properties
@@ -43,7 +43,7 @@ appender.FA.layout.type = PatternLayout
 appender.FA.layout.pattern = %d{ISO8601} %5p [%t] %c{2}: %m%n
 
 # list of all loggers
-loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX
+loggers = NIOServerCnxn, ClientCnxnSocketNIO, DataNucleus
 
 logger.NIOServerCnxn.name = org.apache.zookeeper.server.NIOServerCnxn
 logger.NIOServerCnxn.level = WARN
@@ -53,12 +53,6 @@ logger.ClientCnxnSocketNIO.level = WARN
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 # root logger
 rootLogger.level = ${sys:hive.log.level}

--- a/standalone-metastore/metastore-common/src/main/resources/metastore-log4j2.properties
+++ b/standalone-metastore/metastore-common/src/main/resources/metastore-log4j2.properties
@@ -51,16 +51,10 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = DataNucleus, Datastore, JPOX, PerfLogger
+loggers = DataNucleus, PerfLogger
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.PerfLogger.name = org.apache.hadoop.hive.ql.log.PerfLogger
 logger.PerfLogger.level = ${sys:hive.perflogger.log.level}

--- a/standalone-metastore/metastore-server/src/main/resources/metastore-log4j2.properties
+++ b/standalone-metastore/metastore-server/src/main/resources/metastore-log4j2.properties
@@ -51,16 +51,10 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = DataNucleus, Datastore, JPOX, PerfLogger
+loggers = DataNucleus, PerfLogger
 
 logger.DataNucleus.name = DataNucleus
 logger.DataNucleus.level = ERROR
-
-logger.Datastore.name = Datastore
-logger.Datastore.level = ERROR
-
-logger.JPOX.name = JPOX
-logger.JPOX.level = ERROR
 
 logger.PerfLogger.name = org.apache.hadoop.hive.ql.log.PerfLogger
 logger.PerfLogger.level = ${sys:hive.perflogger.log.level}


### PR DESCRIPTION
HIVE-21392 Misconfigurations of DataNucleus log in log4j.properties

In the patch of [HIVE-12020](https://issues.apache.org/jira/browse/HIVE-12020), we changed the DataNucleus related logging configuration from nine fine-grained loggers with three coarse-grained loggers (DataNucleus, Datastore and JPOX). 

As Prasanth Jayachandran [explain](https://issues.apache.org/jira/browse/HIVE-12020?focusedCommentId=15025612&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15025612), these three loggers are the top-level logger in DataNucleus, so that we don't need to specify other loggers for DataNucleus. 

However, according to the [documents](http://www.datanucleus.org/products/accessplatform/logging.html) and [source codes](https://github.com/datanucleus/datanucleus-core/blob/master/src/main/java/org/datanucleus/util/NucleusLogger.java#L108) of DataNucleus, the top-level logger in DataNucleus is `DataNucleus`. Therefore, we just need to keep the right one.

__Redo this [PR](https://github.com/apache/hive/pull/556) because of my misoperation when resolving the build failure reported by JIRA.__