### PR TITLE
HIVE-21529 : Bootstrap ACID tables as part of incremental dump.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -470,12 +470,6 @@ public class HiveConf extends Configuration {
     REPL_DUMP_METADATA_ONLY("hive.repl.dump.metadata.only", false,
         "Indicates whether replication dump only metadata information or data + metadata. \n"
           + "This config makes hive.repl.include.external.tables config ineffective."),
-    REPL_DUMP_INCLUDE_ACID_TABLES("hive.repl.dump.include.acid.tables", true,
-        "Indicates if repl dump should include information about ACID tables. It should be \n"
-            + "used in conjunction with 'hive.repl.dump.metadata.only' to enable copying of \n"
-            + "metadata for acid tables which do not require the corresponding transaction \n"
-            + "semantics to be applied on target. This can be removed when ACID table \n"
-            + "replication is supported."),
     REPL_BOOTSTRAP_ACID_TABLES("hive.repl.bootstrap.acid.tables", false,
         "Indicates if repl dump should bootstrap the information about ACID tables along with \n"
             + "incremental dump for replication. It is recommended to keep this config parameter \n"

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -470,12 +470,18 @@ public class HiveConf extends Configuration {
     REPL_DUMP_METADATA_ONLY("hive.repl.dump.metadata.only", false,
         "Indicates whether replication dump only metadata information or data + metadata. \n"
           + "This config makes hive.repl.include.external.tables config ineffective."),
-    REPL_DUMP_INCLUDE_ACID_TABLES("hive.repl.dump.include.acid.tables", false,
+    REPL_DUMP_INCLUDE_ACID_TABLES("hive.repl.dump.include.acid.tables", true,
         "Indicates if repl dump should include information about ACID tables. It should be \n"
             + "used in conjunction with 'hive.repl.dump.metadata.only' to enable copying of \n"
             + "metadata for acid tables which do not require the corresponding transaction \n"
             + "semantics to be applied on target. This can be removed when ACID table \n"
             + "replication is supported."),
+    REPL_BOOTSTRAP_ACID_TABLES("hive.repl.bootstrap.acid.tables", false,
+        "Indicates if repl dump should bootstrap the information about ACID tables along with \n"
+            + "incremental dump for replication. It is recommended to keep this config parameter \n"
+            + "as false always and should be set to true only via WITH clause of REPL DUMP \n"
+            + "command. It should be set to true only once for incremental repl dump on \n"
+            + "each of the existing replication policies after enabling acid tables replication."),
     REPL_BOOTSTRAP_DUMP_OPEN_TXN_TIMEOUT("hive.repl.bootstrap.dump.open.txn.timeout", "1h",
         new TimeValidator(TimeUnit.HOURS),
         "Indicates the timeout for all transactions which are opened before triggering bootstrap REPL DUMP. "

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -84,9 +84,9 @@ public class TestReplicationScenariosAcidTables {
     REPL_TEST_ACID_INSERT_UNION
   }
   private static List<String> dumpWithoutAcidClause = Collections.singletonList(
-          "'" + HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES.varname + "'='false'");
+          "'" + ReplUtils.REPL_DUMP_INCLUDE_ACID_TABLES + "'='false'");
   private static List<String> dumpWithAcidBootstrapClause = Arrays.asList(
-          "'" + HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES.varname + "'='true'",
+          "'" + ReplUtils.REPL_DUMP_INCLUDE_ACID_TABLES + "'='true'",
           "'" + HiveConf.ConfVars.REPL_BOOTSTRAP_ACID_TABLES + "'='true'");
   private List<String> acidTableNames = new LinkedList<>();
   private List<String> nonAcidTableNames = new LinkedList<>();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -155,7 +155,7 @@ public class WarehouseInstance implements Closeable {
       hiveConf.set(entry.getKey(), entry.getValue());
     }
 
-    MetaStoreTestUtils.startMetaStoreWithRetry(hiveConf, true);
+    MetaStoreTestUtils.startMetaStoreWithRetry(hiveConf, true, true);
 
     // Add the below mentioned dependency in metastore/pom.xml file. For postgres need to copy postgresql-42.2.1.jar to
     // .m2//repository/postgresql/postgresql/9.3-1102.jdbc41/postgresql-9.3-1102.jdbc41.jar.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -268,7 +268,9 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
           // Dump the table to be bootstrapped if required.
           if (shouldBootstrapDumpTable(table)) {
             HiveWrapper.Tuple<Table> tableTuple = new HiveWrapper(hiveDb, dbName).table(table);
-            dumpTable(dbName, tableName, validTxnList.toString(), dbRoot, bootDumpBeginReplId, hiveDb,
+            dumpTable(dbName, tableName, validTxnList == null ? null : validTxnList.toString(),
+                    dbRoot, bootDumpBeginReplId,
+                    hiveDb,
                       tableTuple);
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -199,7 +199,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
     // same factory, restricting by message format is effectively a guard against
     // older leftover data that would cause us problems.
 
-    work.overrideEventTo(hiveDb, bootDumpBeginReplId);
+    work.overrideLastEventToDump(hiveDb, bootDumpBeginReplId);
 
     IMetaStoreClient.NotificationFilter evFilter = new AndFilter(
         new DatabaseAndTableFilter(work.dbNameOrPattern, work.tableNameOrPattern),

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -65,17 +65,22 @@ public class ReplDumpWork implements Serializable {
     return maxEventLimit;
   }
 
-  void overrideEventTo(Hive fromDb, long bootstrapLastId) throws Exception {
+  // Override any user specification that changes the last event to be dumped.
+  void overrideLastEventToDump(Hive fromDb, long bootstrapLastId) throws Exception {
+    // If no last event is specified get the current last from the metastore.
     if (eventTo == null) {
       eventTo = fromDb.getMSC().getCurrentNotificationEventId().getEventId();
       LoggerFactory.getLogger(this.getClass())
           .debug("eventTo not specified, using current event id : {}", eventTo);
     }
 
-    // If we are bootstrapping ACID tables, we need to restrict events only upto the event id at
-    // the beginning of the bootstrap dump. See bootstrampDump() for more details.
+    // If we are bootstrapping ACID tables, we need to dump all the events upto the event id at
+    // the beginning of the bootstrap dump and also not dump any event after that. So we override
+    // both, the last event as well as any user specified limit on the number of events. See
+    // bootstrampDump() for more details.
     if (bootstrapLastId >= 0) {
       eventTo = bootstrapLastId;
+      maxEventLimit = null;
       LoggerFactory.getLogger(this.getClass())
               .debug("eventTo restricted to event id : {} because of bootstrap of ACID tables",
                       eventTo);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -71,7 +71,7 @@ public class ReplDumpWork implements Serializable {
     // the beginning of the bootstrap dump and also not dump any event after that. So we override
     // both, the last event as well as any user specified limit on the number of events. See
     // bootstrampDump() for more details.
-    if (bootstrapLastId >= 0) {
+    if (bootstrapLastId > 0) {
       eventTo = bootstrapLastId;
       maxEventLimit = null;
       LoggerFactory.getLogger(this.getClass())

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -67,13 +67,6 @@ public class ReplDumpWork implements Serializable {
 
   // Override any user specification that changes the last event to be dumped.
   void overrideLastEventToDump(Hive fromDb, long bootstrapLastId) throws Exception {
-    // If no last event is specified get the current last from the metastore.
-    if (eventTo == null) {
-      eventTo = fromDb.getMSC().getCurrentNotificationEventId().getEventId();
-      LoggerFactory.getLogger(this.getClass())
-          .debug("eventTo not specified, using current event id : {}", eventTo);
-    }
-
     // If we are bootstrapping ACID tables, we need to dump all the events upto the event id at
     // the beginning of the bootstrap dump and also not dump any event after that. So we override
     // both, the last event as well as any user specified limit on the number of events. See
@@ -84,6 +77,14 @@ public class ReplDumpWork implements Serializable {
       LoggerFactory.getLogger(this.getClass())
               .debug("eventTo restricted to event id : {} because of bootstrap of ACID tables",
                       eventTo);
+      return;
+    }
+
+    // If no last event is specified get the current last from the metastore.
+    if (eventTo == null) {
+      eventTo = fromDb.getMSC().getCurrentNotificationEventId().getEventId();
+      LoggerFactory.getLogger(this.getClass())
+          .debug("eventTo not specified, using current event id : {}", eventTo);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -65,11 +65,20 @@ public class ReplDumpWork implements Serializable {
     return maxEventLimit;
   }
 
-  void overrideEventTo(Hive fromDb) throws Exception {
+  void overrideEventTo(Hive fromDb, long bootstrapLastId) throws Exception {
     if (eventTo == null) {
       eventTo = fromDb.getMSC().getCurrentNotificationEventId().getEventId();
       LoggerFactory.getLogger(this.getClass())
           .debug("eventTo not specified, using current event id : {}", eventTo);
+    }
+
+    // If we are bootstrapping ACID tables, we need to restrict events only upto the event id at
+    // the beginning of the bootstrap dump. See bootstrampDump() for more details.
+    if (bootstrapLastId >= 0) {
+      eventTo = bootstrapLastId;
+      LoggerFactory.getLogger(this.getClass())
+              .debug("eventTo restricted to event id : {} because of bootstrap of ACID tables",
+                      eventTo);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/util/ReplUtils.java
@@ -88,6 +88,10 @@ public class ReplUtils {
   // duplicate check. Note : Stmt id is not used for base directory now, but to avoid misuse later, its maintained.
   public static final int REPL_BOOTSTRAP_MIGRATION_BASE_STMT_ID = 0;
 
+  // Configuration to enable/disable dumping ACID tables. Used only for testing and shouldn't be
+  // seen in production or in case of tests other than the ones where it's required.
+  public static final String REPL_DUMP_INCLUDE_ACID_TABLES = "hive.repl.dump.include.acid.tables";
+
   /**
    * Bootstrap REPL LOAD operation type on the examined object based on ckpt state.
    */
@@ -263,5 +267,14 @@ public class ReplUtils {
       return null;
     }
     return Long.parseLong(writeIdString);
+  }
+
+  // Only for testing, we do not include ACID tables in the dump (and replicate) if config says so.
+  public static boolean includeAcidTableInDump(HiveConf conf) {
+    if (conf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL)) {
+      return conf.getBoolean(REPL_DUMP_INCLUDE_ACID_TABLES, true);
+    }
+
+    return true;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
@@ -196,6 +196,23 @@ public class Utils {
         }
         return shouldReplicateExternalTables;
       }
+
+      if (AcidUtils.isTransactionalTable(tableHandle.getTTable())) {
+        // For testing purposes only, do not replicate ACID tables when config says so
+        boolean shouldReplicateAcidTables = true;
+        if (hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL)) {
+          shouldReplicateAcidTables =
+                        hiveConf.getBoolVar((HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES));
+        }
+        if (!shouldReplicateAcidTables) {
+          return false;
+        }
+
+        // Skip dumping events related to ACID tables if bootstrap is enabled on it
+        if (isEventDump) {
+           return !hiveConf.getBoolVar(HiveConf.ConfVars.REPL_BOOTSTRAP_ACID_TABLES);
+        }
+      }
     }
     return true;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/Utils.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -198,13 +199,7 @@ public class Utils {
       }
 
       if (AcidUtils.isTransactionalTable(tableHandle.getTTable())) {
-        // For testing purposes only, do not replicate ACID tables when config says so
-        boolean shouldReplicateAcidTables = true;
-        if (hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL)) {
-          shouldReplicateAcidTables =
-                        hiveConf.getBoolVar((HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES));
-        }
-        if (!shouldReplicateAcidTables) {
+        if (!ReplUtils.includeAcidTableInDump(hiveConf)) {
           return false;
         }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/AllocWriteIdHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/AllocWriteIdHandler.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.parse.repl.dump.events;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.messaging.AllocWriteIdMessage;
+import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.parse.repl.DumpType;
 import org.apache.hadoop.hive.ql.parse.repl.load.DumpMetaData;
 
@@ -44,10 +45,7 @@ class AllocWriteIdHandler extends AbstractEventHandler<AllocWriteIdMessage> {
       return;
     }
 
-    // Also only for testing, we do not include ACID tables in the dump (and replicate) if config
-    // says so.
-    if (withinContext.hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL) &&
-        !withinContext.hiveConf.getBoolVar(HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES)) {
+    if (!ReplUtils.includeAcidTableInDump(withinContext.hiveConf)) {
       return;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/CommitTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/CommitTxnHandler.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.NotificationEvent;
 import org.apache.hadoop.hive.metastore.api.WriteEventInfo;
 import org.apache.hadoop.hive.metastore.messaging.CommitTxnMessage;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
+import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.parse.EximUtil;
@@ -113,15 +114,14 @@ class CommitTxnHandler extends AbstractEventHandler<CommitTxnMessage> {
         // part of an incremental dump. So we shouldn't be dumping any changes to ACID table as
         // part of the commit. At the same time we need to dump the commit transaction event so
         // that replication can end a transaction opened when replaying open transaction event.
-        LOG.info("writeEventsInfoList will be removed from commit message because we are " +
+        LOG.debug("writeEventsInfoList will be removed from commit message because we are " +
                 "bootstrapping acid tables.");
         replicatingAcidEvents = false;
-      } else if (withinContext.hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_IN_TEST_REPL) &&
-        !withinContext.hiveConf.getBoolVar(HiveConf.ConfVars.REPL_DUMP_INCLUDE_ACID_TABLES)) {
+      } else if (!ReplUtils.includeAcidTableInDump(withinContext.hiveConf)) {
         // Similar to the above condition, only for testing purposes, if the config doesn't allow
         // ACID tables to be replicated, we don't dump any changes to the ACID tables as part of
         // commit.
-        LOG.info("writeEventsInfoList will be removed from commit message because we are " +
+        LOG.debug("writeEventsInfoList will be removed from commit message because we are " +
                 "not dumping acid tables.");
         replicatingAcidEvents = false;
       }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.repl.dump.HiveWrapper;
@@ -36,6 +37,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -120,6 +122,8 @@ public class TestReplDumpTask {
     when(queryState.getConf()).thenReturn(conf);
     when(conf.getLong("hive.repl.last.repl.id", -1L)).thenReturn(1L);
     when(conf.getBoolVar(HiveConf.ConfVars.REPL_INCLUDE_EXTERNAL_TABLES)).thenReturn(false);
+    when(HiveConf.getVar(conf,
+            HiveConf.ConfVars.REPL_BOOTSTRAP_DUMP_OPEN_TXN_TIMEOUT)).thenReturn("1h");
 
     whenNew(Writer.class).withAnyArguments().thenReturn(mock(Writer.class));
     whenNew(HiveWrapper.class).withAnyArguments().thenReturn(mock(HiveWrapper.class));

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.exec.repl;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
@@ -41,8 +40,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.validation.Valid;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.exec.repl;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -38,6 +39,8 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.validation.Valid;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -78,8 +81,9 @@ public class TestReplDumpTask {
     }
 
     @Override
-    String getValidTxnListForReplDump(Hive hiveDb) {
-      return "";
+    ValidTxnList getValidTxnListForReplDump(Hive hiveDb, ValidTxnList validTxnList,
+                                            long waitUntilTime) {
+      return validTxnList;
     }
 
     @Override

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/repl/TestReplDumpTask.java
@@ -83,9 +83,8 @@ public class TestReplDumpTask {
     }
 
     @Override
-    ValidTxnList getValidTxnListForReplDump(Hive hiveDb, ValidTxnList validTxnList,
-                                            long waitUntilTime) {
-      return validTxnList;
+    String getValidTxnListForReplDump(Hive hiveDb, long waitUntilTime) {
+      return "";
     }
 
     @Override


### PR DESCRIPTION
In order to replicate ACID tables in existing cluster on which replication is going on, we allow an
incremental (and only one) to bootstrap ACID tables.