### PR TITLE
HIVE-21736: Fixed operator(:=) error

### DIFF
--- a/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
+++ b/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
@@ -748,7 +748,7 @@ for_range_stmt :        // FOR (Integer range) statement
      ;
      
 label :
-       L_LABEL
+       ident T_COLON
      | T_LESS T_LESS L_ID T_GREATER T_GREATER
      ;
 
@@ -1920,9 +1920,6 @@ L_S_COMMENT : ('--' | '//')  .*? '\r'? '\n' -> channel(HIDDEN) ;       // Single
 L_FILE      : ([a-zA-Z] ':' '\\'?)? L_ID ('\\' L_ID)*                  // File path (a/b/c Linux path causes conflicts with division operator and handled at parser level)
             ; 
 
-L_LABEL     : ([a-zA-Z] | L_DIGIT | '_')* ':'            
-            ;
-            
 fragment
 L_ID_PART  :
              [a-zA-Z] ([a-zA-Z] | L_DIGIT | '_')*                           // Identifier part

--- a/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
@@ -2116,7 +2116,7 @@ public class Exec extends HplsqlBaseVisitor<Integer> {
       exec.labels.push(ctx.L_ID().toString());
     }
     else {
-      String label = ctx.L_LABEL().getText();
+      String label = ctx.ident().getText();
       if (label.endsWith(":")) {
         label = label.substring(0, label.length() - 1);
       }


### PR DESCRIPTION
This PR fixes the bug HIVE-21736 -- https://issues.apache.org/jira/browse/HIVE-21736

When using the assignment operator (:=), you must add a space before the operator, otherwise a syntax error will be thrown, if merge this PR will solve the issue.