### PR TITLE
[HIVE-21636] ReplaceAll() -> replace() for non regex strings

### DIFF
--- a/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/compare/StringCompare.java
+++ b/accumulo-handler/src/java/org/apache/hadoop/hive/accumulo/predicate/compare/StringCompare.java
@@ -67,7 +67,7 @@ public class StringCompare implements PrimitiveComparison {
 
   @Override
   public boolean like(byte[] value) {
-    String temp = new String(value).replaceAll("%", "[\\\\\\w]+?");
+    String temp = new String(value).replace("%", "[\\\\\\w]+?");
     Pattern pattern = Pattern.compile(temp);
     boolean match = pattern.matcher(constant).matches();
     return match;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/FileOutputCommitterContainer.java
@@ -681,7 +681,7 @@ class FileOutputCommitterContainer extends OutputCommitterContainer {
 
       // construct a path pattern (e.g., /*/*) to find all dynamically generated paths
       String dynPathSpec = loadPath.toUri().getPath();
-      dynPathSpec = dynPathSpec.replaceAll("__HIVE_DEFAULT_PARTITION__", "*");
+      dynPathSpec = dynPathSpec.replace("__HIVE_DEFAULT_PARTITION__", "*");
 
       //      LOG.info("Searching for "+dynPathSpec);
       Path pathPattern = new Path(dynPathSpec);

--- a/vector-code-gen/src/org/apache/hadoop/hive/tools/GenVectorCode.java
+++ b/vector-code-gen/src/org/apache/hadoop/hive/tools/GenVectorCode.java
@@ -3179,8 +3179,8 @@ public class GenVectorCode extends Task {
     // Read the template into a string;
     File templateFile = new File(joinPath(this.expressionTemplateDirectory, tdesc[0] + ".txt"));
     String templateString = readFile(templateFile);
-    templateString = templateString.replaceAll("<ClassName>", className);
-    templateString = templateString.replaceAll("<Operator>", operatorName.toLowerCase());
+    templateString = templateString.replace("<ClassName>", className);
+    templateString = templateString.replace("<Operator>", operatorName.toLowerCase());
 
     writeFile(templateFile.lastModified(), expressionOutputDirectory, expressionClassesDirectory,
        className, templateString);


### PR DESCRIPTION
[HIVE-21636](https://issues.apache.org/jira/browse/HIVE-21636) replaceAll() to replace() where the extra regex compilation associated with replaceAll() is not needed