### PR TITLE
HIVE-22537: getAcidState() not saving directory causes multiple files…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1217,7 +1217,7 @@ public class AcidUtils {
 
     TxnBase bestBase = new TxnBase();
     final List<HdfsFileStatusWithId> original = new ArrayList<>();
-    List<HdfsDirSnapshot> dirSnapshots = null;
+    Map<Path, HdfsDirSnapshot> dirSnapshots = null;
     if (childrenWithId != null) {
       for (HdfsFileStatusWithId child : childrenWithId) {
         getChildState(child.getFileStatus(), child, writeIdList, working, originalDirectories, original, obsolete,
@@ -1307,7 +1307,7 @@ public class AcidUtils {
     }
 
     if(bestBase.oldestBase != null && bestBase.status == null &&
-        isCompactedBase(ParsedBase.parseBase(bestBase.oldestBase), fs)) {
+        isCompactedBase(ParsedBase.parseBase(bestBase.oldestBase), fs, dirSnapshots)) {
       /**
        * If here, it means there was a base_x (> 1 perhaps) but none were suitable for given
        * {@link writeIdList}.  Note that 'original' files are logically a base_Long.MIN_VALUE and thus
@@ -1331,7 +1331,7 @@ public class AcidUtils {
     boolean isBaseInRawFormat = false;
     if (bestBase.status != null) {
       base = bestBase.status.getPath();
-      isBaseInRawFormat = MetaDataFile.isRawFormat(base, fs, null);
+      isBaseInRawFormat = MetaDataFile.isRawFormat(base, fs, dirSnapshots != null ? dirSnapshots.get(base) : null);
       if (isBaseInRawFormat && (bestBase.dirSnapShot != null)) {
         for (FileStatus stat : bestBase.dirSnapShot.getFiles()) {
           if ((!ignoreEmptyFiles) || (stat.getLen() != 0)) {
@@ -1357,7 +1357,8 @@ public class AcidUtils {
         obsolete, deltas, base);
   }
   
-  public static List<HdfsDirSnapshot> getHdfsDirSnapshots(final FileSystem fs, final Path path) throws IOException {
+  public static Map<Path, HdfsDirSnapshot> getHdfsDirSnapshots(final FileSystem fs,
+      final Path path) throws IOException {
     try {
       Map<Path, HdfsDirSnapshot> dirToSnapshots = new HashMap<Path, HdfsDirSnapshot>();
       RemoteIterator<LocatedFileStatus> itr = fs.listFiles(path, true);
@@ -1374,8 +1375,11 @@ public class AcidUtils {
           } else {
             Path parentDirPath = fPath.getParent();
             if (acidTempDirFilter.accept(parentDirPath)) {
-              FileStatus parentDirFStatus = fs.getFileStatus(parentDirPath);
               HdfsDirSnapshot dirSnapshot = dirToSnapshots.get(parentDirPath);
+              FileStatus parentDirFStatus = null;
+              if (!parentDirPath.equals(path)) {
+                parentDirFStatus = fs.getFileStatus(parentDirPath);
+              }
               if (dirSnapshot == null) {
                 dirSnapshot = new HdfsDirSnapshotImpl(parentDirPath, parentDirFStatus);
                 dirToSnapshots.put(parentDirPath, dirSnapshot);
@@ -1393,7 +1397,7 @@ public class AcidUtils {
           }
         }
       }
-      return new ArrayList<HdfsDirSnapshot>(dirToSnapshots.values());
+      return dirToSnapshots;
     } catch (IOException e) {
       e.printStackTrace();
       throw new IOException(e);
@@ -1410,41 +1414,43 @@ public class AcidUtils {
     public Path getPath();
 
     public void addOrcAcidFormatFile(FileStatus fStatus);
-    
+
     public FileStatus getOrcAcidFormatFile();
 
     public void addMetadataFile(FileStatus fStatus);
-    
+
     public FileStatus getMetadataFile(FileStatus fStatus);
 
     // FileStatus of this HDFS directory
     public FileStatus getFileStatus();
-    
+
     // Get the list of files if any within this directory
     public List<FileStatus> getFiles();
-    
+
     public void setFileStatus(FileStatus fStatus);
-    
+
     public void addFile(FileStatus file);
-    
+
     // File id or null
     public Long getFileId();
-    
+
     public Boolean isRawFormat();
-    
+
     public void setIsRawFormat(boolean isRawFormat);
-    
+
     public Boolean isBase();
-    
+
     public void setIsBase(boolean isBase);
-    
-    public Boolean isValidBase();    
-    
+
+    Boolean isValidBase();
+
     public void setIsValidBase(boolean isValidBase);
-    
-    public Boolean isCompactedBase();    
-    
+
+    Boolean isCompactedBase();
+
     public void setIsCompactedBase(boolean isCompactedBase);
+
+    boolean contains(Path path);
   }
   
   public static class HdfsDirSnapshotImpl implements HdfsDirSnapshot {
@@ -1559,7 +1565,17 @@ public class AcidUtils {
     public FileStatus getMetadataFile(FileStatus fStatus) {
       return metadataFStatus;
     }
-    
+
+    @Override
+    public boolean contains(Path path) {
+      for (FileStatus fileStatus: getFiles()) {
+        if (fileStatus.getPath().equals(path)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder();
@@ -1592,7 +1608,7 @@ public class AcidUtils {
       //By definition there are no open txns with id < 1.
       return true;
     }
-    if(isCompactedBase(parsedBase, fs)) {
+    if(isCompactedBase(parsedBase, fs, (HdfsDirSnapshot) null)) {
       return writeIdList.isValidBase(parsedBase.getWriteId());
     }
     //if here, it's a result of IOW
@@ -1605,7 +1621,11 @@ public class AcidUtils {
     if (dirSnapshot.isValidBase() != null) {
       isValidBase = dirSnapshot.isValidBase();
     } else {
-      isValidBase = isValidBase(parsedBase, writeIdList, fs);
+      if (isCompactedBase(parsedBase, fs, dirSnapshot)) {
+        isValidBase = writeIdList.isValidBase(parsedBase.getWriteId());
+      } else {
+        isValidBase = writeIdList.isWriteIdValid(parsedBase.getWriteId());
+      }
       dirSnapshot.setIsValidBase(isValidBase);
     }
     return isValidBase;
@@ -1617,9 +1637,14 @@ public class AcidUtils {
    * presence of {@link AcidUtils#VISIBILITY_PATTERN} suffix.  Base directories written prior to
    * that, have to rely on the {@link MetaDataFile} in the directory. So look at the filename first
    * since that is the cheaper test.*/
-  private static boolean isCompactedBase(ParsedBase parsedBase, FileSystem fs) throws IOException {
-    return parsedBase.getVisibilityTxnId() > 0 || MetaDataFile.isCompacted(parsedBase.getBaseDirPath(), fs);
+  private static boolean isCompactedBase(ParsedBase parsedBase, FileSystem fs,
+      Map<Path, HdfsDirSnapshot> snapshotMap) throws IOException {
+    return isCompactedBase(parsedBase, fs, snapshotMap != null ? snapshotMap.get(parsedBase.getBaseDirPath()) : null);
+  }
 
+  private static boolean isCompactedBase(ParsedBase parsedBase, FileSystem fs,
+      HdfsDirSnapshot snapshot) throws IOException {
+    return parsedBase.getVisibilityTxnId() > 0 || MetaDataFile.isCompacted(parsedBase.getBaseDirPath(), fs, snapshot);
   }
   
   private static void getChildState(FileStatus child, HdfsFileStatusWithId childWithId,
@@ -1683,15 +1708,24 @@ public class AcidUtils {
     }
   }
   
-  private static void getChildState(Path candidateDirectory, List<HdfsDirSnapshot> dirSnapshots, ValidWriteIdList writeIdList,
-      List<ParsedDelta> working, List<Path> originalDirectories, List<HdfsFileStatusWithId> original,
+  private static void getChildState(Path candidateDirectory, Map<Path, HdfsDirSnapshot> dirSnapshots,
+      ValidWriteIdList writeIdList, List<ParsedDelta> working, List<Path> originalDirectories,
+      List<HdfsFileStatusWithId> original,
       List<Path> obsolete, TxnBase bestBase, boolean ignoreEmptyFiles, List<Path> aborted,
       Map<String, String> tblproperties, FileSystem fs, ValidTxnList validTxnList) throws IOException {
-    for (HdfsDirSnapshot dirSnapshot : dirSnapshots) {
+    for (HdfsDirSnapshot dirSnapshot : dirSnapshots.values()) {
       FileStatus fStat = dirSnapshot.getFileStatus();
       Path dirPath = dirSnapshot.getPath();
       String dirName = dirPath.getName();
-      if (dirName.startsWith(BASE_PREFIX)) {
+      if (dirPath.equals(candidateDirectory)) {
+        // if the candidateDirectory is itself a delta directory, we need to add originals in that directory
+        // and return. This is the case when compaction thread calls getChildState.
+        for (FileStatus fileStatus : dirSnapshot.getFiles()) {
+          if (!ignoreEmptyFiles || fileStatus.getLen() != 0) {
+            original.add(createOriginalObj(null, fileStatus));
+          }
+        }
+      } else if (dirName.startsWith(BASE_PREFIX)) {
         bestBase.dirSnapShot = dirSnapshot;
         ParsedBase parsedBase = ParsedBase.parseBase(dirPath);
         if (!isDirUsable(dirPath, parsedBase.getVisibilityTxnId(), aborted, validTxnList)) {
@@ -1723,25 +1757,15 @@ public class AcidUtils {
         if (!isDirUsable(dirPath, delta.getVisibilityTxnId(), aborted, validTxnList)) {
           continue;
         }
-        if (ValidWriteIdList.RangeResponse.ALL == writeIdList.isWriteIdRangeAborted(delta.minWriteId,
-            delta.maxWriteId)) {
+        if (ValidWriteIdList.RangeResponse.ALL == writeIdList
+            .isWriteIdRangeAborted(delta.minWriteId, delta.maxWriteId)) {
           aborted.add(dirPath);
-        } else if (writeIdList.isWriteIdRangeValid(delta.minWriteId,
-            delta.maxWriteId) != ValidWriteIdList.RangeResponse.NONE) {
-          if (delta.isRawFormat) {
-            for (FileStatus stat : dirSnapshot.getFiles()) {
-              if ((!ignoreEmptyFiles) || (stat.getLen() != 0)) {
-                original.add(createOriginalObj(null, stat));
-              }
-            }
-          } else {
-            working.add(delta);
-          }
+        } else if (writeIdList.isWriteIdRangeValid(delta.minWriteId, delta.maxWriteId)
+            != ValidWriteIdList.RangeResponse.NONE) {
+          working.add(delta);
         }
       } else {
-        if (!candidateDirectory.equals(dirPath)) {
-          originalDirectories.add(dirPath);
-        }
+        originalDirectories.add(dirPath);
         for (FileStatus stat : dirSnapshot.getFiles()) {
           if ((!ignoreEmptyFiles) || (stat.getLen() != 0)) {
             original.add(createOriginalObj(null, stat));
@@ -2365,14 +2389,17 @@ public class AcidUtils {
       String COMPACTED = "compacted";
     }
 
-    static boolean isCompacted(Path baseOrDeltaDir, FileSystem fs) throws IOException {
+    static boolean isCompacted(Path baseOrDeltaDir, FileSystem fs, HdfsDirSnapshot dirSnapshot) throws IOException {
       /**
        * this file was written by Hive versions before 4.0 into a base_x/ dir
        * created by compactor so that it can be distinguished from the one
        * created by Insert Overwrite
        */
       Path formatFile = new Path(baseOrDeltaDir, METADATA_FILE);
-      if(!fs.exists(formatFile)) {
+      if (dirSnapshot != null && !dirSnapshot.contains(formatFile)) {
+        return false;
+      }
+      if(dirSnapshot == null && !fs.exists(formatFile)) {
         return false;
       }
       try (FSDataInputStream strm = fs.open(formatFile)) {
@@ -2450,14 +2477,18 @@ public class AcidUtils {
       }
       else {
         //must be base_x
-        if(isCompactedBase(ParsedBase.parseBase(baseOrDeltaDir), fs)) {
+        if(isCompactedBase(ParsedBase.parseBase(baseOrDeltaDir), fs, dirSnapshot)) {
           return false;
         }
       }
       //if here, have to check the files
-      Path dataFile;
+      Path dataFile = null;
       if ((dirSnapshot != null) && (dirSnapshot.getFiles() != null) && (dirSnapshot.getFiles().size() > 0)) {
-        dataFile = dirSnapshot.getFiles().get(0).getPath();
+        for (FileStatus fileStatus: dirSnapshot.getFiles()) {
+          if (originalBucketFilter.accept(fileStatus.getPath())) {
+            dataFile = fileStatus.getPath();
+          }
+        }
       } else {
         dataFile = chooseFile(baseOrDeltaDir, fs);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -1273,7 +1273,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
       }
       //todo: shouldn't ignoreEmptyFiles be set based on ExecutionEngine?
       AcidUtils.Directory dirInfo = AcidUtils.getAcidState(
-          fs, dir, context.conf, context.writeIdList, useFileIds, true, null, false);
+          fs, dir, context.conf, context.writeIdList, useFileIds, true, null, true);
       // find the base files (original or new style)
       List<AcidBaseFileInfo> baseFiles = new ArrayList<>();
       if (dirInfo.getBaseDirectory() == null) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -1211,9 +1211,16 @@ public class TestInputOutputFormat {
     private static String blockedUgi = null;
     private final static List<MockFile> globalFiles = new ArrayList<MockFile>();
     protected Statistics statistics;
+    private int numExistsCalls;
 
     public MockFileSystem() {
       // empty
+    }
+
+    @Override
+    public boolean exists(Path f) throws IOException {
+      numExistsCalls++;
+      return super.exists(f);
     }
 
     @Override
@@ -1570,6 +1577,10 @@ public class TestInputOutputFormat {
       }
       buffer.append("]}");
       return buffer.toString();
+    }
+
+    public int getNumExistsCalls() {
+      return numExistsCalls;
     }
 
     public static void addGlobalFile(MockFile mockFile) {
@@ -3521,7 +3532,7 @@ public class TestInputOutputFormat {
         readOpsDelta = statistics.getReadOps() - readOpsBefore;
       }
     }
-    assertEquals(10, readOpsDelta);
+    assertEquals(6, readOpsDelta);
 
     // revert back to local fs
     conf.set("fs.defaultFS", "file:///");
@@ -3600,7 +3611,7 @@ public class TestInputOutputFormat {
     // call-4: AcidUtils.getAcidState - split 2 => ls mock:/mocktable6
     // call-5: read footer - split 2 => mock:/mocktable6/0_0 (to get offset since it's original file)
     // call-6: file stat - split 2 => mock:/mocktable6/0_0
-    assertEquals(10, readOpsDelta);
+    assertEquals(6, readOpsDelta);
 
     // revert back to local fs
     conf.set("fs.defaultFS", "file:///");
@@ -3675,7 +3686,7 @@ public class TestInputOutputFormat {
         readOpsDelta = statistics.getReadOps() - readOpsBefore;
       }
     }
-    assertEquals(10, readOpsDelta);
+    assertEquals(7, readOpsDelta);
 
     // revert back to local fs
     conf.set("fs.defaultFS", "file:///");
@@ -3749,7 +3760,7 @@ public class TestInputOutputFormat {
         readOpsDelta = statistics.getReadOps() - readOpsBefore;
       }
     }
-    assertEquals(10, readOpsDelta);
+    assertEquals(7, readOpsDelta);
 
     // revert back to local fs
     conf.set("fs.defaultFS", "file:///");


### PR DESCRIPTION
…ystem calls

getAcidState() can make use of single recursive directory listing call and save a snapshot of the directory. Later this snapshot is used to probe existence of some files, such as _acid_version. This optimization was turned of in OrcInputFormat. Even after turning this on, isCompactedBase and isMetadataFile were not using the snapshot saved.

Change-Id: I9eb69b1715c7f577ec5e5b21e505bbed5a953230