### PR TITLE
[HIVE-22936] NPE in SymbolicInputFormat

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/SymbolicInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/SymbolicInputFormat.java
@@ -75,7 +75,12 @@ public class SymbolicInputFormat implements ReworkMapredInputFormat {
             while ((line = reader.readLine()) != null) {
               // no check for the line? How to check?
               // if the line is invalid for any reason, the job will fail.
-              FileStatus[] matches = fileSystem.globStatus(new Path(line));
+              Path linePath = new Path(line);
+              FileStatus[] matches = linePath.getFileSystem(job).globStatus(linePath);
+              if (matches == null) {
+                throw new IOException("failed to glob for patten " + line +
+                  ", filesystem: " + linePath.getFileSystem(job).getScheme());
+              }
               for (FileStatus fileStatus : matches) {
                 Path schemaLessPath = Path.getPathWithoutSchemeAndAuthority(fileStatus.getPath());
                 StringInternUtils.internUriStringsInPath(schemaLessPath);


### PR DESCRIPTION
Fix a bug which causes NullPointException in SymbolicInputFormat, when the symlink file contains URI with schema different from default file system.

Jira: https://issues.apache.org/jira/browse/HIVE-22936
