### PR TITLE
Sort fields for deterministic behaviors

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/objectinspector/ObjectInspectorUtils.java
@@ -24,6 +24,7 @@ import java.lang.reflect.Type;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -556,6 +557,12 @@ public final class ObjectInspectorUtils {
    */
   public static Field[] getDeclaredNonStaticFields(Class<?> c) {
     Field[] f = c.getDeclaredFields();
+    Arrays.sort(f, new Comparator<Field>() {
+              @Override
+              public int compare(Field a, Field b) {
+                return a.getName().compareTo(b.getName());
+              }
+            });
     ArrayList<Field> af = new ArrayList<Field>();
     for (int i = 0; i < f.length; ++i) {
       if (!Modifier.isStatic(f[i].getModifiers())) {


### PR DESCRIPTION
The test in `org.apache.hadoop.hive.serde2.columnar.TestLazyBinaryColumnarSerDe#testHandlingAlteredSchemas` can fail due to an assertion failure `java.lang.AssertionError: expected:<12> but was:<11>` when running `Assert.assertEquals(((LongWritable) objs2.get(0)).get(), 11L);`

The root cause of it lies in the ObjectInspectorUtils.java, where `getDeclaredFields()` is called. The specification about `getDeclaredFields()` says that "the elements in the returned array are not sorted and are not in any particular order". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--

The fix is to sort the fields so that the behavior will be the same across different JVM versions or vendors. In this way, the non-deterministic behaviors are eliminated and the test becomes more stable.
