### PR TITLE
HIVE-22209: Graceful error msg when there is no table for a materiali…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QB.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QB.java
@@ -456,4 +456,11 @@ public class QB {
     }
     return aliasToTabs.size()==0 && aliasToSubq.size()==0;
   }
+
+  // returns false when the query block doesn't have
+  // a table defined, e.g. "select 5"
+  public boolean hasTableDefined() {
+    return !(aliases.size() == 1 && aliases.get(0).equals(SemanticAnalyzer.DUMMY_TABLE));
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -14122,6 +14122,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       }
 
+      if (createVwDesc.isMaterialized() && !qb.hasTableDefined()) {
+        throw new SemanticException("Materialized view must have a table defined.");
+      }
+
       if (createVwDesc.isMaterialized() && createVwDesc.isRewriteEnabled()) {
         if (!ctx.isCboSucceeded()) {
           String msg = "Cannot enable automatic rewriting for materialized view.";

--- a/ql/src/test/queries/clientnegative/materialized_view_no_tbl.q
+++ b/ql/src/test/queries/clientnegative/materialized_view_no_tbl.q
@@ -1,0 +1,4 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create materialized view cmv_no_tbl_as AS select 5;

--- a/ql/src/test/results/clientnegative/materialized_view_no_tbl.q.out
+++ b/ql/src/test/results/clientnegative/materialized_view_no_tbl.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException Materialized view must have a table defined.


### PR DESCRIPTION
…zed view.

A materialized view is not allowed to be created when there
is no table defined (e.g. select 5;).  A graceful error msg
is now printed out rather than a stack trace.