### PR TITLE
HIVE-22338: Shade dependent jars into the kudu-handler

### DIFF
--- a/kudu-handler/pom.xml
+++ b/kudu-handler/pom.xml
@@ -39,20 +39,21 @@
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <version>${project.version}</version>
+      <scope>provided</scope>
     </dependency>
     <!-- inter-project -->
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
-      <scope>provided</scope>
       <version>${hadoop.version}</version>
+      <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
-      <scope>provided</scope>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
       <version>${hadoop.version}</version>
+      <scope>provided</scope>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -150,6 +151,62 @@
         <!-- Kudu tests do not support Windows. -->
         <exclude.tests>**/*.java</exclude.tests>
       </properties>
+    </profile>
+    <profile>
+      <id>dev-fast-build</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>${maven.shade.plugin.version}</version>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <createDependencyReducedPom>false</createDependencyReducedPom>
+                  <artifactSet>
+                    <includes>
+                      <include>org.apache.kudu:kudu-client</include>
+                      <include>com.stumbleupon:async</include>
+                    </includes>
+                  </artifactSet>
+                  <relocations>
+                    <relocation>
+                      <pattern>org.apache.kudu</pattern>
+                      <shadedPattern>org.apache.hive.kudu.org.apache.kudu</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>com.stumbleupon.async</pattern>
+                      <shadedPattern>org.apache.hive.kudu.com.stumbleupon.async</shadedPattern>
+                    </relocation>
+                  </relocations>
+                  <filters>
+                    <filter>
+                      <artifact>*:*</artifact>
+                      <excludes>
+                        <exclude>META-INF/*.SF</exclude>
+                        <exclude>META-INF/*.DSA</exclude>
+                        <exclude>META-INF/*.RSA</exclude>
+                        <exclude>static/</exclude>
+                      </excludes>
+                    </filter>
+                  </filters>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
   </profiles>
 </project>

--- a/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
+++ b/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
@@ -66,15 +66,16 @@ public final class KuduHiveUtils {
   }
 
   public static String getMasterAddresses(Configuration conf) throws IOException {
-    // Load the default configuration.
-    String masterAddresses = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_KUDU_MASTER_ADDRESSES_DEFAULT);
+    // Use the table property if it exists.
+    String masterAddresses = conf.get(KUDU_MASTER_ADDRS_KEY);
     if (StringUtils.isEmpty(masterAddresses)) {
-      throw new IOException("Kudu master addresses are not specified with " +
-          HiveConf.ConfVars.HIVE_KUDU_MASTER_ADDRESSES_DEFAULT.varname);
+      // Fall back to the default configuration.
+      masterAddresses = HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_KUDU_MASTER_ADDRESSES_DEFAULT);
     }
-    // Override with the table configuration if it exists.
-    if (!StringUtils.isEmpty(conf.get(KUDU_MASTER_ADDRS_KEY))) {
-      masterAddresses = conf.get(KUDU_MASTER_ADDRS_KEY);
+    if (StringUtils.isEmpty(masterAddresses)) {
+      throw new IOException("Kudu master addresses are not specified in the table property (" +
+          KUDU_MASTER_ADDRS_KEY + "), or default configuration (" +
+          HiveConf.ConfVars.HIVE_KUDU_MASTER_ADDRESSES_DEFAULT.varname + ").");
     }
     return masterAddresses;
   }

--- a/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduStorageHandler.java
+++ b/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduStorageHandler.java
@@ -137,7 +137,7 @@ public class KuduStorageHandler extends DefaultStorageHandler implements HiveSto
       jobConf.set(HiveConf.ConfVars.HIVE_AM_SPLIT_GENERATION.toString(), Boolean.FALSE.toString());
     }
     try {
-      addDependencyJars(jobConf, KuduRecordWriter.class);
+      addDependencyJars(jobConf, KuduStorageHandler.class);
     } catch (IOException e) {
       Throwables.propagate(e);
     }

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduSerDe.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduSerDe.java
@@ -152,7 +152,7 @@ public class TestKuduSerDe {
       fail("Should fail on missing table");
     } catch (SerDeException ex) {
       assertThat(ex.getMessage(),
-          containsString("Kudu master addresses are not specified with hive.kudu.master.addresses.default"));
+          containsString("Kudu master addresses are not specified in the table property"));
     }
   }
 

--- a/kudu-handler/src/test/results/negative/kudu_config.q.out
+++ b/kudu-handler/src/test/results/negative/kudu_config.q.out
@@ -4,4 +4,4 @@ TBLPROPERTIES ("kudu.table_name" = "default.kudu_kv")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@kv_table
-FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException java.io.IOException: Kudu master addresses are not specified with hive.kudu.master.addresses.default)
+FAILED: Execution Error, return code 1 from org.apache.hadoop.hive.ql.ddl.DDLTask. java.lang.RuntimeException: MetaException(message:org.apache.hadoop.hive.serde2.SerDeException java.io.IOException: Kudu master addresses are not specified in the table property (kudu.master_addresses), or default configuration (hive.kudu.master.addresses.default).)


### PR DESCRIPTION
This patch shades the Kudu client and it’s async dependency into the
kudu-handler jar to simplify add jar style usage and ensure the
addDependencyJars method adds all the required classes.

It also adjusts the master address property to fallback to the default
instead of looking it up first. This allows the default to be unset when
the table property exists. I ran into this when using the
handler via `add jar`.

Change-Id: Ie900abe21b685c9591e6147efe5c3b4b96791f5e