### PR TITLE
HIVE-22989: Don't close parent classloader when session being closed

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -723,12 +723,15 @@ public class Registry {
     }
   }
 
-  public void closeCUDFLoaders() {
+  public void closeCUDFLoaders(ClassLoader baseLoader) {
     lock.lock();
     try {
       try {
         for(ClassLoader loader: mSessionUDFLoaders) {
-          JavaUtils.closeClassLoader(loader);
+          // do a sanity check here just in case
+          if (loader != baseLoader) {
+            JavaUtils.closeClassLoader(loader);
+          }
         }
       } catch (IOException ie) {
           LOG.error("Error in close loader: " + ie);

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1801,7 +1801,7 @@ public class SessionState implements ISessionAuthState{
 
     try {
       closeSparkSession();
-      registry.closeCUDFLoaders();
+      registry.closeCUDFLoaders(parentLoader);
       dropSessionPaths(sessionConf);
       unCacheDataNucleusClassLoaders();
     } finally {


### PR DESCRIPTION
Add a sanity check when Registry closing the cached classloaders just in case