### PR TITLE
Change Math.random to Random.nextDouble for lower performance overhead

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatOutputFormat.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -113,7 +114,8 @@ public class HCatOutputFormat extends HCatBaseOutputFormat {
       // later on, it is guaranteed to be unique.
       String idHash;
       if ((idHash = conf.get(HCatConstants.HCAT_OUTPUT_ID_HASH)) == null) {
-        idHash = String.valueOf(Math.random());
+	Random rand = new Random();
+        idHash = String.valueOf(rand.nextDouble());
       }
       conf.set(HCatConstants.HCAT_OUTPUT_ID_HASH,idHash);
 

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
@@ -20,6 +20,7 @@ package org.apache.hive.hcatalog.templeton.tool;
 
 import java.io.IOException;
 import java.util.Date;
+import java.util.Random;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -112,7 +113,8 @@ public class HDFSCleanup extends Thread {
           }
         }
 
-        long sleepMillis = (long) (Math.random() * interval);
+	Random rand = new Random();
+        long sleepMillis = (long) (rand.nextDouble() * interval);
         LOG.info("Next execution: " + new Date(new Date().getTime()
                              + sleepMillis));
         Thread.sleep(sleepMillis);

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Date;
+import java.util.Random;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.conf.Configuration;
@@ -113,7 +114,8 @@ public class ZooKeeperCleanup extends Thread {
           if (zk != null) zk.close();
         }
 
-        long sleepMillis = (long) (Math.random() * interval);
+        Random rand = new Random();
+        long sleepMillis = (long) (rand.nextDouble()  * interval);
         LOG.info("Next execution: " + new Date(new Date().getTime()
           + sleepMillis));
         Thread.sleep(sleepMillis);


### PR DESCRIPTION
[HIVE-21719](https://issues.apache.org/jira/browse/HIVE-21719)

Some performance can be saved by using Random.nextDouble instead of Math.random. Furthermore, the Random class is highly configurable if random configuration is needed in future developments.