### PR TITLE
HIVE-21485: Add flag to turn off fetching partition stats in DESCRIBE…

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3140,6 +3140,9 @@ public class HiveConf extends Configuration {
         "partition columns or non-partition columns while displaying columns in describe\n" +
         "table. From 0.12 onwards, they are displayed separately. This flag will let you\n" +
         "get old behavior, if desired. See, test-case in patch for HIVE-6689."),
+    HIVE_DISPLAY_PARTITIONED_TABLE_STATS("hive.display.partitioned.table.stats", true,
+         "A flag that determines whether 'DESCRIBE [EXTENDED|FORMATTED]' operation display\n" +
+         "partitioned table stats or not. See Hive-21485 for details."),
 
     HIVE_SSL_PROTOCOL_BLACKLIST("hive.ssl.protocol.blacklist", "SSLv2,SSLv3",
         "SSL Versions to disable for all Hive Servers"),

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/DescTableOperation.java
@@ -114,6 +114,7 @@ public class DescTableOperation extends DDLOperation {
         }
       }
 
+      boolean displayPartitionedTblStats = context.getConf().getBoolVar(HiveConf.ConfVars.HIVE_DISPLAY_PARTITIONED_TABLE_STATS);
       if (colPath.equals(tableName)) {
         cols = (part == null || tbl.getTableType() == TableType.VIRTUAL_VIEW) ?
             tbl.getCols() : part.getCols();
@@ -122,7 +123,7 @@ public class DescTableOperation extends DDLOperation {
           cols.addAll(tbl.getPartCols());
         }
 
-        if (tbl.isPartitioned() && part == null) {
+        if (tbl.isPartitioned() && part == null && displayPartitionedTblStats) {
           // No partitioned specified for partitioned table, lets fetch all.
           Map<String, String> tblProps = tbl.getParameters() == null ?
               new HashMap<String, String>() : tbl.getParameters();
@@ -162,7 +163,7 @@ public class DescTableOperation extends DDLOperation {
           List<String> colNames = new ArrayList<String>();
           colNames.add(colName.toLowerCase());
           if (null == part) {
-            if (tbl.isPartitioned()) {
+            if (tbl.isPartitioned() && displayPartitionedTblStats) {
               Map<String, String> tblProps = tbl.getParameters() == null ?
                   new HashMap<String, String>() : tbl.getParameters();
               if (tbl.isPartitionKey(colNames.get(0))) {

--- a/ql/src/test/queries/clientpositive/describe_table.q
+++ b/ql/src/test/queries/clientpositive/describe_table.q
@@ -27,6 +27,10 @@ describe formatted `srcpart` PARTITION(ds='2008-04-08', hr='12');
 describe formatted `srcpart` `ds`;
 describe formatted `srcpart` `hr`;
 
+set hive.display.partitioned.table.stats=false;
+describe formatted `srcpart`;
+set hive.display.partitioned.table.stats=true;
+
 create table srcpart_serdeprops like srcpart;
 alter table srcpart_serdeprops set serdeproperties('xyz'='0');
 alter table srcpart_serdeprops set serdeproperties('pqrs'='1');

--- a/ql/src/test/results/clientpositive/describe_table.q.out
+++ b/ql/src/test/results/clientpositive/describe_table.q.out
@@ -388,6 +388,41 @@ num_falses
 bitVector           	                    	 	 	 	 	 	 	 	 	 	 
 comment             	                    	 	 	 	 	 	 	 	 	 	 
 COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"hr\":\"true\"}}	 	 	 	 	 	 	 	 	 	 
+PREHOOK: query: describe formatted `srcpart`
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@srcpart
+POSTHOOK: query: describe formatted `srcpart`
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@srcpart
+# col_name            	data_type           	comment             
+key                 	string              	default             
+value               	string              	default             
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+ds                  	string              	                    
+hr                  	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	bucketing_version   	2                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
 PREHOOK: query: create table srcpart_serdeprops like srcpart
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default


### PR DESCRIPTION
## What changes were proposed in this pull request?
Hive DESCRIBE [formatted|extended] operation cost more than 100 seconds after upgrading from Hive 1.2.1 to 2.3.4. This is mainly caused by showing stats for partitioned tables which was introduced by [HIVE-16098](https://issues.apache.org/jira/browse/HIVE-16098) when the partitioned tables have a large amount of partitions.

So，could we add a flag that determines whether 'DESCRIBE [EXTENDED|FORMATTED]' operation display partitioned table stats or not?

## How was this patch tested?
Query Unit Test