### PR TITLE
HIVE-22959 Expose FilterContext as part of Hive storage-api

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/io/filter/TestFilterContext.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/filter/TestFilterContext.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hive.ql.io.filter;
 
 import org.junit.Assert;

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/filter/TestFilterContext.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/filter/TestFilterContext.java
@@ -1,0 +1,107 @@
+package org.apache.hadoop.hive.ql.io.filter;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+/**
+ * Test creation and manipulation of MutableFilterContext and FilterContext.
+ */
+public class TestFilterContext {
+
+  private int[] makeValidSelected() {
+    int[] selected = new int[512];
+    for (int i=0; i < selected.length; i++){
+      selected[i] = i*2;
+    }
+    return selected;
+  }
+
+  private int[] makeInvalidSelected() {
+    int[] selected = new int[512];
+    Arrays.fill(selected, 1);
+    return selected;
+  }
+
+  @Test
+  public void testInitFilterContext(){
+    MutableFilterContext mutableFilterContext = new MutableFilterContext();
+    int[] selected = makeValidSelected();
+
+    mutableFilterContext.setFilterContext(true, selected, selected.length);
+    FilterContext filterContext = mutableFilterContext.immutable();
+
+    Assert.assertEquals(true, filterContext.isSelectedInUse());
+    Assert.assertEquals(512, filterContext.getSelectedSize());
+    Assert.assertEquals(512, filterContext.getSelected().length);
+  }
+
+
+  @Test
+  public void testResetFilterContext(){
+    MutableFilterContext mutableFilterContext = new MutableFilterContext();
+    int[] selected = makeValidSelected();
+
+    mutableFilterContext.setFilterContext(true, selected, selected.length);
+    FilterContext filterContext = mutableFilterContext.immutable();
+
+    Assert.assertEquals(true, filterContext.isSelectedInUse());
+    Assert.assertEquals(512, filterContext.getSelectedSize());
+    Assert.assertEquals(512, filterContext.getSelected().length);
+
+    filterContext.resetFilterContext();
+
+    Assert.assertEquals(false, filterContext.isSelectedInUse());
+    Assert.assertEquals(0, filterContext.getSelectedSize());
+    Assert.assertEquals(null, filterContext.getSelected());
+  }
+
+  @Test(expected=AssertionError.class)
+  public void testInitInvalidFilterContext(){
+    MutableFilterContext mutableFilterContext = new MutableFilterContext();
+    int[] selected = makeInvalidSelected();
+
+    mutableFilterContext.setFilterContext(true, selected, selected.length);
+  }
+
+
+  @Test
+  public void testCopyFilterContext(){
+    MutableFilterContext mutableFilterContext = new MutableFilterContext();
+    int[] selected = makeValidSelected();
+
+    mutableFilterContext.setFilterContext(true, selected, selected.length);
+
+    MutableFilterContext mutableFilterContextToCopy = new MutableFilterContext();
+    mutableFilterContextToCopy.setFilterContext(true, new int[] {100}, 1);
+
+    mutableFilterContext.copyFilterContextFrom(mutableFilterContextToCopy);
+    FilterContext filterContext = mutableFilterContext.immutable();
+
+    Assert.assertEquals(true, filterContext.isSelectedInUse());
+    Assert.assertEquals(1, filterContext.getSelectedSize());
+    Assert.assertEquals(100, filterContext.getSelected()[0]);
+    // make sure we kept the remaining array space
+    Assert.assertEquals(512, filterContext.getSelected().length);
+  }
+
+
+  @Test
+  public void testBorrowSelected(){
+    MutableFilterContext mutableFilterContext = new MutableFilterContext();
+    mutableFilterContext.setFilterContext(true, new int[] {100, 200}, 2);
+
+    int[] borrowedSelected = mutableFilterContext.borrowSelected(1);
+    // make sure we borrowed the existing array
+    Assert.assertEquals(2, borrowedSelected.length);
+    Assert.assertEquals(100, borrowedSelected[0]);
+    Assert.assertEquals(200, borrowedSelected[1]);
+
+    borrowedSelected = mutableFilterContext.borrowSelected(3);
+    Assert.assertEquals(3, borrowedSelected.length);
+    Assert.assertEquals(0, borrowedSelected[0]);
+    Assert.assertEquals(0, borrowedSelected[1]);
+    Assert.assertEquals(0, borrowedSelected[2]);
+  }
+}

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
@@ -21,41 +21,19 @@ package org.apache.hadoop.hive.ql.io.filter;
  * A representation of a Filter applied on the rows of a VectorizedRowBatch
  * {@link org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch}.
  *
