### PR TITLE
HIVE-22305: Add the kudu-handler to the packaging module

### DIFF
--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -318,6 +318,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hive</groupId>
+      <artifactId>hive-kudu-handler</artifactId>
+      <version>${project.version}</version>
+    </dependency>
   </dependencies>
 
 </project>

--- a/packaging/src/main/assembly/src.xml
+++ b/packaging/src/main/assembly/src.xml
@@ -104,6 +104,7 @@
         <include>upgrade-acid/**/*</include>
         <include>vector-code-gen/**/*</include>
         <include>kryo-registrator/**/*</include>
+        <include>kudu-handler/**/*</include>
       </includes>
       <outputDirectory>/</outputDirectory>
     </fileSet>


### PR DESCRIPTION
This patch adds the hive-kudu-handler to the packaging module to
ensure the jars are packaged into the tar distribution.

Change-Id: Iebdb46f7d89bfa5c7a36035b39c3d58b01e58fca