### PR TITLE
[HIVE-21555] fix a high risk in memory error

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/LlapCacheResourceProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/LlapCacheResourceProcessor.java
@@ -133,7 +133,7 @@ public class LlapCacheResourceProcessor implements CommandProcessor {
   }
 
   private void llapCachePurge(final SessionState ss, final LlapRegistryService llapRegistryService) throws Exception {
-    ExecutorService executorService = Executors.newCachedThreadPool();
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
     List<Future<Long>> futures = new ArrayList<>();
     Collection<LlapServiceInstance> instances = llapRegistryService.getInstances().getAll();
     for (LlapServiceInstance instance : instances) {


### PR DESCRIPTION
Fix: [#HIVE-21555](https://issues.apache.org/jira/browse/HIVE-21555).

The cached thread pool is proper when the task is light-weight and the number of sub-threads are not too many. Otherwise, fixed thread pool should be used to avoid OutOfMemoryError. 