### PR TITLE
HIVE-22347 Break up DDLSemanticAnalyzer - extract Other analyzers

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataAnalyzer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.misc.cache.metadata;
+
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.function.AbstractFunctionAnalyzer;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.AnalyzeCommandUtils;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for cache metadata commands.
+ */
+@DDLType(type=HiveParser.TOK_CACHE_METADATA)
+public class CacheMetadataAnalyzer extends AbstractFunctionAnalyzer {
+  public CacheMetadataAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    Table table = AnalyzeCommandUtils.getTable(root, this);
+
+    CacheMetadataDesc desc;
+    // In 2 cases out of 3, we could pass the path and type directly to metastore...
+    if (AnalyzeCommandUtils.isPartitionLevelStats(root)) {
+      Map<String, String> partSpec = AnalyzeCommandUtils.getPartKeyValuePairsFromAST(table, root, conf);
+      Partition part = getPartition(table, partSpec, true);
+      desc = new CacheMetadataDesc(table.getDbName(), table.getTableName(), part.getName());
+      inputs.add(new ReadEntity(part));
+    } else {
+      // Should we get all partitions for a partitioned table?
+      desc = new CacheMetadataDesc(table.getDbName(), table.getTableName(), table.isPartitioned());
+      inputs.add(new ReadEntity(table));
+    }
+
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataDesc.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.cache.metadata;
 
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
 import org.apache.hadoop.hive.ql.plan.Explain;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/CacheMetadataOperation.java
@@ -16,38 +16,27 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.cache.metadata;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 
-import org.apache.hadoop.hive.metastore.DefaultHiveMetaHook;
-import org.apache.hadoop.hive.metastore.HiveMetaHook;
-import org.apache.hadoop.hive.metastore.api.MetaException;
+import java.io.IOException;
+
 import org.apache.hadoop.hive.ql.ddl.DDLOperation;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 
 /**
- * Operation process of inserting a commit hook.
+ * Operation process of caching the metadata.
  */
-public class InsertCommitHookOperation extends DDLOperation<InsertCommitHookDesc> {
-  public InsertCommitHookOperation(DDLOperationContext context, InsertCommitHookDesc desc) {
+public class CacheMetadataOperation extends DDLOperation<CacheMetadataDesc> {
+  public CacheMetadataOperation(DDLOperationContext context, CacheMetadataDesc desc) {
     super(context, desc);
   }
 
   @Override
-  public int execute() throws MetaException {
-    HiveMetaHook hook = desc.getTable().getStorageHandler().getMetaHook();
-    if (hook == null || !(hook instanceof DefaultHiveMetaHook)) {
-      return 0;
-    }
-    DefaultHiveMetaHook hiveMetaHook = (DefaultHiveMetaHook) hook;
-
-    try {
-      hiveMetaHook.commitInsertTable(desc.getTable().getTTable(), desc.isOverwrite());
-    } catch (Throwable t) {
-      hiveMetaHook.rollbackInsertTable(desc.getTable().getTTable(), desc.isOverwrite());
-      throw t;
-    }
-
+  public int execute() throws HiveException, IOException {
+    context.getDb().cacheFileMetadata(desc.getDbName(), desc.getTableName(), desc.getPartitionName(),
+        desc.isAllPartitions());
     return 0;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/cache/metadata/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Cache metadata DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.misc.cache.metadata;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/insert/commit/hook/InsertCommitHookDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/insert/commit/hook/InsertCommitHookDesc.java
@@ -15,39 +15,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.misc;
 
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.ql.ddl.DDLDesc;
-import org.apache.hadoop.hive.ql.plan.Explain;
-import org.apache.hadoop.hive.ql.plan.Explain.Level;
+package org.apache.hadoop.hive.ql.ddl.misc.insert.commit.hook;
 
 import java.io.Serializable;
 
+import org.apache.hadoop.hive.ql.ddl.DDLDesc;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.plan.Explain;
+import org.apache.hadoop.hive.ql.plan.Explain.Level;
+
 /**
- * DDL task description for SHOW CONF commands.
+ * DDL task description for Inserting Commit Hooks.
  */
-@Explain(displayName = "Show Configuration", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class ShowConfDesc implements DDLDesc, Serializable {
+@Explain(displayName = "Commit Insert Hook", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class InsertCommitHookDesc implements DDLDesc, Serializable {
   private static final long serialVersionUID = 1L;
 
-  public static final String SCHEMA = "default,type,desc#string,string,string";
+  private final Table table;
+  private final boolean overwrite;
 
-  private Path resFile;
-  private String confName;
-
-  public ShowConfDesc(Path resFile, String confName) {
-    this.resFile = resFile;
-    this.confName = confName;
+  public InsertCommitHookDesc(Table table, boolean overwrite) {
+    this.table = table;
+    this.overwrite = overwrite;
   }
 
-  @Explain(displayName = "result file", explainLevels = { Level.EXTENDED })
-  public Path getResFile() {
-    return resFile;
+  public Table getTable() {
+    return table;
   }
 
-  @Explain(displayName = "conf name", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-  public String getConfName() {
-    return confName;
+  @Explain(displayName = "is overwrite", displayOnlyOnTrue = true,
+      explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+  public boolean isOverwrite() {
+    return overwrite;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/insert/commit/hook/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/insert/commit/hook/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Insert commit hook DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.misc.insert.commit.hook;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckAnalyzer.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.misc.msck;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.function.AbstractFunctionAnalyzer;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.hooks.WriteEntity;
+import org.apache.hadoop.hive.ql.hooks.WriteEntity.WriteType;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for metastore check commands.
+ */
+@DDLType(type=HiveParser.TOK_MSCK)
+public class MsckAnalyzer extends AbstractFunctionAnalyzer {
+  public MsckAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    if (root.getChildCount() == 0) {
+      throw new SemanticException("MSCK command must have arguments");
+    }
+
+    ctx.setResFile(ctx.getLocalTmpPath());
+
+    boolean repair = root.getChild(0).getType() == HiveParser.KW_REPAIR;
+    int offset = repair ? 1 : 0;
+    String tableName = getUnescapedName((ASTNode) root.getChild(0 + offset));
+
+    boolean addPartitions = true;
+    boolean dropPartitions = false;
+    if (root.getChildCount() > 1 + offset) {
+      addPartitions = isMsckAddPartition(root.getChild(1 + offset).getType());
+      dropPartitions = isMsckDropPartition(root.getChild(1 + offset).getType());
+    }
+
+    Table table = getTable(tableName);
+    List<Map<String, String>> specs = getPartitionSpecs(table, root);
+    if (repair && AcidUtils.isTransactionalTable(table)) {
+      outputs.add(new WriteEntity(table, WriteType.DDL_EXCLUSIVE));
+    } else {
+      outputs.add(new WriteEntity(table, WriteEntity.WriteType.DDL_SHARED));
+    }
+    MsckDesc desc = new MsckDesc(tableName, specs, ctx.getResFile(), repair, addPartitions, dropPartitions);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+
+  private boolean isMsckAddPartition(int type) {
+    return type == HiveParser.KW_SYNC || type == HiveParser.KW_ADD;
+  }
+
+  private boolean isMsckDropPartition(int type) {
+    return type == HiveParser.KW_SYNC || type == HiveParser.KW_DROP;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckDesc.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.msck;
 
 import java.io.Serializable;
 import java.util.List;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/MsckOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.msck;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.exec.Utilities;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/msck/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Msck DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.misc.msck;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/ReplRemoveFirstIncLoadPendFlagDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/ReplRemoveFirstIncLoadPendFlagDesc.java
@@ -16,37 +16,29 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
-
-import java.io.Serializable;
+package org.apache.hadoop.hive.ql.ddl.misc.remove.flag;
 
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
-import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 
+import java.io.Serializable;
+
 /**
- * DDL task description for Inserting Commit Hooks.
+ * Remove the flag from db property if its already present.
  */
-@Explain(displayName = "Commit Insert Hook", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class InsertCommitHookDesc implements DDLDesc, Serializable {
+@Explain(displayName = "Set First Incr Load Pend Flag", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class ReplRemoveFirstIncLoadPendFlagDesc implements DDLDesc, Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final Table table;
-  private final boolean overwrite;
+  private final String databaseName;
 
-  public InsertCommitHookDesc(Table table, boolean overwrite) {
-    this.table = table;
-    this.overwrite = overwrite;
+  public ReplRemoveFirstIncLoadPendFlagDesc(String databaseName) {
+    this.databaseName = databaseName;
   }
 
-  public Table getTable() {
-    return table;
-  }
-
-  @Explain(displayName = "is overwrite", displayOnlyOnTrue = true,
-      explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-  public boolean isOverwrite() {
-    return overwrite;
+  @Explain(displayName="db name", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+  public String getDatabaseName() {
+    return databaseName;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/ReplRemoveFirstIncLoadPendFlagOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/ReplRemoveFirstIncLoadPendFlagOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.remove.flag;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/remove/flag/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Remove the flag from db property if its already present operation. */
+package org.apache.hadoop.hive.ql.ddl.misc.remove.flag;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfAnalyzer.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.misc.show.conf;
+
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.function.AbstractFunctionAnalyzer;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for show conf commands.
+ */
+@DDLType(type=HiveParser.TOK_SHOWCONF)
+public class ShowConfAnalyzer extends AbstractFunctionAnalyzer {
+  public ShowConfAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    ctx.setResFile(ctx.getLocalTmpPath());
+
+    String confName = stripQuotes(root.getChild(0).getText());
+    ShowConfDesc desc = new ShowConfDesc(ctx.getResFile(), confName);
+    Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
+    rootTasks.add(task);
+
+    task.setFetchSource(true);
+    setFetchTask(createFetchTask(ShowConfDesc.SCHEMA));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfDesc.java
@@ -15,9 +15,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.hadoop.hive.ql.ddl.misc.show.conf;
 
-package org.apache.hadoop.hive.ql.ddl.misc;
-
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
 import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
@@ -25,20 +25,29 @@ import org.apache.hadoop.hive.ql.plan.Explain.Level;
 import java.io.Serializable;
 
 /**
- * Remove the flag from db property if its already present.
+ * DDL task description for SHOW CONF commands.
  */
-@Explain(displayName = "Set First Incr Load Pend Flag", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class ReplRemoveFirstIncLoadPendFlagDesc implements DDLDesc, Serializable {
+@Explain(displayName = "Show Configuration", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class ShowConfDesc implements DDLDesc, Serializable {
   private static final long serialVersionUID = 1L;
 
-  private final String databaseName;
+  public static final String SCHEMA = "default,type,desc#string,string,string";
 
-  public ReplRemoveFirstIncLoadPendFlagDesc(String databaseName) {
-    this.databaseName = databaseName;
+  private Path resFile;
+  private String confName;
+
+  public ShowConfDesc(Path resFile, String confName) {
+    this.resFile = resFile;
+    this.confName = confName;
   }
 
-  @Explain(displayName="db name", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-  public String getDatabaseName() {
-    return databaseName;
+  @Explain(displayName = "result file", explainLevels = { Level.EXTENDED })
+  public Path getResFile() {
+    return resFile;
+  }
+
+  @Explain(displayName = "conf name", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+  public String getConfName() {
+    return confName;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/ShowConfOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.misc;
+package org.apache.hadoop.hive.ql.ddl.misc.show.conf;
 
 import org.apache.hadoop.hive.ql.ddl.DDLOperationContext;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/show/conf/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Show Configuration operation. */
+package org.apache.hadoop.hive.ql.ddl.misc.show.conf;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/incremental/IncrementalLoadTasksBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/incremental/IncrementalLoadTasksBuilder.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.hive.metastore.api.ReplLastIdInfo;
 import org.apache.hadoop.hive.ql.DriverContext;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.database.alter.poperties.AlterDatabaseSetPropertiesDesc;
-import org.apache.hadoop.hive.ql.ddl.misc.ReplRemoveFirstIncLoadPendFlagDesc;
+import org.apache.hadoop.hive.ql.ddl.misc.remove.flag.ReplRemoveFirstIncLoadPendFlagDesc;
 import org.apache.hadoop.hive.ql.ddl.table.misc.AlterTableSetPropertiesDesc;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/AnalyzeCommandUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/AnalyzeCommandUtils.java
@@ -25,7 +25,14 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
-public class AnalyzeCommandUtils {
+/**
+ * Utilities for semantic analyzers.
+ */
+public final class AnalyzeCommandUtils {
+  private AnalyzeCommandUtils() {
+    throw new UnsupportedOperationException("AnalyzeCommandUtils should not be instantiated");
+  }
+
   public static boolean isPartitionLevelStats(ASTNode tree) {
     boolean isPartitioned = false;
     ASTNode child = (ASTNode) tree.getChild(0);
@@ -50,7 +57,7 @@ public class AnalyzeCommandUtils {
     ASTNode child = ((ASTNode) tree.getChild(0).getChild(1));
     Map<String,String> partSpec = new HashMap<String, String>();
     if (child != null) {
-      partSpec = DDLSemanticAnalyzer.getValidatedPartSpec(tbl, child, hiveConf, false);
+      partSpec = BaseSemanticAnalyzer.getValidatedPartSpec(tbl, child, hiveConf, false);
     } //otherwise, it is the case of analyze table T compute statistics for columns;
     return partSpec;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -105,7 +105,7 @@ import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.cache.results.CacheUsage;
 import org.apache.hadoop.hive.ql.cache.results.QueryResultsCache;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
-import org.apache.hadoop.hive.ql.ddl.misc.InsertCommitHookDesc;
+import org.apache.hadoop.hive.ql.ddl.misc.insert.commit.hook.InsertCommitHookDesc;
 import org.apache.hadoop.hive.ql.ddl.table.creation.CreateTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.creation.CreateTableLikeDesc;
 import org.apache.hadoop.hive.ql.ddl.table.misc.AlterTableUnsetPropertiesDesc;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
@@ -122,7 +122,6 @@ public final class SemanticAnalyzerFactory {
       case HiveParser.TOK_LOCKTABLE:
       case HiveParser.TOK_UNLOCKTABLE:
       case HiveParser.TOK_TRUNCATETABLE:
-      case HiveParser.TOK_CACHE_METADATA:
         return new DDLSemanticAnalyzer(queryState);
 
       case HiveParser.TOK_ANALYZE:


### PR DESCRIPTION
DDLSemanticAnalyzer is a huge class, more than 4000 lines long. The goal is to refactor it in order to have everything cut into more handleable classes under the package  org.apache.hadoop.hive.ql.exec.ddl:

- have a separate class for each analyzers
- have a package for each operation, containing an analyzer, a description, and an operation, so the amount of classes under a package is more manageable

Step #8: extract all the rest of the analyzers from DDLSemanticAnalyzer, which can not be classified otherwise, and move them under the new package.