### PR TITLE
HIVE-21966: Llap external client - Arrow Serializer throws ArrayIndexOutOfBoundsException

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/BaseJdbcWithMiniLlap.java
@@ -107,7 +107,7 @@ public abstract class BaseJdbcWithMiniLlap {
   private static Path dataTypesFilePath;
 
   protected static HiveConf conf = null;
-  private static Connection hs2Conn = null;
+  protected static Connection hs2Conn = null;
 
   // This method should be called by sub-classes in a @BeforeClass initializer
   public static MiniHS2 beforeTest(HiveConf inputConf) throws Exception {


### PR DESCRIPTION
This patch readjusts selected[] and size in VectorizedRowBatch according to the actual vectors inside MultiValuedColumnVector.