### PR TITLE
where tez engine and off auto.mapjoin or size more then smalltable.fi…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
@@ -689,6 +689,9 @@ public class GroupByOperator extends Operator<GroupByDesc> implements
   @Override
   public void processOp(Object row, int tag) throws HiveException {
     firstRow = false;
+    if (tag > inputObjInspectors.length -1){
+      tag = 0;
+    }
     ObjectInspector rowInspector = inputObjInspectors[tag];
     // Total number of input rows is needed for hash aggregation only
     if (hashAggr && !groupKeyIsNotReduceKey) {


### PR DESCRIPTION
…lesize , where predicate is not booleans , Compile executing -group operator would occur error java.lang.ClassCastException