### PR TITLE
HIVE-21556 remove configuraion for old version of jetty (6.x)

### DIFF
--- a/data/conf/hive-log4j2.properties
+++ b/data/conf/hive-log4j2.properties
@@ -50,7 +50,7 @@ appender.DRFA.strategy.type = DefaultRolloverStrategy
 appender.DRFA.strategy.max = 30
 
 # list of all loggers
-loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Mortbay, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange
+loggers = HadoopIPC, HadoopSecurity, Hdfs, HdfsServer, HadoopMetrics2, Yarn, YarnServer, Tez, HadoopConf, Zookeeper, ServerCnxn, NIOServerCnxn, ClientCnxn, ClientCnxnSocket, ClientCnxnSocketNIO, DataNucleus, Datastore, JPOX, Operator, Serde2Lazy, ObjectStore, CalcitePlanner, AmazonAws, ApacheHttp, Thrift, Jetty, BlockStateChange
 
 logger.HadoopIPC.name = org.apache.hadoop.ipc
 logger.HadoopIPC.level = WARN
@@ -66,9 +66,6 @@ logger.HdfsServer.level = WARN
 
 logger.HadoopMetrics2.name = org.apache.hadoop.metrics2
 logger.HadoopMetrics2.level = INFO
-
-logger.Mortbay.name = org.mortbay
-logger.Mortbay.level = INFO
 
 logger.Yarn.name = org.apache.hadoop.yarn
 logger.Yarn.level = INFO


### PR DESCRIPTION
```
logger.Mortbay.name = org.mortbay
logger.Mortbay.level = INFO
```
The logger `Mortbay` in log4j.properties is used to control logging activities of jetty (6.x). However, we have upgrade to jetty 9 in [HIVE-16049](https://issues.apache.org/jira/browse/HIVE-16049), the package name has changed to `org.eclipse.jetty` and we have added the new logger to control jetty. `Mortbay` is useless. I guess we can remove it.