### PR TITLE
HIVE-22190: Class HiveMetaStoreClient fails to instantiate when runni…

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -195,9 +195,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
 
         }
         // make metastore URIS random
-        List uriList = Arrays.asList(metastoreUris);
+        List<URI> uriList = Arrays.asList(metastoreUris);
         Collections.shuffle(uriList);
-        metastoreUris = (URI[]) uriList.toArray();
+        metastoreUris = uriList.toArray(metastoreUris);
       } catch (IllegalArgumentException e) {
         throw (e);
       } catch (Exception e) {


### PR DESCRIPTION
…ng on Java 11

HiveMetaStoreClient fails to initialize in JDK with error:
Unable to instantiate org.apache.hadoop.hive.metastore.HiveMetaStoreClient with cause
class [Ljava.lang.Object; cannot be cast to class [Ljava.net.URI; ([Ljava.lang.Object; and [Ljava.net.URI; are in module java.base of loader 'bootstrap')

This commit refactors the code to convert a List to array