### PR TITLE
HIVE-22248 Fix statistics persisting issues

### DIFF
--- a/ql/src/test/results/clientpositive/alter_table_update_status.q.out
+++ b/ql/src/test/results/clientpositive/alter_table_update_status.q.out
@@ -339,7 +339,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	s                   	 	 	 	 	 	 	 	 	 	 
 data_type           	smallint            	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	3                   	 	 	 	 	 	 	 	 	 	 
 max                 	3                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -358,7 +358,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	i                   	 	 	 	 	 	 	 	 	 	 
 data_type           	int                 	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	45                  	 	 	 	 	 	 	 	 	 	 
 max                 	45                  	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -377,7 +377,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	b                   	 	 	 	 	 	 	 	 	 	 
 data_type           	bigint              	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	456                 	 	 	 	 	 	 	 	 	 	 
 max                 	456                 	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -396,7 +396,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	f                   	 	 	 	 	 	 	 	 	 	 
 data_type           	float               	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 max                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -415,7 +415,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	d                   	 	 	 	 	 	 	 	 	 	 
 data_type           	double              	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 max                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -453,7 +453,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	ts                  	 	 	 	 	 	 	 	 	 	 
 data_type           	timestamp           	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 max                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -586,7 +586,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	t                   	 	 	 	 	 	 	 	 	 	 
 data_type           	tinyint             	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	2                   	 	 	 	 	 	 	 	 	 	 
 max                 	2                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -632,7 +632,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	s                   	 	 	 	 	 	 	 	 	 	 
 data_type           	smallint            	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	3                   	 	 	 	 	 	 	 	 	 	 
 max                 	3                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -678,7 +678,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	i                   	 	 	 	 	 	 	 	 	 	 
 data_type           	int                 	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	45                  	 	 	 	 	 	 	 	 	 	 
 max                 	45                  	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -724,7 +724,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	b                   	 	 	 	 	 	 	 	 	 	 
 data_type           	bigint              	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	456                 	 	 	 	 	 	 	 	 	 	 
 max                 	456                 	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -770,7 +770,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	f                   	 	 	 	 	 	 	 	 	 	 
 data_type           	float               	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 max                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -816,7 +816,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	d                   	 	 	 	 	 	 	 	 	 	 
 data_type           	double              	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 max                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -908,7 +908,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats_n0
 col_name            	ts                  	 	 	 	 	 	 	 	 	 	 
 data_type           	timestamp           	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 max                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 

--- a/ql/src/test/results/clientpositive/alter_table_update_status_disable_bitvector.q.out
+++ b/ql/src/test/results/clientpositive/alter_table_update_status_disable_bitvector.q.out
@@ -339,7 +339,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	s                   	 	 	 	 	 	 	 	 	 	 
 data_type           	smallint            	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	3                   	 	 	 	 	 	 	 	 	 	 
 max                 	3                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -358,7 +358,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	i                   	 	 	 	 	 	 	 	 	 	 
 data_type           	int                 	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	45                  	 	 	 	 	 	 	 	 	 	 
 max                 	45                  	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -377,7 +377,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	b                   	 	 	 	 	 	 	 	 	 	 
 data_type           	bigint              	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	456                 	 	 	 	 	 	 	 	 	 	 
 max                 	456                 	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -396,7 +396,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	f                   	 	 	 	 	 	 	 	 	 	 
 data_type           	float               	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 max                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -415,7 +415,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	d                   	 	 	 	 	 	 	 	 	 	 
 data_type           	double              	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 max                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -453,7 +453,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	ts                  	 	 	 	 	 	 	 	 	 	 
 data_type           	timestamp           	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 max                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -586,7 +586,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	t                   	 	 	 	 	 	 	 	 	 	 
 data_type           	tinyint             	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	2                   	 	 	 	 	 	 	 	 	 	 
 max                 	2                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -632,7 +632,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	s                   	 	 	 	 	 	 	 	 	 	 
 data_type           	smallint            	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	3                   	 	 	 	 	 	 	 	 	 	 
 max                 	3                   	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -678,7 +678,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	i                   	 	 	 	 	 	 	 	 	 	 
 data_type           	int                 	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	45                  	 	 	 	 	 	 	 	 	 	 
 max                 	45                  	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -724,7 +724,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	b                   	 	 	 	 	 	 	 	 	 	 
 data_type           	bigint              	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	456                 	 	 	 	 	 	 	 	 	 	 
 max                 	456                 	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -770,7 +770,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	f                   	 	 	 	 	 	 	 	 	 	 
 data_type           	float               	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 max                 	45454.3984375       	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -816,7 +816,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	d                   	 	 	 	 	 	 	 	 	 	 
 data_type           	double              	 	 	 	 	 	 	 	 	 	 
