### PR TITLE
HivePreparedStatement.setString: fix backslash escaping

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HivePreparedStatement.java
@@ -695,27 +695,6 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
     this.parameters.put(parameterIndex,""+x);
   }
 
-  private String replaceBackSlashSingleQuote(String x) {
-    // scrutinize escape pair, specifically, replace \' to '
-    StringBuffer newX = new StringBuffer();
-    for (int i = 0; i < x.length(); i++) {
-      char c = x.charAt(i);
-      if (c == '\\' && i < x.length()-1) {
-        char c1 = x.charAt(i+1);
-        if (c1 == '\'') {
-          newX.append(c1);
-        } else {
-          newX.append(c);
-          newX.append(c1);
-        }
-        i++;
-      } else {
-        newX.append(c);
-      }
-    }
-    return newX.toString();
-  }
-
   /*
    * (non-Javadoc)
    *
@@ -723,8 +702,8 @@ public class HivePreparedStatement extends HiveStatement implements PreparedStat
    */
 
   public void setString(int parameterIndex, String x) throws SQLException {
-    x = replaceBackSlashSingleQuote(x);
-    x=x.replace("'", "\\'");
+    x = x.replace("\\", "\\\\");
+    x = x.replace("'", "\\'");
     this.parameters.put(parameterIndex, "'"+x+"'");
   }
 

--- a/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestHivePreparedStatement.java
@@ -177,16 +177,22 @@ public class TestHivePreparedStatement {
         ArgumentCaptor.forClass(TExecuteStatementReq.class);
     HivePreparedStatement ps = new HivePreparedStatement(connection, client, sessHandle, sql);
 
-    ps.setString(1, "anyValue\\' or 1=1 --");
+    ps.setString(1, "anyValue' or 1=1 --");
     ps.execute();
     verify(client).ExecuteStatement(argument.capture());
     assertEquals("select * from table where value='anyValue\\' or 1=1 --'",
         argument.getValue().getStatement());
 
-    ps.setString(1, "anyValue\\\\' or 1=1 --");
+    ps.setString(1, "anyValue\\' or 1=1 --");
     ps.execute();
     verify(client, times(2)).ExecuteStatement(argument.capture());
     assertEquals("select * from table where value='anyValue\\\\\\' or 1=1 --'",
+        argument.getValue().getStatement());
+
+    ps.setString(1, "anyValue\\");
+    ps.execute();
+    verify(client, times(3)).ExecuteStatement(argument.capture());
+    assertEquals("select * from table where value='anyValue\\\\'",
         argument.getValue().getStatement());
   }
 
@@ -206,7 +212,7 @@ public class TestHivePreparedStatement {
     ps.setBinaryStream(1, new ByteArrayInputStream("\\'anyValue\\' or 1=1".getBytes()));
     ps.execute();
     verify(client, times(2)).ExecuteStatement(argument.capture());
-    assertEquals("select * from table where value='\\'anyValue\\' or 1=1'",
+    assertEquals("select * from table where value='\\\\\\'anyValue\\\\\\' or 1=1'",
         argument.getValue().getStatement());
   }
 }


### PR DESCRIPTION
HivePreparedStatement.setString handles backslash escaping incorrectly.
So using setString with strings ending with backslash ("xxxxx\") lead to syntax error.