### PR TITLE
Support delegation token renewal

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/security/TokenStoreDelegationTokenSecretManager.java
@@ -161,7 +161,9 @@ public class TokenStoreDelegationTokenSecretManager extends DelegationTokenSecre
     synchronized (this) {
       super.currentTokens.put(id,  tokenInfo);
       try {
-        return super.renewToken(token, renewer);
+        long res = super.renewToken(token, renewer);
+        this.tokenStore.removeToken(id);
+        this.tokenStore.addToken(id, super.currentTokens.get(id));
       } finally {
         super.currentTokens.remove(id);
       }


### PR DESCRIPTION
Hive uses the TokenStoreDelegationTokenSecretManager to store
the delegation tokens.

The renewal is delegated to the AbstractDelegationTokenSecretManager
of hadoop-commons. This class stores the tokens in a protected attribute
Map<DelegationTokenIdentifier, DelegationTokenInformation> 'currentTokens'.

On the other hand,
TokenStoreDelegationTokenSecretManager that inherits from AbstractDelegationTokenSecretManager,
stores the tokens in a private DelegationTokenStore 'tokenStore' that
permits to associate a DelegationTokenIdentifier to a DelegationTokenInformation too.

The expiry date of the delegation token is stored in the
DelegationTokenInformation (the value of the map).

TokenStoreDelegationTokenSecretManager.renewToken
populates the attribute 'currentTokens', with the value tokenStore
associated to the releated DelegationTokenIdentifier. Let's call this
value tokenId.

Then it calls super.renewToken that updates the
DelegationTokenInformation, of tokenId, with a new expiry date,
in 'currentTokens'.

Unfortunately
1. TokenStoreDelegationTokenSecretManager
cleans the 'currentTokens' attribute,
without updating the DelegationTokenInformation associated to tokenId
in 'tokenStore'.
2. Returning the new expiry date, reflecting what was in
currentTokens, but not what's in 'tokenStore'.

Fix the two issues by updating tokenStore once the delegation
is renewed.