### PR TITLE
HIVE-21569 Bump guava version to 28.1-jre

### DIFF
--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -29,7 +29,7 @@
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <druid.guava.version>16.0.1</druid.guava.version>
+    <druid.guava.version>28.1-jre</druid.guava.version>
   </properties>
 
   <dependencies>

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -47,16 +47,6 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>
-      <artifactId>hive-common</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-metastore</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -82,11 +72,6 @@
       <scope>test</scope>
     </dependency>
     <!-- inter-project -->
-    <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>${guava.version}</version>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatContext.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatContext.java
@@ -19,8 +19,8 @@
 
 package org.apache.hive.hcatalog.common;
 
-import org.apache.hive.com.google.guava.base.Optional;
-import org.apache.hive.com.google.guava.base.Preconditions;
+import org.apache.hive.com.google.common.base.Optional;
+import org.apache.hive.com.google.common.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatContext.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatContext.java
@@ -19,8 +19,8 @@
 
 package org.apache.hive.hcatalog.common;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
+import org.apache.hive.com.google.guava.base.Optional;
+import org.apache.hive.com.google.guava.base.Preconditions;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.classification.InterfaceAudience;
 import org.apache.hadoop.hive.common.classification.InterfaceStability;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
@@ -35,7 +35,7 @@ import java.util.Properties;
 
 import javax.security.auth.login.LoginException;
 
-import com.google.common.collect.Maps;
+import org.apache.hive.com.google.guava.collect.Maps;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HCatUtil.java
@@ -35,7 +35,7 @@ import java.util.Properties;
 
 import javax.security.auth.login.LoginException;
 
-import org.apache.hive.com.google.guava.collect.Maps;
+import org.apache.hive.com.google.common.collect.Maps;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.classification.InterfaceAudience;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HiveClientCache.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HiveClientCache.java
@@ -47,11 +47,11 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hive.com.google.guava.cache.Cache;
+import org.apache.hive.com.google.guava.cache.CacheBuilder;
+import org.apache.hive.com.google.guava.cache.RemovalListener;
+import org.apache.hive.com.google.guava.cache.RemovalNotification;
+import org.apache.hive.com.google.guava.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * A thread safe time expired cache for HiveMetaStoreClient

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HiveClientCache.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/common/HiveClientCache.java
@@ -47,11 +47,11 @@ import org.apache.thrift.TException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hive.com.google.guava.cache.Cache;
-import org.apache.hive.com.google.guava.cache.CacheBuilder;
-import org.apache.hive.com.google.guava.cache.RemovalListener;
-import org.apache.hive.com.google.guava.cache.RemovalNotification;
-import org.apache.hive.com.google.guava.util.concurrent.ThreadFactoryBuilder;
+import org.apache.hive.com.google.common.cache.Cache;
+import org.apache.hive.com.google.common.cache.CacheBuilder;
+import org.apache.hive.com.google.common.cache.RemovalListener;
+import org.apache.hive.com.google.common.cache.RemovalNotification;
+import org.apache.hive.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * A thread safe time expired cache for HiveMetaStoreClient

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/HCatRecordObjectInspectorFactory.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/HCatRecordObjectInspectorFactory.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import org.apache.hive.com.google.guava.cache.Cache;
+import org.apache.hive.com.google.guava.cache.CacheBuilder;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/HCatRecordObjectInspectorFactory.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/data/HCatRecordObjectInspectorFactory.java
@@ -22,8 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hive.com.google.guava.cache.Cache;
-import org.apache.hive.com.google.guava.cache.CacheBuilder;
+import org.apache.hive.com.google.common.cache.Cache;
+import org.apache.hive.com.google.common.cache.CacheBuilder;
 import org.apache.hadoop.hive.serde2.SerDeException;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatInputFormat.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatInputFormat.java
@@ -22,7 +22,7 @@ package org.apache.hive.hcatalog.mapreduce;
 import java.io.IOException;
 import java.util.Properties;
 
