### PR TITLE
HIVE-21825: Improve client error msg when Active/Passive HA is enable…

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -65,7 +65,10 @@ import org.slf4j.LoggerFactory;
 public class SessionManager extends CompositeService {
 
   private static final String INACTIVE_ERROR_MESSAGE =
-      "Cannot open sessions on an inactive HS2 instance; use service discovery to connect";
+          "Cannot open sessions on an inactive HS2 instance, " +
+                  "or the HS2 server leader is not ready; please use service discovery to connect again";
+  private static final String FAILCLOSE_ERROR_MESSAGE="Cannot close the session opened " +
+          "during the HA state change time";
   public static final String HIVERCFILE = ".hiverc";
   private static final Logger LOG = LoggerFactory.getLogger(CompositeService.class);
   private HiveConf hiveConf;
@@ -478,7 +481,7 @@ public class SessionManager extends CompositeService {
       } catch (Exception e) {
         LOG.warn("Failed to close the session opened during an HA state change; ignoring", e);
       }
-      throw new HiveSQLException(INACTIVE_ERROR_MESSAGE);
+      throw new HiveSQLException(FAILCLOSE_ERROR_MESSAGE);
     }
     LOG.info("Session opened, " + session.getSessionHandle()
         + ", current sessions:" + getOpenSessionCount());

--- a/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -66,8 +66,9 @@ public class SessionManager extends CompositeService {
 
   private static final String INACTIVE_ERROR_MESSAGE =
           "Cannot open sessions on an inactive HS2 instance, " +
-                  "or the HS2 server leader is not ready; please use service discovery to connect again";
-  private static final String FAILCLOSE_ERROR_MESSAGE="Cannot close the session opened " +
+                  "or the HS2 server leader is not ready; please use service discovery to " +
+                  "connect the server leader again";
+  private static final String FAIL_CLOSE_ERROR_MESSAGE="Cannot close the session opened " +
           "during the HA state change time";
   public static final String HIVERCFILE = ".hiverc";
   private static final Logger LOG = LoggerFactory.getLogger(CompositeService.class);
@@ -481,7 +482,7 @@ public class SessionManager extends CompositeService {
       } catch (Exception e) {
         LOG.warn("Failed to close the session opened during an HA state change; ignoring", e);
       }
-      throw new HiveSQLException(FAILCLOSE_ERROR_MESSAGE);
+      throw new HiveSQLException(FAIL_CLOSE_ERROR_MESSAGE);
     }
     LOG.info("Session opened, " + session.getSessionHandle()
         + ", current sessions:" + getOpenSessionCount());


### PR DESCRIPTION
When Active/Passive HA is enabled and when client tries to connect to Passive HA or when HS2 is still starting up, clients will receive the following the error msg

'Cannot open sessions on an inactive HS2 instance; use service discovery to connect'
This error msg can be improved to say that HS2 is still starting up (or more user-friendly error msg). 