### PR TITLE
HIVE-21892: Trusted domain authentication should look at X-Forwarded-For header as well

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3486,6 +3486,13 @@ public class HiveConf extends Configuration {
         " it is empty, which means that all the connections to HiveServer2 are authenticated. " +
         "When it is non-empty, the client has to provide a Hive user name. Any password, if " +
         "provided, will not be used when authentication is skipped."),
+    HIVE_SERVER2_TRUSTED_DOMAIN_USE_XFF_HEADER("hive.server2.trusted.domain.use.xff.header", false,
+      "When trusted domain authentication is enabled, the clients connecting to the HS2 could pass" +
+        "through many layers of proxy. Some proxies append its own ip address to 'X-Forwarded-For' header" +
+        "before passing on the request to another proxy or HS2. Some proxies also connect on behalf of client" +
+        "and may create a separate connection to HS2 without binding using client IP. For such environments, instead" +
+        "of looking at client IP from the request, if this config is set and if 'X-Forwarded-For' is present," +
+        "trusted domain authentication will use left most ip address from X-Forwarded-For header."),
     HIVE_SERVER2_ALLOW_USER_SUBSTITUTION("hive.server2.allow.user.substitution", true,
         "Allow alternate user to be specified as part of HiveServer2 open connection request."),
     HIVE_SERVER2_KERBEROS_KEYTAB("hive.server2.authentication.kerberos.keytab", "",


### PR DESCRIPTION
HIVE-21783 added trusted domain authentication. However, it looks only at request.getRemoteAddr() which works in most cases where there are no intermediate forward/reverse proxies. In trusted domain scenarios, if there intermediate proxies, the proxies typically append its own ip address "X-Forwarded-For" header. The X-Forwarded-For will look like clientIp -> proxyIp1 -> proxyIp2. The left most ip address in the X-Forwarded-For represents the real client ip address. For such scenarios, add a config to optionally look at X-Forwarded-For header when available to determine the real client ip. 