### PR TITLE
[HIVE-21877]: Change HCatTableInfo to not be transient in PartInfo

### DIFF
--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/PartInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/PartInfo.java
@@ -57,11 +57,8 @@ public class PartInfo implements Serializable {
   /** Job properties associated with this parition */
   Map<String, String> jobProperties;
 
-  /**
-   * The table info associated with this partition.
-   * Not serialized per PartInfo instance. Constant, per table.
-   */
-  transient HCatTableInfo tableInfo;
+  /** The table info associated with this partition.*/
+  HCatTableInfo tableInfo;
 
   /**
    * Instantiates a new hcat partition info.


### PR DESCRIPTION
While using Hcatalog with Apache Beam, we ran into an issue with HCatTableInfo being null during serialization. I don't see a reason why it should be transient. However, there might be use-cases that I may not be aware of and might require it to be transient. Would love to hear some feedback regardless.