### PR TITLE
HIVE-22224: Support Parquet-Avro Timestamp Type in Hive2

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableTimestampObjectInspector.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/primitive/WritableTimestampObjectInspector.java
@@ -21,6 +21,7 @@ import java.sql.Timestamp;
 
 import org.apache.hadoop.hive.serde2.io.TimestampWritable;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.apache.hadoop.io.LongWritable;
 
 public class WritableTimestampObjectInspector extends
     AbstractPrimitiveWritableObjectInspector implements
@@ -32,19 +33,34 @@ public class WritableTimestampObjectInspector extends
 
   @Override
   public TimestampWritable getPrimitiveWritableObject(Object o) {
+    if (o instanceof LongWritable) {
+      return (TimestampWritable) PrimitiveObjectInspectorFactory.writableTimestampObjectInspector
+              .create(new Timestamp(((LongWritable) o).get()));
+    }
     return o == null ? null : (TimestampWritable) o;
   }
 
   public Timestamp getPrimitiveJavaObject(Object o) {
+    if (o instanceof LongWritable) {
+      return new Timestamp(((LongWritable) o).get());
+    }
     return o == null ? null : ((TimestampWritable) o).getTimestamp();
   }
 
   public Object copyObject(Object o) {
+    if (o instanceof LongWritable) {
+      return new TimestampWritable(new Timestamp(((LongWritable) o).get()));
+    }
     return o == null ? null : new TimestampWritable((TimestampWritable) o);
   }
 
   public Object set(Object o, byte[] bytes, int offset) {
-    ((TimestampWritable) o).set(bytes, offset);
+    if (o instanceof LongWritable) {
+      o = PrimitiveObjectInspectorFactory.writableTimestampObjectInspector
+              .create(new Timestamp(((LongWritable) o).get()));
+    } else {
+      ((TimestampWritable) o).set(bytes, offset);
+    }
     return o;
   }
 
@@ -52,7 +68,12 @@ public class WritableTimestampObjectInspector extends
     if (t == null) {
       return null;
     }
-    ((TimestampWritable) o).set(t);
+
+    if (o instanceof LongWritable) {
+      o = PrimitiveObjectInspectorFactory.writableTimestampObjectInspector.create(t);
+    } else {
+      ((TimestampWritable) o).set(t);
+    }
     return o;
   }
 
@@ -60,7 +81,13 @@ public class WritableTimestampObjectInspector extends
     if (t == null) {
       return null;
     }
-    ((TimestampWritable) o).set(t);
+
+    if (o instanceof LongWritable) {
+      o = PrimitiveObjectInspectorFactory.writableTimestampObjectInspector
+              .create(new Timestamp(((LongWritable) o).get()));
+    } else {
+      ((TimestampWritable) o).set(t);
+    }
     return o;
   }
 


### PR DESCRIPTION
Parquet-avro 1.8.2 use Avro 1.8 which support avro logical_type, but hive use avro 1.7. So that hive just use primitive types to read avro. In avro 1.8, decimal can be transformed to fix, and date can transformed to int (logical_type= date), hive can read these two type with primitive types fix and int. But timestamp will be transformed to long (logical_type=timestamp-micros).
If user create a table with column timestamp, hive will report error that long can not cast to timestamp. So I create a PR to let hive can read long as timestamp.