-min                 	0.0                 	 	 	 	 	 	 	 	 	 	 
+min                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 max                 	454.6565            	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 
@@ -908,7 +908,7 @@ POSTHOOK: type: DESCTABLE
 POSTHOOK: Input: default@datatype_stats
 col_name            	ts                  	 	 	 	 	 	 	 	 	 	 
 data_type           	timestamp           	 	 	 	 	 	 	 	 	 	 
-min                 	0                   	 	 	 	 	 	 	 	 	 	 
+min                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 max                 	1325379723          	 	 	 	 	 	 	 	 	 	 
 num_nulls           	1                   	 	 	 	 	 	 	 	 	 	 
 distinct_count      	1                   	 	 	 	 	 	 	 	 	 	 

--- a/ql/src/test/results/clientpositive/llap/vector_coalesce_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_coalesce_3.q.out
@@ -117,7 +117,7 @@ STAGE PLANS:
                       outputColumnNames: _col0, _col2
                       input vertices:
                         1 Map 2
-                      Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: _col0 (type: bigint), _col2 (type: bigint)
                         outputColumnNames: _col0, _col1
@@ -125,13 +125,13 @@ STAGE PLANS:
                             className: VectorSelectOperator
                             native: true
                             projectedOutputColumnNums: [0, 2]
-                        Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                         File Output Operator
                           compressed: false
                           File Sink Vectorization:
                               className: VectorFileSinkOperator
                               native: false
-                          Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                           table:
                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/vector_coalesce_3.q.out
+++ b/ql/src/test/results/clientpositive/vector_coalesce_3.q.out
@@ -131,7 +131,7 @@ STAGE PLANS:
                     nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Outer Join has keys IS true, Optimized Table and Supports Key Types IS true
                     nativeConditionsNotMet: hive.execution.engine mr IN [tez, spark] IS false
                 outputColumnNames: _col0, _col2
-                Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: bigint), _col2 (type: bigint)
                   outputColumnNames: _col0, _col1
@@ -139,13 +139,13 @@ STAGE PLANS:
                       className: VectorSelectOperator
                       native: true
                       projectedOutputColumnNums: [0, 1]
-                  Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
                     File Sink Vectorization:
                         className: VectorFileSinkOperator
                         native: false
-                    Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 7 Data size: 80 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DateColumnStatsMerger.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DateColumnStatsMerger.java
@@ -54,6 +54,8 @@ public class DateColumnStatsMerger extends ColumnStatsMerger {
           + aggregateData.getNumDVs() + " and " + newData.getNumDVs() + " to be " + ndv);
       aggregateData.setNumDVs(ndv);
     }
+
+    aggregateColStats.getStatsData().setDateStats(aggregateData);
   }
 
   private Date min(Date v1, Date v2) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DecimalColumnStatsMerger.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DecimalColumnStatsMerger.java
@@ -29,10 +29,8 @@ import static org.apache.hadoop.hive.metastore.columnstats.ColumnsStatsUtils.dec
 public class DecimalColumnStatsMerger extends ColumnStatsMerger {
   @Override
   public void merge(ColumnStatisticsObj aggregateColStats, ColumnStatisticsObj newColStats) {
-    DecimalColumnStatsDataInspector aggregateData =
-        decimalInspectorFromStats(aggregateColStats);
-    DecimalColumnStatsDataInspector newData =
-        decimalInspectorFromStats(newColStats);
+    DecimalColumnStatsDataInspector aggregateData = decimalInspectorFromStats(aggregateColStats);
+    DecimalColumnStatsDataInspector newData = decimalInspectorFromStats(newColStats);
 
     Decimal lowValue = getMin(aggregateData.getLowValue(), newData.getLowValue());
     aggregateData.setLowValue(lowValue);
@@ -59,6 +57,8 @@ public class DecimalColumnStatsMerger extends ColumnStatsMerger {
           + aggregateData.getNumDVs() + " and " + newData.getNumDVs() + " to be " + ndv);
       aggregateData.setNumDVs(ndv);
     }
+
+    aggregateColStats.getStatsData().setDecimalStats(aggregateData);
   }
 
   Decimal getMax(Decimal firstValue, Decimal secondValue) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DoubleColumnStatsMerger.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/DoubleColumnStatsMerger.java