- * Each FilterContext consists of an array with the ids (int) of rows that are selected
- * by the filter, an integer representing the number of selected rows, and a boolean showing
- * if the filter actually selected any rows.
+ * Each FilterContext consists of an array with the ids (int) of rows that are selected by the
+ * filter, an integer representing the number of selected rows, and a boolean showing if the filter
+ * actually selected any rows.
  *
  */
-public class FilterContext {
-  private boolean currBatchIsSelectedInUse = false;
-  private int[] currBatchSelected = null;
-  private int currBatchSelectedSize = 0;
+public abstract class FilterContext {
 
-  /**
-   * Empty constructor
-   */
-  public FilterContext(){};
+  protected boolean currBatchIsSelectedInUse = false;
+  protected int[] currBatchSelected = null;
+  protected int currBatchSelectedSize = 0;
 
-  /**
-   * Update context with the given values
-   * @param isSelectedInUse if the filter is applied
-   * @param selected an array of the selected rows
-   * @param selectedSize the number of the selected rows
-   */
-  public void updateFilterContext(boolean isSelectedInUse, int[] selected, int selectedSize) {
-    this.currBatchIsSelectedInUse = isSelectedInUse;
-    this.currBatchSelected = selected;
-    this.currBatchSelectedSize = selectedSize;
-  }
-
-  /**
-   * Copy context variables from the a given FilterContext
-   * @param other FilterContext to copy from
-   */
-  public void copyFilterContextFromOther(FilterContext other) {
-    this.currBatchIsSelectedInUse = other.currBatchIsSelectedInUse;
-    this.currBatchSelected = other.currBatchSelected;
-    this.currBatchSelectedSize = other.currBatchSelectedSize;
+  public FilterContext() {
+    super();
   }
 
   /**
@@ -68,15 +46,8 @@ public class FilterContext {
   }
 
   /**
-   * Set the selectedInUse boolean showing if the filter is applied
-   * @param selectedInUse
-   */
-  public void setSelectedInUse(boolean selectedInUse) {
-    this.currBatchIsSelectedInUse = selectedInUse;
-  }
-
-  /**
    * Is the filter applied?
+   * 
    * @return true if the filter is actually applied
    */
   public boolean isSelectedInUse() {
@@ -84,15 +55,9 @@ public class FilterContext {
   }
 
   /**
-   * Set the array of the rows that pass the filter
-   * @param selectedArray
-   */
-  public void setSelected(int[] selectedArray) {
-    this.currBatchSelected = selectedArray;
-  }
-
-  /**
-   * Return an int array with the rows that pass the filter
+   * Return an int array with the rows that pass the filter. 
+   * Do not modify the array returned!
+   * 
    * @return int array
    */
   public int[] getSelected() {
@@ -100,15 +65,8 @@ public class FilterContext {
   }
 
   /**
-   * Set the number of the rows that pass the filter
-   * @param selectedSize
-   */
-  public void setSelectedSize(int selectedSize) {
-    this.currBatchSelectedSize = selectedSize;
-  }
-
-  /**
    * Return the number of rows that pass the filter
+   * 
    * @return an int
    */
   public int getSelectedSize() {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.filter;
+
+/**
+ * A representation of a Filter applied on the rows of a VectorizedRowBatch
+ * {@link org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch}.
+ *
+ * Each FilterContext consists of an array with the ids (int) of rows that are selected
+ * by the filter, an integer representing the number of selected rows, and a boolean showing
+ * if the filter actually selected any rows.
+ *
+ */
+public class FilterContext {
+  private boolean currBatchIsSelectedInUse = false;
+  private int[] currBatchSelected = null;
+  private int currBatchSelectedSize = 0;
+
+  /**
+   * Empty constructor
+   */
+  public FilterContext(){};
+
+  /**
+   * Update context with the given values
+   * @param isSelectedInUse if the filter is applied
+   * @param selected an array of the selected rows
+   * @param selectedSize the number of the selected rows
+   */
+  public void updateFilterContext(boolean isSelectedInUse, int[] selected, int selectedSize) {
+    this.currBatchIsSelectedInUse = isSelectedInUse;
+    this.currBatchSelected = selected;
+    this.currBatchSelectedSize = selectedSize;
+  }
+
+  /**
+   * Copy context variables from the a given FilterContext
+   * @param other FilterContext to copy from
+   */
+  public void copyFilterContextFromOther(FilterContext other) {
+    this.currBatchIsSelectedInUse = other.currBatchIsSelectedInUse;
+    this.currBatchSelected = other.currBatchSelected;
+    this.currBatchSelectedSize = other.currBatchSelectedSize;
+  }
+
+  /**
+   * Reset FilterContext variables
+   */
+  public void resetFilterContext() {
+    this.currBatchIsSelectedInUse = false;
+    this.currBatchSelected = null;
+    this.currBatchSelectedSize = 0;
+  }
+
+  /**
+   * Set the selectedInUse boolean showing if the filter is applied
+   * @param selectedInUse
+   */
+  public void setSelectedInUse(boolean selectedInUse) {
+    this.currBatchIsSelectedInUse = selectedInUse;
+  }
+
+  /**
+   * Is the filter applied?
+   * @return true if the filter is actually applied
+   */
+  public boolean isSelectedInUse() {
+    return this.currBatchIsSelectedInUse;
+  }
+
+  /**
+   * Set the array of the rows that pass the filter
+   * @param selectedArray
+   */
+  public void setSelected(int[] selectedArray) {
+    this.currBatchSelected = selectedArray;
+  }
+
+  /**
+   * Return an int array with the rows that pass the filter
+   * @return int array
+   */
+  public int[] getSelected() {
+    return this.currBatchSelected;
+  }
+
+  /**
+   * Set the number of the rows that pass the filter
+   * @param selectedSize
+   */
+  public void setSelectedSize(int selectedSize) {
+    this.currBatchSelectedSize = selectedSize;
+  }
+
+  /**
+   * Return the number of rows that pass the filter
+   * @return an int
+   */
+  public int getSelectedSize() {
+    return this.currBatchSelectedSize;
+  }
+}

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
@@ -37,7 +37,7 @@ public abstract class FilterContext {
   }
 
   /**
-   * Reset FilterContext variables
+   * Reset FilterContext variables.
    */
   public void resetFilterContext() {
     this.currBatchIsSelectedInUse = false;
@@ -47,7 +47,6 @@ public abstract class FilterContext {
 
   /**
    * Is the filter applied?
-   * 
    * @return true if the filter is actually applied
    */
   public boolean isSelectedInUse() {
@@ -57,7 +56,6 @@ public abstract class FilterContext {
   /**
    * Return an int array with the rows that pass the filter. 
    * Do not modify the array returned!
-   * 
    * @return int array
    */
   public int[] getSelected() {
@@ -65,8 +63,7 @@ public abstract class FilterContext {
   }
 
   /**
-   * Return the number of rows that pass the filter
-   * 
+   * Return the number of rows that pass the filter.
    * @return an int
    */
   public int getSelectedSize() {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/FilterContext.java
@@ -54,7 +54,7 @@ public abstract class FilterContext {
   }
 
   /**
-   * Return an int array with the rows that pass the filter. 
+   * Return an int array with the rows that pass the filter.
    * Do not modify the array returned!
    * @return int array
    */

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
@@ -31,8 +31,7 @@ import java.util.Arrays;
 public class MutableFilterContext extends FilterContext {
 
   /**
-   * Set context with the given values by reference
-   * 
+   * Set context with the given values by reference.
    * @param isSelectedInUse if the filter is applied
    * @param selected an array of the selected rows
    * @param selectedSize the number of the selected rows
@@ -49,7 +48,6 @@ public class MutableFilterContext extends FilterContext {
   /**
    * Copy context variables from the a given FilterContext.
    * Always does a deep copy of the data.
-   *
    * @param other FilterContext to copy from
    */
   public void copyFilterContextFrom(MutableFilterContext other) {
@@ -69,9 +67,8 @@ public class MutableFilterContext extends FilterContext {
   }
 
   /**
-   * Validate method checking if existing selected array contains values that
-   * are in order and does not without duplicates i.e [1,1,1] is illegal
-   *
+   * Validate method checking if existing selected array contains accepted values.
+   * Values should be in order and without duplicates i.e [1,1,1] is illegal
    * @return true if the selected array is valid
    */
   public boolean isValidSelected() {
@@ -86,7 +83,6 @@ public class MutableFilterContext extends FilterContext {
    * Borrow the current selected array to be modified if it satisfies minimum capacity.
    * If it is too small or unset, allocates one.
    * This method never returns null!
-   *
    * @param minCapacity
    * @return the current selected array to be modified
    */
@@ -100,16 +96,15 @@ public class MutableFilterContext extends FilterContext {
   }
 
   /**
-   * Get the immutable version of the current FilterContext
-   * @return
+   * Get the immutable version of the current FilterContext.
+   * @return immutable FilterContext instance
    */
   public FilterContext immutable(){
     return this;
   }
 
   /**
-   * Set the selectedInUse boolean showing if the filter is applied
-   * 
+   * Set the selectedInUse boolean showing if the filter is applied.
    * @param selectedInUse
    */
   public void setSelectedInUse(boolean selectedInUse) {
@@ -117,8 +112,7 @@ public class MutableFilterContext extends FilterContext {
   }
 
   /**
-   * Set the array of the rows that pass the filter by reference
-   * 
+   * Set the array of the rows that pass the filter by reference.
    * @param selectedArray
    */
   public void setSelected(int[] selectedArray) {
@@ -126,8 +120,7 @@ public class MutableFilterContext extends FilterContext {
   }
 
   /**
-   * Set the number of the rows that pass the filter
-   * 
+   * Set the number of the rows that pass the filter.
    * @param selectedSize
    */
   public void setSelectedSize(int selectedSize) {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.filter;
+
+import java.util.Arrays;
+
+/**
+ * A representation of a Filter applied on the rows of a VectorizedRowBatch
+ * {@link org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch}.
+ *
+ * Each FilterContext consists of an array with the ids (int) of rows that are selected by the
+ * filter, an integer representing the number of selected rows, and a boolean showing if the filter
+ * actually selected any rows.
+ *
+ */
+public class MutableFilterContext extends FilterContext {
+
+  /**
+   * Set context with the given values by reference
+   * 
+   * @param isSelectedInUse if the filter is applied
+   * @param selected an array of the selected rows
+   * @param selectedSize the number of the selected rows
+   */
+  public void setFilterContext(boolean isSelectedInUse, int[] selected, int selectedSize) {
+    this.currBatchIsSelectedInUse = isSelectedInUse;
+    this.currBatchSelected = selected;
+    this.currBatchSelectedSize = selectedSize;
+    // Avoid selected.length < selectedSize since we can borrow a larger array for selected
+    // debug loop for checking if selected is in order without duplicates (i.e [1,1,1] is illegal)
+    for (int i = 0; i < selectedSize-1; i++)
+      assert selected[i] < selected[i+1];
+  }
+
+  /**
+   * Copy context variables from the a given FilterContext.
+   * Always does a deep copy of the data.
+   *
+   * @param other FilterContext to copy from
+   */
+  public void copyFilterContextFrom(MutableFilterContext other) {
+    // assert if copying into self
+    assert this != other;
+
+    if (this.currBatchSelected == null || this.currBatchSelected.length < other.currBatchSelectedSize) {
+      // note: still allocating a full size buffer, for later use
+      this.currBatchSelected = Arrays.copyOf(other.currBatchSelected, other.currBatchSelected.length);
+    } else {
+      System.arraycopy(other.currBatchSelected, 0, this.currBatchSelected, 0, other.currBatchSelectedSize);
+    }
+    this.currBatchSelectedSize = other.currBatchSelectedSize;
+    this.currBatchIsSelectedInUse = other.currBatchIsSelectedInUse;
+  }
+
+  /**
+   * Borrow the current selected array to be modified if it satisfies minimum capacity.
+   * If it is too small or unset, allocates one.
+   * This method never returns null!
+   *
+   * @param minCapacity
+   * @return the current selected array to be modified
+   */
+  public int[] borrowSelected(int minCapacity) {
+    int[] existing = this.currBatchSelected;
+    this.currBatchSelected = null;
+    if (existing == null || existing.length < minCapacity) {
+      return new int[minCapacity];
+    }
+    return existing;
+  }
+
+  /**
+   * Get the immutable version of the current FilterContext
+   * @return
+   */
+  public FilterContext immutable(){
+    return this;
+  }
+
+  /**
+   * Set the selectedInUse boolean showing if the filter is applied
+   * 
+   * @param selectedInUse
+   */
+  public void setSelectedInUse(boolean selectedInUse) {
+    this.currBatchIsSelectedInUse = selectedInUse;
+  }
+
+  /**
+   * Set the array of the rows that pass the filter by reference
+   * 
+   * @param selectedArray
+   */
+  public void setSelected(int[] selectedArray) {
+    this.currBatchSelected = selectedArray;
+  }
+
+  /**
+   * Set the number of the rows that pass the filter
+   * 
+   * @param selectedSize
+   */
+  public void setSelectedSize(int selectedSize) {
+    this.currBatchSelectedSize = selectedSize;
+  }
+}

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/filter/MutableFilterContext.java
@@ -73,8 +73,9 @@ public class MutableFilterContext extends FilterContext {
    */
   public boolean isValidSelected() {
     for (int i = 1; i < this.currBatchSelectedSize; i++) {
-      if (this.currBatchSelected[i-1] >= this.currBatchSelected[i])
+      if (this.currBatchSelected[i-1] >= this.currBatchSelected[i]) {
         return false;
+      }
     }
     return true;
   }


### PR DESCRIPTION
To enable row-level filtering at the ORC level ORC-577, or as an extension ProDecode MapJoin HIVE-22731 we need a common context class that will hold all the needed information for the filter.