### PR TITLE
HIVE-22203 Break up DDLSemanticAnalyzer - extract Process related analyzers

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsAnalyzer.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.process.abort;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.runtime.tree.Tree;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.lib.Node;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for abort transactions commands.
+ */
+@DDLType(type=HiveParser.TOK_ABORT_TRANSACTIONS)
+public class AbortTransactionsAnalyzer extends BaseSemanticAnalyzer {
+  public AbortTransactionsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    List<Long> transactionIds = new ArrayList<Long>();
+    for (Node child : root.getChildren()) {
+      transactionIds.add(Long.parseLong(((Tree)child).getText()));
+    }
+    AbortTransactionsDesc desc = new AbortTransactionsDesc(transactionIds);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsDesc.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.abort;
 
 import java.io.Serializable;
 import java.util.List;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/AbortTransactionsOperation.java
@@ -16,28 +16,23 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.abort;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.session.SessionState;
 
 /**
- * Operation process of killing queries.
+ * Operation process of aborting transactions.
  */
-public class KillQueriesOperation extends DDLOperation<KillQueriesDesc> {
-  public KillQueriesOperation(DDLOperationContext context, KillQueriesDesc desc) {
+public class AbortTransactionsOperation extends DDLOperation<AbortTransactionsDesc> {
+  public AbortTransactionsOperation(DDLOperationContext context, AbortTransactionsDesc desc) {
     super(context, desc);
   }
 
   @Override
   public int execute() throws HiveException {
-    SessionState sessionState = SessionState.get();
-    for (String queryId : desc.getQueryIds()) {
-      sessionState.getKillQuery().killQuery(queryId, "User invoked KILL QUERY", context.getDb().getConf());
-    }
-    LOG.info("kill query called ({})", desc.getQueryIds());
+    context.getDb().abortTransactions(desc.getTransactionIds());
     return 0;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/abort/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Abort Transactions DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.process.abort;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesAnalyzer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.process.kill;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.antlr.runtime.tree.Tree;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLUtils;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.lib.Node;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for kill query commands.
+ */
+@DDLType(type=HiveParser.TOK_KILL_QUERY)
+public class KillQueriesAnalyzer extends BaseSemanticAnalyzer {
+  public KillQueriesAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    List<String> queryIds = new ArrayList<String>();
+    for (Node child : root.getChildren()) {
+      queryIds.add(stripQuotes(((Tree)child).getText()));
+    }
+
+    KillQueriesDesc desc = new KillQueriesDesc(queryIds);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+
+    DDLUtils.addServiceOutput(conf, outputs);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesDesc.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.ddl.process.kill;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.apache.hadoop.hive.ql.ddl.DDLDesc;
+import org.apache.hadoop.hive.ql.plan.Explain;
+import org.apache.hadoop.hive.ql.plan.Explain.Level;
+
+/**
+ * DDL task description for KILL QUERY commands.
+ */
+@Explain(displayName = "Kill Query", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class KillQueriesDesc implements DDLDesc, Serializable {
+  private static final long serialVersionUID = 1L;
+
+  private List<String> queryIds;
+
+  public KillQueriesDesc(List<String> queryIds) {
+    this.queryIds = queryIds;
+  }
+
+  @Explain(displayName = "Query IDs", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+  public List<String> getQueryIds() {
+    return queryIds;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/KillQueriesOperation.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.process.kill;
+
+import org.apache.hadoop.hive.ql.ddl.DDLOperation;
+import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.session.SessionState;
+
+/**
+ * Operation process of killing queries.
+ */
+public class KillQueriesOperation extends DDLOperation<KillQueriesDesc> {
+  public KillQueriesOperation(DDLOperationContext context, KillQueriesDesc desc) {
+    super(context, desc);
+  }
+
+  @Override
+  public int execute() throws HiveException {
+    SessionState sessionState = SessionState.get();
+    for (String queryId : desc.getQueryIds()) {
+      sessionState.getKillQuery().killQuery(queryId, "User invoked KILL QUERY", context.getDb().getConf());
+    }
+    LOG.info("kill query called ({})", desc.getQueryIds());
+    return 0;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/kill/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Kill Queries DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.process.kill;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsAnalyzer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.process.show.compactions;
+
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for show compactions commands.
+ */
+@DDLType(type=HiveParser.TOK_SHOW_COMPACTIONS)
+public class ShowCompactionsAnalyzer extends BaseSemanticAnalyzer {
+  public ShowCompactionsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    ctx.setResFile(ctx.getLocalTmpPath());
+    ShowCompactionsDesc desc = new ShowCompactionsDesc(ctx.getResFile());
+    Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
+    rootTasks.add(task);
+
+    task.setFetchSource(true);
+    setFetchTask(createFetchTask(ShowCompactionsDesc.SCHEMA));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsDesc.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.show.compactions;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.show.compactions;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/package-info.java
@@ -15,30 +15,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.process;
 
-import java.io.Serializable;
-import java.util.List;
-
-import org.apache.hadoop.hive.ql.ddl.DDLDesc;
-import org.apache.hadoop.hive.ql.plan.Explain;
-import org.apache.hadoop.hive.ql.plan.Explain.Level;
-
-/**
- * DDL task description for KILL QUERY commands.
- */
-@Explain(displayName = "Kill Query", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class KillQueriesDesc implements DDLDesc, Serializable {
-  private static final long serialVersionUID = 1L;
-
-  private List<String> queryIds;
-
-  public KillQueriesDesc(List<String> queryIds) {
-    this.queryIds = queryIds;
-  }
-
-  @Explain(displayName = "Query IDs", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-  public List<String> getQueryIds() {
-    return queryIds;
-  }
-}
+/** Show Compactions DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.process.show.compactions;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsAnalyzer.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.process.show.transactions;
+
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for show transactions commands.
+ */
+@DDLType(type=HiveParser.TOK_SHOW_TRANSACTIONS)
+public class ShowTransactionsAnalyzer extends BaseSemanticAnalyzer {
+  public ShowTransactionsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    ctx.setResFile(ctx.getLocalTmpPath());
+    ShowTransactionsDesc desc = new ShowTransactionsDesc(ctx.getResFile());
+    Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
+    rootTasks.add(task);
+
+    task.setFetchSource(true);
+    setFetchTask(createFetchTask(ShowTransactionsDesc.SCHEMA));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsDesc.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.show.transactions;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.process;
+package org.apache.hadoop.hive.ql.ddl.process.show.transactions;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/package-info.java
@@ -16,23 +16,5 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.process;
-
-import org.apache.hadoop.hive.ql.ddl.DDLOperation;
-import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-
-/**
- * Operation process of aborting transactions.
- */
-public class AbortTransactionsOperation extends DDLOperation<AbortTransactionsDesc> {
-  public AbortTransactionsOperation(DDLOperationContext context, AbortTransactionsDesc desc) {
-    super(context, desc);
-  }
-
-  @Override
-  public int execute() throws HiveException {
-    context.getDb().abortTransactions(desc.getTransactionIds());
-    return 0;
-  }
-}
+/** Show Transactions DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.process.show.transactions;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
@@ -134,9 +134,6 @@ public final class SemanticAnalyzerFactory {
       case HiveParser.TOK_SHOWPARTITIONS:
       case HiveParser.TOK_SHOWLOCKS:
       case HiveParser.TOK_SHOWDBLOCKS:
-      case HiveParser.TOK_SHOW_COMPACTIONS:
-      case HiveParser.TOK_SHOW_TRANSACTIONS:
-      case HiveParser.TOK_ABORT_TRANSACTIONS:
       case HiveParser.TOK_SHOWCONF:
       case HiveParser.TOK_SHOWVIEWS:
       case HiveParser.TOK_SHOWMATERIALIZEDVIEWS:
@@ -144,7 +141,6 @@ public final class SemanticAnalyzerFactory {
       case HiveParser.TOK_UNLOCKTABLE:
       case HiveParser.TOK_TRUNCATETABLE:
       case HiveParser.TOK_CACHE_METADATA:
-      case HiveParser.TOK_KILL_QUERY:
       case HiveParser.TOK_CREATE_RP:
       case HiveParser.TOK_SHOW_RP:
       case HiveParser.TOK_ALTER_RP:


### PR DESCRIPTION
DDLSemanticAnalyzer is a huge class, more than 4000 lines long. The goal is to refactor it in order to have everything cut into more handleable classes under the package  org.apache.hadoop.hive.ql.exec.ddl:

- have a separate class for each analyzers
- have a package for each operation, containing an analyzer, a description, and an operation, so the amount of classes under a package is more manageable

Step #4: extract all the process related analyzers from DDLSemanticAnalyzer, and move them under the new package.