@@ -30,7 +30,7 @@ public class DoubleColumnStatsMerger extends ColumnStatsMerger {
   public void merge(ColumnStatisticsObj aggregateColStats, ColumnStatisticsObj newColStats) {
     DoubleColumnStatsDataInspector aggregateData = doubleInspectorFromStats(aggregateColStats);
     DoubleColumnStatsDataInspector newData = doubleInspectorFromStats(newColStats);
-    aggregateData.setLowValue(Math.min(aggregateData.getLowValue(), newData.getLowValue()));
+    setMinValue(aggregateData, newData);
     aggregateData.setHighValue(Math.max(aggregateData.getHighValue(), newData.getHighValue()));
     aggregateData.setNumNulls(aggregateData.getNumNulls() + newData.getNumNulls());
     if (aggregateData.getNdvEstimator() == null || newData.getNdvEstimator() == null) {
@@ -50,5 +50,17 @@ public class DoubleColumnStatsMerger extends ColumnStatsMerger {
           + aggregateData.getNumDVs() + " and " + newData.getNumDVs() + " to be " + ndv);
       aggregateData.setNumDVs(ndv);
     }
+
+    aggregateColStats.getStatsData().setDoubleStats(aggregateData);
+  }
+
+  private void setMinValue(DoubleColumnStatsDataInspector aggregateData, DoubleColumnStatsDataInspector newData) {
+    if (!aggregateData.isSetLowValue() && !newData.isSetLowValue()) {
+      return;
+    }
+    double lowValue = Math.min(
+        aggregateData.isSetLowValue() ? aggregateData.getLowValue() : Double.MAX_VALUE,
+        newData.isSetLowValue() ? newData.getLowValue() : Double.MAX_VALUE);
+    aggregateData.setLowValue(lowValue);
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/LongColumnStatsMerger.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/LongColumnStatsMerger.java
@@ -30,7 +30,7 @@ public class LongColumnStatsMerger extends ColumnStatsMerger {
   public void merge(ColumnStatisticsObj aggregateColStats, ColumnStatisticsObj newColStats) {
     LongColumnStatsDataInspector aggregateData = longInspectorFromStats(aggregateColStats);
     LongColumnStatsDataInspector newData = longInspectorFromStats(newColStats);
-    aggregateData.setLowValue(Math.min(aggregateData.getLowValue(), newData.getLowValue()));
+    setMinValue(aggregateData, newData);
     aggregateData.setHighValue(Math.max(aggregateData.getHighValue(), newData.getHighValue()));
     aggregateData.setNumNulls(aggregateData.getNumNulls() + newData.getNumNulls());
     if (aggregateData.getNdvEstimator() == null || newData.getNdvEstimator() == null) {
@@ -50,5 +50,17 @@ public class LongColumnStatsMerger extends ColumnStatsMerger {
           + aggregateData.getNumDVs() + " and " + newData.getNumDVs() + " to be " + ndv);
       aggregateData.setNumDVs(ndv);
     }
+
+    aggregateColStats.getStatsData().setLongStats(aggregateData);
+  }
+
+  private void setMinValue(LongColumnStatsDataInspector aggregateData, LongColumnStatsDataInspector newData) {
+    if (!aggregateData.isSetLowValue() && !newData.isSetLowValue()) {
+      return;
+    }
+    long lowValue = Math.min(
+        aggregateData.isSetLowValue() ? aggregateData.getLowValue() : Long.MAX_VALUE,
+        newData.isSetLowValue() ? newData.getLowValue() : Long.MAX_VALUE);
+    aggregateData.setLowValue(lowValue);
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/StringColumnStatsMerger.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/columnstats/merge/StringColumnStatsMerger.java
@@ -50,5 +50,7 @@ public class StringColumnStatsMerger extends ColumnStatsMerger {
           + aggregateData.getNumDVs() + " and " + newData.getNumDVs() + " to be " + ndv);
       aggregateData.setNumDVs(ndv);
     }
+
+    aggregateColStats.getStatsData().setStringStats(aggregateData);
   }
 }


### PR DESCRIPTION
- During the thrift call the XXXXColumnStatsDataInspector was transformed into a XXXXColumnStatsData object, which then was converted back, by calling the xxxxInspectorFromStats functions. The new object was never put back though to the aggregateStats, so all the modifications made by the XXXXColumnStatsMerger was made on an object that was never used again. Added aggregateColStats.getStatsData().setXXXXStats(aggregateData); calls to put them there, so the changes made by the merger are actually in effect.

- The min value was miscalculated for Long and Double types, as the null value was treated as 0. It was fixed by calculating the min values by also using the isSetLowValue() function.

- In case of vector_coalesce_3.q the bad statistics made the engine "think" that the column is a primary key following some heuristics based on statistics, and made it guess the statistics in a different way, thus is the output change.