### PR TITLE
HIVE-22243 Align Apache Thrift version to 0.9.3-1 in standalone-metas…

### DIFF
--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -86,7 +86,7 @@
     <javolution.version>5.5.1</javolution.version>
     <junit.version>4.11</junit.version>
     <libfb303.version>0.9.3</libfb303.version>
-    <libthrift.version>0.9.3</libthrift.version>
+    <libthrift.version>0.9.3-1</libthrift.version>
     <log4j2.version>2.8.2</log4j2.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <orc.version>1.5.1</orc.version>


### PR DESCRIPTION
…tore as well

Change-Id: Ia82684e7c69684080da7aa6669566bf5fc999cb1