### PR TITLE
HIVE-22644 Break up DDLSemanticAnalyzer - extract Table column analyzers

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AbstractAlterTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AbstractAlterTableAnalyzer.java
@@ -21,8 +21,18 @@ package org.apache.hadoop.hive.ql.ddl.table;
 import java.util.Map;
 
 import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLDesc.DDLDescWithWriteId;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.hooks.WriteEntity;
+import org.apache.hadoop.hive.ql.hooks.WriteEntity.WriteType;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
@@ -33,6 +43,9 @@ import org.apache.hadoop.hive.ql.parse.SemanticException;
  * tableName command partitionSpec?
  */
 public abstract class AbstractAlterTableAnalyzer extends BaseSemanticAnalyzer {
+  // Equivalent to acidSinks, but for DDL operations that change data.
+  private DDLDescWithWriteId ddlDescWithWriteId;
+
   public AbstractAlterTableAnalyzer(QueryState queryState) throws SemanticException {
     super(queryState);
   }
@@ -61,4 +74,121 @@ public abstract class AbstractAlterTableAnalyzer extends BaseSemanticAnalyzer {
 
   protected abstract void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
       throws SemanticException;
+
+  protected void setAcidDdlDesc(DDLDescWithWriteId descWithWriteId) {
+    if(this.ddlDescWithWriteId != null) {
+      throw new IllegalStateException("ddlDescWithWriteId is already set: " + this.ddlDescWithWriteId);
+    }
+    this.ddlDescWithWriteId = descWithWriteId;
+  }
+
+  @Override
+  public DDLDescWithWriteId getAcidDdlDesc() {
+    return ddlDescWithWriteId;
+  }
+
+  protected void addInputsOutputsAlterTable(TableName tableName, Map<String, String> partitionSpec,
+      AbstractAlterTableDesc desc, AlterTableType op, boolean doForceExclusive) throws SemanticException {
+    boolean isCascade = desc != null && desc.isCascade();
+    boolean alterPartitions = partitionSpec != null && !partitionSpec.isEmpty();
+    //cascade only occurs at table level then cascade to partition level
+    if (isCascade && alterPartitions) {
+      throw new SemanticException(ErrorMsg.ALTER_TABLE_PARTITION_CASCADE_NOT_SUPPORTED, op.getName());
+    }
+
+    Table table = getTable(tableName, true);
+    // cascade only occurs with partitioned table
+    if (isCascade && !table.isPartitioned()) {
+      throw new SemanticException(ErrorMsg.ALTER_TABLE_NON_PARTITIONED_TABLE_CASCADE_NOT_SUPPORTED);
+    }
+
+    // Determine the lock type to acquire
+    WriteEntity.WriteType writeType = doForceExclusive ?
+        WriteType.DDL_EXCLUSIVE : determineAlterTableWriteType(table, desc, op);
+
+    if (!alterPartitions) {
+      inputs.add(new ReadEntity(table));
+      WriteEntity alterTableOutput = new WriteEntity(table, writeType);
+      outputs.add(alterTableOutput);
+      //do not need the lock for partitions since they are covered by the table lock
+      if (isCascade) {
+        for (Partition part : getPartitions(table, partitionSpec, false)) {
+          outputs.add(new WriteEntity(part, WriteEntity.WriteType.DDL_NO_LOCK));
+        }
+      }
+    } else {
+      ReadEntity re = new ReadEntity(table);
+      // In the case of altering a table for its partitions we don't need to lock the table
+      // itself, just the partitions.  But the table will have a ReadEntity.  So mark that
+      // ReadEntity as no lock.
+      re.noLockNeeded();
+      inputs.add(re);
+
+      if (AlterTableUtils.isFullPartitionSpec(table, partitionSpec)) {
+        // Fully specified partition spec
+        Partition part = getPartition(table, partitionSpec, true);
+        outputs.add(new WriteEntity(part, writeType));
+      } else {
+        // Partial partition spec supplied. Make sure this is allowed.
+        if (!AlterTableType.SUPPORT_PARTIAL_PARTITION_SPEC.contains(op)) {
+          throw new SemanticException(
+              ErrorMsg.ALTER_TABLE_TYPE_PARTIAL_PARTITION_SPEC_NO_SUPPORTED, op.getName());
+        } else if (!conf.getBoolVar(HiveConf.ConfVars.DYNAMICPARTITIONING)) {
+          throw new SemanticException(ErrorMsg.DYNAMIC_PARTITION_DISABLED);
+        }
+
+        for (Partition part : getPartitions(table, partitionSpec, true)) {
+          outputs.add(new WriteEntity(part, writeType));
+        }
+      }
+    }
+
+    if (desc != null) {
+      validateAlterTableType(table, op, desc.expectView());
+    }
+  }
+
+  // For the time while all the alter table operations are getting migrated there is a duplication of this method here
+  private WriteType determineAlterTableWriteType(Table tab, AbstractAlterTableDesc desc, AlterTableType op) {
+    boolean convertingToAcid = false;
+    if (desc != null && desc.getProps() != null &&
+        Boolean.parseBoolean(desc.getProps().get(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL))) {
+      convertingToAcid = true;
+    }
+    if (!AcidUtils.isTransactionalTable(tab) && convertingToAcid) {
+      // non-acid to transactional conversion (property itself) must be mutexed to prevent concurrent writes.
+      // See HIVE-16688 for use cases.
+      return WriteType.DDL_EXCLUSIVE;
+    }
+    return WriteEntity.determineAlterTableWriteType(op);
+  }
+
+  private void validateAlterTableType(Table tbl, AlterTableType op, boolean expectView)
+      throws SemanticException {
+    if (tbl.isView()) {
+      if (!expectView) {
+        throw new SemanticException(ErrorMsg.ALTER_COMMAND_FOR_VIEWS.getMsg());
+      }
+
+      switch (op) {
+      case ADDPARTITION:
+      case DROPPARTITION:
+      case RENAMEPARTITION:
+      case ADDPROPS:
+      case DROPPROPS:
+      case RENAME:
+        // allow this form
+        break;
+      default:
+        throw new SemanticException(ErrorMsg.ALTER_VIEW_DISALLOWED_OP.getMsg(op.toString()));
+      }
+    } else {
+      if (expectView) {
+        throw new SemanticException(ErrorMsg.ALTER_COMMAND_FOR_TABLES.getMsg());
+      }
+    }
+    if (tbl.isNonNative() && !AlterTableType.NON_NATIVE_TABLE_ALLOWED.contains(op)) {
+      throw new SemanticException(ErrorMsg.ALTER_TABLE_NON_NATIVE.getMsg(tbl.getTableName()));
+    }
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AbstractAlterTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AbstractAlterTableOperation.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
-import org.apache.hadoop.hive.ql.parse.DDLSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.session.SessionState;
 
 /**
@@ -88,7 +87,7 @@ public abstract class AbstractAlterTableOperation<T extends AbstractAlterTableDe
       throws HiveException {
     List<Partition> partitions = null;
     if (partSpec != null) {
-      if (DDLSemanticAnalyzer.isFullSpec(tbl, partSpec)) {
+      if (AlterTableUtils.isFullPartitionSpec(tbl, partSpec)) {
         partitions = new ArrayList<Partition>();
         Partition part = context.getDb().getPartition(tbl, partSpec, false);
         if (part == null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AlterTableUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/AlterTableUtils.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
@@ -69,5 +70,14 @@ public final class AlterTableUtils {
   public static boolean isSchemaEvolutionEnabled(Table table, Configuration conf) {
     return AcidUtils.isTablePropertyTransactional(table.getMetadata()) ||
         HiveConf.getBoolVar(conf, ConfVars.HIVE_SCHEMA_EVOLUTION);
+  }
+
+  public static boolean isFullPartitionSpec(Table table, Map<String, String> partitionSpec) {
+    for (FieldSchema partitionCol : table.getPartCols()) {
+      if (partitionSpec.get(partitionCol.getName()) == null) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsAnalyzer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.table.column.add;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableAnalyzer;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for add columns commands.
+ */
+@DDLType(type=HiveParser.TOK_ALTERTABLE_ADDCOLS)
+public class AlterTableAddColumnsAnalyzer extends AbstractAlterTableAnalyzer {
+  public AlterTableAddColumnsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
+      throws SemanticException {
+    List<FieldSchema> newCols = getColumns((ASTNode) command.getChild(0));
+    boolean isCascade = false;
+    if (null != command.getFirstChildWithType(HiveParser.TOK_CASCADE)) {
+      isCascade = true;
+    }
+
+    AlterTableAddColumnsDesc desc = new AlterTableAddColumnsDesc(tableName, partitionSpec, isCascade, newCols);
+    Table table = getTable(tableName, true);
+    if (AcidUtils.isTransactionalTable(table)) {
+      setAcidDdlDesc(desc);
+    }
+
+    addInputsOutputsAlterTable(tableName, partitionSpec, desc, desc.getType(), false);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsDesc.java
@@ -16,27 +16,43 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.add;
 
+import java.util.List;
 import java.util.Map;
 
 import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
+import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 
 /**
- * DDL task description for ALTER TABLE ... UPDATE COLUMNS ... commands.
+ * DDL task description for ALTER TABLE ... ADD COLUMNS ... commands.
  */
-@Explain(displayName = "Update Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class AlterTableUpdateColumnsDesc extends AbstractAlterTableDesc {
+@Explain(displayName = "Add Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class AlterTableAddColumnsDesc extends AbstractAlterTableDesc {
   private static final long serialVersionUID = 1L;
 
-  public AlterTableUpdateColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade)
-      throws SemanticException {
-    super(AlterTableType.UPDATE_COLUMNS, tableName, partitionSpec, null, isCascade, false, null);
+  private final List<FieldSchema> newColumns;
+
+  public AlterTableAddColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade,
+      List<FieldSchema> newColumns) throws SemanticException {
+    super(AlterTableType.ADDCOLS, tableName, partitionSpec, null, isCascade, false, null);
+    this.newColumns = newColumns;
+  }
+
+  public List<FieldSchema> getNewColumns() {
+    return newColumns;
+  }
+
+  // Only for explain
+  @Explain(displayName = "new columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+  public List<String> getNewColsString() {
+    return Utilities.getFieldSchemaString(newColumns);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/AlterTableAddColumnsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.add;
 
 import java.util.List;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/add/package-info.java
@@ -16,5 +16,5 @@
  * limitations under the License.
  */
 
-/** Table column related DDL operation descriptions and operations. */
-package org.apache.hadoop.hive.ql.ddl.table.column;
+/** Add columns DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.table.column.add;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnAnalyzer.java
@@ -1,0 +1,173 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.table.column.change;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.TableType;
+import org.apache.hadoop.hive.metastore.api.SQLCheckConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLDefaultConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
+import org.apache.hadoop.hive.metastore.api.SQLNotNullConstraint;
+import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
+import org.apache.hadoop.hive.metastore.api.SQLUniqueConstraint;
+import org.apache.hadoop.hive.metastore.api.SkewedInfo;
+import org.apache.hadoop.hive.ql.ErrorMsg;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableAnalyzer;
+import org.apache.hadoop.hive.ql.ddl.table.constraint.Constraints;
+import org.apache.hadoop.hive.ql.ddl.table.constraint.ConstraintsUtils;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Analyzer for change columns commands.
+ */
+@DDLType(type=HiveParser.TOK_ALTERTABLE_RENAMECOL)
+public class AlterTableChangeColumnAnalyzer extends AbstractAlterTableAnalyzer {
+  public AlterTableChangeColumnAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
+      throws SemanticException {
+    //col_old_name col_new_name column_type [COMMENT col_comment] [FIRST|AFTER column_name] [CASCADE|RESTRICT]
+    String oldColumnName = command.getChild(0).getText();
+    String newColumnName = command.getChild(1).getText();
+    String newType = getTypeStringFromAST((ASTNode) command.getChild(2));
+
+    Table table = getTable(tableName);
+    SkewedInfo skewInfo = table.getTTable().getSd().getSkewedInfo();
+    if ((null != skewInfo) && (null != skewInfo.getSkewedColNames()) &&
+        skewInfo.getSkewedColNames().contains(oldColumnName)) {
+      throw new SemanticException(oldColumnName + ErrorMsg.ALTER_TABLE_NOT_ALLOWED_RENAME_SKEWED_COLUMN.getMsg());
+    }
+
+    String newComment = null;
+    boolean first = false;
+    String flagCol = null;
+    boolean isCascade = false;
+    ASTNode constraintChild = null;
+    for (int i = 3; i < command.getChildCount(); i++) {
+      ASTNode child = (ASTNode)command.getChild(i);
+      switch (child.getToken().getType()) {
+      case HiveParser.StringLiteral:
+        newComment = unescapeSQLString(child.getText());
+        break;
+      case HiveParser.TOK_ALTERTABLE_CHANGECOL_AFTER_POSITION:
+        flagCol = unescapeIdentifier(child.getChild(0).getText());
+        break;
+      case HiveParser.KW_FIRST:
+        first = true;
+        break;
+      case HiveParser.TOK_CASCADE:
+        isCascade = true;
+        break;
+      case HiveParser.TOK_RESTRICT:
+        break;
+      default:
+        constraintChild = child;
+      }
+    }
+
+    Constraints constraints = getConstraints(tableName, command, newColumnName, table, constraintChild);
+
+    AlterTableChangeColumnDesc desc = new AlterTableChangeColumnDesc(tableName, partitionSpec, isCascade, constraints,
+        unescapeIdentifier(oldColumnName), unescapeIdentifier(newColumnName), newType, newComment, first, flagCol);
+    if (AcidUtils.isTransactionalTable(table)) {
+      // Note: we might actually need it only when certain changes (e.g. name or type?) are made.
+      setAcidDdlDesc(desc);
+    }
+
+    addInputsOutputsAlterTable(tableName, partitionSpec, desc, desc.getType(), false);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+
+  private Constraints getConstraints(TableName tableName, ASTNode command, String newColumnName, Table table,
+      ASTNode constraintChild) throws SemanticException {
+    List<SQLPrimaryKey> primaryKeys = null;
+    List<SQLForeignKey> foreignKeys = null;
+    List<SQLUniqueConstraint> uniqueConstraints = null;
+    List<SQLNotNullConstraint> notNullConstraints = null;
+    List<SQLDefaultConstraint> defaultConstraints = null;
+    List<SQLCheckConstraint> checkConstraints = null;
+    if (constraintChild != null) {
+      // Process column constraint
+      switch (constraintChild.getToken().getType()) {
+      case HiveParser.TOK_CHECK_CONSTRAINT:
+        checkConstraints = new ArrayList<>();
+        ConstraintsUtils.processCheckConstraints(tableName, constraintChild, ImmutableList.of(newColumnName),
+            checkConstraints, (ASTNode) command.getChild(2), this.ctx.getTokenRewriteStream());
+        break;
+      case HiveParser.TOK_DEFAULT_VALUE:
+        defaultConstraints = new ArrayList<>();
+        ConstraintsUtils.processDefaultConstraints(tableName, constraintChild, ImmutableList.of(newColumnName),
+            defaultConstraints, (ASTNode) command.getChild(2), this.ctx.getTokenRewriteStream());
+        break;
+      case HiveParser.TOK_NOT_NULL:
+        notNullConstraints = new ArrayList<>();
+        ConstraintsUtils.processNotNullConstraints(tableName, constraintChild, ImmutableList.of(newColumnName),
+            notNullConstraints);
+        break;
+      case HiveParser.TOK_UNIQUE:
+        uniqueConstraints = new ArrayList<>();
+        ConstraintsUtils.processUniqueConstraints(tableName, constraintChild, ImmutableList.of(newColumnName),
+            uniqueConstraints);
+        break;
+      case HiveParser.TOK_PRIMARY_KEY:
+        primaryKeys = new ArrayList<>();
+        ConstraintsUtils.processPrimaryKeys(tableName, constraintChild, ImmutableList.of(newColumnName), primaryKeys);
+        break;
+      case HiveParser.TOK_FOREIGN_KEY:
+        foreignKeys = new ArrayList<>();
+        ConstraintsUtils.processForeignKeys(tableName, constraintChild, foreignKeys);
+        break;
+      default:
+        throw new SemanticException(ErrorMsg.NOT_RECOGNIZED_CONSTRAINT.getMsg(
+            constraintChild.getToken().getText()));
+      }
+    }
+
+    /* Validate the operation of renaming a column name. */
+    if (checkConstraints != null && !checkConstraints.isEmpty()) {
+      ConstraintsUtils.validateCheckConstraint(table.getCols(), checkConstraints, ctx.getConf());
+    }
+
+    if (table.getTableType() == TableType.EXTERNAL_TABLE &&
+        ConstraintsUtils.hasEnabledOrValidatedConstraints(notNullConstraints, defaultConstraints, checkConstraints)) {
+      throw new SemanticException(ErrorMsg.INVALID_CSTR_SYNTAX.getMsg(
+          "Constraints are disallowed with External tables. Only RELY is allowed."));
+    }
+
+    return new Constraints(primaryKeys, foreignKeys, notNullConstraints, uniqueConstraints, defaultConstraints,
+        checkConstraints);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnDesc.java
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.change;
 
 import java.util.Map;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/AlterTableChangeColumnOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.change;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/change/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Change columns DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.table.column.change;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsAnalyzer.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.table.column.replace;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableAnalyzer;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for replace columns commands.
+ */
+@DDLType(type=HiveParser.TOK_ALTERTABLE_REPLACECOLS)
+public class AlterTableReplaceColumnsAnalyzer extends AbstractAlterTableAnalyzer {
+  public AlterTableReplaceColumnsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
+      throws SemanticException {
+    List<FieldSchema> newCols = getColumns((ASTNode) command.getChild(0));
+    boolean isCascade = false;
+    if (null != command.getFirstChildWithType(HiveParser.TOK_CASCADE)) {
+      isCascade = true;
+    }
+
+    AlterTableReplaceColumnsDesc desc = new AlterTableReplaceColumnsDesc(tableName, partitionSpec, isCascade, newCols);
+    Table table = getTable(tableName, true);
+    if (AcidUtils.isTransactionalTable(table)) {
+      setAcidDdlDesc(desc);
+    }
+
+    addInputsOutputsAlterTable(tableName, partitionSpec, desc, desc.getType(), false);
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsDesc.java
@@ -15,8 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.replace;
 
 import java.util.List;
 import java.util.Map;
@@ -31,17 +30,17 @@ import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 
 /**
- * DDL task description for ALTER TABLE ... ADD COLUMNS ... commands.
+ * DDL task description for ALTER TABLE ... REPLACE COLUMNS ... commands.
  */
-@Explain(displayName = "Add Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class AlterTableAddColumnsDesc extends AbstractAlterTableDesc {
+@Explain(displayName = "Replace Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class AlterTableReplaceColumnsDesc extends AbstractAlterTableDesc {
   private static final long serialVersionUID = 1L;
 
   private final List<FieldSchema> newColumns;
 
-  public AlterTableAddColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade,
+  public AlterTableReplaceColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade,
       List<FieldSchema> newColumns) throws SemanticException {
-    super(AlterTableType.ADDCOLS, tableName, partitionSpec, null, isCascade, false, null);
+    super(AlterTableType.REPLACE_COLUMNS, tableName, partitionSpec, null, isCascade, false, null);
     this.newColumns = newColumns;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/AlterTableReplaceColumnsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.replace;
 
 import java.util.List;
 import java.util.Set;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/replace/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Replace columns DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.table.column.replace;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsAnalyzer.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.table.column.show;
+
+import org.apache.hadoop.hive.ql.ErrorMsg;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.exec.Task;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.hooks.ReadEntity;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for show columns commands.
+ */
+@DDLType(type=HiveParser.TOK_SHOWCOLUMNS)
+public class ShowColumnsAnalyzer extends BaseSemanticAnalyzer {
+  public ShowColumnsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  public void analyzeInternal(ASTNode root) throws SemanticException {
+    // table name has to be present so min child 1 and max child 4
+    if (root.getChildCount() > 4 || root.getChildCount() < 1) {
+      throw new SemanticException(ErrorMsg.INVALID_AST_TREE.getMsg(root.toStringTree()));
+    }
+
+    ctx.setResFile(ctx.getLocalTmpPath());
+
+    String tableName = getUnescapedName((ASTNode) root.getChild(0));
+    String pattern = null;
+    switch (root.getChildCount()) {
+    case 1: //  only tablename no pattern and db
+      break;
+    case 2: // tablename and pattern
+      pattern = unescapeSQLString(root.getChild(1).getText());
+      break;
+    case 3: // specifies db
+      if (tableName.contains(".")) {
+        throw new SemanticException("Duplicates declaration for database name");
+      }
+      tableName = getUnescapedName((ASTNode) root.getChild(2)) + "." + tableName;
+      break;
+    case 4: // specifies db and pattern
+      if (tableName.contains(".")) {
+        throw new SemanticException("Duplicates declaration for database name");
+      }
+      tableName = getUnescapedName((ASTNode) root.getChild(2)) + "." + tableName;
+      pattern = unescapeSQLString(root.getChild(3).getText());
+      break;
+    default:
+      break;
+    }
+
+    Table table = getTable(tableName);
+    inputs.add(new ReadEntity(table));
+
+    ShowColumnsDesc desc = new ShowColumnsDesc(ctx.getResFile(), tableName, pattern);
+    Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
+    rootTasks.add(task);
+
+    task.setFetchSource(true);
+    setFetchTask(createFetchTask(ShowColumnsDesc.SCHEMA));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsDesc.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.show;
 
 import java.io.Serializable;
 
@@ -37,10 +37,6 @@ public class ShowColumnsDesc implements DDLDesc, Serializable {
   private final String resFile;
   private final String tableName;
   private final String pattern;
-
-  public ShowColumnsDesc(Path resFile, String tableName) {
-    this(resFile, tableName, null);
-  }
 
   public ShowColumnsDesc(Path resFile, String tableName, String pattern) {
     this.resFile = resFile.toString();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.show;
 
 import java.io.DataOutputStream;
 import java.io.IOException;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Show columns DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.table.column.show;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsAnalyzer.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.ddl.table.column.update;
+
+import java.util.Map;
+
+import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.ql.QueryState;
+import org.apache.hadoop.hive.ql.ddl.DDLWork;
+import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
+import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableAnalyzer;
+import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.parse.ASTNode;
+import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+
+/**
+ * Analyzer for update columns commands.
+ */
+@DDLType(type=HiveParser.TOK_ALTERTABLE_UPDATECOLUMNS)
+public class AlterTableUpdateColumnsAnalyzer extends AbstractAlterTableAnalyzer {
+  public AlterTableUpdateColumnsAnalyzer(QueryState queryState) throws SemanticException {
+    super(queryState);
+  }
+
+  @Override
+  protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
+      throws SemanticException {
+    boolean isCascade = (null != command.getFirstChildWithType(HiveParser.TOK_CASCADE));
+
+    AlterTableUpdateColumnsDesc desc = new AlterTableUpdateColumnsDesc(tableName, partitionSpec, isCascade);
+    Table table = getTable(tableName);
+    if (AcidUtils.isTransactionalTable(table)) {
+      setAcidDdlDesc(desc);
+    }
+
+    rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc), conf));
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsDesc.java
@@ -15,43 +15,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hive.ql.ddl.table.column;
 
-import java.util.List;
+package org.apache.hadoop.hive.ql.ddl.table.column.update;
+
 import java.util.Map;
 
 import org.apache.hadoop.hive.common.TableName;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 
 /**
- * DDL task description for ALTER TABLE ... REPLACE COLUMNS ... commands.
+ * DDL task description for ALTER TABLE ... UPDATE COLUMNS ... commands.
  */
-@Explain(displayName = "Replace Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class AlterTableReplaceColumnsDesc extends AbstractAlterTableDesc {
+@Explain(displayName = "Update Columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
+public class AlterTableUpdateColumnsDesc extends AbstractAlterTableDesc {
   private static final long serialVersionUID = 1L;
 
-  private final List<FieldSchema> newColumns;
-
-  public AlterTableReplaceColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade,
-      List<FieldSchema> newColumns) throws SemanticException {
-    super(AlterTableType.REPLACE_COLUMNS, tableName, partitionSpec, null, isCascade, false, null);
-    this.newColumns = newColumns;
-  }
-
-  public List<FieldSchema> getNewColumns() {
-    return newColumns;
-  }
-
-  // Only for explain
-  @Explain(displayName = "new columns", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-  public List<String> getNewColsString() {
-    return Utilities.getFieldSchemaString(newColumns);
+  public AlterTableUpdateColumnsDesc(TableName tableName, Map<String, String> partitionSpec, boolean isCascade)
+      throws SemanticException {
+    super(AlterTableType.UPDATE_COLUMNS, tableName, partitionSpec, null, isCascade, false, null);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/AlterTableUpdateColumnsOperation.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hadoop.hive.ql.ddl.table.column;
+package org.apache.hadoop.hive.ql.ddl.table.column.update;
 
 import java.util.Collection;
 import java.util.List;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/package-info.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/update/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Update columns DDL operation. */
+package org.apache.hadoop.hive.ql.ddl.table.column.update;

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/ConstraintsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/ConstraintsUtils.java
@@ -20,10 +20,13 @@ package org.apache.hadoop.hive.ql.ddl.table.constraint;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.antlr.runtime.TokenRewriteStream;
 import org.antlr.runtime.tree.Tree;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.TableName;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.SQLCheckConstraint;
 import org.apache.hadoop.hive.metastore.api.SQLDefaultConstraint;
 import org.apache.hadoop.hive.metastore.api.SQLForeignKey;
@@ -31,16 +34,21 @@ import org.apache.hadoop.hive.metastore.api.SQLNotNullConstraint;
 import org.apache.hadoop.hive.metastore.api.SQLPrimaryKey;
 import org.apache.hadoop.hive.metastore.api.SQLUniqueConstraint;
 import org.apache.hadoop.hive.ql.ErrorMsg;
+import org.apache.hadoop.hive.ql.exec.ColumnInfo;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.BaseSemanticAnalyzer;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
+import org.apache.hadoop.hive.ql.parse.ParseDriver;
+import org.apache.hadoop.hive.ql.parse.RowResolver;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.TypeCheckCtx;
 import org.apache.hadoop.hive.ql.parse.TypeCheckProcFactory;
+import org.apache.hadoop.hive.ql.parse.UnparseTranslator;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 
@@ -416,5 +424,106 @@ public final class ConstraintsUtils {
 
       foreignKeys.add(sqlForeignKey);
     }
+  }
+
+  public static void validateCheckConstraint(List<FieldSchema> columns, List<SQLCheckConstraint> checkConstraints,
+      Configuration conf) throws SemanticException{
+    // create colinfo and then row resolver
+    RowResolver rr = new RowResolver();
+    for (FieldSchema column : columns) {
+      ColumnInfo ci = new ColumnInfo(column.getName(),
+          TypeInfoUtils.getTypeInfoFromTypeString(column.getType()), null, false);
+      rr.put(null, column.getName(), ci);
+    }
+
+    TypeCheckCtx typeCheckCtx = new TypeCheckCtx(rr);
+    // TypeCheckProcFactor expects typecheckctx to have unparse translator
+    UnparseTranslator unparseTranslator = new UnparseTranslator(conf);
+    typeCheckCtx.setUnparseTranslator(unparseTranslator);
+    for (SQLCheckConstraint cc : checkConstraints) {
+      try {
+        ParseDriver parseDriver = new ParseDriver();
+        ASTNode checkExprAST = parseDriver.parseExpression(cc.getCheck_expression());
+        validateCheckExprAST(checkExprAST);
+        Map<ASTNode, ExprNodeDesc> genExprs = TypeCheckProcFactory.genExprNode(checkExprAST, typeCheckCtx);
+        ExprNodeDesc checkExpr = genExprs.get(checkExprAST);
+        if (checkExpr == null) {
+          throw new SemanticException(
+              ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Invalid type for CHECK constraint: ") + cc.getCheck_expression());
+        }
+        if (checkExpr.getTypeInfo().getTypeName() != serdeConstants.BOOLEAN_TYPE_NAME) {
+          throw new SemanticException(
+              ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Only boolean type is supported for CHECK constraint: ") +
+              cc.getCheck_expression() + ". Found: " + checkExpr.getTypeInfo().getTypeName());
+        }
+        validateCheckExpr(checkExpr);
+      } catch (Exception e) {
+        throw new SemanticException(ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Invalid CHECK constraint expression: ") +
+            cc.getCheck_expression() + ". " + e.getMessage(), e);
+      }
+    }
+  }
+
+  // given an ast node this method recursively goes over checkExpr ast. If it finds a node of type TOK_SUBQUERY_EXPR
+  // it throws an error.
+  // This method is used to validate check expression since check expression isn't allowed to have subquery
+  private static void validateCheckExprAST(ASTNode checkExpr) throws SemanticException {
+    if (checkExpr == null) {
+      return;
+    }
+    if (checkExpr.getType() == HiveParser.TOK_SUBQUERY_EXPR) {
+      throw new SemanticException(
+          ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Subqueries are not allowed in Check Constraints"));
+    }
+    for (int i = 0; i < checkExpr.getChildCount(); i++) {
+      validateCheckExprAST((ASTNode)checkExpr.getChild(i));
+    }
+  }
+
+  // recursively go through expression and make sure the following:
+  // * If expression is UDF it is not permanent UDF
+  private static void validateCheckExpr(ExprNodeDesc checkExpr) throws SemanticException {
+    if (checkExpr instanceof ExprNodeGenericFuncDesc) {
+      ExprNodeGenericFuncDesc funcDesc = (ExprNodeGenericFuncDesc)checkExpr;
+      boolean isBuiltIn = FunctionRegistry.isBuiltInFuncExpr(funcDesc);
+      boolean isPermanent = FunctionRegistry.isPermanentFunction(funcDesc);
+      if (!isBuiltIn && !isPermanent) {
+        throw new SemanticException(
+            ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Temporary UDFs are not allowed in Check Constraints"));
+      }
+
+      if (FunctionRegistry.impliesOrder(funcDesc.getFuncText())) {
+        throw new SemanticException(
+            ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Window functions are not allowed in Check Constraints"));
+      }
+    }
+
+    if (checkExpr.getChildren() == null) {
+      return;
+    }
+    for (ExprNodeDesc childExpr:checkExpr.getChildren()) {
+      validateCheckExpr(childExpr);
+    }
+  }
+
+  public static boolean hasEnabledOrValidatedConstraints(List<SQLNotNullConstraint> notNullConstraints,
+      List<SQLDefaultConstraint> defaultConstraints, List<SQLCheckConstraint> checkConstraints) {
+    if (notNullConstraints != null) {
+      for (SQLNotNullConstraint nnC : notNullConstraints) {
+        if (nnC.isEnable_cstr() || nnC.isValidate_cstr()) {
+          return true;
+        }
+      }
+    }
+
+    if (defaultConstraints != null && !defaultConstraints.isEmpty()) {
+      return true;
+    }
+
+    if (checkConstraints != null && !checkConstraints.isEmpty()) {
+      return true;
+    }
+
+    return false;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -104,6 +104,7 @@ import org.apache.hadoop.hive.ql.cache.results.CacheUsage;
 import org.apache.hadoop.hive.ql.cache.results.QueryResultsCache;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.misc.hooks.InsertCommitHookDesc;
+import org.apache.hadoop.hive.ql.ddl.table.constraint.ConstraintsUtils;
 import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.create.like.CreateTableLikeDesc;
 import org.apache.hadoop.hive.ql.ddl.table.misc.AlterTableUnsetPropertiesDesc;
@@ -13524,15 +13525,15 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       throw new SemanticException("Unrecognized command.");
     }
 
-    if(isExt && hasEnabledOrValidatedConstraints(notNullConstraints, defaultConstraints, checkConstraints)){
+    if (isExt && ConstraintsUtils.hasEnabledOrValidatedConstraints(notNullConstraints, defaultConstraints,
+        checkConstraints)) {
       throw new SemanticException(
           ErrorMsg.INVALID_CSTR_SYNTAX.getMsg("Constraints are disallowed with External tables. "
               + "Only RELY is allowed."));
     }
-    if(checkConstraints != null && !checkConstraints.isEmpty()) {
-      validateCheckConstraint(cols, checkConstraints, ctx.getConf());
+    if (checkConstraints != null && !checkConstraints.isEmpty()) {
+      ConstraintsUtils.validateCheckConstraint(cols, checkConstraints, ctx.getConf());
     }
-
 
     storageFormat.fillDefaultStorageFormat(isExt, false);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzerFactory.java
@@ -108,7 +108,6 @@ public final class SemanticAnalyzerFactory {
       case HiveParser.TOK_DESCTABLE:
       case HiveParser.TOK_MSCK:
       case HiveParser.TOK_SHOWTABLES:
-      case HiveParser.TOK_SHOWCOLUMNS:
       case HiveParser.TOK_SHOW_TABLESTATUS:
       case HiveParser.TOK_SHOW_TBLPROPERTIES:
       case HiveParser.TOK_SHOWPARTITIONS:


### PR DESCRIPTION
DDLSemanticAnalyzer is a huge class, more than 4000 lines long. The goal is to refactor it in order to have everything cut into more handleable classes under the package  org.apache.hadoop.hive.ql.exec.ddl:

- have a separate class for each analyzers
- have a package for each operation, containing an analyzer, a description, and an operation, so the amount of classes under a package is more manageable

Step #11: extract the table column related analyzers from DDLSemanticAnalyzer, and move them under the new package.