### PR TITLE
Spark read not fallback to fileSchema when indexColumnsWanted is empty

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -444,7 +444,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
     Configuration configuration) {
     Set<String> groupPaths = ColumnProjectionUtils.getNestedColumnPaths(configuration);
     List<Integer> indexColumnsWanted = ColumnProjectionUtils.getReadColumnIDs(configuration);
-    if (!ColumnProjectionUtils.isReadAllColumns(configuration) && !indexColumnsWanted.isEmpty()) {
+    if (!ColumnProjectionUtils.isReadAllColumns(configuration)) {
       return getProjectedSchema(fileSchema, columnNamesList, indexColumnsWanted, groupPaths);
     } else {
       return fileSchema;


### PR DESCRIPTION
Query "select count(*) from t" on parquet table read in all the data (all columns), which is not needed other than reading metadata.

Don't know why this empty list check was added, please suggest if there're any other impact.

JIRA: https://issues.apache.org/jira/browse/HIVE-22495#