### PR TITLE
HIVE-21776 : Replication fails to replicate a UDF with jar on HDFS during incremental

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/CreateFunctionHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/events/CreateFunctionHandler.java
@@ -39,7 +39,7 @@ class CreateFunctionHandler extends AbstractEventHandler<CreateFunctionMessage> 
 
   @Override
   public void handle(Context withinContext) throws Exception {
-    LOG.info("Processing#{} CREATE_MESSAGE message : {}", fromEventId(), eventMessageAsJSON);
+    LOG.info("Processing#{} CREATE_FUNCTION message : {}", fromEventId(), eventMessageAsJSON);
     Path metadataPath = new Path(withinContext.eventRoot, EximUtil.METADATA_NAME);
     FileSystem fileSystem = metadataPath.getFileSystem(withinContext.hiveConf);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/FunctionSerializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/FunctionSerializer.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ReplChangeManager;
 import org.apache.hadoop.hive.metastore.api.Function;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.ResourceUri;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
@@ -47,7 +48,7 @@ public class FunctionSerializer implements JsonWriter.Serializer {
 
   @Override
   public void writeTo(JsonWriter writer, ReplicationSpec additionalPropertiesProvider)
-      throws SemanticException, IOException {
+      throws SemanticException, IOException, MetaException {
     TSerializer serializer = new TSerializer(new TJSONProtocol.Factory());
     List<ResourceUri> resourceUris = new ArrayList<>();
     for (ResourceUri uri : function.getResourceUris()) {
@@ -55,6 +56,8 @@ public class FunctionSerializer implements JsonWriter.Serializer {
       if ("hdfs".equals(inputPath.toUri().getScheme())) {
         FileSystem fileSystem = inputPath.getFileSystem(hiveConf);
         Path qualifiedUri = PathBuilder.fullyQualifiedHDFSUri(inputPath, fileSystem);
+        // Initialize ReplChangeManager instance since we will require it to encode file URI.
+        ReplChangeManager.getInstance(hiveConf);
         String checkSum = ReplChangeManager.checksumFor(qualifiedUri, fileSystem);
         String newFileUri = ReplChangeManager.encodeFileUri(qualifiedUri.toString(), checkSum, null);
         resourceUris.add(new ResourceUri(uri.getResourceType(), newFileUri));

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/JsonWriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/dump/io/JsonWriter.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.parse.repl.dump.io;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.codehaus.jackson.JsonFactory;
@@ -50,6 +51,6 @@ public class JsonWriter implements Closeable {
   public interface Serializer {
     String UTF_8 = "UTF-8";
     void writeTo(JsonWriter writer, ReplicationSpec additionalPropertiesProvider) throws
-        SemanticException, IOException;
+        SemanticException, IOException, MetaException;
   }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -356,6 +356,9 @@ public class ReplChangeManager {
   // Currently using fileuri#checksum#cmrooturi#subdirs as the format
   public static String encodeFileUri(String fileUriStr, String fileChecksum, String encodedSubDir)
           throws IOException {
+    if (instance == null) {
+      throw new IOException("Uninitialized ReplChangeManager instance.");
+    }
     String encodedUri = fileUriStr;
     if ((fileChecksum != null) && (cmroot != null)) {
       encodedUri = encodedUri + URI_FRAGMENT_SEPARATOR + fileChecksum

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/ReplChangeManager.java
@@ -357,7 +357,7 @@ public class ReplChangeManager {
   public static String encodeFileUri(String fileUriStr, String fileChecksum, String encodedSubDir)
           throws IOException {
     if (instance == null) {
-      throw new IOException("Uninitialized ReplChangeManager instance.");
+      throw new IllegalStateException("Uninitialized ReplChangeManager instance.");
     }
     String encodedUri = fileUriStr;
     if ((fileChecksum != null) && (cmroot != null)) {


### PR DESCRIPTION
@sankarh can you please review?

When function is dumped during incremental, ReplChangeManager may not be initialized. In such case, JAR URL dumped will not have checksum and cmroot appended to it. Hence ReplCopyTask interprets it as normal file instead of function JAR resource and doesn't copy it. Hence function creation fails on the target.