### PR TITLE
Rename grammar rule string into char_string

### DIFF
--- a/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
+++ b/hplsql/src/main/antlr4/org/apache/hive/hplsql/Hplsql.g4
@@ -1023,7 +1023,7 @@ expr_atom :
      | timestamp_literal
      | bool_literal
      | ident 
-     | string
+     | char_string
      | dec_number
      | int_number
      | null_const
@@ -1175,18 +1175,18 @@ file_name :
      ;
      
 date_literal :                             // DATE 'YYYY-MM-DD' literal
-       T_DATE string
+       T_DATE char_string
      ;
 
 timestamp_literal :                       // TIMESTAMP 'YYYY-MM-DD HH:MI:SS.FFF' literal
-       T_TIMESTAMP string
+       T_TIMESTAMP char_string
      ;
      
 ident :
        '-'? (L_ID | non_reserved_words) ('.' (L_ID | non_reserved_words))*
      ;
      
-string :                                   // String literal (single or double quoted)
+char_string :                                   // String literal (single or double quoted)
        L_S_STRING                          # single_quotedString
      | L_D_STRING                          # double_quotedString
      ;

--- a/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
@@ -2251,7 +2251,7 @@ public class Exec extends HplsqlBaseVisitor<Integer> {
   @Override 
   public Integer visitTimestamp_literal(HplsqlParser.Timestamp_literalContext ctx) { 
     if (!exec.buildSql) {
-      String str = evalPop(ctx.string()).toString();
+      String str = evalPop(ctx.char_string()).toString();
       int len = str.length();
       int precision = 0;
       if (len > 19 && len <= 29) {

--- a/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Exec.java
@@ -2236,7 +2236,7 @@ public class Exec extends HplsqlBaseVisitor<Integer> {
   @Override 
   public Integer visitDate_literal(HplsqlParser.Date_literalContext ctx) { 
     if (!exec.buildSql) {
-      String str = evalPop(ctx.string()).toString();
+      String str = evalPop(ctx.char_string()).toString();
       stackPush(new Var(Var.Type.DATE, Utils.toDate(str)));
     }
     else {


### PR DESCRIPTION
When I run `antlr -Dlanguage=Go` to generate the Go version parser from `Hplsql.g4`, antlr complains that the grammar rule name string conflicts with the name of Go data type string.

```
# java org.antlr.v4.Tool -Dlanguage=Go 2.0.1/Hplsql.g4 
error(134): 2.0.1/Hplsql.g4:1025:0: symbol string conflicts with generated code in target language or runtime
error(134): 2.0.1/Hplsql.g4:868:7: symbol string conflicts with generated code in target language or runtime
error(134): 2.0.1/Hplsql.g4:1013:14: symbol string conflicts with generated code in target language or runtime
error(134): 2.0.1/Hplsql.g4:1017:19: symbol string conflicts with generated code in target language or runtim
```

I renamed grammar rule string into char_string and antlr works to generate the parser in Go. Hence this PR.