### PR TITLE
[HIVE-22634]Improperly SemanticException when filter is optimized to False on a partition table

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ppr/PartitionPruner.java
@@ -184,7 +184,7 @@ public class PartitionPruner extends Transform {
       return getAllPartsFromCacheOrServer(tab, key, false, prunedPartitionsMap);
     }
 
-    if (!hasColumnExpr(prunerExpr)) {
+    if (!hasColumnExpr(prunerExpr) && !isFalseExpr(prunerExpr)) {
       // If the "strict" mode is on, we have to provide partition pruner for each table.
       String error = StrictChecks.checkNoPartitionFilter(conf);
       if (error != null) {


### PR DESCRIPTION
When filter is optimized to False on a partition table, it will throw improperly SemanticException reporting that there is no partition predicate found.

The step to reproduce is
```
set hive.strict.checks.no.partition.filter=true;
CREATE TABLE test(id int, name string)PARTITIONED BY (`date` string);
select * from test where `date` = '20191201' and 1<>1;
```

The above sql will throw "Queries against partitioned tables without a partition filter"  exception.