-import com.google.common.base.Preconditions;
+import org.apache.hive.com.google.guava.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatInputFormat.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatInputFormat.java
@@ -22,7 +22,7 @@ package org.apache.hive.hcatalog.mapreduce;
 import java.io.IOException;
 import java.util.Properties;
 
-import org.apache.hive.com.google.guava.base.Preconditions;
+import org.apache.hive.com.google.common.base.Preconditions;
 import org.apache.hadoop.classification.InterfaceAudience;
 import org.apache.hadoop.classification.InterfaceStability;
 import org.apache.hadoop.conf.Configuration;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
-import com.google.common.collect.Lists;
+import org.apache.hive.com.google.guava.collect.Lists;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hive.hcatalog.common.HCatUtil;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/HCatTableInfo.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.List;
 
-import org.apache.hive.com.google.guava.collect.Lists;
+import org.apache.hive.com.google.common.collect.Lists;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hive.hcatalog.common.HCatUtil;

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.hive.com.google.guava.collect.Maps;
+import org.apache.hive.com.google.common.collect.Maps;
 
 /**
  * This class is a place to put all the code associated with

--- a/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
+++ b/hcatalog/core/src/main/java/org/apache/hive/hcatalog/mapreduce/SpecialCases.java
@@ -42,7 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.Maps;
+import org.apache.hive.com.google.guava.collect.Maps;
 
 /**
  * This class is a place to put all the code associated with

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/common/TestHCatUtil.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/common/TestHCatUtil.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import org.apache.hive.com.google.guava.collect.Lists;
-import org.apache.hive.com.google.guava.collect.Maps;
+import org.apache.hive.com.google.common.collect.Lists;
+import org.apache.hive.com.google.common.collect.Maps;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsAction;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/common/TestHCatUtil.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/common/TestHCatUtil.java
@@ -25,8 +25,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
+import org.apache.hive.com.google.guava.collect.Lists;
+import org.apache.hive.com.google.guava.collect.Maps;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.permission.FsAction;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.hive.hcatalog.mapreduce;
 
-import org.apache.hive.com.google.guava.collect.ImmutableSet;
+import org.apache.hive.com.google.common.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/HCatMapReduceTest.java
@@ -19,7 +19,7 @@
 
 package org.apache.hive.hcatalog.mapreduce;
 
-import com.google.common.collect.ImmutableSet;
+import org.apache.hive.com.google.guava.collect.ImmutableSet;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatOutputFormat.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatOutputFormat.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.Lists;
+import org.apache.hive.com.google.guava.collect.Lists;
 
 
 import org.apache.hadoop.conf.Configuration;

--- a/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatOutputFormat.java
+++ b/hcatalog/core/src/test/java/org/apache/hive/hcatalog/mapreduce/TestHCatOutputFormat.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.hive.com.google.guava.collect.Lists;
+import org.apache.hive.com.google.common.collect.Lists;
 
 
 import org.apache.hadoop.conf.Configuration;

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -41,7 +41,7 @@
     <druid.jersey.version>1.19.3</druid.jersey.version>
     <druid.jetty.version>9.4.10.v20180503</druid.jetty.version>
     <druid.derby.version>10.11.1.1</druid.derby.version>
-    <druid.guava.version>16.0.1</druid.guava.version>
+    <druid.guava.version>28.1-jre</druid.guava.version>
     <druid.guice.version>4.1.0</druid.guice.version>
     <kafka.test.version>2.0.0</kafka.test.version>
     <slf4j.version>1.7.25</slf4j.version>

--- a/llap-common/src/java/org/apache/hadoop/hive/llap/AsyncPbRpcProxy.java
+++ b/llap-common/src/java/org/apache/hadoop/hive/llap/AsyncPbRpcProxy.java
@@ -171,7 +171,7 @@ public abstract class AsyncPbRpcProxy<ProtocolType, TokenType extends TokenIdent
           CallableRequest<T, U> request, LlapNodeId nodeId) {
         ListenableFuture<U> future = executor.submit(request);
         Futures.addCallback(future, new ResponseCallback<U>(
-            request.getCallback(), nodeId, this));
+            request.getCallback(), nodeId, this), MoreExecutors.directExecutor());
       }
 
       @VisibleForTesting
@@ -283,7 +283,7 @@ public abstract class AsyncPbRpcProxy<ProtocolType, TokenType extends TokenIdent
           LOG.warn("RequestManager shutdown with error", t);
         }
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   @Override

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
@@ -174,7 +174,7 @@ public class AMReporter extends AbstractService {
           Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), t);
         }
       }
-    });
+    }, MoreExecutors.directExecutor());
     // TODO: why is this needed? we could just save the host and port?
     nodeId = LlapNodeId.getInstance(localAddress.get().getHostName(), localAddress.get().getPort());
     LOG.info("AMReporter running with DaemonId: {}, NodeId: {}", daemonId, nodeId);
@@ -274,7 +274,7 @@ public class AMReporter extends AbstractService {
         LOG.warn("Failed to send taskKilled for {}. The attempt will likely time out.",
             taskAttemptId);
       }
-    });
+    }, MoreExecutors.directExecutor());
   }
 
   public void queryComplete(QueryIdentifier queryIdentifier) {
@@ -342,7 +342,7 @@ public class AMReporter extends AbstractService {
                     amNodeInfo.amNodeId, currentQueryIdentifier, t);
                   queryFailedHandler.queryFailed(currentQueryIdentifier);
                 }
-              });
+              }, MoreExecutors.directExecutor());
             }
           }
         } catch (InterruptedException e) {

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapTaskReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapTaskReporter.java
@@ -128,7 +128,7 @@ public class LlapTaskReporter implements TaskReporterInterface {
         sendCounterInterval, maxEventsToGet, requestCounter, containerIdStr, initialEvent,
         fragmentRequestId, wmCounters);
     ListenableFuture<Boolean> future = heartbeatExecutor.submit(currentCallable);
-    Futures.addCallback(future, new HeartbeatCallback(errorReporter));
+    Futures.addCallback(future, new HeartbeatCallback(errorReporter), MoreExecutors.directExecutor());
   }
 
   /**

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -186,7 +186,7 @@ public class TaskExecutorService extends AbstractService
     executionCompletionExecutorService = MoreExecutors.listeningDecorator(
         executionCompletionExecutorServiceRaw);
     ListenableFuture<?> future = waitQueueExecutorService.submit(new WaitQueueWorker());
-    Futures.addCallback(future, new WaitQueueWorkerCallback());
+    Futures.addCallback(future, new WaitQueueWorkerCallback(), MoreExecutors.directExecutor());
   }
 
   /**

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -799,15 +799,17 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       }, 0, 10000L, TimeUnit.MILLISECONDS);
 
       nodeEnablerFuture = nodeEnabledExecutor.submit(nodeEnablerCallable);
-      Futures.addCallback(nodeEnablerFuture, new LoggingFutureCallback("NodeEnablerThread", LOG));
+      Futures.addCallback(nodeEnablerFuture, new LoggingFutureCallback("NodeEnablerThread", LOG),
+          MoreExecutors.directExecutor());
 
       delayedTaskSchedulerFuture =
           delayedTaskSchedulerExecutor.submit(delayedTaskSchedulerCallable);
       Futures.addCallback(delayedTaskSchedulerFuture,
-          new LoggingFutureCallback("DelayedTaskSchedulerThread", LOG));
+          new LoggingFutureCallback("DelayedTaskSchedulerThread", LOG), MoreExecutors.directExecutor());
 
       schedulerFuture = schedulerExecutor.submit(schedulerCallable);
-      Futures.addCallback(schedulerFuture, new LoggingFutureCallback("SchedulerThread", LOG));
+      Futures.addCallback(schedulerFuture, new LoggingFutureCallback("SchedulerThread", LOG),
+          MoreExecutors.directExecutor());
 
       registry.start();
       registry.registerStateChangeListener(new NodeStateChangeListener());

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
     <druid.version>0.14.0-incubating</druid.version>
     <flatbuffers.version>1.2.0-3f79e055</flatbuffers.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>28.1-jre</guava.version>
     <groovy.version>2.4.11</groovy.version>
     <h2database.version>1.3.166</h2database.version>
     <hadoop.version>3.1.0</hadoop.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1023,7 +1023,7 @@
                   <shadedPattern>org.apache.hive.com.zaxxer.hikari</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>com.google.guava</pattern>
+                  <pattern>com.google.common</pattern>
                   <shadedPattern>org.apache.hive.com.google.guava</shadedPattern>
                 </relocation>
               </relocations>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -1024,7 +1024,7 @@
                 </relocation>
                 <relocation>
                   <pattern>com.google.common</pattern>
-                  <shadedPattern>org.apache.hive.com.google.guava</shadedPattern>
+                  <shadedPattern>org.apache.hive.com.google.common</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.exec.tez;
 
+import com.google.common.util.concurrent.*;
 import org.apache.hadoop.hive.metastore.api.WMPoolSchedulingPolicy;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 
@@ -24,11 +25,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.math.DoubleMath;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -1102,7 +1098,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
   }
 
   private void failOnFutureFailure(ListenableFuture<?> future) {
-    Futures.addCallback(future, FATAL_ERROR_CALLBACK);
+    Futures.addCallback(future, FATAL_ERROR_CALLBACK, MoreExecutors.directExecutor());
   }
 
   private void queueGetRequestOnMasterThread(
@@ -1936,7 +1932,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
 
     public void start() throws Exception {
       ListenableFuture<WmTezSession> getFuture = tezAmPool.getSessionAsync();
-      Futures.addCallback(getFuture, this);
+      Futures.addCallback(getFuture, this, MoreExecutors.directExecutor());
     }
 
     @Override
@@ -1990,7 +1986,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
       case GETTING: {
         ListenableFuture<WmTezSession> waitFuture = session.waitForAmRegistryAsync(
             amRegistryTimeoutMs, timeoutPool);
-        Futures.addCallback(waitFuture, this);
+        Futures.addCallback(waitFuture, this, MoreExecutors.directExecutor());
         break;
       }
       case WAITING_FOR_REGISTRY: {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/SampleTezSessionState.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/SampleTezSessionState.java
@@ -19,10 +19,8 @@
 package org.apache.hadoop.hive.ql.exec.tez;
 
 
-import com.google.common.util.concurrent.Futures;
-import com.google.common.util.concurrent.FutureCallback;
-import com.google.common.util.concurrent.ListenableFuture;
-import com.google.common.util.concurrent.SettableFuture;
+import com.google.common.util.concurrent.*;
+
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 import javax.security.auth.login.LoginException;
@@ -128,7 +126,7 @@ public class SampleTezSessionState extends WmTezSession {
       public void onFailure(Throwable t) {
         future.setException(t);
       }
-    });
+    }, MoreExecutors.directExecutor());
     return future;
   }
 

--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
@@ -451,9 +451,9 @@ public final class Util {
     HostAndPort hp = HostAndPort.fromString(host)
             .withDefaultPort(port);
 
-    LOG.info("Connecting to {}:{}", hp.getHostText(), hp.getPort());
+    LOG.info("Connecting to {}:{}", hp.getHost(), hp.getPort());
 
-    return new URI(THRIFT_SCHEMA, null, hp.getHostText(), hp.getPort(),
+    return new URI(THRIFT_SCHEMA, null, hp.getHost(), hp.getPort(),
             null, null, null);
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -81,7 +81,7 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>28.1-jre</guava.version>
     <hadoop.version>3.1.0</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.9.9</jackson.version>


### PR DESCRIPTION
This still needs some additional work to align guava versions with spark's guava 14 correctly.