### PR TITLE
HIVE-22228 SemanticAnalyzer cleanup - visibility + types

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/VerifyHiveSortedInputFormatUsedHook.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/hooks/VerifyHiveSortedInputFormatUsedHook.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hive.ql.hooks;
 
 import java.io.Serializable;
-import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Assert;
 
@@ -33,8 +33,7 @@ public class VerifyHiveSortedInputFormatUsedHook implements ExecuteWithHookConte
 
       // Go through the root tasks, and verify the input format of the map reduce task(s) is
       // HiveSortedInputFormat
-      ArrayList<Task<? extends Serializable>> rootTasks =
-          hookContext.getQueryPlan().getRootTasks();
+      List<Task<? extends Serializable>> rootTasks = hookContext.getQueryPlan().getRootTasks();
       for (Task<? extends Serializable> rootTask : rootTasks) {
         if (rootTask.getWork() instanceof MapredWork) {
           Assert.assertTrue("The root map reduce task's input was not marked as sorted.",

--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryPlan.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryPlan.java
@@ -76,18 +76,18 @@ public class QueryPlan implements Serializable {
   private String optimizedCBOPlan;
   private String optimizedQueryString;
 
-  private ArrayList<Task<? extends Serializable>> rootTasks;
+  private List<Task<? extends Serializable>> rootTasks;
   private FetchTask fetchTask;
   private final List<ReducerTimeStatsPerJob> reducerTimeStatsPerJobList;
 
-  private HashSet<ReadEntity> inputs;
+  private Set<ReadEntity> inputs;
   /**
    * Note: outputs are not all determined at compile time.
    * Some of the tasks can change the outputs at run time, because only at run
    * time, we know what are the changes.  These tasks should keep a reference
    * to the outputs here.
    */
-  private HashSet<WriteEntity> outputs;
+  private Set<WriteEntity> outputs;
   /**
    * Lineage information for the query.
    */
@@ -96,7 +96,7 @@ public class QueryPlan implements Serializable {
   private ColumnAccessInfo columnAccessInfo;
   private Schema resultSchema;
 
-  private HashMap<String, String> idToTableNameMap;
+  private Map<String, String> idToTableNameMap;
 
   private String queryId;
   private org.apache.hadoop.hive.ql.plan.api.Query query;
@@ -696,11 +696,11 @@ public class QueryPlan implements Serializable {
     return done;
   }
 
-  public ArrayList<Task<? extends Serializable>> getRootTasks() {
+  public List<Task<? extends Serializable>> getRootTasks() {
     return rootTasks;
   }
 
-  public void setRootTasks(ArrayList<Task<? extends Serializable>> rootTasks) {
+  public void setRootTasks(List<Task<? extends Serializable>> rootTasks) {
     this.rootTasks = rootTasks;
   }
 
@@ -716,7 +716,7 @@ public class QueryPlan implements Serializable {
     this.fetchTask = fetchTask;
   }
 
-  public HashSet<ReadEntity> getInputs() {
+  public Set<ReadEntity> getInputs() {
     return inputs;
   }
 
@@ -724,7 +724,7 @@ public class QueryPlan implements Serializable {
     this.inputs = inputs;
   }
 
-  public HashSet<WriteEntity> getOutputs() {
+  public Set<WriteEntity> getOutputs() {
     return outputs;
   }
 
@@ -736,11 +736,11 @@ public class QueryPlan implements Serializable {
     return resultSchema;
   }
 
-  public HashMap<String, String> getIdToTableNameMap() {
+  public Map<String, String> getIdToTableNameMap() {
     return idToTableNameMap;
   }
 
-  public void setIdToTableNameMap(HashMap<String, String> idToTableNameMap) {
+  public void setIdToTableNameMap(Map<String, String> idToTableNameMap) {
     this.idToTableNameMap = idToTableNameMap;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/GroupByOperator.java
@@ -273,7 +273,7 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
       }
     }
     // init aggregationParameterFields
-    ArrayList<AggregationDesc> aggrs = conf.getAggregators();
+    List<AggregationDesc> aggrs = conf.getAggregators();
     aggregationParameterFields = new ExprNodeEvaluator[aggrs.size()][];
     aggregationParameterObjectInspectors = new ObjectInspector[aggrs.size()][];
     aggregationParameterStandardObjectInspectors = new ObjectInspector[aggrs.size()][];
@@ -281,7 +281,7 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
     aggregationIsDistinct = new boolean[aggrs.size()];
     for (int i = 0; i < aggrs.size(); i++) {
       AggregationDesc aggr = aggrs.get(i);
-      ArrayList<ExprNodeDesc> parameters = aggr.getParameters();
+      List<ExprNodeDesc> parameters = aggr.getParameters();
       aggregationParameterFields[i] = new ExprNodeEvaluator[parameters.size()];
       aggregationParameterObjectInspectors[i] = new ObjectInspector[parameters
           .size()];
@@ -542,7 +542,7 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
     // 64 bytes is the overhead for a reference
     fixedRowSize = javaHashEntryOverHead;
 
-    ArrayList<ExprNodeDesc> keys = conf.getKeys();
+    List<ExprNodeDesc> keys = conf.getKeys();
 
     // Go over all the keys and get the size of the fields of fixed length. Keep
     // track of the variable length keys
@@ -1118,14 +1118,14 @@ public class GroupByOperator extends Operator<GroupByDesc> implements IConfigure
   public List<String> genColLists(
       HashMap<Operator<? extends OperatorDesc>, OpParseContext> opParseCtx) {
     List<String> colLists = new ArrayList<String>();
-    ArrayList<ExprNodeDesc> keys = conf.getKeys();
+    List<ExprNodeDesc> keys = conf.getKeys();
     for (ExprNodeDesc key : keys) {
       colLists = Utilities.mergeUniqElems(colLists, key.getCols());
     }
 
-    ArrayList<AggregationDesc> aggrs = conf.getAggregators();
+    List<AggregationDesc> aggrs = conf.getAggregators();
     for (AggregationDesc aggr : aggrs) {
-      ArrayList<ExprNodeDesc> params = aggr.getParameters();
+      List<ExprNodeDesc> params = aggr.getParameters();
       for (ExprNodeDesc param : params) {
         colLists = Utilities.mergeUniqElems(colLists, param.getCols());
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/LateralViewJoinOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/LateralViewJoinOperator.java
@@ -95,8 +95,8 @@ public class LateralViewJoinOperator extends Operator<LateralViewJoinDesc> {
   protected void initializeOp(Configuration hconf) throws HiveException {
     super.initializeOp(hconf);
 
-    ArrayList<ObjectInspector> ois = new ArrayList<ObjectInspector>();
-    ArrayList<String> fieldNames = conf.getOutputInternalColNames();
+    List<ObjectInspector> ois = new ArrayList<ObjectInspector>();
+    List<String> fieldNames = conf.getOutputInternalColNames();
 
     // The output of the lateral view join will be the columns from the select
     // parent, followed by the column from the UDTF parent
@@ -118,10 +118,10 @@ public class LateralViewJoinOperator extends Operator<LateralViewJoinDesc> {
   }
 
   // acc is short for accumulator. It's used to build the row before forwarding
-  ArrayList<Object> acc = new ArrayList<Object>();
+  List<Object> acc = new ArrayList<Object>();
   // selectObjs hold the row from the select op, until receiving a row from
   // the udtf op
-  ArrayList<Object> selectObjs = new ArrayList<Object>();
+  List<Object> selectObjs = new ArrayList<Object>();
 
   /**
    * An important assumption for processOp() is that for a given row from the

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/RowSchema.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/RowSchema.java
@@ -31,24 +31,24 @@ import java.util.Set;
 public class RowSchema implements Serializable {
 
   private static final long serialVersionUID = 1L;
-  private ArrayList<ColumnInfo> signature = new ArrayList<ColumnInfo>();
+  private List<ColumnInfo> signature = new ArrayList<ColumnInfo>();
 
   public RowSchema() {
   }
 
   public RowSchema(RowSchema that) {
-    this.signature = (ArrayList<ColumnInfo>) that.signature.clone();
+    this.signature = new ArrayList<>(that.signature);
   }
 
-  public RowSchema(ArrayList<ColumnInfo> signature) {
+  public RowSchema(List<ColumnInfo> signature) {
     this.signature = signature;
   }
 
-  public void setSignature(ArrayList<ColumnInfo> signature) {
+  public void setSignature(List<ColumnInfo> signature) {
     this.signature = signature;
   }
 
-  public ArrayList<ColumnInfo> getSignature() {
+  public List<ColumnInfo> getSignature() {
     return signature;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/NoOperatorReuseCheckerHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/NoOperatorReuseCheckerHook.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hive.ql.hooks;
 
 import java.io.Serializable;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -41,15 +40,11 @@ import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.MapredWork;
 import org.apache.hadoop.hive.ql.plan.ReduceWork;
 import org.apache.hadoop.hive.ql.plan.TezWork;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Checks whenever operator ids are not reused.
  */
 public class NoOperatorReuseCheckerHook implements ExecuteWithHookContext {
-
-  private static final Logger LOG = LoggerFactory.getLogger(NoOperatorReuseCheckerHook.class);
 
   static class UniqueOpIdChecker implements NodeProcessor {
 
@@ -74,7 +69,7 @@ public class NoOperatorReuseCheckerHook implements ExecuteWithHookContext {
 
     List<Node> rootOps = Lists.newArrayList();
 
-    ArrayList<Task<? extends Serializable>> roots = hookContext.getQueryPlan().getRootTasks();
+    List<Task<? extends Serializable>> roots = hookContext.getQueryPlan().getRootTasks();
     for (Task<? extends Serializable> task : roots) {
 
       Object work = task.getWork();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractBucketJoinProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/AbstractBucketJoinProc.java
@@ -191,21 +191,19 @@ abstract public class AbstractBucketJoinProc implements NodeProcessor {
       String baseBigAlias,
       List<String> joinAliases) throws SemanticException {
 
-    LinkedHashMap<String, List<Integer>> tblAliasToNumberOfBucketsInEachPartition =
+    Map<String, List<Integer>> tblAliasToNumberOfBucketsInEachPartition =
         new LinkedHashMap<String, List<Integer>>();
-    LinkedHashMap<String, List<List<String>>> tblAliasToBucketedFilePathsInEachPartition =
+    Map<String, List<List<String>>> tblAliasToBucketedFilePathsInEachPartition =
         new LinkedHashMap<String, List<List<String>>>();
 
-    HashMap<String, TableScanOperator> topOps = pGraphContext.getTopOps();
+    Map<String, TableScanOperator> topOps = pGraphContext.getTopOps();
 
-    HashMap<String, String> aliasToNewAliasMap = new HashMap<String, String>();
+    Map<String, String> aliasToNewAliasMap = new HashMap<String, String>();
 
     // (partition to bucket file names) and (partition to bucket number) for
     // the big table;
-    LinkedHashMap<Partition, List<String>> bigTblPartsToBucketFileNames =
-        new LinkedHashMap<Partition, List<String>>();
-    LinkedHashMap<Partition, Integer> bigTblPartsToBucketNumber =
-        new LinkedHashMap<Partition, Integer>();
+    Map<Partition, List<String>> bigTblPartsToBucketFileNames = new LinkedHashMap<Partition, List<String>>();
+    Map<Partition, Integer> bigTblPartsToBucketNumber = new LinkedHashMap<Partition, Integer>();
 
     Integer[] joinKeyOrder = null; // accessing order of join cols to bucket cols, should be same
     boolean bigTablePartitioned = true;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
@@ -139,14 +139,14 @@ public final class ColumnPrunerProcFactory {
       List<FieldNode> colLists = new ArrayList<>();
       GroupByDesc conf = gbOp.getConf();
 
-      ArrayList<ExprNodeDesc> keys = conf.getKeys();
+      List<ExprNodeDesc> keys = conf.getKeys();
       for (ExprNodeDesc key : keys) {
         colLists = mergeFieldNodesWithDesc(colLists, key);
       }
 
-      ArrayList<AggregationDesc> aggrs = conf.getAggregators();
+      List<AggregationDesc> aggrs = conf.getAggregators();
       for (AggregationDesc aggr : aggrs) {
-        ArrayList<ExprNodeDesc> params = aggr.getParameters();
+        List<ExprNodeDesc> params = aggr.getParameters();
         for (ExprNodeDesc param : params) {
           colLists = mergeFieldNodesWithDesc(colLists, param);
         }
@@ -812,10 +812,10 @@ public final class ColumnPrunerProcFactory {
         }
       }
       if (cols.size() < originalOutputColumnNames.size()) {
-        ArrayList<ExprNodeDesc> newColList = new ArrayList<ExprNodeDesc>();
-        ArrayList<String> newOutputColumnNames = new ArrayList<String>();
-        ArrayList<ColumnInfo> rs_oldsignature = op.getSchema().getSignature();
-        ArrayList<ColumnInfo> rs_newsignature = new ArrayList<ColumnInfo>();
+        List<ExprNodeDesc> newColList = new ArrayList<ExprNodeDesc>();
+        List<String> newOutputColumnNames = new ArrayList<String>();
+        List<ColumnInfo> rs_oldsignature = op.getSchema().getSignature();
+        List<ColumnInfo> rs_newsignature = new ArrayList<ColumnInfo>();
         // The pruning needs to preserve the order of columns in the input schema
         Set<String> colNames = new HashSet<String>();
         for (FieldNode col : cols) {
@@ -899,8 +899,8 @@ public final class ColumnPrunerProcFactory {
     Map<String, ExprNodeDesc> oldMap = reduce.getColumnExprMap();
     LOG.info("RS " + reduce.getIdentifier() + " oldColExprMap: " + oldMap);
     RowSchema oldRS = reduce.getSchema();
-    ArrayList<ColumnInfo> old_signature = oldRS.getSignature();
-    ArrayList<ColumnInfo> signature = new ArrayList<ColumnInfo>(old_signature);
+    List<ColumnInfo> old_signature = oldRS.getSignature();
+    List<ColumnInfo> signature = new ArrayList<ColumnInfo>(old_signature);
 
     List<String> valueColNames = reduceConf.getOutputValueColumnNames();
     ArrayList<String> newValueColNames = new ArrayList<String>();
@@ -1071,8 +1071,8 @@ public final class ColumnPrunerProcFactory {
       throws SemanticException {
     RowSchema inputSchema = op.getSchema();
     if (inputSchema != null) {
-      ArrayList<FieldNode> rs = new ArrayList<>();
-      ArrayList<ColumnInfo> inputCols = inputSchema.getSignature();
+      List<FieldNode> rs = new ArrayList<>();
+      List<ColumnInfo> inputCols = inputSchema.getSignature();
       for (ColumnInfo i: inputCols) {
         FieldNode fn = lookupColumn(cols, i.getInternalName());
         if (fn != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcCtx.java
@@ -36,10 +36,8 @@ import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.exec.LimitOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
-import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.RowSchema;
 import org.apache.hadoop.hive.ql.exec.UnionOperator;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
@@ -136,7 +134,7 @@ public class ConstantPropagateProcCtx implements NodeProcessorCtx {
       return constants;
     }
 
-    ArrayList<ColumnInfo> signature = op.getSchema().getSignature();
+    List<ColumnInfo> signature = op.getSchema().getSignature();
     if (op instanceof LimitOperator || op instanceof FilterOperator) {
       // there should be only one parent.
       if (op.getParentOperators().size() == 1) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
@@ -1120,7 +1120,7 @@ public final class ConstantPropagateProcFactory {
       }
 
       GroupByDesc conf = op.getConf();
-      ArrayList<ExprNodeDesc> keys = conf.getKeys();
+      List<ExprNodeDesc> keys = conf.getKeys();
       for (int i = 0; i < keys.size(); i++) {
         ExprNodeDesc key = keys.get(i);
         ExprNodeDesc newkey = foldExpr(key, colToConstants, cppCtx, op, 0, false);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/CountDistinctRewriteProc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/CountDistinctRewriteProc.java
@@ -142,7 +142,7 @@ public class CountDistinctRewriteProc extends Transform {
         GroupByOperator rGby) {
       // Position of distinct column in aggregator list of map Gby before rewrite.
       int indexOfDist = -1;
-      ArrayList<ExprNodeDesc> keys = mGby.getConf().getKeys();
+      List<ExprNodeDesc> keys = mGby.getConf().getKeys();
       if (!(mGby.getConf().getMode() == GroupByDesc.Mode.HASH
           && !mGby.getConf().isGroupingSetsPresent() && rs.getConf().getKeyCols().size() == 1
           && rs.getConf().getPartitionCols().size() == 0

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -1305,7 +1305,7 @@ public final class GenMapRedUtils {
     DynamicPartitionCtx dpCtx = fsInputDesc.getDynPartCtx();
     if (dpCtx != null && dpCtx.getNumDPCols() > 0) {
       // adding DP ColumnInfo to the RowSchema signature
-      ArrayList<ColumnInfo> signature = inputRS.getSignature();
+      List<ColumnInfo> signature = inputRS.getSignature();
       String tblAlias = fsInputDesc.getTableInfo().getTableName();
       for (String dpCol : dpCtx.getDPColNames()) {
         ColumnInfo colInfo = new ColumnInfo(dpCol,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SamplePruner.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
-import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.lib.DefaultGraphWalker;
 import org.apache.hadoop.hive.ql.lib.DefaultRuleDispatcher;
 import org.apache.hadoop.hive.ql.lib.Dispatcher;
@@ -63,17 +62,17 @@ public class SamplePruner extends Transform {
    *
    */
   public static class SamplePrunerCtx implements NodeProcessorCtx {
-    HashMap<TableScanOperator, SampleDesc> opToSamplePruner;
+    Map<TableScanOperator, SampleDesc> opToSamplePruner;
 
     public SamplePrunerCtx(
-        HashMap<TableScanOperator, SampleDesc> opToSamplePruner) {
+        Map<TableScanOperator, SampleDesc> opToSamplePruner) {
       this.opToSamplePruner = opToSamplePruner;
     }
 
     /**
      * @return the opToSamplePruner
      */
-    public HashMap<TableScanOperator, SampleDesc> getOpToSamplePruner() {
+    public Map<TableScanOperator, SampleDesc> getOpToSamplePruner() {
       return opToSamplePruner;
     }
 
@@ -102,8 +101,7 @@ public class SamplePruner extends Transform {
   public ParseContext transform(ParseContext pctx) throws SemanticException {
 
     // create a the context for walking operators
-    SamplePrunerCtx samplePrunerCtx = new SamplePrunerCtx(pctx
-        .getOpToSamplePruner());
+    SamplePrunerCtx samplePrunerCtx = new SamplePrunerCtx(pctx.getOpToSamplePruner());
 
     Map<Rule, NodeProcessor> opRules = new LinkedHashMap<Rule, NodeProcessor>();
     opRules.put(new RuleRegExp("R1",

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/HiveOpConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/HiveOpConverter.java
@@ -498,7 +498,7 @@ public class HiveOpConverter {
       List<String> keepColumns = new ArrayList<String>();
       final ImmutableBitSet sortColsPos = sortColsPosBuilder.build();
       final ImmutableBitSet sortOutputColsPos = sortOutputColsPosBuilder.build();
-      final ArrayList<ColumnInfo> inputSchema = inputOp.getSchema().getSignature();
+      final List<ColumnInfo> inputSchema = inputOp.getSchema().getSignature();
       for (int pos=0; pos<inputSchema.size(); pos++) {
         if ((sortColsPos.get(pos) && sortOutputColsPos.get(pos)) ||
                 (!sortColsPos.get(pos) && !sortOutputColsPos.get(pos))) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/lineage/OpProcFactory.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.optimizer.lineage;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -320,7 +319,7 @@ public class OpProcFactory {
       LateralViewJoinOperator op = (LateralViewJoinOperator)nd;
       boolean isUdtfPath = true;
       Operator<? extends OperatorDesc> inpOp = getParent(stack);
-      ArrayList<ColumnInfo> cols = inpOp.getSchema().getSignature();
+      List<ColumnInfo> cols = inpOp.getSchema().getSignature();
       lCtx.getIndex().copyPredicates(inpOp, op);
 
       if (inpOp instanceof SelectOperator) {
@@ -331,7 +330,7 @@ public class OpProcFactory {
       // For the select path the columns are the ones at the beginning of the
       // current operators schema and for the udtf path the columns are
       // at the end of the operator schema.
-      ArrayList<ColumnInfo> out_cols = op.getSchema().getSignature();
+      List<ColumnInfo> out_cols = op.getSchema().getSignature();
       int out_cols_size = out_cols.size();
       int cols_size = cols.size();
       int outColOffset = isUdtfPath ? out_cols_size - cols_size : 0;
@@ -376,7 +375,7 @@ public class OpProcFactory {
       lctx.getIndex().copyPredicates(inpOp, sop);
 
       RowSchema rs = sop.getSchema();
-      ArrayList<ColumnInfo> col_infos = rs.getSignature();
+      List<ColumnInfo> col_infos = rs.getSignature();
       int cnt = 0;
       for(ExprNodeDesc expr : sop.getConf().getColList()) {
         Dependency dep = ExprProcFactory.getExprDependency(lctx, inpOp, expr, outputMap);
@@ -417,7 +416,7 @@ public class OpProcFactory {
 
       LineageCtx lctx = (LineageCtx)procCtx;
       GroupByOperator gop = (GroupByOperator)nd;
-      ArrayList<ColumnInfo> col_infos = gop.getSchema().getSignature();
+      List<ColumnInfo> col_infos = gop.getSchema().getSignature();
       Operator<? extends OperatorDesc> inpOp = getParent(stack);
       lctx.getIndex().copyPredicates(inpOp, gop);
       int cnt = 0;
@@ -551,7 +550,7 @@ public class OpProcFactory {
       Operator<? extends OperatorDesc> inpOp = getParent(stack);
       lCtx.getIndex().copyPredicates(inpOp, op);
       RowSchema rs = op.getSchema();
-      ArrayList<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
+      List<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
 
       // check only for input cols
       for(ColumnInfo input : inp_cols) {
@@ -596,7 +595,7 @@ public class OpProcFactory {
       }
 
       if (op instanceof GroupByOperator) {
-        ArrayList<ColumnInfo> col_infos = rop.getSchema().getSignature();
+        List<ColumnInfo> col_infos = rop.getSchema().getSignature();
         for(ExprNodeDesc expr : rop.getConf().getKeyCols()) {
           lCtx.getIndex().putDependency(rop, col_infos.get(cnt++),
               ExprProcFactory.getExprDependency(lCtx, inpOp, expr, outputMap));
@@ -666,7 +665,7 @@ public class OpProcFactory {
         lCtx.getIndex().addPredicate(fop, cond);
       }
 
-      ArrayList<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
+      List<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
       int cnt = 0;
       for(ColumnInfo ci : rs.getSignature()) {
         lCtx.getIndex().putDependency(fop, ci,
@@ -700,7 +699,7 @@ public class OpProcFactory {
       Operator<? extends OperatorDesc> inpOp = getParent(stack);
       lCtx.getIndex().copyPredicates(inpOp, op);
       RowSchema rs = op.getSchema();
-      ArrayList<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
+      List<ColumnInfo> inp_cols = inpOp.getSchema().getSignature();
       int cnt = 0;
       for(ColumnInfo ci : rs.getSignature()) {
         lCtx.getIndex().putDependency(op, ci,

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -3177,7 +3177,7 @@ public class Vectorizer implements PhysicalPlanResolver {
     }
 
 
-    ArrayList<ExprNodeDesc> parameters = aggDesc.getParameters();
+    List<ExprNodeDesc> parameters = aggDesc.getParameters();
 
     if (parameters != null && !validateExprNodeDesc(parameters, "Aggregation Function UDF " + udfName + " parameter")) {
       return false;
@@ -4603,7 +4603,7 @@ public class Vectorizer implements PhysicalPlanResolver {
     // For now, we don't support group by on DECIMAL_64 keys.
     VectorExpression[] vecKeyExpressions =
         vContext.getVectorExpressionsUpConvertDecimal64(keysDesc);
-    ArrayList<AggregationDesc> aggrDesc = groupByDesc.getAggregators();
+    List<AggregationDesc> aggrDesc = groupByDesc.getAggregators();
     final int size = aggrDesc.size();
 
     VectorAggregationDesc[] vecAggrDescs = new VectorAggregationDesc[size];
@@ -4820,7 +4820,7 @@ public class Vectorizer implements PhysicalPlanResolver {
     List<WindowFunctionDef> windowsFunctions = windowTableFunctionDef.getWindowFunctions();
     final int functionCount = windowsFunctions.size();
 
-    ArrayList<ColumnInfo> outputSignature = ptfOp.getSchema().getSignature();
+    List<ColumnInfo> outputSignature = ptfOp.getSchema().getSignature();
     final int outputSize = outputSignature.size();
 
     /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/OpWalkerCtx.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/OpWalkerCtx.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.optimizer.ppr;
 
-import java.util.HashMap;
+import java.util.Map;
 
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
@@ -34,16 +34,16 @@ public class OpWalkerCtx implements NodeProcessorCtx {
    * Map from tablescan operator to partition pruning predicate that is
    * initialized from the ParseContext.
    */
-  private final HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner;
+  private final Map<TableScanOperator, ExprNodeDesc> opToPartPruner;
 
   /**
    * Constructor.
    */
-  public OpWalkerCtx(HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner) {
+  public OpWalkerCtx(Map<TableScanOperator, ExprNodeDesc> opToPartPruner) {
     this.opToPartPruner = opToPartPruner;
   }
 
-  public HashMap<TableScanOperator, ExprNodeDesc> getOpToPartPruner() {
+  public Map<TableScanOperator, ExprNodeDesc> getOpToPartPruner() {
     return opToPartPruner;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -127,7 +127,7 @@ public abstract class BaseSemanticAnalyzer {
 
   protected CompilationOpContext cContext;
   protected Context ctx;
-  protected HashMap<String, String> idToTableNameMap;
+  protected Map<String, String> idToTableNameMap;
   protected QueryProperties queryProperties;
 
   /**
@@ -147,11 +147,11 @@ public abstract class BaseSemanticAnalyzer {
   /**
    * ReadEntities that are passed to the hooks.
    */
-  protected HashSet<ReadEntity> inputs;
+  protected Set<ReadEntity> inputs;
   /**
    * List of WriteEntities that are passed to the hooks.
    */
-  protected HashSet<WriteEntity> outputs;
+  protected Set<WriteEntity> outputs;
   /**
    * Lineage information for the query.
    */
@@ -266,7 +266,7 @@ public abstract class BaseSemanticAnalyzer {
     }
   }
 
-  public HashMap<String, String> getIdToTableNameMap() {
+  public Map<String, String> getIdToTableNameMap() {
     return idToTableNameMap;
   }
 
@@ -656,11 +656,11 @@ public abstract class BaseSemanticAnalyzer {
     return str.substring(0, i) + replacement + str.substring(i + length);
   }
 
-  public HashSet<ReadEntity> getInputs() {
+  public Set<ReadEntity> getInputs() {
     return inputs;
   }
 
-  public HashSet<WriteEntity> getOutputs() {
+  public Set<WriteEntity> getOutputs() {
     return outputs;
   }
 
@@ -1943,7 +1943,7 @@ public abstract class BaseSemanticAnalyzer {
         }
         break;
       case HiveParser.TOK_TABCOLVALUE_PAIR:
-        ArrayList<Node> vLNodes = vAstNode.getChildren();
+        List<Node> vLNodes = vAstNode.getChildren();
         for (Node node : vLNodes) {
           if ( ((ASTNode) node).getToken().getType() != HiveParser.TOK_TABCOLVALUES) {
             throw new SemanticException(
@@ -2239,11 +2239,11 @@ public abstract class BaseSemanticAnalyzer {
     return rootTasks;
   }
 
-  public HashSet<ReadEntity> getAllInputs() {
+  public Set<ReadEntity> getAllInputs() {
     return inputs;
   }
 
-  public HashSet<WriteEntity> getAllOutputs() {
+  public Set<WriteEntity> getAllOutputs() {
     return outputs;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1604,8 +1604,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
   // SemanticAnalyzer
   Operator<?> handleInsertStatement(String dest, Operator<?> input, RowResolver inputRR, QB qb)
       throws SemanticException {
-    ArrayList<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
-    ArrayList<ColumnInfo> columns = inputRR.getColumnInfos();
+    List<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
+    List<ColumnInfo> columns = inputRR.getColumnInfos();
     for (int i = 0; i < columns.size(); i++) {
       ColumnInfo col = columns.get(i);
       colList.add(new ExprNodeColumnDesc(col));
@@ -1614,7 +1614,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
     RowResolver out_rwsch = handleInsertStatementSpec(colList, dest, inputRR, qb, selExprList);
 
-    ArrayList<String> columnNames = new ArrayList<String>();
+    List<String> columnNames = new ArrayList<String>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     for (int i = 0; i < colList.size(); i++) {
       String outputCol = getColumnInternalName(i);
@@ -2493,8 +2493,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
       // SetOp Rel
       RowResolver leftRR = this.relToHiveRR.get(leftRel);
       RowResolver rightRR = this.relToHiveRR.get(rightRel);
-      HashMap<String, ColumnInfo> leftmap = leftRR.getFieldMap(leftalias);
-      HashMap<String, ColumnInfo> rightmap = rightRR.getFieldMap(rightalias);
+      Map<String, ColumnInfo> leftmap = leftRR.getFieldMap(leftalias);
+      Map<String, ColumnInfo> rightmap = rightRR.getFieldMap(rightalias);
 
       // 2. Validate that SetOp is feasible according to Hive (by using type
       // info from RR)
@@ -3677,7 +3677,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
           GenericUDAFEvaluator genericUDAFEvaluator = null;
           if (aggName.toLowerCase().equals(FunctionRegistry.LEAD_FUNC_NAME)
               || aggName.toLowerCase().equals(FunctionRegistry.LAG_FUNC_NAME)) {
-            ArrayList<ObjectInspector> originalParameterTypeInfos = SemanticAnalyzer
+            List<ObjectInspector> originalParameterTypeInfos = SemanticAnalyzer
                 .getWritableObjectInspector(aggParameters);
             genericUDAFEvaluator = FunctionRegistry.getGenericWindowingEvaluator(aggName,
                 originalParameterTypeInfos, isDistinct, isAllColumns);
@@ -3762,7 +3762,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       }
 
       List<ASTNode> grpByAstExprs = getGroupByForClause(qbp, detsClauseName);
-      HashMap<String, ASTNode> aggregationTrees = qbp.getAggregationExprsForClause(detsClauseName);
+      Map<String, ASTNode> aggregationTrees = qbp.getAggregationExprsForClause(detsClauseName);
       boolean hasGrpByAstExprs = (grpByAstExprs != null && !grpByAstExprs.isEmpty()) ? true : false;
       boolean hasAggregationTrees = (aggregationTrees != null && !aggregationTrees.isEmpty()) ? true
           : false;
@@ -4818,11 +4818,11 @@ public class CalcitePlanner extends SemanticAnalyzer {
       // ObjectInspector that can be used to initialize the UDTF. Then, the
       // resulting output object inspector can be used to make the RowResolver
       // for the UDTF operator
-      ArrayList<ColumnInfo> inputCols = selectRR.getColumnInfos();
+      List<ColumnInfo> inputCols = selectRR.getColumnInfos();
 
       // Create the object inspector for the input columns and initialize the
       // UDTF
-      ArrayList<String> colNames = new ArrayList<String>();
+      List<String> colNames = new ArrayList<String>();
       ObjectInspector[] colOIs = new ObjectInspector[inputCols.size()];
       for (int i = 0; i < inputCols.size(); i++) {
         colNames.add(inputCols.get(i).getInternalName());
@@ -4848,7 +4848,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       }
 
       // Generate the output column info's / row resolver using internal names.
-      ArrayList<ColumnInfo> udtfCols = new ArrayList<ColumnInfo>();
+      List<ColumnInfo> udtfCols = new ArrayList<ColumnInfo>();
 
       Iterator<String> colAliasesIter = colAliases.iterator();
       for (StructField sf : outputOI.getAllStructFieldRefs()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsAutoGatherContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsAutoGatherContext.java
@@ -234,12 +234,12 @@ public class ColumnStatsAutoGatherContext {
   private void replaceSelectOperatorProcess(SelectOperator operator, Operator<? extends OperatorDesc> input)
       throws HiveException {
     RowSchema selRS = operator.getSchema();
-    ArrayList<ColumnInfo> signature = new ArrayList<>();
+    List<ColumnInfo> signature = new ArrayList<>();
     OpParseContext inputCtx = sa.opParseCtx.get(input);
     RowResolver inputRR = inputCtx.getRowResolver();
-    ArrayList<ColumnInfo> columns = inputRR.getColumnInfos();
-    ArrayList<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> columnNames = new ArrayList<String>();
+    List<ColumnInfo> columns = inputRR.getColumnInfos();
+    List<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
+    List<String> columnNames = new ArrayList<String>();
     Map<String, ExprNodeDesc> columnExprMap =
         new HashMap<String, ExprNodeDesc>();
     // the column positions in the operator should be like this

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/EximUtil.java
@@ -57,11 +57,11 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.StringTokenizer;
 
 /**
@@ -91,8 +91,8 @@ public class EximUtil {
   public static class SemanticAnalyzerWrapperContext {
     private HiveConf conf;
     private Hive db;
-    private HashSet<ReadEntity> inputs;
-    private HashSet<WriteEntity> outputs;
+    private Set<ReadEntity> inputs;
+    private Set<WriteEntity> outputs;
     private List<Task<? extends Serializable>> tasks;
     private Logger LOG;
     private Context ctx;
@@ -107,11 +107,11 @@ public class EximUtil {
       return db;
     }
 
-    public HashSet<ReadEntity> getInputs() {
+    public Set<ReadEntity> getInputs() {
       return inputs;
     }
 
-    public HashSet<WriteEntity> getOutputs() {
+    public Set<WriteEntity> getOutputs() {
       return outputs;
     }
 
@@ -136,8 +136,8 @@ public class EximUtil {
     }
 
     public SemanticAnalyzerWrapperContext(HiveConf conf, Hive db,
-                                          HashSet<ReadEntity> inputs,
-                                          HashSet<WriteEntity> outputs,
+                                          Set<ReadEntity> inputs,
+                                          Set<WriteEntity> outputs,
                                           List<Task<? extends Serializable>> tasks,
                                           Logger LOG, Context ctx){
       this.conf = conf;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -24,11 +24,10 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
+import java.util.Set;
 
 import org.antlr.runtime.tree.Tree;
 import org.apache.commons.codec.DecoderException;
@@ -42,7 +41,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.StrictChecks;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
@@ -390,8 +388,7 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     }
 
     Task<?> childTask = TaskFactory.get(
-        new MoveWork(getInputs(), getOutputs(), loadTableWork, null, true,
-            isLocal)
+        new MoveWork(getInputs(), getOutputs(), loadTableWork, null, true, isLocal)
     );
 
     rootTasks.add(childTask);
@@ -558,7 +555,7 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
   }
 
   @Override
-  public HashSet<WriteEntity> getAllOutputs() {
+  public Set<WriteEntity> getAllOutputs() {
     return outputs;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
@@ -841,9 +841,9 @@ public class PTFTranslator {
    */
   public static StructObjectInspector getStandardStructOI(RowResolver rr) {
     StructObjectInspector oi;
-    ArrayList<ColumnInfo> colLists = rr.getColumnInfos();
-    ArrayList<String> structFieldNames = new ArrayList<String>();
-    ArrayList<ObjectInspector> structFieldObjectInspectors = new ArrayList<ObjectInspector>();
+    List<ColumnInfo> colLists = rr.getColumnInfos();
+    List<String> structFieldNames = new ArrayList<String>();
+    List<ObjectInspector> structFieldObjectInspectors = new ArrayList<ObjectInspector>();
     for (ColumnInfo columnInfo : colLists) {
       String colName = columnInfo.getInternalName();
       ObjectInspector colOI = columnInfo.getObjectInspector();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseContext.java
@@ -76,23 +76,23 @@ import java.util.Set;
 
 public class ParseContext {
 
-  private HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner;
-  private HashMap<TableScanOperator, PrunedPartitionList> opToPartList;
-  private HashMap<TableScanOperator, SampleDesc> opToSamplePruner;
+  private Map<TableScanOperator, ExprNodeDesc> opToPartPruner;
+  private Map<TableScanOperator, PrunedPartitionList> opToPartList;
+  private Map<TableScanOperator, SampleDesc> opToSamplePruner;
   private Map<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner;
-  private HashMap<String, TableScanOperator> topOps;
+  private Map<String, TableScanOperator> topOps;
   private Set<JoinOperator> joinOps;
   private Set<MapJoinOperator> mapJoinOps;
   private Set<SMBMapJoinOperator> smbMapJoinOps;
   private List<ReduceSinkOperator> reduceSinkOperatorsAddedByEnforceBucketingSorting;
-  private HashMap<String, SplitSample> nameToSplitSample;
+  private Map<String, SplitSample> nameToSplitSample;
   private List<LoadTableDesc> loadTableWork;
   private List<LoadFileDesc> loadFileWork;
   private List<ColumnStatsAutoGatherContext> columnStatsAutoGatherContexts;
   private Context ctx;
   private QueryState queryState;
   private HiveConf conf;
-  private HashMap<String, String> idToTableNameMap;
+  private Map<String, String> idToTableNameMap;
   private int destTableId;
   private UnionProcContext uCtx;
   private List<AbstractMapJoinOperator<? extends MapJoinDesc>> listMapJoinOpsNoReducer; // list of map join
@@ -109,7 +109,7 @@ public class ParseContext {
 
   private GlobalLimitCtx globalLimitCtx;
 
-  private HashSet<ReadEntity> semanticInputs;
+  private Set<ReadEntity> semanticInputs;
   private List<Task<? extends Serializable>> rootTasks;
 
   private FetchTask fetchTask;
@@ -132,10 +132,8 @@ public class ParseContext {
 
   private Map<ReduceSinkOperator, RuntimeValuesInfo> rsToRuntimeValuesInfo =
           new LinkedHashMap<ReduceSinkOperator, RuntimeValuesInfo>();
-  private Map<ReduceSinkOperator, SemiJoinBranchInfo> rsToSemiJoinBranchInfo =
-          new HashMap<>();
-  private Map<ExprNodeDesc, GroupByOperator> colExprToGBMap =
-          new HashMap<>();
+  private Map<ReduceSinkOperator, SemiJoinBranchInfo> rsToSemiJoinBranchInfo = new HashMap<>();
+  private Map<ExprNodeDesc, GroupByOperator> colExprToGBMap = new HashMap<>();
 
   private Map<String, List<SemiJoinHint>> semiJoinHints;
   private boolean disableMapJoin;
@@ -180,21 +178,21 @@ public class ParseContext {
    */
   public ParseContext(
       QueryState queryState,
-      HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner,
-      HashMap<TableScanOperator, PrunedPartitionList> opToPartList,
-      HashMap<String, TableScanOperator> topOps,
+      Map<TableScanOperator, ExprNodeDesc> opToPartPruner,
+      Map<TableScanOperator, PrunedPartitionList> opToPartList,
+      Map<String, TableScanOperator> topOps,
       Set<JoinOperator> joinOps,
       Set<SMBMapJoinOperator> smbMapJoinOps,
       List<LoadTableDesc> loadTableWork, List<LoadFileDesc> loadFileWork,
       List<ColumnStatsAutoGatherContext> columnStatsAutoGatherContexts,
-      Context ctx, HashMap<String, String> idToTableNameMap, int destTableId,
+      Context ctx, Map<String, String> idToTableNameMap, int destTableId,
       UnionProcContext uCtx, List<AbstractMapJoinOperator<? extends MapJoinDesc>> listMapJoinOpsNoReducer,
       Map<String, PrunedPartitionList> prunedPartitions,
       Map<String, Table> tabNameToTabObject,
-      HashMap<TableScanOperator, SampleDesc> opToSamplePruner,
+      Map<TableScanOperator, SampleDesc> opToSamplePruner,
       GlobalLimitCtx globalLimitCtx,
-      HashMap<String, SplitSample> nameToSplitSample,
-      HashSet<ReadEntity> semanticInputs, List<Task<? extends Serializable>> rootTasks,
+      Map<String, SplitSample> nameToSplitSample,
+      Set<ReadEntity> semanticInputs, List<Task<? extends Serializable>> rootTasks,
       Map<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner,
       Map<String, ReadEntity> viewAliasToInput,
       List<ReduceSinkOperator> reduceSinkOperatorsAddedByEnforceBucketingSorting,
@@ -292,7 +290,7 @@ public class ParseContext {
   /**
    * @return the opToPartPruner
    */
-  public HashMap<TableScanOperator, ExprNodeDesc> getOpToPartPruner() {
+  public Map<TableScanOperator, ExprNodeDesc> getOpToPartPruner() {
     return opToPartPruner;
   }
 
@@ -300,12 +298,11 @@ public class ParseContext {
    * @param opToPartPruner
    *          the opToPartPruner to set
    */
-  public void setOpToPartPruner(
-      HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner) {
+  public void setOpToPartPruner(Map<TableScanOperator, ExprNodeDesc> opToPartPruner) {
     this.opToPartPruner = opToPartPruner;
   }
 
-  public HashMap<TableScanOperator, PrunedPartitionList> getOpToPartList() {
+  public Map<TableScanOperator, PrunedPartitionList> getOpToPartList() {
     return opToPartList;
   }
 
@@ -322,7 +319,7 @@ public class ParseContext {
   /**
    * @return the topOps
    */
-  public HashMap<String, TableScanOperator> getTopOps() {
+  public Map<String, TableScanOperator> getTopOps() {
     return topOps;
   }
 
@@ -330,15 +327,15 @@ public class ParseContext {
    * @param topOps
    *          the topOps to set
    */
-  public void setTopOps(HashMap<String, TableScanOperator> topOps) {
+  public void setTopOps(Map<String, TableScanOperator> topOps) {
     this.topOps = topOps;
   }
 
-  public HashMap<String, SplitSample> getNameToSplitSample() {
+  public Map<String, SplitSample> getNameToSplitSample() {
     return nameToSplitSample;
   }
 
-  public void setNameToSplitSample(HashMap<String, SplitSample> nameToSplitSample) {
+  public void setNameToSplitSample(Map<String, SplitSample> nameToSplitSample) {
     this.nameToSplitSample = nameToSplitSample;
   }
 
@@ -364,11 +361,11 @@ public class ParseContext {
     this.loadFileWork = loadFileWork;
   }
 
-  public HashMap<String, String> getIdToTableNameMap() {
+  public Map<String, String> getIdToTableNameMap() {
     return idToTableNameMap;
   }
 
-  public void setIdToTableNameMap(HashMap<String, String> idToTableNameMap) {
+  public void setIdToTableNameMap(Map<String, String> idToTableNameMap) {
     this.idToTableNameMap = idToTableNameMap;
   }
 
@@ -422,7 +419,7 @@ public class ParseContext {
   /**
    * @return the opToSamplePruner
    */
-  public HashMap<TableScanOperator, SampleDesc> getOpToSamplePruner() {
+  public Map<TableScanOperator, SampleDesc> getOpToSamplePruner() {
     return opToSamplePruner;
   }
 
@@ -431,7 +428,7 @@ public class ParseContext {
    *          the opToSamplePruner to set
    */
   public void setOpToSamplePruner(
-      HashMap<TableScanOperator, SampleDesc> opToSamplePruner) {
+      Map<TableScanOperator, SampleDesc> opToSamplePruner) {
     this.opToSamplePruner = opToSamplePruner;
   }
 
@@ -507,7 +504,7 @@ public class ParseContext {
     this.globalLimitCtx = globalLimitCtx;
   }
 
-  public HashSet<ReadEntity> getSemanticInputs() {
+  public Set<ReadEntity> getSemanticInputs() {
     return semanticInputs;
   }
 
@@ -551,8 +548,7 @@ public class ParseContext {
    * @param opToPartToSkewedPruner
    *          the opToSkewedPruner to set
    */
-  public void setOpPartToSkewedPruner(
-      HashMap<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner) {
+  public void setOpPartToSkewedPruner(Map<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner) {
     this.opToPartToSkewedPruner = opToPartToSkewedPruner;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBJoinTree.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBJoinTree.java
@@ -53,22 +53,22 @@ public class QBJoinTree implements Serializable, Cloneable {
 
   // keeps track of the right-hand-side table name of the left-semi-join, and
   // its list of join keys
-  private transient final HashMap<String, ArrayList<ASTNode>> rhsSemijoin;
+  private transient final Map<String, List<ASTNode>> rhsSemijoin;
 
   // join conditions
-  private transient ArrayList<ArrayList<ASTNode>> expressions;
+  private transient List<List<ASTNode>> expressions;
 
   // key index to nullsafe join flag
-  private ArrayList<Boolean> nullsafes;
+  private List<Boolean> nullsafes;
 
   // filters
-  private transient ArrayList<ArrayList<ASTNode>> filters;
+  private transient List<List<ASTNode>> filters;
 
   // outerjoin-pos = other-pos:filter-len, other-pos:filter-len, ...
   private int[][] filterMap;
 
   // filters for pushing
-  private transient ArrayList<ArrayList<ASTNode>> filtersForPushing;
+  private transient List<List<ASTNode>> filtersForPushing;
 
   // user asked for map-side join
   private boolean mapSideJoin;
@@ -93,7 +93,7 @@ public class QBJoinTree implements Serializable, Cloneable {
     nextTag = 0;
     noOuterJoin = true;
     noSemiJoin = true;
-    rhsSemijoin = new HashMap<String, ArrayList<ASTNode>>();
+    rhsSemijoin = new HashMap<String, List<ASTNode>>();
     aliasToOpInfo = new HashMap<String, Operator<? extends OperatorDesc>>();
     postJoinFilters = new ArrayList<ASTNode>();
   }
@@ -137,11 +137,11 @@ public class QBJoinTree implements Serializable, Cloneable {
     this.leftAliases = leftAliases;
   }
 
-  public ArrayList<ArrayList<ASTNode>> getExpressions() {
+  public List<List<ASTNode>> getExpressions() {
     return expressions;
   }
 
-  public void setExpressions(ArrayList<ArrayList<ASTNode>> expressions) {
+  public void setExpressions(List<List<ASTNode>> expressions) {
     this.expressions = expressions;
   }
 
@@ -192,7 +192,7 @@ public class QBJoinTree implements Serializable, Cloneable {
   /**
    * @return the filters
    */
-  public ArrayList<ArrayList<ASTNode>> getFilters() {
+  public List<List<ASTNode>> getFilters() {
     return filters;
   }
 
@@ -200,14 +200,14 @@ public class QBJoinTree implements Serializable, Cloneable {
    * @param filters
    *          the filters to set
    */
-  public void setFilters(ArrayList<ArrayList<ASTNode>> filters) {
+  public void setFilters(List<List<ASTNode>> filters) {
     this.filters = filters;
   }
 
   /**
    * @return the filters for pushing
    */
-  public ArrayList<ArrayList<ASTNode>> getFiltersForPushing() {
+  public List<List<ASTNode>> getFiltersForPushing() {
     return filtersForPushing;
   }
 
@@ -215,7 +215,7 @@ public class QBJoinTree implements Serializable, Cloneable {
    * @param filters for pushing
    *          the filters to set
    */
-  public void setFiltersForPushing(ArrayList<ArrayList<ASTNode>> filters) {
+  public void setFiltersForPushing(List<List<ASTNode>> filters) {
     this.filtersForPushing = filters;
   }
 
@@ -275,8 +275,8 @@ public class QBJoinTree implements Serializable, Cloneable {
    * @param alias
    * @param columns
    */
-  public void addRHSSemijoinColumns(String alias, ArrayList<ASTNode> columns) {
-    ArrayList<ASTNode> cols = rhsSemijoin.get(alias);
+  public void addRHSSemijoinColumns(String alias, List<ASTNode> columns) {
+    List<ASTNode> cols = rhsSemijoin.get(alias);
     if (cols == null) {
       rhsSemijoin.put(alias, columns);
     } else {
@@ -291,7 +291,7 @@ public class QBJoinTree implements Serializable, Cloneable {
    * @param column
    */
   public void addRHSSemijoinColumns(String alias, ASTNode column) {
-    ArrayList<ASTNode> cols = rhsSemijoin.get(alias);
+    List<ASTNode> cols = rhsSemijoin.get(alias);
     if (cols == null) {
       cols = new ArrayList<ASTNode>();
       cols.add(column);
@@ -301,7 +301,7 @@ public class QBJoinTree implements Serializable, Cloneable {
     }
   }
 
-  public ArrayList<ASTNode> getRHSSemijoinColumns(String alias) {
+  public List<ASTNode> getRHSSemijoinColumns(String alias) {
     return rhsSemijoin.get(alias);
   }
 
@@ -312,9 +312,9 @@ public class QBJoinTree implements Serializable, Cloneable {
    *          the source join tree
    */
   public void mergeRHSSemijoin(QBJoinTree src) {
-    for (Entry<String, ArrayList<ASTNode>> e : src.rhsSemijoin.entrySet()) {
+    for (Entry<String, List<ASTNode>> e : src.rhsSemijoin.entrySet()) {
       String key = e.getKey();
-      ArrayList<ASTNode> value = rhsSemijoin.get(key);
+      List<ASTNode> value = rhsSemijoin.get(key);
       if (value == null) {
         rhsSemijoin.put(key, e.getValue());
       } else {
@@ -323,11 +323,11 @@ public class QBJoinTree implements Serializable, Cloneable {
     }
   }
 
-  public ArrayList<Boolean> getNullSafes() {
+  public List<Boolean> getNullSafes() {
     return nullsafes;
   }
 
-  public void setNullSafes(ArrayList<Boolean> nullSafes) {
+  public void setNullSafes(List<Boolean> nullSafes) {
     this.nullsafes = nullSafes;
   }
 
@@ -426,7 +426,7 @@ public class QBJoinTree implements Serializable, Cloneable {
       cloned.addPostJoinFilter(filter);
     }
     // clone rhsSemijoin
-    for (Entry<String, ArrayList<ASTNode>> entry : rhsSemijoin.entrySet()) {
+    for (Entry<String, List<ASTNode>> entry : rhsSemijoin.entrySet()) {
       cloned.addRHSSemijoinColumns(entry.getKey(), entry.getValue());
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBParseInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBParseInfo.java
@@ -46,21 +46,21 @@ public class QBParseInfo {
   private ASTNode joinExpr;
   private ASTNode hints;
   private List<ASTNode> hintList;
-  private final HashMap<String, ASTNode> aliasToSrc;
+  private final Map<String, ASTNode> aliasToSrc;
   /**
    * insclause-0 -> TOK_TAB ASTNode
    */
-  private final HashMap<String, ASTNode> nameToDest;
+  private final Map<String, ASTNode> nameToDest;
   /**
    * For 'insert into FOO(x,y) select ...' this stores the
    * insclause-0 -> x,y mapping
    */
   private final Map<String, List<String>> nameToDestSchema;
-  private final HashMap<String, TableSample> nameToSample;
+  private final Map<String, TableSample> nameToSample;
   private final Map<ASTNode, String> exprToColumnAlias;
   private final Map<String, ASTNode> destToSelExpr;
-  private final HashMap<String, ASTNode> destToWhereExpr;
-  private final HashMap<String, ASTNode> destToGroupby;
+  private final Map<String, ASTNode> destToWhereExpr;
+  private final Map<String, ASTNode> destToGroupby;
   private final Set<String> destRollups;
   private final Set<String> destCubes;
   private final Set<String> destGroupingSets;
@@ -74,7 +74,7 @@ public class QBParseInfo {
   private boolean isAnalyzeCommand; // used for the analyze command (statistics)
   private boolean isNoScanAnalyzeCommand; // used for the analyze command (statistics) (noscan)
 
-  private final HashMap<String, TableSpec> tableSpecs; // used for statistics
+  private final Map<String, TableSpec> tableSpecs; // used for statistics
 
   private AnalyzeRewriteContext analyzeRewrite;
 
@@ -82,40 +82,40 @@ public class QBParseInfo {
   /**
    * ClusterBy is a short name for both DistributeBy and SortBy.
    */
-  private final HashMap<String, ASTNode> destToClusterby;
+  private final Map<String, ASTNode> destToClusterby;
   /**
    * DistributeBy controls the hashcode of the row, which determines which
    * reducer the rows will go to.
    */
-  private final HashMap<String, ASTNode> destToDistributeby;
+  private final Map<String, ASTNode> destToDistributeby;
   /**
    * SortBy controls the reduce keys, which affects the order of rows that the
    * reducer receives.
    */
 
-  private final HashMap<String, ASTNode> destToSortby;
+  private final Map<String, ASTNode> destToSortby;
 
   /**
    * Maping from table/subquery aliases to all the associated lateral view nodes.
    */
-  private final HashMap<String, ArrayList<ASTNode>> aliasToLateralViews;
+  private final Map<String, List<ASTNode>> aliasToLateralViews;
 
-  private final HashMap<String, ASTNode> destToLateralView;
+  private final Map<String, ASTNode> destToLateralView;
 
   /* Order by clause */
-  private final HashMap<String, ASTNode> destToOrderby;
+  private final Map<String, ASTNode> destToOrderby;
   // Use SimpleEntry to save the offset and rowcount of limit clause
   // KEY of SimpleEntry: offset
   // VALUE of SimpleEntry: rowcount
-  private final HashMap<String, SimpleEntry<Integer, Integer>> destToLimit;
+  private final Map<String, SimpleEntry<Integer, Integer>> destToLimit;
   private int outerQueryLimit;
 
   // used by GroupBy
-  private final LinkedHashMap<String, LinkedHashMap<String, ASTNode>> destToAggregationExprs;
-  private final HashMap<String, List<ASTNode>> destToDistinctFuncExprs;
+  private final Map<String, Map<String, ASTNode>> destToAggregationExprs;
+  private final Map<String, List<ASTNode>> destToDistinctFuncExprs;
 
   // used by Windowing
-  private final LinkedHashMap<String, LinkedHashMap<String, ASTNode>> destToWindowingExprs;
+  private final Map<String, Map<String, ASTNode>> destToWindowingExprs;
 
 
   @SuppressWarnings("unused")
@@ -144,15 +144,15 @@ public class QBParseInfo {
     destCubes = new HashSet<String>();
     destGroupingSets = new HashSet<String>();
 
-    destToAggregationExprs = new LinkedHashMap<String, LinkedHashMap<String, ASTNode>>();
-    destToWindowingExprs = new LinkedHashMap<String, LinkedHashMap<String, ASTNode>>();
+    destToAggregationExprs = new LinkedHashMap<String, Map<String, ASTNode>>();
+    destToWindowingExprs = new LinkedHashMap<String, Map<String, ASTNode>>();
     destToDistinctFuncExprs = new HashMap<String, List<ASTNode>>();
 
     this.alias = StringInternUtils.internIfNotNull(alias);
     this.isSubQ = isSubQ;
     outerQueryLimit = -1;
 
-    aliasToLateralViews = new HashMap<String, ArrayList<ASTNode>>();
+    aliasToLateralViews = new HashMap<String, List<ASTNode>>();
 
     tableSpecs = new HashMap<String, BaseSemanticAnalyzer.TableSpec>();
 
@@ -166,13 +166,11 @@ public class QBParseInfo {
     destToAggregationExprs.get(clause).clear();
   }
 
-  public void setAggregationExprsForClause(String clause,
-      LinkedHashMap<String, ASTNode> aggregationTrees) {
+  public void setAggregationExprsForClause(String clause, Map<String, ASTNode> aggregationTrees) {
     destToAggregationExprs.put(clause, aggregationTrees);
   }
 
-  public void addAggregationExprsForClause(String clause,
-      LinkedHashMap<String, ASTNode> aggregationTrees) {
+  public void addAggregationExprsForClause(String clause, Map<String, ASTNode> aggregationTrees) {
     if (destToAggregationExprs.containsKey(clause)) {
       destToAggregationExprs.get(clause).putAll(aggregationTrees);
     } else {
@@ -214,12 +212,12 @@ public class QBParseInfo {
     return insertIntoTables.containsKey(fullTableName.toLowerCase());
   }
 
-  public HashMap<String, ASTNode> getAggregationExprsForClause(String clause) {
+  public Map<String, ASTNode> getAggregationExprsForClause(String clause) {
     return destToAggregationExprs.get(clause);
   }
 
   public void addWindowingExprToClause(String clause, ASTNode windowingExprNode) {
-    LinkedHashMap<String, ASTNode> windowingExprs = destToWindowingExprs.get(clause);
+    Map<String, ASTNode> windowingExprs = destToWindowingExprs.get(clause);
     if ( windowingExprs == null ) {
       windowingExprs = new LinkedHashMap<String, ASTNode>();
       destToWindowingExprs.put(clause, windowingExprs);
@@ -227,7 +225,7 @@ public class QBParseInfo {
     windowingExprs.put(windowingExprNode.toStringTree(), windowingExprNode);
   }
 
-  public HashMap<String, ASTNode> getWindowingExprsForClause(String clause) {
+  public Map<String, ASTNode> getWindowingExprsForClause(String clause) {
     return destToWindowingExprs.get(clause);
   }
 
@@ -337,7 +335,7 @@ public class QBParseInfo {
     return destToWhereExpr.get(clause);
   }
 
-  public HashMap<String, ASTNode> getDestToWhereExpr() {
+  public Map<String, ASTNode> getDestToWhereExpr() {
     return destToWhereExpr;
   }
 
@@ -357,7 +355,7 @@ public class QBParseInfo {
     return destGroupingSets;
   }
 
-  public HashMap<String, ASTNode> getDestToGroupBy() {
+  public Map<String, ASTNode> getDestToGroupBy() {
     return destToGroupby;
   }
 
@@ -388,7 +386,7 @@ public class QBParseInfo {
     return destToClusterby.get(clause);
   }
 
-  public HashMap<String, ASTNode> getDestToClusterBy() {
+  public Map<String, ASTNode> getDestToClusterBy() {
     return destToClusterby;
   }
 
@@ -403,7 +401,7 @@ public class QBParseInfo {
     return destToDistributeby.get(clause);
   }
 
-  public HashMap<String, ASTNode> getDestToDistributeBy() {
+  public Map<String, ASTNode> getDestToDistributeBy() {
     return destToDistributeby;
   }
 
@@ -422,11 +420,11 @@ public class QBParseInfo {
     return destToOrderby.get(clause);
   }
 
-  public HashMap<String, ASTNode> getDestToSortBy() {
+  public Map<String, ASTNode> getDestToSortBy() {
     return destToSortby;
   }
 
-  public HashMap<String, ASTNode> getDestToOrderBy() {
+  public Map<String, ASTNode> getDestToOrderBy() {
     return destToOrderby;
   }
 
@@ -578,7 +576,7 @@ public class QBParseInfo {
     return hints;
   }
 
-  public Map<String, ArrayList<ASTNode>> getAliasToLateralViews() {
+  public Map<String, List<ASTNode>> getAliasToLateralViews() {
     return aliasToLateralViews;
   }
 
@@ -587,7 +585,7 @@ public class QBParseInfo {
   }
 
   public void addLateralViewForAlias(String alias, ASTNode lateralView) {
-    ArrayList<ASTNode> lateralViews = aliasToLateralViews.get(alias);
+    List<ASTNode> lateralViews = aliasToLateralViews.get(alias);
     if (lateralViews == null) {
       lateralViews = new ArrayList<ASTNode>();
       aliasToLateralViews.put(alias, lateralViews);
@@ -620,23 +618,23 @@ public class QBParseInfo {
     return tableSpecs.get(tName.next());
   }
 
-  public HashMap<String, SimpleEntry<Integer,Integer>> getDestToLimit() {
+  public Map<String, SimpleEntry<Integer,Integer>> getDestToLimit() {
     return destToLimit;
   }
 
-  public LinkedHashMap<String, LinkedHashMap<String, ASTNode>> getDestToAggregationExprs() {
+  public Map<String, Map<String, ASTNode>> getDestToAggregationExprs() {
     return destToAggregationExprs;
   }
 
-  public HashMap<String, List<ASTNode>> getDestToDistinctFuncExprs() {
+  public Map<String, List<ASTNode>> getDestToDistinctFuncExprs() {
     return destToDistinctFuncExprs;
   }
 
-  public HashMap<String, TableSample> getNameToSample() {
+  public Map<String, TableSample> getNameToSample() {
     return nameToSample;
   }
 
-  public HashMap<String, ASTNode> getDestToLateralView() {
+  public Map<String, ASTNode> getDestToLateralView() {
     return destToLateralView;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -42,6 +42,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.UUID;
@@ -312,10 +313,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   /** Marks the temporary table created for a serialized CTE. The table is scoped to the query. */
   static final String MATERIALIZATION_MARKER = "$MATERIALIZATION";
 
-  private HashMap<TableScanOperator, ExprNodeDesc> opToPartPruner;
-  private HashMap<TableScanOperator, PrunedPartitionList> opToPartList;
-  protected HashMap<String, TableScanOperator> topOps;
-  protected LinkedHashMap<Operator<? extends OperatorDesc>, OpParseContext> opParseCtx;
+  private Map<TableScanOperator, ExprNodeDesc> opToPartPruner;
+  private Map<TableScanOperator, PrunedPartitionList> opToPartList;
+  protected Map<String, TableScanOperator> topOps;
+  protected Map<Operator<? extends OperatorDesc>, OpParseContext> opParseCtx;
   private List<LoadTableDesc> loadTableWork;
   private List<LoadFileDesc> loadFileWork;
   private final List<ColumnStatsAutoGatherContext> columnStatsAutoGatherContexts;
@@ -326,21 +327,21 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private ASTNode ast;
   private int destTableId;
   private UnionProcContext uCtx;
-  List<AbstractMapJoinOperator<? extends MapJoinDesc>> listMapJoinOpsNoReducer;
-  private HashMap<TableScanOperator, SampleDesc> opToSamplePruner;
+  private List<AbstractMapJoinOperator<? extends MapJoinDesc>> listMapJoinOpsNoReducer;
+  private Map<TableScanOperator, SampleDesc> opToSamplePruner;
   private final Map<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner;
   private Map<SelectOperator, Table> viewProjectToTableSchema;
   /**
    * a map for the split sampling, from alias to an instance of SplitSample
    * that describes percentage and number.
    */
-  private final HashMap<String, SplitSample> nameToSplitSample;
-  Map<GroupByOperator, Set<String>> groupOpToInputTables;
-  Map<String, PrunedPartitionList> prunedPartitions;
+  private final Map<String, SplitSample> nameToSplitSample;
+  private Map<GroupByOperator, Set<String>> groupOpToInputTables;
+  protected Map<String, PrunedPartitionList> prunedPartitions;
   protected List<FieldSchema> resultSchema;
   protected CreateViewDesc createVwDesc;
-  protected MaterializedViewUpdateDesc materializedViewUpdateDesc;
-  protected ArrayList<String> viewsExpanded;
+  private  MaterializedViewUpdateDesc materializedViewUpdateDesc;
+  private List<String> viewsExpanded;
   protected ASTNode viewSelect;
   protected final UnparseTranslator unparseTranslator;
   private final GlobalLimitCtx globalLimitCtx;
@@ -360,7 +361,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private boolean mergeIsDirect;
 
   // flag for no scan during analyze ... compute statistics
-  protected boolean noscan;
+  private boolean noscan;
 
   // whether this is a mv rebuild rewritten expression
   protected MaterializationRebuildMode mvRebuildMode = MaterializationRebuildMode.NONE;
@@ -373,19 +374,19 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   /*
    * Capture the CTE definitions in a Query.
    */
-  final Map<String, CTEClause> aliasToCTEs;
+  protected final Map<String, CTEClause> aliasToCTEs;
 
   /*
    * Used to check recursive CTE invocations. Similar to viewsExpanded
    */
-  ArrayList<String> ctesExpanded;
+  private List<String> ctesExpanded;
 
   /*
    * Whether root tasks after materialized CTE linkage have been resolved
    */
-  boolean rootTasksResolved;
+  private boolean rootTasksResolved;
 
-  protected TableMask tableMask;
+  private TableMask tableMask;
 
   CreateTableDesc tableDesc;
 
@@ -514,7 +515,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     outputs.clear();
   }
 
-  public void initParseCtx(ParseContext pctx) {
+  void initParseCtx(ParseContext pctx) {
     opToPartPruner = pctx.getOpToPartPruner();
     opToPartList = pctx.getOpToPartList();
     opToSamplePruner = pctx.getOpToSamplePruner();
@@ -551,7 +552,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return ctx.getOpContext();
   }
 
-  public static String genPartValueString(String partColType, String partVal) throws SemanticException {
+  static String genPartValueString(String partColType, String partVal) throws SemanticException {
     String returnVal = partVal;
     if (partColType.equals(serdeConstants.STRING_TYPE_NAME) ||
         partColType.contains(serdeConstants.VARCHAR_TYPE_NAME) ||
@@ -578,13 +579,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return returnVal;
   }
 
-  public void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias)
+  private void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias)
       throws SemanticException {
     doPhase1QBExpr(ast, qbexpr, id, alias, false);
   }
 
   @SuppressWarnings("nls")
-  public void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias, boolean insideView)
+  private void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias, boolean insideView)
       throws SemanticException {
 
     assert (ast.getToken() != null);
@@ -635,12 +636,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  private LinkedHashMap<String, ASTNode> doPhase1GetAggregationsFromSelect(
+  private Map<String, ASTNode> doPhase1GetAggregationsFromSelect(
       ASTNode selExpr, QB qb, String dest) throws SemanticException {
 
     // Iterate over the selects search for aggregation Trees.
     // Use String as keys to eliminate duplicate trees.
-    LinkedHashMap<String, ASTNode> aggregationTrees = new LinkedHashMap<String, ASTNode>();
+    Map<String, ASTNode> aggregationTrees = new LinkedHashMap<String, ASTNode>();
     List<ASTNode> wdwFns = new ArrayList<ASTNode>();
     for (int i = 0; i < selExpr.getChildCount(); ++i) {
       ASTNode function = (ASTNode) selExpr.getChild(i);
@@ -659,7 +660,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         spec = new WindowingSpec();
         qb.addDestToWindowingSpec(dest, spec);
       }
-      HashMap<String, ASTNode> wExprsInDest = qb.getParseInfo().getWindowingExprsForClause(dest);
+      Map<String, ASTNode> wExprsInDest = qb.getParseInfo().getWindowingExprsForClause(dest);
       int wColIdx = spec.getWindowExpressions() == null ? 0 : spec.getWindowExpressions().size();
       WindowFunctionSpec wFnSpec = processWindowFunction(wdwFn,
           (ASTNode)wdwFn.getChild(wdwFn.getChildCount()-1));
@@ -888,7 +889,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @throws SemanticException
    */
   private void doPhase1GetAllAggregations(ASTNode expressionTree,
-                                          HashMap<String, ASTNode> aggregations, List<ASTNode> wdwFns,
+                                          Map<String, ASTNode> aggregations, List<ASTNode> wdwFns,
                                           ASTNode wndParent) throws SemanticException {
     int exprTokenType = expressionTree.getToken().getType();
     if(exprTokenType == HiveParser.TOK_SUBQUERY_EXPR) {
@@ -945,7 +946,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private List<ASTNode> doPhase1GetDistinctFuncExprs(
-      HashMap<String, ASTNode> aggregationTrees) throws SemanticException {
+      Map<String, ASTNode> aggregationTrees) throws SemanticException {
     List<ASTNode> exprs = new ArrayList<ASTNode>();
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
       ASTNode value = entry.getValue();
@@ -957,7 +958,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return exprs;
   }
 
-  public static String generateErrorMessage(ASTNode ast, String message) {
+  static String generateErrorMessage(ASTNode ast, String message) {
     StringBuilder sb = new StringBuilder();
     if (ast == null) {
       sb.append(message).append(". Cannot tell the position of null AST.");
@@ -1003,7 +1004,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return new int[] {aliasIndex, propsIndex, tsampleIndex, ssampleIndex};
   }
 
-  String findSimpleTableName(ASTNode tabref, int aliasIndex) throws SemanticException {
+  private String findSimpleTableName(ASTNode tabref, int aliasIndex) throws SemanticException {
     assert tabref.getType() == HiveParser.TOK_TABREF;
     ASTNode tableTree = (ASTNode) (tabref.getChild(0));
 
@@ -1056,7 +1057,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
     if (tsampleIndex >= 0) {
       ASTNode sampleClause = (ASTNode) tabref.getChild(tsampleIndex);
-      ArrayList<ASTNode> sampleCols = new ArrayList<ASTNode>();
+      List<ASTNode> sampleCols = new ArrayList<ASTNode>();
       if (sampleClause.getChildCount() > 2) {
         for (int i = 2; i < sampleClause.getChildCount(); i++) {
           sampleCols.add((ASTNode) sampleClause.getChild(i));
@@ -1267,8 +1268,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   @Override
-  public HashSet<ReadEntity> getAllInputs() {
-    HashSet<ReadEntity> readEntities = new HashSet<ReadEntity>(getInputs());
+  public Set<ReadEntity> getAllInputs() {
+    Set<ReadEntity> readEntities = new HashSet<ReadEntity>(getInputs());
     for (CTEClause cte : rootClause.asExecutionOrder()) {
       if (cte.source != null) {
         readEntities.addAll(cte.source.getInputs());
@@ -1278,8 +1279,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   @Override
-  public HashSet<WriteEntity> getAllOutputs() {
-    HashSet<WriteEntity> writeEntities = new HashSet<WriteEntity>(getOutputs());
+  public Set<WriteEntity> getAllOutputs() {
+    Set<WriteEntity> writeEntities = new HashSet<WriteEntity>(getOutputs());
     for (CTEClause cte : rootClause.asExecutionOrder()) {
       if (cte.source != null) {
         writeEntities.addAll(cte.source.getOutputs());
@@ -1544,7 +1545,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @throws SemanticException
    */
   @SuppressWarnings({"fallthrough", "nls"})
-  public boolean doPhase1(ASTNode ast, QB qb, Phase1Ctx ctx_1, PlannerContext plannerCtx)
+  boolean doPhase1(ASTNode ast, QB qb, Phase1Ctx ctx_1, PlannerContext plannerCtx)
       throws SemanticException {
 
     boolean phase1Result = true;
@@ -1570,8 +1571,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           queryProperties.setUsesScript(true);
         }
 
-        LinkedHashMap<String, ASTNode> aggregations = doPhase1GetAggregationsFromSelect(ast,
-            qb, ctx_1.dest);
+        Map<String, ASTNode> aggregations = doPhase1GetAggregationsFromSelect(ast, qb, ctx_1.dest);
         doPhase1GetColumnAliasesFromSelect(ast, qbp, ctx_1.dest);
         qbp.setAggregationExprsForClause(ctx_1.dest, aggregations);
         qbp.setDistinctFuncExprsForClause(ctx_1.dest,
@@ -1807,7 +1807,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
           Tree partitions = tab.getChild(1);
           int childCount = partitions.getChildCount();
-          HashMap<String, String> partition = new HashMap<String, String>();
+          Map<String, String> partition = new HashMap<String, String>();
           for (int i = 0; i < childCount; i++) {
             String partitionName = partitions.getChild(i).getChild(0).getText();
             // Convert to lowercase for the comparison
@@ -1987,7 +1987,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  public void getMaterializationMetadata(QB qb) throws SemanticException {
+  private void getMaterializationMetadata(QB qb) throws SemanticException {
     try {
       gatherCTEReferences(qb, rootClause);
       int threshold = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVE_CTE_MATERIALIZE_THRESHOLD);
@@ -2047,11 +2047,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  public void getMetaData(QB qb) throws SemanticException {
+  void getMetaData(QB qb) throws SemanticException {
     getMetaData(qb, false);
   }
 
-  public void getMetaData(QB qb, boolean enableMaterialization) throws SemanticException {
+  private void getMetaData(QB qb, boolean enableMaterialization) throws SemanticException {
     try {
       if (enableMaterialization) {
         getMaterializationMetadata(qb);
@@ -2666,8 +2666,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   @SuppressWarnings("nls")
   void parseJoinCondPopulateAlias(QBJoinTree joinTree, ASTNode condn,
-                                  ArrayList<String> leftAliases, ArrayList<String> rightAliases,
-                                  ArrayList<String> fields,
+                                  List<String> leftAliases, List<String> rightAliases,
+                                  List<String> fields,
                                   Map<String, Operator> aliasToOpInfo) throws SemanticException {
     // String[] allAliases = joinTree.getAllAliases();
     switch (condn.getToken().getType()) {
@@ -2749,7 +2749,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
             leftAliases, rightAliases, null, aliasToOpInfo);
       } else if (condn.getChildCount() == 2) {
 
-        ArrayList<String> fields1 = null;
+        List<String> fields1 = null;
         // if it is a dot operator, remember the field name of the rhs of the
         // left semijoin
         if (joinTree.getNoSemiJoin() == false
@@ -2959,7 +2959,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     JoinType type = cond.getJoinType();
     parseJoinCondition(joinTree, joinCond, leftSrc, type, aliasToOpInfo);
 
-    List<ArrayList<ASTNode>> filters = joinTree.getFilters();
+    List<List<ASTNode>> filters = joinTree.getFilters();
     if (type == JoinType.LEFTOUTER || type == JoinType.FULLOUTER) {
       joinTree.addFilterMapping(cond.getLeft(), cond.getRight(), filters.get(0).size());
     }
@@ -3013,14 +3013,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     case HiveParser.EQUAL_NS:
     case HiveParser.EQUAL:
       ASTNode leftCondn = (ASTNode) joinCond.getChild(0);
-      ArrayList<String> leftCondAl1 = new ArrayList<String>();
-      ArrayList<String> leftCondAl2 = new ArrayList<String>();
+      List<String> leftCondAl1 = new ArrayList<String>();
+      List<String> leftCondAl2 = new ArrayList<String>();
       parseJoinCondPopulateAlias(joinTree, leftCondn, leftCondAl1, leftCondAl2,
           null, aliasToOpInfo);
 
       ASTNode rightCondn = (ASTNode) joinCond.getChild(1);
-      ArrayList<String> rightCondAl1 = new ArrayList<String>();
-      ArrayList<String> rightCondAl2 = new ArrayList<String>();
+      List<String> rightCondAl1 = new ArrayList<String>();
+      List<String> rightCondAl2 = new ArrayList<String>();
       parseJoinCondPopulateAlias(joinTree, rightCondn, rightCondAl1,
           rightCondAl2, null, aliasToOpInfo);
 
@@ -3046,13 +3046,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
       // Create all children
       int childrenBegin = (isFunction ? 1 : 0);
-      ArrayList<ArrayList<String>> leftAlias = new ArrayList<ArrayList<String>>(
-          joinCond.getChildCount() - childrenBegin);
-      ArrayList<ArrayList<String>> rightAlias = new ArrayList<ArrayList<String>>(
-          joinCond.getChildCount() - childrenBegin);
+      List<List<String>> leftAlias = new ArrayList<List<String>>(joinCond.getChildCount() - childrenBegin);
+      List<List<String>> rightAlias = new ArrayList<List<String>>(joinCond.getChildCount() - childrenBegin);
       for (int ci = 0; ci < joinCond.getChildCount() - childrenBegin; ci++) {
-        ArrayList<String> left = new ArrayList<String>();
-        ArrayList<String> right = new ArrayList<String>();
+        List<String> left = new ArrayList<String>();
+        List<String> right = new ArrayList<String>();
         leftAlias.add(left);
         rightAlias.add(right);
       }
@@ -3064,7 +3062,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
 
       boolean leftAliasNull = true;
-      for (ArrayList<String> left : leftAlias) {
+      for (List<String> left : leftAlias) {
         if (left.size() != 0) {
           leftAliasNull = false;
           break;
@@ -3072,7 +3070,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
 
       boolean rightAliasNull = true;
-      for (ArrayList<String> right : rightAlias) {
+      for (List<String> right : rightAlias) {
         if (right.size() != 0) {
           rightAliasNull = false;
           break;
@@ -3118,19 +3116,18 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     case HiveParser.EQUAL:
 
       ASTNode leftCondn = (ASTNode) predicate.getChild(0);
-      ArrayList<String> leftCondAl1 = new ArrayList<String>();
-      ArrayList<String> leftCondAl2 = new ArrayList<String>();
+      List<String> leftCondAl1 = new ArrayList<String>();
+      List<String> leftCondAl2 = new ArrayList<String>();
       try {
-        parseJoinCondPopulateAlias(joinTree, leftCondn, leftCondAl1, leftCondAl2,
-            null, aliasToOpInfo);
+        parseJoinCondPopulateAlias(joinTree, leftCondn, leftCondAl1, leftCondAl2, null, aliasToOpInfo);
       } catch(SemanticException se) {
         // suppress here; if it is a real issue will get caught in where clause handling.
         return;
       }
 
       ASTNode rightCondn = (ASTNode) predicate.getChild(1);
-      ArrayList<String> rightCondAl1 = new ArrayList<String>();
-      ArrayList<String> rightCondAl2 = new ArrayList<String>();
+      List<String> rightCondAl1 = new ArrayList<String>();
+      List<String> rightCondAl2 = new ArrayList<String>();
       try {
         parseJoinCondPopulateAlias(joinTree, rightCondn, rightCondAl1,
             rightCondAl2, null, aliasToOpInfo);
@@ -3171,7 +3168,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   @SuppressWarnings("nls")
-  public <T extends OperatorDesc> Operator<T> putOpInsertMap(Operator<T> op,
+  <T extends OperatorDesc> Operator<T> putOpInsertMap(Operator<T> op,
                                                              RowResolver rr) {
     OpParseContext ctx = new OpParseContext(rr);
     opParseCtx.put(op, ctx);
@@ -3573,7 +3570,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   @SuppressWarnings("nls")
     // TODO: make aliases unique, otherwise needless rewriting takes place
   Integer genColListRegex(String colRegex, String tabAlias, ASTNode sel,
-                          ArrayList<ExprNodeDesc> col_list, HashSet<ColumnInfo> excludeCols, RowResolver input,
+                          List<ExprNodeDesc> col_list, Set<ColumnInfo> excludeCols, RowResolver input,
                           RowResolver colSrcRR, Integer pos, RowResolver output, List<String> aliases,
                           boolean ensureUniqueCols) throws SemanticException {
 
@@ -3614,9 +3611,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       // We got using() clause in previous join. Need to generate select list as
       // per standard. For * we will have joining columns first non-repeated
       // followed by other columns.
-      HashMap<String, ColumnInfo> leftMap = colSrcRR.getFieldMap(colSrcRR.getNamedJoinInfo().getAliases().get(0));
-      HashMap<String, ColumnInfo> rightMap = colSrcRR.getFieldMap(colSrcRR.getNamedJoinInfo().getAliases().get(1));
-      HashMap<String, ColumnInfo> chosenMap = null;
+      Map<String, ColumnInfo> leftMap = colSrcRR.getFieldMap(colSrcRR.getNamedJoinInfo().getAliases().get(0));
+      Map<String, ColumnInfo> rightMap = colSrcRR.getFieldMap(colSrcRR.getNamedJoinInfo().getAliases().get(1));
+      Map<String, ColumnInfo> chosenMap = null;
       if (colSrcRR.getNamedJoinInfo().getHiveJoinType() != JoinType.RIGHTOUTER) {
         chosenMap = leftMap;
       } else {
@@ -3673,7 +3670,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
     }
     for (String alias : aliases) {
-      HashMap<String, ColumnInfo> fMap = colSrcRR.getFieldMap(alias);
+      Map<String, ColumnInfo> fMap = colSrcRR.getFieldMap(alias);
       if (fMap == null) {
         continue;
       }
@@ -3791,7 +3788,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return (end == -1) ? "" : cmd.substring(end, cmd.length());
   }
 
-  static int getPositionFromInternalName(String internalName) {
+  private static int getPositionFromInternalName(String internalName) {
     return HiveConf.getPositionFromInternalName(internalName);
   }
 
@@ -3905,7 +3902,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private Operator genScriptPlan(ASTNode trfm, QB qb, Operator input)
       throws SemanticException {
     // If there is no "AS" clause, the output schema will be "key,value"
-    ArrayList<ColumnInfo> outputCols = new ArrayList<ColumnInfo>();
+    List<ColumnInfo> outputCols = new ArrayList<ColumnInfo>();
     int inputSerDeNum = 1, inputRecordWriterNum = 2;
     int outputSerDeNum = 4, outputRecordReaderNum = 5;
     int outputColsNum = 6;
@@ -3988,8 +3985,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     StringBuilder inpColumns = new StringBuilder();
     StringBuilder inpColumnTypes = new StringBuilder();
-    ArrayList<ColumnInfo> inputSchema = opParseCtx.get(input).getRowResolver()
-        .getColumnInfos();
+    List<ColumnInfo> inputSchema = opParseCtx.get(input).getRowResolver().getColumnInfos();
     for (int i = 0; i < inputSchema.size(); ++i) {
       if (i != 0) {
         inpColumns.append(",");
@@ -4119,7 +4115,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  protected List<Long> getGroupingSetsForRollup(int size) {
+  private List<Long> getGroupingSetsForRollup(int size) {
     List<Long> groupingSetKeys = new ArrayList<Long>();
     for (int i = 0; i <= size; i++) {
       groupingSetKeys.add((1L << i) - 1);
@@ -4127,7 +4123,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return groupingSetKeys;
   }
 
-  protected List<Long> getGroupingSetsForCube(int size) {
+  private List<Long> getGroupingSetsForCube(int size) {
     long count = 1L << size;
     List<Long> results = new ArrayList<Long>();
     for (long i = 0; i < count; ++i) {
@@ -4159,7 +4155,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return Pair.of(groupByExprs, groupingSets);
   }
 
-  protected List<Long> getGroupingSets(List<ASTNode> groupByExpr, QBParseInfo parseInfo,
+  private List<Long> getGroupingSets(List<ASTNode> groupByExpr, QBParseInfo parseInfo,
       String dest) throws SemanticException {
     Map<String, Integer> exprPos = new HashMap<String, Integer>();
     for (int i = 0; i < groupByExpr.size(); ++i) {
@@ -4209,7 +4205,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return bitmap | (1L << bitIdx);
   }
 
-  public static long unsetBit(long bitmap, int bitIdx) {
+  private static long unsetBit(long bitmap, int bitIdx) {
     return bitmap & ~(1L << bitIdx);
   }
 
@@ -4267,7 +4263,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return expr.getType() == HiveParser.TOK_SELECTDI;
   }
 
-  protected boolean isAggregateInSelect(Node node, Collection<ASTNode> aggregateFunction) {
+  private boolean isAggregateInSelect(Node node, Collection<ASTNode> aggregateFunction) {
     if (node.getChildren() == null) {
       return false;
     }
@@ -4392,7 +4388,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       LOG.debug("tree: " + selExprList.toStringTree());
     }
 
-    ArrayList<ExprNodeDesc> col_list = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> col_list = new ArrayList<ExprNodeDesc>();
     RowResolver out_rwsch = new RowResolver();
     ASTNode trfm = null;
     Integer pos = Integer.valueOf(0);
@@ -4423,7 +4419,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // the lack of a special token.
     boolean isUDTF = false;
     String udtfTableAlias = null;
-    ArrayList<String> udtfColAliases = new ArrayList<String>();
+    List<String> udtfColAliases = new ArrayList<String>();
     ASTNode udtfExpr = (ASTNode) selExprList.getChild(posn).getChild(0);
     GenericUDTF genericUDTF = null;
 
@@ -4631,7 +4627,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     out_rwsch = handleInsertStatementSpec(col_list, dest, out_rwsch, qb, selExprList);
 
-    ArrayList<String> columnNames = new ArrayList<String>();
+    List<String> columnNames = new ArrayList<String>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     for (int i = 0; i < col_list.size(); i++) {
       String outputCol = getColumnInternalName(i);
@@ -4649,8 +4645,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     if (isUDTF) {
-      output = genUDTFPlan(genericUDTF, udtfTableAlias, udtfColAliases, qb,
-          output, outerLV);
+      output = genUDTFPlan(genericUDTF, udtfTableAlias, udtfColAliases, qb, output, outerLV);
     }
 
     if (LOG.isDebugEnabled()) {
@@ -4661,7 +4656,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   private RowResolver getColForInsertStmtSpec(Map<String, ExprNodeDesc> targetCol2Projection, final Table target,
                                               Map<String, ColumnInfo> targetCol2ColumnInfo, int colListPos,
-                                              List<TypeInfo> targetTableColTypes, ArrayList<ExprNodeDesc> new_col_list,
+                                              List<TypeInfo> targetTableColTypes, List<ExprNodeDesc> new_col_list,
                                               List<String> targetTableColNames)
       throws SemanticException {
     RowResolver newOutputRR = new RowResolver();
@@ -4728,7 +4723,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @see #handleInsertStatementSpecPhase1(ASTNode, QBParseInfo, org.apache.hadoop.hive.ql.parse.SemanticAnalyzer.Phase1Ctx)
    * @throws SemanticException
    */
-  public RowResolver handleInsertStatementSpec(List<ExprNodeDesc> col_list, String dest,
+  RowResolver handleInsertStatementSpec(List<ExprNodeDesc> col_list, String dest,
                                                RowResolver outputRR, QB qb,
                                                ASTNode selExprList) throws SemanticException {
     //(z,x)
@@ -4760,7 +4755,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       throw new SemanticException(generateErrorMessage(selExprList,
           "No table/partition found in QB metadata for dest='" + dest + "'"));
     }
-    ArrayList<ExprNodeDesc> new_col_list = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> new_col_list = new ArrayList<ExprNodeDesc>();
     colListPos = 0;
     List<FieldSchema> targetTableCols = target != null ? target.getCols() : partition.getCols();
     List<String> targetTableColNames = new ArrayList<String>();
@@ -4814,7 +4809,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * Class to store GenericUDAF related information.
    */
   public static class GenericUDAFInfo {
-    public ArrayList<ExprNodeDesc> convertedParameters;
+    public List<ExprNodeDesc> convertedParameters;
     public GenericUDAFEvaluator genericUDAFEvaluator;
     public TypeInfo returnType;
   }
@@ -4822,8 +4817,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   /**
    * Convert exprNodeDesc array to ObjectInspector array.
    */
-  static ArrayList<ObjectInspector> getWritableObjectInspector(ArrayList<ExprNodeDesc> exprs) {
-    ArrayList<ObjectInspector> result = new ArrayList<ObjectInspector>();
+  static List<ObjectInspector> getWritableObjectInspector(List<ExprNodeDesc> exprs) {
+    List<ObjectInspector> result = new ArrayList<ObjectInspector>();
     for (ExprNodeDesc expr : exprs) {
       result.add(expr.getWritableObjectInspector());
     }
@@ -4835,11 +4830,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * for each GroupBy aggregation.
    */
   public static GenericUDAFEvaluator getGenericUDAFEvaluator(String aggName,
-                                                             ArrayList<ExprNodeDesc> aggParameters, ASTNode aggTree,
+                                                             List<ExprNodeDesc> aggParameters, ASTNode aggTree,
                                                              boolean isDistinct, boolean isAllColumns)
       throws SemanticException {
-    ArrayList<ObjectInspector> originalParameterTypeInfos =
-        getWritableObjectInspector(aggParameters);
+    List<ObjectInspector> originalParameterTypeInfos = getWritableObjectInspector(aggParameters);
     GenericUDAFEvaluator result = FunctionRegistry.getGenericUDAFEvaluator(
         aggName, originalParameterTypeInfos, isDistinct, isAllColumns);
     if (null == result) {
@@ -4863,7 +4857,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    *           when the UDAF is not found or has problems.
    */
   public static GenericUDAFInfo getGenericUDAFInfo(GenericUDAFEvaluator evaluator,
-                                                   GenericUDAFEvaluator.Mode emode, ArrayList<ExprNodeDesc> aggParameters)
+                                                   GenericUDAFEvaluator.Mode emode, List<ExprNodeDesc> aggParameters)
       throws SemanticException {
 
     GenericUDAFInfo r = new GenericUDAFInfo();
@@ -4874,7 +4868,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // set r.returnType
     ObjectInspector returnOI = null;
     try {
-      ArrayList<ObjectInspector> aggOIs = getWritableObjectInspector(aggParameters);
+      List<ObjectInspector> aggOIs = getWritableObjectInspector(aggParameters);
       ObjectInspector[] aggOIArray = new ObjectInspector[aggOIs.size()];
       for (int ii = 0; ii < aggOIs.size(); ++ii) {
         aggOIArray[ii] = aggOIs.get(ii);
@@ -4980,9 +4974,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         .get(input).getRowResolver();
     RowResolver groupByOutputRowResolver = new RowResolver();
     groupByOutputRowResolver.setIsExprResolver(true);
-    ArrayList<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
+    List<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
+    List<String> outputColumnNames = new ArrayList<String>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     List<ASTNode> grpByExprs = getGroupByForClause(parseInfo, dest);
     for (int i = 0; i < grpByExprs.size(); ++i) {
@@ -5004,7 +4998,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       colExprMap.put(field, groupByKeys.get(groupByKeys.size() - 1));
     }
     // For each aggregation
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
+    Map<String, ASTNode> aggregationTrees = parseInfo
         .getAggregationExprsForClause(dest);
     assert (aggregationTrees != null);
     // get the last colName for the reduce KEY
@@ -5025,7 +5019,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       boolean isAllColumns = value.getType() == HiveParser.TOK_FUNCTIONSTAR;
 
       // Convert children to aggParameters
-      ArrayList<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
       // 0 is the function name
       for (int i = 1; i < value.getChildCount(); i++) {
         ASTNode paraExpr = (ASTNode) value.getChild(i);
@@ -5067,8 +5061,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       GenericUDAFEvaluator genericUDAFEvaluator = getGenericUDAFEvaluator(
           aggName, aggParameters, value, isDistinct, isAllColumns);
       assert (genericUDAFEvaluator != null);
-      GenericUDAFInfo udaf = getGenericUDAFInfo(genericUDAFEvaluator, amode,
-          aggParameters);
+      GenericUDAFInfo udaf = getGenericUDAFInfo(genericUDAFEvaluator, amode, aggParameters);
       aggregations.add(new AggregationDesc(aggName.toLowerCase(),
           udaf.genericUDAFEvaluator, udaf.convertedParameters, isDistinct,
           amode));
@@ -5188,13 +5181,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       List<Long> groupingSets,
       boolean groupingSetsPresent,
       boolean groupingSetsNeedAdditionalMRJob) throws SemanticException {
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<String> outputColumnNames = new ArrayList<String>();
     RowResolver groupByInputRowResolver = opParseCtx
         .get(reduceSinkOperatorInfo).getRowResolver();
     RowResolver groupByOutputRowResolver = new RowResolver();
     groupByOutputRowResolver.setIsExprResolver(true);
-    ArrayList<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
+    List<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
+    List<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
     List<ASTNode> grpByExprs = getGroupByForClause(parseInfo, dest);
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     for (int i = 0; i < grpByExprs.size(); ++i) {
@@ -5250,7 +5243,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
+    Map<String, ASTNode> aggregationTrees = parseInfo
         .getAggregationExprsForClause(dest);
     // get the last colName for the reduce KEY
     // it represents the column name corresponding to distinct aggr, if any
@@ -5269,7 +5262,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
       ASTNode value = entry.getValue();
       String aggName = unescapeIdentifier(value.getChild(0).getText());
-      ArrayList<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
       boolean isDistinct = (value.getType() == HiveParser.TOK_FUNCTIONDI);
       containsDistinctAggr = containsDistinctAggr || isDistinct;
 
@@ -5422,9 +5415,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     QBParseInfo parseInfo = qb.getParseInfo();
     RowResolver groupByOutputRowResolver = new RowResolver();
     groupByOutputRowResolver.setIsExprResolver(true);
-    ArrayList<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
-    ArrayList<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
+    List<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumnNames = new ArrayList<String>();
+    List<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     for (int i = 0; i < grpByExprs.size(); ++i) {
       ASTNode grpbyExpr = grpByExprs.get(i);
@@ -5486,15 +5479,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     // For each aggregation
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
-        .getAggregationExprsForClause(dest);
+    Map<String, ASTNode> aggregationTrees = parseInfo.getAggregationExprsForClause(dest);
     assert (aggregationTrees != null);
 
     boolean containsDistinctAggr = false;
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
       ASTNode value = entry.getValue();
       String aggName = unescapeIdentifier(value.getChild(0).getText());
-      ArrayList<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
       // 0 is the function name
       for (int i = 1; i < value.getChildCount(); i++) {
         ASTNode paraExpr = (ASTNode) value.getChild(i);
@@ -5581,7 +5573,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     List<String> outputKeyColumnNames = new ArrayList<String>();
     List<String> outputValueColumnNames = new ArrayList<String>();
 
-    ArrayList<ExprNodeDesc> reduceKeys = getReduceKeysForReduceSink(grpByExprs,
+    List<ExprNodeDesc> reduceKeys = getReduceKeysForReduceSink(grpByExprs,
         reduceSinkInputRowResolver, reduceSinkOutputRowResolver, outputKeyColumnNames,
         colExprMap);
 
@@ -5607,9 +5599,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         reduceKeys, reduceSinkInputRowResolver, reduceSinkOutputRowResolver, outputKeyColumnNames,
         colExprMap);
 
-    ArrayList<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
-        .getAggregationExprsForClause(dest);
+    List<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
+    Map<String, ASTNode> aggregationTrees = parseInfo.getAggregationExprsForClause(dest);
 
     if (!mapAggrDone) {
       getReduceValuesForReduceSinkNoMapAgg(parseInfo, dest, reduceSinkInputRowResolver,
@@ -5649,12 +5640,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return rsOp;
   }
 
-  private ArrayList<ExprNodeDesc> getReduceKeysForReduceSink(List<ASTNode> grpByExprs,
+  private List<ExprNodeDesc> getReduceKeysForReduceSink(List<ASTNode> grpByExprs,
                                                              RowResolver reduceSinkInputRowResolver, RowResolver reduceSinkOutputRowResolver,
                                                              List<String> outputKeyColumnNames, Map<String, ExprNodeDesc> colExprMap)
       throws SemanticException {
 
-    ArrayList<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
 
     for (int i = 0; i < grpByExprs.size(); ++i) {
       ASTNode grpbyExpr = grpByExprs.get(i);
@@ -5740,10 +5731,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   private void getReduceValuesForReduceSinkNoMapAgg(QBParseInfo parseInfo, String dest,
                                                     RowResolver reduceSinkInputRowResolver, RowResolver reduceSinkOutputRowResolver,
-                                                    List<String> outputValueColumnNames, ArrayList<ExprNodeDesc> reduceValues,
+                                                    List<String> outputValueColumnNames, List<ExprNodeDesc> reduceValues,
                                                     Map<String, ExprNodeDesc> colExprMap) throws SemanticException {
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
-        .getAggregationExprsForClause(dest);
+    Map<String, ASTNode> aggregationTrees = parseInfo.getAggregationExprsForClause(dest);
 
     // Put parameters to aggregations in reduceValues
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
@@ -5787,7 +5777,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     List<String> outputValueColumnNames = new ArrayList<String>();
     List<ASTNode> grpByExprs = getGroupByForClause(parseInfo, dest);
 
-    ArrayList<ExprNodeDesc> reduceKeys = getReduceKeysForReduceSink(grpByExprs,
+    List<ExprNodeDesc> reduceKeys = getReduceKeysForReduceSink(grpByExprs,
         reduceSinkInputRowResolver, reduceSinkOutputRowResolver, outputKeyColumnNames,
         colExprMap);
 
@@ -5797,7 +5787,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         reduceKeys, reduceSinkInputRowResolver, reduceSinkOutputRowResolver, outputKeyColumnNames,
         colExprMap);
 
-    ArrayList<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
 
     // The dests can have different non-distinct aggregations, so we have to iterate over all of
     // them
@@ -5905,8 +5895,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     RowResolver reduceSinkOutputRowResolver2 = new RowResolver();
     reduceSinkOutputRowResolver2.setIsExprResolver(true);
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumnNames = new ArrayList<String>();
     // Get group-by keys and store in reduceKeys
     List<ASTNode> grpByExprs = getGroupByForClause(parseInfo, dest);
     for (int i = 0; i < grpByExprs.size(); ++i) {
@@ -5937,10 +5927,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     // Get partial aggregation results and store in reduceValues
-    ArrayList<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
     int inputField = reduceKeys.size();
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
-        .getAggregationExprsForClause(dest);
+    Map<String, ASTNode> aggregationTrees = parseInfo.getAggregationExprsForClause(dest);
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
       String field = getColumnInternalName(inputField);
       ASTNode t = entry.getValue();
@@ -5993,11 +5982,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         reduceSinkOperatorInfo2).getRowResolver();
     RowResolver groupByOutputRowResolver2 = new RowResolver();
     groupByOutputRowResolver2.setIsExprResolver(true);
-    ArrayList<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
+    List<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
+    List<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
     List<ASTNode> grpByExprs = getGroupByForClause(parseInfo, dest);
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<String> outputColumnNames = new ArrayList<String>();
     for (int i = 0; i < grpByExprs.size(); ++i) {
       ASTNode grpbyExpr = grpByExprs.get(i);
       ColumnInfo exprInfo = groupByInputRowResolver2.getExpression(grpbyExpr);
@@ -6029,11 +6018,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           colExprMap);
     }
 
-    HashMap<String, ASTNode> aggregationTrees = parseInfo
-        .getAggregationExprsForClause(dest);
+    Map<String, ASTNode> aggregationTrees = parseInfo.getAggregationExprsForClause(dest);
     boolean containsDistinctAggr = false;
     for (Map.Entry<String, ASTNode> entry : aggregationTrees.entrySet()) {
-      ArrayList<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> aggParameters = new ArrayList<ExprNodeDesc>();
       ASTNode value = entry.getValue();
       ColumnInfo paraExprInfo = groupByInputRowResolver2.getExpression(value);
       if (paraExprInfo == null) {
@@ -6768,7 +6756,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private static class SortBucketRSCtx {
-    ArrayList<ExprNodeDesc> partnCols;
+    List<ExprNodeDesc> partnCols;
     boolean multiFileSpray;
     int numFiles;
     int totalFiles;
@@ -6783,7 +6771,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     /**
      * @return the partnCols
      */
-    public ArrayList<ExprNodeDesc> getPartnCols() {
+    public List<ExprNodeDesc> getPartnCols() {
       return partnCols;
     }
 
@@ -6791,7 +6779,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
      * @param partnCols
      *          the partnCols to set
      */
-    public void setPartnCols(ArrayList<ExprNodeDesc> partnCols) {
+    public void setPartnCols(List<ExprNodeDesc> partnCols) {
       this.partnCols = partnCols;
     }
 
@@ -6852,9 +6840,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // spray the data into multiple buckets. That way, we can support a very large
     // number of buckets without needing a very large number of reducers.
     boolean enforceBucketing = false;
-    ArrayList<ExprNodeDesc> partnCols = new ArrayList<>();
-    ArrayList<ExprNodeDesc> sortCols = new ArrayList<>();
-    ArrayList<Integer> sortOrders = new ArrayList<>();
+    List<ExprNodeDesc> partnCols = new ArrayList<>();
+    List<ExprNodeDesc> sortCols = new ArrayList<>();
+    List<Integer> sortOrders = new ArrayList<>();
     boolean multiFileSpray = false;
     int numFiles = 1;
     int totalFiles = 1;
@@ -6935,7 +6923,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private void genPartnCols(String dest, Operator input, QB qb,
       TableDesc table_desc, Table dest_tab, SortBucketRSCtx ctx) throws SemanticException {
     boolean enforceBucketing = false;
-    ArrayList<ExprNodeDesc> partnColsNoConvert = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> partnColsNoConvert = new ArrayList<ExprNodeDesc>();
 
     if ((dest_tab.getNumBuckets() > 0)) {
       enforceBucketing = true;
@@ -6995,13 +6983,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     Set<String> distributeKeys = distributeColInfos.stream()
         .map(ColumnInfo::getInternalName)
         .collect(Collectors.toSet());
-    ArrayList<ExprNodeDesc> keyCols = new ArrayList<>();
-    ArrayList<String> keyColNames = new ArrayList<>();
+    List<ExprNodeDesc> keyCols = new ArrayList<>();
+    List<String> keyColNames = new ArrayList<>();
     StringBuilder order = new StringBuilder();
     StringBuilder nullOrder = new StringBuilder();
-    ArrayList<ExprNodeDesc> valCols = new ArrayList<>();
-    ArrayList<String> valColNames = new ArrayList<>();
-    ArrayList<ExprNodeDesc> partCols = new ArrayList<>();
+    List<ExprNodeDesc> valCols = new ArrayList<>();
+    List<String> valColNames = new ArrayList<>();
+    List<ExprNodeDesc> partCols = new ArrayList<>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<>();
     Map<String, String> nameMapping = new HashMap<>();
     // map _col0 to KEY._col0, etc
@@ -7043,7 +7031,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         keyColNames, distinctColumnIndices, valColNames, -1, partCols, -1, keyTable,
         valueTable, Operation.NOT_ACID);
     RowResolver rsRR = new RowResolver();
-    ArrayList<ColumnInfo> rsSignature = new ArrayList<>();
+    List<ColumnInfo> rsSignature = new ArrayList<>();
     for (int index = 0; index < input.getSchema().getSignature().size(); index++) {
       ColumnInfo colInfo = new ColumnInfo(input.getSchema().getSignature().get(index));
       String[] nm = inputRR.reverseLookup(colInfo.getInternalName());
@@ -7061,7 +7049,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     // Create SEL operator
     RowResolver selRR = new RowResolver();
-    ArrayList<ColumnInfo> selSignature = new ArrayList<>();
+    List<ColumnInfo> selSignature = new ArrayList<>();
     List<ExprNodeDesc> columnExprs = new ArrayList<>();
     List<String> colNames = new ArrayList<>();
     Map<String, ExprNodeDesc> selColExprMap = new HashMap<>();
@@ -7087,8 +7075,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       selColExprMap.put(colName, exprNodeDesc);
     }
     SelectDesc selConf = new SelectDesc(columnExprs, colNames);
-    result = putOpInsertMap(OperatorFactory.getAndMakeChild(
-        selConf, new RowSchema(selSignature), result), selRR);
+    result = putOpInsertMap(OperatorFactory.getAndMakeChild(selConf, new RowSchema(selSignature), result), selRR);
     result.setColumnExprMap(selColExprMap);
 
     return result;
@@ -7097,7 +7084,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private void setStatsForNonNativeTable(String dbName, String tableName) throws SemanticException {
     String qTableName = DDLSemanticAnalyzer.getDotName(new String[] { dbName,
         tableName });
-    HashMap<String, String> mapProp = new HashMap<>();
+    Map<String, String> mapProp = new HashMap<>();
     mapProp.put(StatsSetupConst.COLUMN_STATS_ACCURATE, null);
     AlterTableUnsetPropertiesDesc alterTblDesc = new AlterTableUnsetPropertiesDesc(qTableName, null, null, false,
         mapProp, false, null);
@@ -7892,7 +7879,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     inputRR = opParseCtx.get(input).getRowResolver();
 
-    ArrayList<ColumnInfo> vecCol = new ArrayList<ColumnInfo>();
+    List<ColumnInfo> vecCol = new ArrayList<ColumnInfo>();
 
     if (updating(dest) || deleting(dest)) {
       vecCol.add(new ColumnInfo(VirtualColumn.ROWID.getName(), VirtualColumn.ROWID.getTypeInfo(),
@@ -8431,7 +8418,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * Generate the conversion SelectOperator that converts the columns into the
    * types that are expected by the table_desc.
    */
-  Operator genConversionSelectOperator(String dest, QB qb, Operator input,
+  private Operator genConversionSelectOperator(String dest, QB qb, Operator input,
                                        TableDesc table_desc, DynamicPartitionCtx dpCtx) throws SemanticException {
     StructObjectInspector oi = null;
     try {
@@ -8446,8 +8433,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // Check column number
     List<? extends StructField> tableFields = oi.getAllStructFieldRefs();
     boolean dynPart = HiveConf.getBoolVar(conf, HiveConf.ConfVars.DYNAMICPARTITIONING);
-    ArrayList<ColumnInfo> rowFields = opParseCtx.get(input).getRowResolver()
-        .getColumnInfos();
+    List<ColumnInfo> rowFields = opParseCtx.get(input).getRowResolver().getColumnInfos();
     int inColumnCnt = rowFields.size();
     int outColumnCnt = tableFields.size();
     if (dynPart && dpCtx != null) {
@@ -8465,8 +8451,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // Check column types
     boolean converted = false;
     int columnNumber = tableFields.size();
-    ArrayList<ExprNodeDesc> expressions = new ArrayList<ExprNodeDesc>(
-        columnNumber);
+    List<ExprNodeDesc> expressions = new ArrayList<ExprNodeDesc>(columnNumber);
 
     // MetadataTypedColumnsetSerDe does not need type conversions because it
     // does the conversion to String by itself.
@@ -8533,7 +8518,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (converted) {
       // add the select operator
       RowResolver rowResolver = new RowResolver();
-      ArrayList<String> colNames = new ArrayList<String>();
+      List<String> colNames = new ArrayList<String>();
       Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
       for (int i = 0; i < expressions.size(); i++) {
         String name = getColumnInternalName(i);
@@ -8577,9 +8562,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return limitMap;
   }
 
-  private Operator genUDTFPlan(GenericUDTF genericUDTF,
-                               String outputTableAlias, ArrayList<String> colAliases, QB qb,
-                               Operator input, boolean outerLV) throws SemanticException {
+  private Operator genUDTFPlan(GenericUDTF genericUDTF, String outputTableAlias, List<String> colAliases, QB qb,
+      Operator input, boolean outerLV) throws SemanticException {
 
     // No GROUP BY / DISTRIBUTE BY / SORT BY / CLUSTER BY
     QBParseInfo qbp = qb.getParseInfo();
@@ -8610,10 +8594,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // resulting output object inspector can be used to make the RowResolver
     // for the UDTF operator
     RowResolver selectRR = opParseCtx.get(input).getRowResolver();
-    ArrayList<ColumnInfo> inputCols = selectRR.getColumnInfos();
+    List<ColumnInfo> inputCols = selectRR.getColumnInfos();
 
     // Create the object inspector for the input columns and initialize the UDTF
-    ArrayList<String> colNames = new ArrayList<String>();
+    List<String> colNames = new ArrayList<String>();
     ObjectInspector[] colOIs = new ObjectInspector[inputCols.size()];
     for (int i = 0; i < inputCols.size(); i++) {
       colNames.add(inputCols.get(i).getInternalName());
@@ -8640,7 +8624,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     // Generate the output column info's / row resolver using internal names.
-    ArrayList<ColumnInfo> udtfCols = new ArrayList<ColumnInfo>();
+    List<ColumnInfo> udtfCols = new ArrayList<ColumnInfo>();
 
     Iterator<String> colAliasesIter = colAliases.iterator();
     for (StructField sf : outputOI.getAllStructFieldRefs()) {
@@ -8691,8 +8675,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return genLimitPlan(dest, qb, curr, offset, limit);
   }
 
-  private ArrayList<ExprNodeDesc> getPartitionColsFromBucketCols(String dest, QB qb, Table tab,
-                                                                 TableDesc table_desc, Operator input, boolean convert)
+  private List<ExprNodeDesc> getPartitionColsFromBucketCols(String dest, QB qb, Table tab, TableDesc table_desc,
+      Operator input, boolean convert)
       throws SemanticException {
     List<String> tabBucketCols = tab.getBucketCols();
     List<FieldSchema> tabCols = tab.getCols();
@@ -8716,7 +8700,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   // We have to set up the bucketing columns differently for update and deletes,
   // as it is always using the ROW__ID column.
-  private ArrayList<ExprNodeDesc> getPartitionColsFromBucketColsForUpdateDelete(
+  private List<ExprNodeDesc> getPartitionColsFromBucketColsForUpdateDelete(
       Operator input, boolean convert) throws SemanticException {
     //return genConvertCol(dest, qb, tab, table_desc, input, Arrays.asList(0), convert);
     // In the case of update and delete the bucketing column is always the first column,
@@ -8730,14 +8714,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (convert) {
       column = ParseUtils.createConversionCast(column, TypeInfoFactory.intTypeInfo);
     }
-    ArrayList<ExprNodeDesc> rlist = new ArrayList<ExprNodeDesc>(1);
+    List<ExprNodeDesc> rlist = new ArrayList<ExprNodeDesc>(1);
     rlist.add(column);
     return rlist;
   }
 
-  private ArrayList<ExprNodeDesc> genConvertCol(String dest, QB qb, Table tab,
-                                                TableDesc table_desc, Operator input, List<Integer> posns, boolean convert)
-      throws SemanticException {
+  private List<ExprNodeDesc> genConvertCol(String dest, QB qb, Table tab, TableDesc table_desc, Operator input,
+      List<Integer> posns, boolean convert) throws SemanticException {
     StructObjectInspector oi = null;
     try {
       Deserializer deserializer = table_desc.getDeserializerClass()
@@ -8749,12 +8732,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     List<? extends StructField> tableFields = oi.getAllStructFieldRefs();
-    ArrayList<ColumnInfo> rowFields = opParseCtx.get(input).getRowResolver()
-        .getColumnInfos();
+    List<ColumnInfo> rowFields = opParseCtx.get(input).getRowResolver().getColumnInfos();
 
     // Check column type
     int columnNumber = posns.size();
-    ArrayList<ExprNodeDesc> expressions = new ArrayList<ExprNodeDesc>(columnNumber);
+    List<ExprNodeDesc> expressions = new ArrayList<ExprNodeDesc>(columnNumber);
     for (Integer posn : posns) {
       ObjectInspector tableFieldOI = tableFields.get(posn).getFieldObjectInspector();
       TypeInfo tableFieldTypeInfo = TypeInfoUtils.getTypeInfoFromObjectInspector(tableFieldOI);
@@ -8785,7 +8767,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return expressions;
   }
 
-  private ArrayList<ExprNodeDesc> getSortCols(String dest, QB qb, Table tab, TableDesc table_desc,
+  private List<ExprNodeDesc> getSortCols(String dest, QB qb, Table tab, TableDesc table_desc,
                                               Operator input, boolean convert)
       throws SemanticException {
     List<Order> tabSortCols = tab.getSortCols();
@@ -8807,12 +8789,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return genConvertCol(dest, qb, tab, table_desc, input, posns, convert);
   }
 
-  private ArrayList<Integer> getSortOrders(String dest, QB qb, Table tab, Operator input)
+  private List<Integer> getSortOrders(String dest, QB qb, Table tab, Operator input)
       throws SemanticException {
     List<Order> tabSortCols = tab.getSortCols();
     List<FieldSchema> tabCols = tab.getCols();
 
-    ArrayList<Integer> orders = new ArrayList<Integer>();
+    List<Integer> orders = new ArrayList<Integer>();
     for (Order sortCol : tabSortCols) {
       for (FieldSchema tabCol : tabCols) {
         if (sortCol.getCol().equals(tabCol.getName())) {
@@ -8836,7 +8818,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (partitionExprs == null) {
       partitionExprs = qb.getParseInfo().getDistributeByForClause(dest);
     }
-    ArrayList<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
     if (partitionExprs != null) {
       int ccount = partitionExprs.getChildCount();
       for (int i = 0; i < ccount; ++i) {
@@ -8862,7 +8844,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       }
     }
-    ArrayList<ExprNodeDesc> sortCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> sortCols = new ArrayList<ExprNodeDesc>();
     StringBuilder order = new StringBuilder();
     StringBuilder nullOrder = new StringBuilder();
     if (sortExprs != null) {
@@ -8923,7 +8905,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private Operator genReduceSinkPlan(Operator<?> input,
-                                     ArrayList<ExprNodeDesc> partitionCols, ArrayList<ExprNodeDesc> sortCols,
+                                     List<ExprNodeDesc> partitionCols, List<ExprNodeDesc> sortCols,
                                      String sortOrder, String nullOrder, int numReducers, AcidUtils.Operation acidOp)
       throws SemanticException {
     return genReduceSinkPlan(input, partitionCols, sortCols, sortOrder, nullOrder, numReducers,
@@ -8931,8 +8913,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   @SuppressWarnings("nls")
-  private Operator genReduceSinkPlan(Operator<?> input,
-                                     ArrayList<ExprNodeDesc> partitionCols, ArrayList<ExprNodeDesc> sortCols,
+  private Operator genReduceSinkPlan(Operator<?> input, List<ExprNodeDesc> partitionCols, List<ExprNodeDesc> sortCols,
                                      String sortOrder, String nullOrder, int numReducers, AcidUtils.Operation acidOp,
                                      boolean pullConstants) throws SemanticException {
 
@@ -8941,10 +8922,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     Operator dummy = Operator.createDummy();
     dummy.setParentOperators(Arrays.asList(input));
 
-    ArrayList<ExprNodeDesc> newSortCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> newSortCols = new ArrayList<ExprNodeDesc>();
     StringBuilder newSortOrder = new StringBuilder();
     StringBuilder newNullOrder = new StringBuilder();
-    ArrayList<ExprNodeDesc> sortColsBack = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> sortColsBack = new ArrayList<ExprNodeDesc>();
     for (int i = 0; i < sortCols.size(); i++) {
       ExprNodeDesc sortCol = sortCols.get(i);
       // If we are not pulling constants, OR
@@ -8960,13 +8941,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // For the generation of the values expression just get the inputs
     // signature and generate field expressions for those
     RowResolver rsRR = new RowResolver();
-    ArrayList<String> outputColumns = new ArrayList<String>();
-    ArrayList<ExprNodeDesc> valueCols = new ArrayList<ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> valueColsBack = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumns = new ArrayList<String>();
+    List<ExprNodeDesc> valueCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> valueColsBack = new ArrayList<ExprNodeDesc>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> constantCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> constantCols = new ArrayList<ExprNodeDesc>();
 
-    ArrayList<ColumnInfo> columnInfos = inputRR.getColumnInfos();
+    List<ColumnInfo> columnInfos = inputRR.getColumnInfos();
 
     int[] index = new int[columnInfos.size()];
     for (int i = 0; i < index.length; i++) {
@@ -9036,8 +9017,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     interim.setColumnExprMap(colExprMap);
 
     RowResolver selectRR = new RowResolver();
-    ArrayList<ExprNodeDesc> selCols = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> selOutputCols = new ArrayList<String>();
+    List<ExprNodeDesc> selCols = new ArrayList<ExprNodeDesc>();
+    List<String> selOutputCols = new ArrayList<String>();
     Map<String, ExprNodeDesc> selColExprMap = new HashMap<String, ExprNodeDesc>();
 
     Iterator<ExprNodeDesc> constants = constantCols.iterator();
@@ -9079,20 +9060,19 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private Operator genJoinOperatorChildren(QBJoinTree join, Operator left,
-                                           Operator[] right, HashSet<Integer> omitOpts, ExprNodeDesc[][] joinKeys) throws SemanticException {
+                                           Operator[] right, Set<Integer> omitOpts, ExprNodeDesc[][] joinKeys) throws SemanticException {
 
     RowResolver outputRR = new RowResolver();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<String> outputColumnNames = new ArrayList<String>();
     // all children are base classes
     Operator<?>[] rightOps = new Operator[right.length];
     int outputPos = 0;
 
     Map<String, Byte> reversedExprs = new HashMap<String, Byte>();
-    HashMap<Byte, List<ExprNodeDesc>> exprMap = new HashMap<Byte, List<ExprNodeDesc>>();
+    Map<Byte, List<ExprNodeDesc>> exprMap = new HashMap<Byte, List<ExprNodeDesc>>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
-    HashMap<Integer, Set<String>> posToAliasMap = new HashMap<Integer, Set<String>>();
-    HashMap<Byte, List<ExprNodeDesc>> filterMap =
-        new HashMap<Byte, List<ExprNodeDesc>>();
+    Map<Integer, Set<String>> posToAliasMap = new HashMap<Integer, Set<String>>();
+    Map<Byte, List<ExprNodeDesc>> filterMap = new HashMap<Byte, List<ExprNodeDesc>>();
 
     // Only used for semijoin with residual predicates
     List<ColumnInfo> topSelectInputColumns = new ArrayList<>();
@@ -9111,8 +9091,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
       int[] index = rs.getValueIndex();
 
-      ArrayList<ExprNodeDesc> valueDesc = new ArrayList<ExprNodeDesc>();
-      ArrayList<ExprNodeDesc> filterDesc = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> valueDesc = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> filterDesc = new ArrayList<ExprNodeDesc>();
       Byte tag = (byte) rsDesc.getTag();
 
       // check whether this input operator produces output
@@ -9267,9 +9247,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     RowResolver inputRR = opParseCtx.get(child).getRowResolver();
     RowResolver outputRR = new RowResolver();
-    ArrayList<String> outputColumns = new ArrayList<String>();
-    ArrayList<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> reduceKeysBack = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumns = new ArrayList<String>();
+    List<ExprNodeDesc> reduceKeys = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceKeysBack = new ArrayList<ExprNodeDesc>();
 
     // Compute join keys and store in reduceKeys
     for (ExprNodeDesc joinKey : joinKeys) {
@@ -9278,8 +9258,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     // Walk over the input row resolver and copy in the output
-    ArrayList<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> reduceValuesBack = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceValues = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> reduceValuesBack = new ArrayList<ExprNodeDesc>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
 
     List<ColumnInfo> columns = inputRR.getColumnInfos();
@@ -9373,7 +9353,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
 
     if ( joinSrcOp != null ) {
-      ArrayList<ASTNode> filter = joinTree.getFiltersForPushing().get(0);
+      List<ASTNode> filter = joinTree.getFiltersForPushing().get(0);
       for (ASTNode cond : filter) {
         joinSrcOp = genFilterPlan(qb, cond, joinSrcOp, false);
       }
@@ -9382,7 +9362,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String[] baseSrc = joinTree.getBaseSrc();
     Operator[] srcOps = new Operator[baseSrc.length];
 
-    HashSet<Integer> omitOpts = null; // set of input to the join that should be
+    Set<Integer> omitOpts = null; // set of input to the join that should be
     // omitted by the output
     int pos = 0;
     for (String src : baseSrc) {
@@ -9391,7 +9371,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
         // for left-semi join, generate an additional selection & group-by
         // operator before ReduceSink
-        ArrayList<ASTNode> fields = joinTree.getRHSSemijoinColumns(src);
+        List<ASTNode> fields = joinTree.getRHSSemijoinColumns(src);
         if (fields != null) {
           // the RHS table columns should be not be output from the join
           if (omitOpts == null) {
@@ -9404,8 +9384,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
           // generate a groupby operator (HASH mode) for a map-side partial
           // aggregation for semijoin
-          srcOps[pos++] = genMapGroupByForSemijoin(qb, fields, srcOp,
-              GroupByDesc.Mode.HASH);
+          srcOps[pos++] = genMapGroupByForSemijoin(qb, fields, srcOp, GroupByDesc.Mode.HASH);
         } else {
           srcOps[pos++] = srcOp;
         }
@@ -9426,8 +9405,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       srcOps[i] = genJoinReduceSinkChild(qb, joinKeys[i], srcOps[i], srcs, joinTree.getNextTag());
     }
 
-    Operator<?> topOp = genJoinOperatorChildren(joinTree,
-        joinSrcOp, srcOps, omitOpts, joinKeys);
+    Operator<?> topOp = genJoinOperatorChildren(joinTree, joinSrcOp, srcOps, omitOpts, joinKeys);
     JoinOperator joinOp;
     if (topOp instanceof JoinOperator) {
       joinOp = (JoinOperator) topOp;
@@ -9464,12 +9442,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @return the selection operator.
    * @throws SemanticException
    */
-  private Operator insertSelectForSemijoin(ArrayList<ASTNode> fields,
+  private Operator insertSelectForSemijoin(List<ASTNode> fields,
                                            Operator<?> input) throws SemanticException {
 
     RowResolver inputRR = opParseCtx.get(input).getRowResolver();
-    ArrayList<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
+    List<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumnNames = new ArrayList<String>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
 
     RowResolver outputRR = new RowResolver();
@@ -9520,16 +9498,15 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return output;
   }
 
-  private Operator genMapGroupByForSemijoin(QB qb, ArrayList<ASTNode> fields,
+  private Operator genMapGroupByForSemijoin(QB qb, List<ASTNode> fields,
                                             Operator<?> input, GroupByDesc.Mode mode)
       throws SemanticException {
 
-    RowResolver groupByInputRowResolver = opParseCtx.get(input)
-        .getRowResolver();
+    RowResolver groupByInputRowResolver = opParseCtx.get(input).getRowResolver();
     RowResolver groupByOutputRowResolver = new RowResolver();
-    ArrayList<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> outputColumnNames = new ArrayList<String>();
-    ArrayList<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
+    List<ExprNodeDesc> groupByKeys = new ArrayList<ExprNodeDesc>();
+    List<String> outputColumnNames = new ArrayList<String>();
+    List<AggregationDesc> aggregations = new ArrayList<AggregationDesc>();
     Map<String, ExprNodeDesc> colExprMap = new HashMap<String, ExprNodeDesc>();
 
     for (int i = 0; i < fields.size(); ++i) {
@@ -9658,12 +9635,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         pushJoinFilters(qb, joinTree.getJoinSrc(), map);
       }
     }
-    ArrayList<ArrayList<ASTNode>> filters = joinTree.getFiltersForPushing();
+    List<List<ASTNode>> filters = joinTree.getFiltersForPushing();
     int pos = 0;
     for (String src : joinTree.getBaseSrc()) {
       if (src != null) {
         Operator srcOp = map.get(src);
-        ArrayList<ASTNode> filter = filters.get(pos);
+        List<ASTNode> filter = filters.get(pos);
         for (ASTNode cond : filter) {
           srcOp = genFilterPlan(qb, cond, srcOp, false);
         }
@@ -9716,15 +9693,15 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     QBJoinTree joinTree = new QBJoinTree();
     joinTree.setNoOuterJoin(false);
 
-    joinTree.setExpressions(new ArrayList<ArrayList<ASTNode>>());
-    joinTree.setFilters(new ArrayList<ArrayList<ASTNode>>());
-    joinTree.setFiltersForPushing(new ArrayList<ArrayList<ASTNode>>());
+    joinTree.setExpressions(new ArrayList<List<ASTNode>>());
+    joinTree.setFilters(new ArrayList<List<ASTNode>>());
+    joinTree.setFiltersForPushing(new ArrayList<List<ASTNode>>());
 
     // Create joinTree structures to fill them up later
-    ArrayList<String> rightAliases = new ArrayList<String>();
-    ArrayList<String> leftAliases = new ArrayList<String>();
-    ArrayList<String> baseSrc = new ArrayList<String>();
-    ArrayList<Boolean> preserved = new ArrayList<Boolean>();
+    List<String> rightAliases = new ArrayList<String>();
+    List<String> leftAliases = new ArrayList<String>();
+    List<String> baseSrc = new ArrayList<String>();
+    List<Boolean> preserved = new ArrayList<Boolean>();
 
     boolean lastPreserved = false;
     int cols = -1;
@@ -9750,8 +9727,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         } else {
           rightAliases.add(alias);
         }
-        joinTree.getAliasToOpInfo().put(
-            getModifiedAlias(qb, alias), aliasToOpInfo.get(alias));
+        joinTree.getAliasToOpInfo().put(getModifiedAlias(qb, alias), aliasToOpInfo.get(alias));
         joinTree.setId(qb.getId());
         baseSrc.add(alias);
 
@@ -9767,9 +9743,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
               + "number of keys in UNIQUEJOIN");
         }
 
-        ArrayList<ASTNode> expressions = new ArrayList<ASTNode>();
-        ArrayList<ASTNode> filt = new ArrayList<ASTNode>();
-        ArrayList<ASTNode> filters = new ArrayList<ASTNode>();
+        List<ASTNode> expressions = new ArrayList<ASTNode>();
+        List<ASTNode> filt = new ArrayList<ASTNode>();
+        List<ASTNode> filters = new ArrayList<ASTNode>();
 
         for (Node exp : child.getChildren()) {
           expressions.add((ASTNode) exp);
@@ -9909,28 +9885,27 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       joinTree.addRHSSemijoin(rightalias);
     }
 
-    ArrayList<ArrayList<ASTNode>> expressions = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> expressions = new ArrayList<List<ASTNode>>();
     expressions.add(new ArrayList<ASTNode>());
     expressions.add(new ArrayList<ASTNode>());
     joinTree.setExpressions(expressions);
 
-    ArrayList<Boolean> nullsafes = new ArrayList<Boolean>();
+    List<Boolean> nullsafes = new ArrayList<Boolean>();
     joinTree.setNullSafes(nullsafes);
 
-    ArrayList<ArrayList<ASTNode>> filters = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filters = new ArrayList<List<ASTNode>>();
     filters.add(new ArrayList<ASTNode>());
     filters.add(new ArrayList<ASTNode>());
     joinTree.setFilters(filters);
     joinTree.setFilterMap(new int[2][]);
 
-    ArrayList<ArrayList<ASTNode>> filtersForPushing =
-        new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filtersForPushing = new ArrayList<List<ASTNode>>();
     filtersForPushing.add(new ArrayList<ASTNode>());
     filtersForPushing.add(new ArrayList<ASTNode>());
     joinTree.setFiltersForPushing(filtersForPushing);
 
     ASTNode joinCond = subQuery.getJoinConditionAST();
-    ArrayList<String> leftSrc = new ArrayList<String>();
+    List<String> leftSrc = new ArrayList<String>();
     parseJoinCondition(joinTree, joinCond, leftSrc, aliasToOpInfo);
     if (leftSrc.size() == 1) {
       joinTree.setLeftAlias(leftSrc.get(0));
@@ -10045,28 +10020,27 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       assert false;
     }
 
-    ArrayList<ArrayList<ASTNode>> expressions = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> expressions = new ArrayList<List<ASTNode>>();
     expressions.add(new ArrayList<ASTNode>());
     expressions.add(new ArrayList<ASTNode>());
     joinTree.setExpressions(expressions);
 
-    ArrayList<Boolean> nullsafes = new ArrayList<Boolean>();
+    List<Boolean> nullsafes = new ArrayList<Boolean>();
     joinTree.setNullSafes(nullsafes);
 
-    ArrayList<ArrayList<ASTNode>> filters = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filters = new ArrayList<List<ASTNode>>();
     filters.add(new ArrayList<ASTNode>());
     filters.add(new ArrayList<ASTNode>());
     joinTree.setFilters(filters);
     joinTree.setFilterMap(new int[2][]);
 
-    ArrayList<ArrayList<ASTNode>> filtersForPushing =
-        new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filtersForPushing = new ArrayList<List<ASTNode>>();
     filtersForPushing.add(new ArrayList<ASTNode>());
     filtersForPushing.add(new ArrayList<ASTNode>());
     joinTree.setFiltersForPushing(filtersForPushing);
 
     ASTNode joinCond = (ASTNode) joinParseTree.getChild(2);
-    ArrayList<String> leftSrc = new ArrayList<String>();
+    List<String> leftSrc = new ArrayList<String>();
     parseJoinCondition(joinTree, joinCond, leftSrc, aliasToOpInfo);
     if (leftSrc.size() == 1) {
       joinTree.setLeftAlias(leftSrc.get(0));
@@ -10295,29 +10269,29 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
     target.setBaseSrc(baseSrc);
 
-    ArrayList<ArrayList<ASTNode>> expr = target.getExpressions();
+    List<List<ASTNode>> expr = target.getExpressions();
     for (int i = 0; i < nodeRightAliases.length; i++) {
       List<ASTNode> nodeConds = node.getExpressions().get(i + 1);
-      ArrayList<ASTNode> reordereNodeConds = new ArrayList<ASTNode>();
+      List<ASTNode> reordereNodeConds = new ArrayList<ASTNode>();
       for(int k=0; k < tgtToNodeExprMap.length; k++) {
         reordereNodeConds.add(nodeConds.get(tgtToNodeExprMap[k]));
       }
       expr.add(reordereNodeConds);
     }
 
-    ArrayList<Boolean> nns = node.getNullSafes();
-    ArrayList<Boolean> tns = target.getNullSafes();
+    List<Boolean> nns = node.getNullSafes();
+    List<Boolean> tns = target.getNullSafes();
     for (int i = 0; i < tns.size(); i++) {
       tns.set(i, tns.get(i) & nns.get(i)); // any of condition contains non-NS, non-NS
     }
 
-    ArrayList<ArrayList<ASTNode>> filters = target.getFilters();
+    List<List<ASTNode>> filters = target.getFilters();
     for (int i = 0; i < nodeRightAliases.length; i++) {
       filters.add(node.getFilters().get(i + 1));
     }
 
     if (node.getFilters().get(0).size() != 0) {
-      ArrayList<ASTNode> filterPos = filters.get(pos);
+      List<ASTNode> filterPos = filters.get(pos);
       filterPos.addAll(node.getFilters().get(0));
     }
 
@@ -10348,7 +10322,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     System.arraycopy(nmap, 1, newmap, tmap.length, nmap.length - 1);
     target.setFilterMap(newmap);
 
-    ArrayList<ArrayList<ASTNode>> filter = target.getFiltersForPushing();
+    List<List<ASTNode>> filter = target.getFiltersForPushing();
     for (int i = 0; i < nodeRightAliases.length; i++) {
       filter.add(node.getFiltersForPushing().get(i + 1));
     }
@@ -10439,8 +10413,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       return Pair.of(-1, null);
     }
 
-    ArrayList<ASTNode> nodeCondn = node.getExpressions().get(0);
-    ArrayList<ASTNode> targetCondn = null;
+    List<ASTNode> nodeCondn = node.getExpressions().get(0);
+    List<ASTNode> targetCondn = null;
 
     if (leftAlias == null || leftAlias.equals(target.getLeftAlias())) {
       targetCondn = target.getExpressions().get(0);
@@ -10504,7 +10478,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return true;
   }
 
-  boolean shouldMerge(final QBJoinTree node, final QBJoinTree target) {
+  private boolean shouldMerge(final QBJoinTree node, final QBJoinTree target) {
     boolean isNodeOuterJoin=false, isNodeSemiJoin=false, hasNodePostJoinFilters=false;
     boolean isTargetOuterJoin=false, isTargetSemiJoin=false, hasTargetPostJoinFilters=false;
 
@@ -10599,7 +10573,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         curQBJTree = trees.get(i);
         if (curQBJTree != null) {
           if (prevQBJTree != null) {
-            ArrayList<String> newCurLeftAliases = new ArrayList<String>();
+            List<String> newCurLeftAliases = new ArrayList<String>();
             newCurLeftAliases.addAll(Arrays.asList(prevQBJTree.getLeftAliases()));
             newCurLeftAliases.addAll(Arrays.asList(prevQBJTree.getRightAliases()));
             curQBJTree
@@ -10640,11 +10614,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private Operator genSelectAllDesc(Operator input) throws SemanticException {
     OpParseContext inputCtx = opParseCtx.get(input);
     RowResolver inputRR = inputCtx.getRowResolver();
-    ArrayList<ColumnInfo> columns = inputRR.getColumnInfos();
-    ArrayList<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
-    ArrayList<String> columnNames = new ArrayList<String>();
-    Map<String, ExprNodeDesc> columnExprMap =
-        new HashMap<String, ExprNodeDesc>();
+    List<ColumnInfo> columns = inputRR.getColumnInfos();
+    List<ExprNodeDesc> colList = new ArrayList<ExprNodeDesc>();
+    List<String> columnNames = new ArrayList<String>();
+    Map<String, ExprNodeDesc> columnExprMap = new HashMap<String, ExprNodeDesc>();
     for (int i = 0; i < columns.size(); i++) {
       ColumnInfo col = columns.get(i);
       colList.add(new ExprNodeColumnDesc(col, true));
@@ -10667,7 +10640,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     QBParseInfo qbp = qb.getParseInfo();
 
-    TreeSet<String> ks = new TreeSet<String>();
+    SortedSet<String> ks = new TreeSet<String>();
     ks.addAll(qbp.getClauseNames());
 
     List<List<String>> commonGroupByDestGroups = new ArrayList<List<String>>();
@@ -10767,7 +10740,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return commonGroupByDestGroups;
   }
 
-  protected List<ExprNodeDesc> determineSprayKeys(QBParseInfo qbp, String dest,
+  private List<ExprNodeDesc> determineSprayKeys(QBParseInfo qbp, String dest,
       RowResolver inputRR) throws SemanticException {
     List<ExprNodeDesc> sprayKeys = new ArrayList<ExprNodeDesc>();
 
@@ -10833,7 +10806,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       throws SemanticException {
     QBParseInfo qbp = qb.getParseInfo();
 
-    TreeSet<String> ks = new TreeSet<String>(qbp.getClauseNames());
+    SortedSet<String> ks = new TreeSet<String>(qbp.getClauseNames());
     Map<String, Operator<? extends OperatorDesc>> inputs = createInputForDests(qb, input, ks);
 
     Operator curr = input;
@@ -11081,8 +11054,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // This can be easily merged into 1 union
     RowResolver leftRR = opParseCtx.get(leftOp).getRowResolver();
     RowResolver rightRR = opParseCtx.get(rightOp).getRowResolver();
-    LinkedHashMap<String, ColumnInfo> leftmap = leftRR.getFieldMap(leftalias);
-    LinkedHashMap<String, ColumnInfo> rightmap = rightRR.getFieldMap(rightalias);
+    Map<String, ColumnInfo> leftmap = leftRR.getFieldMap(leftalias);
+    Map<String, ColumnInfo> rightmap = rightRR.getFieldMap(rightalias);
     // make sure the schemas of both sides are the same
     ASTNode tabref = qb.getAliases().isEmpty() ? null :
         qb.getParseInfo().getSrcForAlias(qb.getAliases().get(0));
@@ -11245,7 +11218,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       String origInputAlias, RowResolver unionoutRR, String unionalias)
       throws SemanticException {
 
-    HashMap<String, ColumnInfo> fieldMap = unionoutRR.getFieldMap(unionalias);
+    Map<String, ColumnInfo> fieldMap = unionoutRR.getFieldMap(unionalias);
 
     Iterator<ColumnInfo> oIter = origInputFieldMap.values().iterator();
     Iterator<ColumnInfo> uIter = fieldMap.values().iterator();
@@ -11336,7 +11309,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     ExprNodeDesc intMaxExpr = new ExprNodeConstantDesc(
         TypeInfoFactory.intTypeInfo, Integer.valueOf(Integer.MAX_VALUE));
 
-    ArrayList<ExprNodeDesc> args = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> args = new ArrayList<ExprNodeDesc>();
     if (planExpr != null) {
       args.add(planExpr);
     } else if (useBucketCols) {
@@ -11483,7 +11456,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       tableScanOp.getConf().setTableSample(ts);
       int num = ts.getNumerator();
       int den = ts.getDenominator();
-      ArrayList<ASTNode> sampleExprs = ts.getExprs();
+      List<ASTNode> sampleExprs = ts.getExprs();
 
       // TODO: Do the type checking of the expressions
       List<String> tabBucketCols = tab.getBucketCols();
@@ -11730,12 +11703,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return null;
   }
 
-  public Operator genPlan(QB qb) throws SemanticException {
+  Operator genPlan(QB qb) throws SemanticException {
     return genPlan(qb, false);
   }
 
   @SuppressWarnings("nls")
-  public Operator genPlan(QB qb, boolean skipAmbiguityCheck)
+  private Operator genPlan(QB qb, boolean skipAmbiguityCheck)
       throws SemanticException {
 
     // First generate all the opInfos for the elements in the from clause
@@ -11792,7 +11765,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       //After processing subqueries and source tables, process
       // partitioned table functions
 
-      HashMap<ASTNode, PTFInvocationSpec> ptfNodeToSpec = qb.getPTFNodeToSpec();
+      Map<ASTNode, PTFInvocationSpec> ptfNodeToSpec = qb.getPTFNodeToSpec();
       if ( ptfNodeToSpec != null ) {
         for(Entry<ASTNode, PTFInvocationSpec> entry : ptfNodeToSpec.entrySet()) {
           ASTNode ast = entry.getKey();
@@ -11941,15 +11914,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @throws SemanticException
    */
 
-  void genLateralViewPlans(Map<String, Operator> aliasToOpInfo, QB qb)
+  private void genLateralViewPlans(Map<String, Operator> aliasToOpInfo, QB qb)
       throws SemanticException {
-    Map<String, ArrayList<ASTNode>> aliasToLateralViews = qb.getParseInfo()
-        .getAliasToLateralViews();
+    Map<String, List<ASTNode>> aliasToLateralViews = qb.getParseInfo().getAliasToLateralViews();
     for (Entry<String, Operator> e : aliasToOpInfo.entrySet()) {
       String alias = e.getKey();
       // See if the alias has a lateral view. If so, chain the lateral view
       // operator on
-      ArrayList<ASTNode> lateralViews = aliasToLateralViews.get(alias);
+      List<ASTNode> lateralViews = aliasToLateralViews.get(alias);
       if (lateralViews != null) {
         Operator op = e.getValue();
 
@@ -12032,7 +12004,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // names have to be changed to avoid conflicts
 
     RowResolver lateralViewRR = new RowResolver();
-    ArrayList<String> outputInternalColNames = new ArrayList<String>();
+    List<String> outputInternalColNames = new ArrayList<String>();
 
 
     // For PPD, we need a column to expression map so that during the walk,
@@ -12069,7 +12041,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    *          the same order as in the dest row resolver
    */
   private void LVmergeRowResolvers(RowResolver source, RowResolver dest,
-                                   Map<String, ExprNodeDesc> colExprMap, ArrayList<String> outputInternalColNames) {
+                                   Map<String, ExprNodeDesc> colExprMap, List<String> outputInternalColNames) {
     for (ColumnInfo c : source.getColumnInfos()) {
       String internalName = getColumnInternalName(outputInternalColNames.size());
       outputInternalColNames.add(internalName);
@@ -12084,7 +12056,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   @SuppressWarnings("nls")
-  public Phase1Ctx initPhase1Ctx() {
+  Phase1Ctx initPhase1Ctx() {
 
     Phase1Ctx ctx_1 = new Phase1Ctx();
     ctx_1.nextNum = 0;
@@ -12182,7 +12154,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
   // Walk through the AST.
   // Replace all TOK_TABREF with fully qualified table name, if it is not already fully qualified.
-  protected String rewriteQueryWithQualifiedNames(ASTNode ast, TokenRewriteStream tokenRewriteStream)
+  private String rewriteQueryWithQualifiedNames(ASTNode ast, TokenRewriteStream tokenRewriteStream)
       throws SemanticException {
     UnparseTranslator unparseTranslator = new UnparseTranslator(conf);
     unparseTranslator.enable();
@@ -12356,7 +12328,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   // the table needs to be masked or filtered.
   // For the replacement, we leverage the methods that are used for
   // unparseTranslator.
-  protected ASTNode rewriteASTWithMaskAndFilter(TableMask tableMask, ASTNode ast, TokenRewriteStream tokenRewriteStream,
+  private ASTNode rewriteASTWithMaskAndFilter(TableMask tableMask, ASTNode ast, TokenRewriteStream tokenRewriteStream,
       Context ctx, Hive db, Map<String, Table> tabNameToTabObject, Set<Integer> ignoredTokens)
       throws SemanticException {
     // 1. collect information about CTE if there is any.
@@ -12493,7 +12465,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return true;
   }
 
-  public void getHintsFromQB(QB qb, List<ASTNode> hints) {
+  void getHintsFromQB(QB qb, List<ASTNode> hints) {
     if (qb.getParseInfo().getHints() != null) {
       hints.add(qb.getParseInfo().getHints());
     }
@@ -12505,7 +12477,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  public void getHintsFromQB(QBExpr qbExpr, List<ASTNode> hints) {
+  private void getHintsFromQB(QBExpr qbExpr, List<ASTNode> hints) {
     QBExpr qbExpr1 = qbExpr.getQBExpr1();
     QBExpr qbExpr2 = qbExpr.getQBExpr2();
     QB qb = qbExpr.getQB();
@@ -12731,7 +12703,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         if (postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.PostExecutePrinter")
             || postExecHooks.contains("org.apache.hadoop.hive.ql.hooks.LineageLogger")
             || postExecHooks.contains("org.apache.atlas.hive.hook.HiveHook")) {
-          ArrayList<Transform> transformations = new ArrayList<Transform>();
+          List<Transform> transformations = new ArrayList<Transform>();
           transformations.add(new HiveOpConverterPostProc());
           transformations.add(new Generator(postExecHooks));
           for (Transform t : transformations) {
@@ -12832,7 +12804,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  private void putAccessedColumnsToReadEntity(HashSet<ReadEntity> inputs, ColumnAccessInfo columnAccessInfo) {
+  private void putAccessedColumnsToReadEntity(Set<ReadEntity> inputs, ColumnAccessInfo columnAccessInfo) {
     Map<String, List<String>> tableToColumnAccessMap = columnAccessInfo.getTableToColumnAccessMap();
     if (tableToColumnAccessMap != null && !tableToColumnAccessMap.isEmpty()) {
       for(ReadEntity entity: inputs) {
@@ -13029,7 +13001,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return tablesUsed;
   }
 
-  static List<FieldSchema> convertRowSchemaToViewSchema(RowResolver rr) throws SemanticException {
+  private static List<FieldSchema> convertRowSchemaToViewSchema(RowResolver rr) throws SemanticException {
     List<FieldSchema> fieldSchema = convertRowSchemaToResultSetSchema(rr, false);
     ParseUtils.validateColumnNameUniqueness(fieldSchema);
     return fieldSchema;
@@ -13068,7 +13040,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return genExprNodeDesc(expr, input, true, false);
   }
 
-  public ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input,
+  ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input,
                                       RowResolver outerRR, Map<ASTNode, RelNode> subqueryToRelNode,
                                       boolean useCaching) throws SemanticException {
 
@@ -13079,12 +13051,12 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
 
-  public ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching)
+  ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching)
       throws SemanticException {
     return genExprNodeDesc(expr, input, useCaching, false);
   }
 
-  public ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching,
+  private ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input, boolean useCaching,
                                       boolean foldExpr) throws SemanticException {
     TypeCheckCtx tcCtx = new TypeCheckCtx(input, useCaching, foldExpr);
     return genExprNodeDesc(expr, input, tcCtx);
@@ -13094,7 +13066,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * Generates an expression node descriptors for the expression and children of it
    * with default TypeCheckCtx.
    */
-  public Map<ASTNode, ExprNodeDesc> genAllExprNodeDesc(ASTNode expr, RowResolver input)
+  Map<ASTNode, ExprNodeDesc> genAllExprNodeDesc(ASTNode expr, RowResolver input)
       throws SemanticException {
     TypeCheckCtx tcCtx = new TypeCheckCtx(input);
     return genAllExprNodeDesc(expr, input, tcCtx);
@@ -13104,7 +13076,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * Returns expression node descriptor for the expression.
    * If it's evaluated already in previous operator, it can be retrieved from cache.
    */
-  public ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input,
+  ExprNodeDesc genExprNodeDesc(ASTNode expr, RowResolver input,
                                       TypeCheckCtx tcCtx) throws SemanticException {
     // We recursively create the exprNodeDesc. Base cases: when we encounter
     // a column ref, we convert that into an exprNodeColumnDesc; when we
@@ -13158,7 +13130,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @throws SemanticException Failed to evaluate expression
    */
   @SuppressWarnings("nls")
-  public Map<ASTNode, ExprNodeDesc> genAllExprNodeDesc(ASTNode expr, RowResolver input,
+  Map<ASTNode, ExprNodeDesc> genAllExprNodeDesc(ASTNode expr, RowResolver input,
                                                        TypeCheckCtx tcCtx) throws SemanticException {
     // Create the walker and  the rules dispatcher.
     tcCtx.setUnparseTranslator(unparseTranslator);
@@ -13467,7 +13439,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    * @param checkConstraints CHECK constraints
    * @return true or false
    */
-  boolean hasConstraints(final List<FieldSchema> partCols, final List<SQLDefaultConstraint> defConstraints,
+  private boolean hasConstraints(final List<FieldSchema> partCols, final List<SQLDefaultConstraint> defConstraints,
                          final List<SQLNotNullConstraint> notNullConstraints,
                          final List<SQLCheckConstraint> checkConstraints) {
     for(FieldSchema partFS: partCols) {
@@ -14195,7 +14167,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   // Process the position alias in GROUPBY and ORDERBY
-  public void processPositionAlias(ASTNode ast) throws SemanticException {
+  void processPositionAlias(ASTNode ast) throws SemanticException {
     boolean isBothByPos = HiveConf.getBoolVar(conf, ConfVars.HIVE_GROUPBY_ORDERBY_POSITION_ALIAS);
     boolean isGbyByPos = isBothByPos
         || HiveConf.getBoolVar(conf, ConfVars.HIVE_GROUPBY_POSITION_ALIAS);
@@ -14779,10 +14751,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   private static class AggregationExprCheck implements ContextVisitor {
-    HashMap<String, ASTNode> destAggrExprs;
+    Map<String, ASTNode> destAggrExprs;
     boolean isAggr = false;
 
-    public AggregationExprCheck(HashMap<String, ASTNode> destAggrExprs) {
+    public AggregationExprCheck(Map<String, ASTNode> destAggrExprs) {
       super();
       this.destAggrExprs = destAggrExprs;
     }
@@ -14857,8 +14829,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return ptfDesc;
   }
 
-  Operator genPTFPlan(PTFInvocationSpec ptfQSpec, Operator input) throws SemanticException {
-    ArrayList<PTFInvocationSpec> componentQueries = PTFTranslator.componentize(ptfQSpec);
+  private Operator genPTFPlan(PTFInvocationSpec ptfQSpec, Operator input) throws SemanticException {
+    List<PTFInvocationSpec> componentQueries = PTFTranslator.componentize(ptfQSpec);
     for (PTFInvocationSpec ptfSpec : componentQueries) {
       input = genPTFPlanForComponentQuery(ptfSpec, input);
     }
@@ -14876,10 +14848,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
    *
    * @throws SemanticException
    */
-  void buildPTFReduceSinkDetails(PartitionedTableFunctionDef tabDef,
+  private void buildPTFReduceSinkDetails(PartitionedTableFunctionDef tabDef,
                                  RowResolver inputRR,
-                                 ArrayList<ExprNodeDesc> partCols,
-                                 ArrayList<ExprNodeDesc> orderCols,
+                                 List<ExprNodeDesc> partCols,
+                                 List<ExprNodeDesc> orderCols,
                                  StringBuilder orderString,
                                  StringBuilder nullOrderString) throws SemanticException {
 
@@ -14955,8 +14927,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
        * b. Build Reduce Sink Details (keyCols, valueCols, outColNames etc.) for this ptfDesc.
        */
 
-      ArrayList<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
-      ArrayList<ExprNodeDesc> orderCols = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
+      List<ExprNodeDesc> orderCols = new ArrayList<ExprNodeDesc>();
       StringBuilder orderString = new StringBuilder();
       StringBuilder nullOrderString = new StringBuilder();
 
@@ -14999,7 +14971,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
 //--------------------------- Windowing handling: PTFInvocationSpec to PTFDesc --------------------
 
-  Operator genWindowingPlan(QB qb, WindowingSpec wSpec, Operator input) throws SemanticException {
+  private Operator genWindowingPlan(QB qb, WindowingSpec wSpec, Operator input) throws SemanticException {
     wSpec.validateAndMakeEffective();
 
     if (!isCBOExecuted() && !qb.getParseInfo().getDestToGroupBy().isEmpty()) {
@@ -15038,8 +15010,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private Operator genReduceSinkPlanForWindowing(WindowingSpec spec,
                                                  RowResolver inputRR, Operator input) throws SemanticException{
 
-    ArrayList<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
-    ArrayList<ExprNodeDesc> orderCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> partCols = new ArrayList<ExprNodeDesc>();
+    List<ExprNodeDesc> orderCols = new ArrayList<ExprNodeDesc>();
     StringBuilder order = new StringBuilder();
     StringBuilder nullOrder = new StringBuilder();
 
@@ -15074,7 +15046,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         -1, Operation.NOT_ACID);
   }
 
-  public static ArrayList<WindowExpressionSpec> parseSelect(String selectExprStr)
+  public static List<WindowExpressionSpec> parseSelect(String selectExprStr)
       throws SemanticException
   {
     ASTNode selNode = null;
@@ -15085,7 +15057,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       throw new SemanticException(pe);
     }
 
-    ArrayList<WindowExpressionSpec> selSpec = new ArrayList<WindowExpressionSpec>();
+    List<WindowExpressionSpec> selSpec = new ArrayList<WindowExpressionSpec>();
     int childCount = selNode.getChildCount();
     for (int i = 0; i < childCount; i++) {
       ASTNode selExpr = (ASTNode) selNode.getChild(i);
@@ -15197,24 +15169,24 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  protected boolean updating(String destination) {
+  private boolean updating(String destination) {
     return destination.startsWith(Context.DestClausePrefix.UPDATE.toString());
   }
 
-  protected boolean deleting(String destination) {
+  private boolean deleting(String destination) {
     return destination.startsWith(Context.DestClausePrefix.DELETE.toString());
   }
 
   // Make sure the proper transaction manager that supports ACID is being used
-  protected void checkAcidTxnManager(Table table) throws SemanticException {
+  private void checkAcidTxnManager(Table table) throws SemanticException {
     if (SessionState.get() != null && !getTxnMgr().supportsAcid()
         && !HiveConf.getBoolVar(conf, ConfVars.HIVE_IN_TEST_REPL)) {
       throw new SemanticException(ErrorMsg.TXNMGR_NOT_ACID, table.getDbName(), table.getTableName());
     }
   }
 
-  public static ASTNode genSelectDIAST(RowResolver rr) {
-    LinkedHashMap<String, LinkedHashMap<String, ColumnInfo>> map = rr.getRslvMap();
+  static ASTNode genSelectDIAST(RowResolver rr) {
+    Map<String, Map<String, ColumnInfo>> map = rr.getRslvMap();
     ASTNode selectDI = new ASTNode(SELECTDI_TOKEN);
     // Note: this will determine the order of columns in the result. For now, the columns for each
     //       table will be together; the order of the tables, as well as the columns within each

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TableSample.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TableSample.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.ql.parse;
 
-import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 
@@ -49,7 +49,7 @@ public class TableSample {
    * In case the table does not have any clustering column, the usage of a table
    * sample clause without an ON part is disallowed by the compiler
    */
-  private ArrayList<ASTNode> exprs;
+  private List<ASTNode> exprs;
 
   /**
    * Flag to indicate that input files can be pruned.
@@ -67,7 +67,7 @@ public class TableSample {
    * @param exprs
    *          The list of expressions in the ON part of the TABLESAMPLE clause
    */
-  public TableSample(String num, String den, ArrayList<ASTNode> exprs) {
+  public TableSample(String num, String den, List<ASTNode> exprs) {
     numerator = Integer.parseInt(num);
     denominator = Integer.parseInt(den);
     this.exprs = exprs;
@@ -122,7 +122,7 @@ public class TableSample {
    * 
    * @return ArrayList&lt;ASTNode&gt;
    */
-  public ArrayList<ASTNode> getExprs() {
+  public List<ASTNode> getExprs() {
     return exprs;
   }
 
@@ -132,7 +132,7 @@ public class TableSample {
    * @param exprs
    *          The expression list
    */
-  public void setExprs(ArrayList<ASTNode> exprs) {
+  public void setExprs(List<ASTNode> exprs) {
     this.exprs = exprs;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -122,7 +122,7 @@ public abstract class TaskCompiler {
   @SuppressWarnings("nls")
   public void compile(final ParseContext pCtx,
       final List<Task<? extends Serializable>> rootTasks,
-      final HashSet<ReadEntity> inputs, final HashSet<WriteEntity> outputs) throws SemanticException {
+      final Set<ReadEntity> inputs, final Set<WriteEntity> outputs) throws SemanticException {
 
     Context ctx = pCtx.getContext();
     GlobalLimitCtx globalLimitCtx = pCtx.getGlobalLimitCtx();
@@ -405,7 +405,7 @@ public abstract class TaskCompiler {
     return tsk.getWork().getFullTableName();
   }
 
-  private Task<?> genTableStats(ParseContext parseContext, TableScanOperator tableScan, Task currentTask, final HashSet<WriteEntity> outputs)
+  private Task<?> genTableStats(ParseContext parseContext, TableScanOperator tableScan, Task currentTask, final Set<WriteEntity> outputs)
       throws HiveException {
     Class<? extends InputFormat> inputFormat = tableScan.getConf().getTableMetadata()
         .getInputFormatClass();

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -896,11 +896,9 @@ public class TezCompiler extends TaskCompiler {
 
   private static class TerminalOpsInfo {
     public Set<TerminalOperator<?>> terminalOps;
-    public Set<ReduceSinkOperator> rsOps;
 
-    TerminalOpsInfo(Set<TerminalOperator<?>> terminalOps, Set<ReduceSinkOperator> rsOps) {
+    TerminalOpsInfo(Set<TerminalOperator<?>> terminalOps) {
       this.terminalOps = terminalOps;
-      this.rsOps = rsOps;
     }
   }
 
@@ -928,7 +926,7 @@ public class TezCompiler extends TaskCompiler {
       OperatorUtils.findWorkOperatorsAndSemiJoinEdges(selOp,
               pCtx.getRsToSemiJoinBranchInfo(), workRSOps, workTerminalOps);
 
-      TerminalOpsInfo candidate = new TerminalOpsInfo(workTerminalOps, workRSOps);
+      TerminalOpsInfo candidate = new TerminalOpsInfo(workTerminalOps);
 
       // A work may contain multiple semijoin edges, traverse rsOps and add for each
       for (ReduceSinkOperator rsFound : workRSOps) {
@@ -1094,7 +1092,7 @@ public class TezCompiler extends TaskCompiler {
       // <Parent Ops>-SEL-GB1-RS1-GB2-RS2
       GroupByOperator gbOp = (GroupByOperator) stack.get(stack.size() - 2);
       GroupByDesc gbDesc = gbOp.getConf();
-      ArrayList<AggregationDesc> aggregationDescs = gbDesc.getAggregators();
+      List<AggregationDesc> aggregationDescs = gbDesc.getAggregators();
       for (AggregationDesc agg : aggregationDescs) {
         if (!isBloomFilterAgg(agg)) {
           continue;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TypeCheckProcFactory.java
@@ -1617,7 +1617,7 @@ public class TypeCheckProcFactory {
           assert child.getType() == HiveParser.TOK_TABNAME;
           assert child.getChildCount() == 1;
           String tableAlias = BaseSemanticAnalyzer.unescapeIdentifier(child.getChild(0).getText());
-          HashMap<String, ColumnInfo> columns = input.getFieldMap(tableAlias);
+          Map<String, ColumnInfo> columns = input.getFieldMap(tableAlias);
           if (columns == null) {
             throw new SemanticException(ErrorMsg.INVALID_TABLE_ALIAS.getMsg(child));
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/authorization/HiveAuthorizationTaskFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/authorization/HiveAuthorizationTaskFactory.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hive.ql.parse.authorization;
 
 import java.io.Serializable;
-import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience.LimitedPrivate;
@@ -37,40 +37,40 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
 @LimitedPrivate(value = { "Apache Hive, Apache Sentry (incubating)" })
 @Evolving
 public interface HiveAuthorizationTaskFactory {
-  public Task<? extends Serializable> createCreateRoleTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createCreateRoleTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createDropRoleTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createDropRoleTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createShowRoleGrantTask(ASTNode node, Path resultFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createShowRoleGrantTask(ASTNode node, Path resultFile,
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createGrantRoleTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createGrantRoleTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createRevokeRoleTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createRevokeRoleTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createGrantTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createGrantTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createShowGrantTask(ASTNode node, Path resultFile, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createShowGrantTask(ASTNode node, Path resultFile, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createRevokeTask(ASTNode node, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createRevokeTask(ASTNode node, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createSetRoleTask(String roleName,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createSetRoleTask(String roleName,
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createShowCurrentRoleTask(HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs, Path resFile) throws SemanticException;
+  Task<? extends Serializable> createShowCurrentRoleTask(Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs, Path resFile) throws SemanticException;
 
-  public Task<? extends Serializable> createShowRolePrincipalsTask(ASTNode ast, Path resFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createShowRolePrincipalsTask(ASTNode ast, Path resFile,
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) throws SemanticException;
 
-  public Task<? extends Serializable> createShowRolesTask(ASTNode ast, Path resFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException;
+  Task<? extends Serializable> createShowRolesTask(ASTNode ast, Path resFile,
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) throws SemanticException;
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/authorization/HiveAuthorizationTaskFactoryImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/authorization/HiveAuthorizationTaskFactoryImpl.java
@@ -19,9 +19,9 @@ package org.apache.hadoop.hive.ql.parse.authorization;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -73,22 +73,22 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
   }
 
   @Override
-  public Task<? extends Serializable> createCreateRoleTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) {
+  public Task<? extends Serializable> createCreateRoleTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) {
     String roleName = BaseSemanticAnalyzer.unescapeIdentifier(ast.getChild(0).getText());
     CreateRoleDesc createRoleDesc = new CreateRoleDesc(roleName);
     return TaskFactory.get(new DDLWork(inputs, outputs, createRoleDesc));
   }
   @Override
-  public Task<? extends Serializable> createDropRoleTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) {
+  public Task<? extends Serializable> createDropRoleTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) {
     String roleName = BaseSemanticAnalyzer.unescapeIdentifier(ast.getChild(0).getText());
     DropRoleDesc dropRoleDesc = new DropRoleDesc(roleName);
     return TaskFactory.get(new DDLWork(inputs, outputs, dropRoleDesc));
   }
   @Override
   public Task<? extends Serializable> createShowRoleGrantTask(ASTNode ast, Path resultFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) {
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) {
     ASTNode child = (ASTNode) ast.getChild(0);
     PrincipalType principalType = PrincipalType.USER;
     switch (child.getType()) {
@@ -107,8 +107,8 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
     return TaskFactory.get(new DDLWork(inputs, outputs, showRoleGrantDesc));
   }
   @Override
-  public Task<? extends Serializable> createGrantTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException {
+  public Task<? extends Serializable> createGrantTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
     List<PrivilegeDesc> privilegeDesc = analyzePrivilegeListDef(
         (ASTNode) ast.getChild(0));
     List<PrincipalDesc> principalDesc = AuthorizationParseUtils.analyzePrincipalListDef(
@@ -135,8 +135,8 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
   }
 
   @Override
-  public Task<? extends Serializable> createRevokeTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException {
+  public Task<? extends Serializable> createRevokeTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
     List<PrivilegeDesc> privilegeDesc = analyzePrivilegeListDef((ASTNode) ast.getChild(0));
     List<PrincipalDesc> principalDesc = AuthorizationParseUtils.analyzePrincipalListDef((ASTNode) ast.getChild(1));
     PrivilegeObjectDesc hiveObj = null;
@@ -153,8 +153,8 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
     return TaskFactory.get(new DDLWork(inputs, outputs, revokeDesc));
   }
   @Override
-  public Task<? extends Serializable> createShowGrantTask(ASTNode ast, Path resultFile, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) throws SemanticException {
+  public Task<? extends Serializable> createShowGrantTask(ASTNode ast, Path resultFile, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
 
     PrincipalDesc principalDesc = null;
     PrivilegeObjectDesc privHiveObj = null;
@@ -180,17 +180,17 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
     return TaskFactory.get(new DDLWork(inputs, outputs, showGrant));
   }
   @Override
-  public Task<? extends Serializable> createGrantRoleTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) {
+  public Task<? extends Serializable> createGrantRoleTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) {
     return analyzeGrantRevokeRole(true, ast, inputs, outputs);
   }
   @Override
-  public Task<? extends Serializable> createRevokeRoleTask(ASTNode ast, HashSet<ReadEntity> inputs,
-      HashSet<WriteEntity> outputs) {
+  public Task<? extends Serializable> createRevokeRoleTask(ASTNode ast, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) {
     return analyzeGrantRevokeRole(false, ast, inputs, outputs);
   }
   private Task<? extends Serializable> analyzeGrantRevokeRole(boolean isGrant, ASTNode ast,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) {
+      Set<ReadEntity> inputs, Set<WriteEntity> outputs) {
     List<PrincipalDesc> principalDesc = AuthorizationParseUtils.analyzePrincipalListDef(
         (ASTNode) ast.getChild(0));
 
@@ -223,7 +223,7 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
   }
 
   private PrivilegeObjectDesc analyzePrivilegeObject(ASTNode ast,
-      HashSet<WriteEntity> outputs)
+      Set<WriteEntity> outputs)
       throws SemanticException {
 
     PrivilegeObjectDesc subject = parsePrivObject(ast);
@@ -335,24 +335,22 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
   }
 
   @Override
-  public Task<? extends Serializable> createSetRoleTask(String roleName,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs)
-      throws SemanticException {
+  public Task<? extends Serializable> createSetRoleTask(String roleName, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
     SetRoleDesc setRoleDesc = new SetRoleDesc(roleName);
     return TaskFactory.get(new DDLWork(inputs, outputs, setRoleDesc));
   }
 
   @Override
-  public Task<? extends Serializable> createShowCurrentRoleTask(
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs, Path resFile)
-      throws SemanticException {
+  public Task<? extends Serializable> createShowCurrentRoleTask( Set<ReadEntity> inputs, Set<WriteEntity> outputs,
+      Path resFile) throws SemanticException {
     ShowCurrentRoleDesc showCurrentRoleDesc = new ShowCurrentRoleDesc(resFile.toString());
     return TaskFactory.get(new DDLWork(inputs, outputs, showCurrentRoleDesc));
   }
 
   @Override
-  public Task<? extends Serializable> createShowRolePrincipalsTask(ASTNode ast, Path resFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException {
+  public Task<? extends Serializable> createShowRolePrincipalsTask(ASTNode ast, Path resFile, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
     String roleName;
 
     if (ast.getChildCount() == 1) {
@@ -367,8 +365,8 @@ public class HiveAuthorizationTaskFactoryImpl implements HiveAuthorizationTaskFa
   }
 
   @Override
-  public Task<? extends Serializable> createShowRolesTask(ASTNode ast, Path resFile,
-      HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) throws SemanticException {
+  public Task<? extends Serializable> createShowRolesTask(ASTNode ast, Path resFile, Set<ReadEntity> inputs,
+      Set<WriteEntity> outputs) throws SemanticException {
     ShowRolesDesc showRolesDesc = new ShowRolesDesc(resFile.toString());
     return TaskFactory.get(new DDLWork(inputs, outputs, showRolesDesc));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/AggregationDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/AggregationDesc.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.plan;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
@@ -33,7 +34,7 @@ public class AggregationDesc implements java.io.Serializable {
   private static final long serialVersionUID = 1L;
   private String genericUDAFName;
 
-  private java.util.ArrayList<ExprNodeDesc> parameters;
+  private List<ExprNodeDesc> parameters;
   private boolean distinct;
   private GenericUDAFEvaluator.Mode mode;
 
@@ -49,7 +50,7 @@ public class AggregationDesc implements java.io.Serializable {
 
   public AggregationDesc(final String genericUDAFName,
       final GenericUDAFEvaluator genericUDAFEvaluator,
-      final java.util.ArrayList<ExprNodeDesc> parameters,
+      final List<ExprNodeDesc> parameters,
       final boolean distinct, final GenericUDAFEvaluator.Mode mode) {
     this.genericUDAFName = genericUDAFName;
     this.parameters = parameters;
@@ -108,11 +109,11 @@ public class AggregationDesc implements java.io.Serializable {
     this.genericUDAFWritableEvaluator = genericUDAFWritableEvaluator;
   }
 
-  public java.util.ArrayList<ExprNodeDesc> getParameters() {
+  public List<ExprNodeDesc> getParameters() {
     return parameters;
   }
 
-  public void setParameters(final java.util.ArrayList<ExprNodeDesc> parameters) {
+  public void setParameters(List<ExprNodeDesc> parameters) {
     this.parameters = parameters;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExplainWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExplainWork.java
@@ -20,8 +20,8 @@ package org.apache.hadoop.hive.ql.plan;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.Task;
@@ -41,20 +41,20 @@ public class ExplainWork implements Serializable {
   private static final long serialVersionUID = 1L;
 
   private Path resFile;
-  private ArrayList<Task<?>> rootTasks;
+  private List<Task<?>> rootTasks;
   private Task<?> fetchTask;
   private ASTNode astTree;
   private String astStringTree;
-  private HashSet<ReadEntity> inputs;
-  private HashSet<WriteEntity> outputs;
+  private Set<ReadEntity> inputs;
+  private Set<WriteEntity> outputs;
   private ParseContext pCtx;
 
   private ExplainConfiguration config;
 
-  boolean appendTaskType;
+  private boolean appendTaskType;
 
-  String cboInfo;
-  String cboPlan;
+  private String cboInfo;
+  private String cboPlan;
 
   private String optimizedSQL;
 
@@ -101,11 +101,11 @@ public class ExplainWork implements Serializable {
     this.resFile = resFile;
   }
 
-  public ArrayList<Task<?>> getRootTasks() {
+  public List<Task<?>> getRootTasks() {
     return rootTasks;
   }
 
-  public void setRootTasks(ArrayList<Task<?>> rootTasks) {
+  public void setRootTasks(List<Task<?>> rootTasks) {
     this.rootTasks = rootTasks;
   }
 
@@ -117,19 +117,19 @@ public class ExplainWork implements Serializable {
     this.fetchTask = fetchTask;
   }
 
-  public HashSet<ReadEntity> getInputs() {
+  public Set<ReadEntity> getInputs() {
     return inputs;
   }
 
-  public void setInputs(HashSet<ReadEntity> inputs) {
+  public void setInputs(Set<ReadEntity> inputs) {
     this.inputs = inputs;
   }
 
-  public HashSet<WriteEntity> getOutputs() {
+  public Set<WriteEntity> getOutputs() {
     return outputs;
   }
 
-  public void setOutputs(HashSet<WriteEntity> outputs) {
+  public void setOutputs(Set<WriteEntity> outputs) {
     this.outputs = outputs;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/GroupByDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/GroupByDesc.java
@@ -65,12 +65,12 @@ public class GroupByDesc extends AbstractOperatorDesc {
   // no hash aggregations for group by
   private boolean bucketGroup;
 
-  private ArrayList<ExprNodeDesc> keys;
+  private List<ExprNodeDesc> keys;
   private List<Long> listGroupingSets;
   private boolean groupingSetsPresent;
   private int groupingSetPosition = -1; //  /* in case of grouping sets; groupby1 will output values for every setgroup; this is the index of the column that information will be sent */
-  private ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> aggregators;
-  private ArrayList<java.lang.String> outputColumnNames;
+  private List<AggregationDesc> aggregators;
+  private List<String> outputColumnNames;
   private float groupByMemoryUsage;
   private float memoryThreshold;
   private float minReductionHashAggr;
@@ -82,9 +82,9 @@ public class GroupByDesc extends AbstractOperatorDesc {
 
   public GroupByDesc(
       final Mode mode,
-      final ArrayList<java.lang.String> outputColumnNames,
-      final ArrayList<ExprNodeDesc> keys,
-      final ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> aggregators,
+      final List<String> outputColumnNames,
+      final List<ExprNodeDesc> keys,
+      final List<AggregationDesc> aggregators,
       final float groupByMemoryUsage,
       final float memoryThreshold,
       final float minReductionHashAggr,
@@ -99,9 +99,9 @@ public class GroupByDesc extends AbstractOperatorDesc {
 
   public GroupByDesc(
       final Mode mode,
-      final ArrayList<java.lang.String> outputColumnNames,
-      final ArrayList<ExprNodeDesc> keys,
-      final ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> aggregators,
+      final List<String> outputColumnNames,
+      final List<ExprNodeDesc> keys,
+      final List<AggregationDesc> aggregators,
       final boolean bucketGroup,
       final float groupByMemoryUsage,
       final float memoryThreshold,
@@ -166,22 +166,22 @@ public class GroupByDesc extends AbstractOperatorDesc {
     return PlanUtils.getExprListString(keys, true);
   }
 
-  public ArrayList<ExprNodeDesc> getKeys() {
+  public List<ExprNodeDesc> getKeys() {
     return keys;
   }
 
-  public void setKeys(final ArrayList<ExprNodeDesc> keys) {
+  public void setKeys(final List<ExprNodeDesc> keys) {
     this.keys = keys;
   }
 
   @Explain(displayName = "outputColumnNames")
   @Signature
-  public ArrayList<java.lang.String> getOutputColumnNames() {
+  public List<String> getOutputColumnNames() {
     return outputColumnNames;
   }
 
   @Explain(displayName = "Output", explainLevels = { Level.USER })
-  public ArrayList<java.lang.String> getUserLevelExplainOutputColumnNames() {
+  public List<String> getUserLevelExplainOutputColumnNames() {
     return outputColumnNames;
   }
 
@@ -192,8 +192,7 @@ public class GroupByDesc extends AbstractOperatorDesc {
         outputColumnNames.size() != keys.size() + aggregators.size();
   }
 
-  public void setOutputColumnNames(
-      ArrayList<java.lang.String> outputColumnNames) {
+  public void setOutputColumnNames(List<String> outputColumnNames) {
     this.outputColumnNames = outputColumnNames;
   }
 
@@ -236,12 +235,11 @@ public class GroupByDesc extends AbstractOperatorDesc {
     return res;
   }
 
-  public ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> getAggregators() {
+  public List<AggregationDesc> getAggregators() {
     return aggregators;
   }
 
-  public void setAggregators(
-      final ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> aggregators) {
+  public void setAggregators(List<AggregationDesc> aggregators) {
     this.aggregators = aggregators;
   }
 
@@ -267,7 +265,7 @@ public class GroupByDesc extends AbstractOperatorDesc {
    * columns behave like they were distinct - for example min and max operators.
    */
   public boolean isDistinctLike() {
-    ArrayList<AggregationDesc> aggregators = getAggregators();
+    List<AggregationDesc> aggregators = getAggregators();
     for (AggregationDesc ad : aggregators) {
       if (!ad.getDistinct()) {
         GenericUDAFEvaluator udafEval = ad.getGenericUDAFEvaluator();
@@ -328,11 +326,11 @@ public class GroupByDesc extends AbstractOperatorDesc {
 
   @Override
   public Object clone() {
-    ArrayList<java.lang.String> outputColumnNames = new ArrayList<>();
+    List<String> outputColumnNames = new ArrayList<>();
     outputColumnNames.addAll(this.outputColumnNames);
-    ArrayList<ExprNodeDesc> keys = new ArrayList<>();
+    List<ExprNodeDesc> keys = new ArrayList<>();
     keys.addAll(this.keys);
-    ArrayList<org.apache.hadoop.hive.ql.plan.AggregationDesc> aggregators = new ArrayList<>();
+    List<AggregationDesc> aggregators = new ArrayList<>();
     aggregators.addAll(this.aggregators);
     List<Long> listGroupingSets = new ArrayList<>();
     listGroupingSets.addAll(this.listGroupingSets);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ImportTableDesc.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.conf.Constants;
@@ -326,7 +327,7 @@ public class ImportTableDesc {
     return dbName;
   }
 
-  public Task<? extends Serializable> getCreateTableTask(HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs,
+  public Task<? extends Serializable> getCreateTableTask(Set<ReadEntity> inputs, Set<WriteEntity> outputs,
       HiveConf conf) {
     switch (getDescType()) {
     case TABLE:

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/LateralViewJoinDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/LateralViewJoinDesc.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.plan;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
@@ -34,12 +35,12 @@ public class LateralViewJoinDesc extends AbstractOperatorDesc {
   private static final long serialVersionUID = 1L;
 
   private int numSelColumns;
-  private ArrayList<String> outputInternalColNames;
+  private List<String> outputInternalColNames;
 
   public LateralViewJoinDesc() {
   }
 
-  public LateralViewJoinDesc(int numSelColumns, ArrayList<String> outputInternalColNames) {
+  public LateralViewJoinDesc(int numSelColumns, List<String> outputInternalColNames) {
     this.numSelColumns = numSelColumns;
     this.outputInternalColNames = outputInternalColNames;
   }
@@ -49,12 +50,12 @@ public class LateralViewJoinDesc extends AbstractOperatorDesc {
   }
 
   @Explain(displayName = "outputColumnNames")
-  public ArrayList<String> getOutputInternalColNames() {
+  public List<String> getOutputInternalColNames() {
     return outputInternalColNames;
   }
 
   @Explain(displayName = "Output", explainLevels = { Level.USER })
-  public ArrayList<String> getUserLevelExplainOutputInternalColNames() {
+  public List<String> getUserLevelExplainOutputInternalColNames() {
     return outputInternalColNames;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
@@ -399,7 +399,7 @@ public class MapWork extends BaseWork {
     return llapIoDesc.cached;
   }
 
- public void setNameToSplitSample(HashMap<String, SplitSample> nameToSplitSample) {
+ public void setNameToSplitSample(Map<String, SplitSample> nameToSplitSample) {
     this.nameToSplitSample = nameToSplitSample;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MoveWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MoveWork.java
@@ -19,8 +19,8 @@
 package org.apache.hadoop.hive.ql.plan;
 
 import java.io.Serializable;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.ql.exec.Utilities;
@@ -45,30 +45,29 @@ public class MoveWork implements Serializable {
   /**
    * ReadEntitites that are passed to the hooks.
    */
-  protected HashSet<ReadEntity> inputs;
+  protected Set<ReadEntity> inputs;
   /**
    * List of WriteEntities that are passed to the hooks.
    */
-  protected HashSet<WriteEntity> outputs;
+  protected Set<WriteEntity> outputs;
 
   /**
    * List of inserted partitions
    */
   protected List<Partition> movedParts;
-  private boolean isNoop;
   private boolean isInReplicationScope = false;
 
   public MoveWork() {
   }
 
 
-  private MoveWork(HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs) {
+  private MoveWork(Set<ReadEntity> inputs, Set<WriteEntity> outputs) {
     this.inputs = inputs;
     this.outputs = outputs;
     this.needCleanTarget = true;
   }
 
-  public MoveWork(HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs,
+  public MoveWork(Set<ReadEntity> inputs, Set<WriteEntity> outputs,
       final LoadTableDesc loadTableWork, final LoadFileDesc loadFileWork,
       boolean checkFileFormat, boolean srcLocal) {
     this(inputs, outputs);
@@ -82,7 +81,7 @@ public class MoveWork implements Serializable {
     this.srcLocal = srcLocal;
   }
 
-  public MoveWork(HashSet<ReadEntity> inputs, HashSet<WriteEntity> outputs,
+  public MoveWork(Set<ReadEntity> inputs, Set<WriteEntity> outputs,
       final LoadTableDesc loadTableWork, final LoadFileDesc loadFileWork,
       boolean checkFileFormat) {
     this(inputs, outputs, loadTableWork, loadFileWork, checkFileFormat, false);
@@ -134,19 +133,19 @@ public class MoveWork implements Serializable {
     this.checkFileFormat = checkFileFormat;
   }
 
-  public HashSet<ReadEntity> getInputs() {
+  public Set<ReadEntity> getInputs() {
     return inputs;
   }
 
-  public HashSet<WriteEntity> getOutputs() {
+  public Set<WriteEntity> getOutputs() {
     return outputs;
   }
 
-  public void setInputs(HashSet<ReadEntity> inputs) {
+  public void setInputs(Set<ReadEntity> inputs) {
     this.inputs = inputs;
   }
 
-  public void setOutputs(HashSet<WriteEntity> outputs) {
+  public void setOutputs(Set<WriteEntity> outputs) {
     this.outputs = outputs;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -665,7 +665,7 @@ public final class PlanUtils {
    */
   public static List<FieldSchema> getFieldSchemasFromRowSchema(RowSchema row,
       String fieldPrefix) {
-    ArrayList<ColumnInfo> c = row.getSignature();
+    List<ColumnInfo> c = row.getSignature();
     return getFieldSchemasFromColumnInfo(c, fieldPrefix);
   }
 
@@ -673,7 +673,7 @@ public final class PlanUtils {
    * Convert the ColumnInfo to FieldSchema.
    */
   public static List<FieldSchema> getFieldSchemasFromColumnInfo(
-      ArrayList<ColumnInfo> cols, String fieldPrefix) {
+      List<ColumnInfo> cols, String fieldPrefix) {
     if ((cols == null) || (cols.size() == 0)) {
       return new ArrayList<FieldSchema>();
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/MatchPath.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/MatchPath.java
@@ -705,7 +705,7 @@ public class MatchPath extends TableFunctionEvaluator
     TypeCheckCtx selectListInputTypeCheckCtx;
     StructObjectInspector selectListInputOI;
 
-    ArrayList<WindowExpressionSpec> selectSpec;
+    List<WindowExpressionSpec> selectSpec;
 
     ResultExprInfo resultExprInfo;
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestColumnAccess.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestColumnAccess.java
@@ -19,9 +19,9 @@
 package org.apache.hadoop.hive.ql.parse;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.junit.Assert;
 
@@ -159,7 +159,7 @@ public class TestColumnAccess {
     Assert.assertNotNull(cols.contains("name1"));
   }
 
-  private Map<String, List<String>> getColsFromReadEntity(HashSet<ReadEntity> inputs) {
+  private Map<String, List<String>> getColsFromReadEntity(Set<ReadEntity> inputs) {
     Map<String, List<String>> tableColsMap = new HashMap<String, List<String>>();
     for(ReadEntity entity: inputs) {
       switch (entity.getType()) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBJoinTreeApplyPredicate.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/TestQBJoinTreeApplyPredicate.java
@@ -108,22 +108,21 @@ public class TestQBJoinTreeApplyPredicate {
     children[0] = leftAlias;
     children[1] = rightAlias;
     jT.setBaseSrc(children);
-    ArrayList<ArrayList<ASTNode>> expressions = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> expressions = new ArrayList<List<ASTNode>>();
     expressions.add(new ArrayList<ASTNode>());
     expressions.add(new ArrayList<ASTNode>());
     jT.setExpressions(expressions);
 
-    ArrayList<Boolean> nullsafes = new ArrayList<Boolean>();
+    List<Boolean> nullsafes = new ArrayList<Boolean>();
     jT.setNullSafes(nullsafes);
 
-    ArrayList<ArrayList<ASTNode>> filters = new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filters = new ArrayList<List<ASTNode>>();
     filters.add(new ArrayList<ASTNode>());
     filters.add(new ArrayList<ASTNode>());
     jT.setFilters(filters);
     jT.setFilterMap(new int[2][]);
 
-    ArrayList<ArrayList<ASTNode>> filtersForPushing =
-        new ArrayList<ArrayList<ASTNode>>();
+    List<List<ASTNode>> filtersForPushing = new ArrayList<List<ASTNode>>();
     filtersForPushing.add(new ArrayList<ASTNode>());
     filtersForPushing.add(new ArrayList<ASTNode>());
     jT.setFiltersForPushing(filtersForPushing);


### PR DESCRIPTION
Cleaning up SemanticAnalyzer:

- reduce the visibility of those functions/variables that are too wide, so their scope is clearer
- modify the type of data structures, use interface instead of actual implementation (e.g. HashMap -> Map in variable declaration)