### PR TITLE
HIVE-21939: Switch to use protocbuf version 3.7.1 instead of 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@
 
 # https://docs.travis-ci.com/user/ci-environment/
 # trusty - 7.5GB memory and 2 cores
+arch:
+  - arm64
+  - amd64
+
 sudo: required
 dist: trusty
 
@@ -38,6 +42,10 @@ env:
 
 # workaround added: https://github.com/travis-ci/travis-ci/issues/4629
 before_install:
+  - if [ "$(uname -m)" == aarch64 ]; then
+     sudo apt-get -y install openjdk-8-jdk && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64;
+   fi 
+ 
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,6 @@
 
 # https://docs.travis-ci.com/user/ci-environment/
 # trusty - 7.5GB memory and 2 cores
-arch:
-  - arm64
-  - amd64
-
 sudo: required
 dist: trusty
 
@@ -42,10 +38,6 @@ env:
 
 # workaround added: https://github.com/travis-ci/travis-ci/issues/4629
 before_install:
-  - if [ "$(uname -m)" == aarch64 ]; then
-     sudo apt-get -y install openjdk-8-jdk && export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-arm64;
-   fi 
- 
   - sed -i.bak -e 's|https://nexus.codehaus.org/snapshots/|https://oss.sonatype.org/content/repositories/codehaus-snapshots/|g' ~/.m2/settings.xml
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <parquet.version>1.11.0</parquet.version>
     <pig.version>0.16.0</pig.version>
     <plexus.version>1.5.6</plexus.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.7.1</protobuf.version>
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.10</slf4j.version>
     <ST4.version>4.0.4</ST4.version>

--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -486,7 +486,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:3.7.1</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -479,7 +479,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>com.google.protobuf:protoc:3.7.1</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -92,7 +92,7 @@
     <log4j2.version>2.12.1</log4j2.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <orc.version>1.5.1</orc.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <protobuf.version>3.7.1</protobuf.version>
     <sqlline.version>1.9.0</sqlline.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>


### PR DESCRIPTION
protobuf 2.5.0 does not support Aarch64 platform and is outdated in some distro, Hadoop has the same problem and had upgraded to protobuf to 3.7.1. Do the same for Hive.