### PR TITLE
HIVE-21939: Switch to use protoc of version 2.6.1-build3 than 2.5.0

### DIFF
--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -436,7 +436,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>com.github.os72:protoc:2.6.1-build3</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -451,7 +451,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>com.github.os72:protoc:2.6.1-build3</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>


### PR DESCRIPTION
According to [building log](http://80.158.17.129/logs/2/2/c962768b48729abb97321be580d999510143c6bc/check/hive-build-arm64/a4ce152/logs/hive_build.log) on `aarch64` platform of current master of Hive source code, the required package `com.google.protobuf:protoc:2.5.0` has broken the building of Hive on ARM platform, see error message:
```
2019-06-26 08:59:22.426070 | ubuntu-xenial-arm64 | [ERROR] Failed to execute goal com.github.os72:protoc-jar-maven-plugin:3.5.1.1:run (default) on project hive-standalone-metastore-common: Error resolving artifact: com.google.protobuf:protoc:2.5.0: Could not find artifact com.google.protobuf:protoc:exe:linux-aarch_64:2.5.0 in central (https://repo.maven.apache.org/maven2)
```
After change the dependent artifact from `com.google.protobuf:protoc:2.5.0` to `com.github.os72:protoc:2.6.1-build3`, it can successfully build Hive on `aarch64` server. see [building logs](http://80.158.17.129/logs/3/3/738f0ef081e50d7c626e3d5e191d92bfe2f21093/check/hive-build-arm64/1a20879/logs/hive_build.log).