### PR TITLE
CliDriver skipping through comments

### DIFF
--- a/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
+++ b/cli/src/java/org/apache/hadoop/hive/cli/CliDriver.java
@@ -490,7 +490,7 @@ public class CliDriver {
 
     while ((line = r.readLine()) != null) {
       // Skipping through comments
-      if (! line.startsWith("--")) {
+      if (! line.trim().startsWith("--")) {
         qsb.append(line + "\n");
       }
     }


### PR DESCRIPTION
two examples of errors:

case1.hql
``` sql
-- 1
  -- 1;
select 1;
```

case2.hql
``` sql
-- 1
  -- 1
```


