### PR TITLE
HIVE-22979: Support total file size in statistics annotation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SparkMapJoinOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/spark/SparkMapJoinOptimizer.java
@@ -215,7 +215,7 @@ public class SparkMapJoinOptimizer implements SemanticNodeProcessor {
             LOG.debug("Found a big table branch with parent operator {} and position {}", parentOp, pos);
             bigTablePosition = pos;
             bigTableFound = true;
-            bigInputStat = new Statistics(0, Long.MAX_VALUE, 0);
+            bigInputStat = new Statistics(0, Long.MAX_VALUE, Long.MAX_VALUE, 0);
           } else {
             // Either we've found multiple big table branches, or the current branch cannot
             // be a big table branch. Disable mapjoin for these cases.

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -2116,7 +2116,7 @@ public class StatsRulesProcFactory {
           }
         }
 
-        Statistics wcStats = new Statistics(newNumRows, newDataSize, 0);
+        Statistics wcStats = new Statistics(newNumRows, newDataSize, 0, 0);
         wcStats.setBasicStatsState(statsState);
 
         // evaluate filter expression and update statistics

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
@@ -53,6 +53,7 @@ public class Statistics implements Serializable {
   private long numRows;
   private long runTimeNumRows;
   private long dataSize;
+  private long totalFileSize;
   private long numErasureCodedFiles;
   private State basicStatsState;
   private Map<String, ColStatistics> columnStats;
@@ -60,18 +61,27 @@ public class Statistics implements Serializable {
   private boolean runtimeStats;
 
   public Statistics() {
-    this(0, 0, 0);
+    this(0, 0, 0, 0);
   }
 
-  public Statistics(long nr, long ds, long numEcFiles) {
+  public Statistics(long nr, long ds, long fs, long numEcFiles) {
     numRows = nr;
     dataSize = ds;
+    totalFileSize = fs;
     numErasureCodedFiles = numEcFiles;
     runTimeNumRows = -1;
     columnStats = null;
     columnStatsState = State.NONE;
 
     updateBasicStatsState();
+  }
+
+  public void setTotalFileSize(final long totalFileSize) {
+    this.totalFileSize = totalFileSize;
+  }
+
+  public long getTotalFileSize() {
+    return totalFileSize;
   }
 
   public long getNumRows() {
@@ -191,7 +201,7 @@ public class Statistics implements Serializable {
 
   @Override
   public Statistics clone() {
-    Statistics clone = new Statistics(numRows, dataSize, numErasureCodedFiles);
+    Statistics clone = new Statistics(numRows, dataSize, totalFileSize, numErasureCodedFiles);
     clone.setRunTimeNumRows(runTimeNumRows);
     clone.setBasicStatsState(basicStatsState);
     clone.setColumnStatsState(columnStatsState);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/Statistics.java
@@ -52,7 +52,9 @@ public class Statistics implements Serializable {
 
   private long numRows;
   private long runTimeNumRows;
+  // dataSize represents raw data size (estimated in-memory size based on row schema) after decompression and decoding.
   private long dataSize;
+  // totalFileSize represents on-disk size.
   private long totalFileSize;
   private long numErasureCodedFiles;
   private State basicStatsState;

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
@@ -195,7 +195,7 @@ public class BasicStats {
     public void apply(BasicStats stats) {
       long ds = stats.getRawDataSize();
       if (ds <= 0) {
-        ds = stats.getTotalSize();
+        ds = stats.getTotalFileSize();
 
         // if data size is still 0 then get file size
         if (ds <= 0) {
@@ -228,6 +228,7 @@ public class BasicStats {
 
   private long currentNumRows;
   private long currentDataSize;
+  private long currentFileSize;
   private Statistics.State state;
 
   public BasicStats(Partish p) {
@@ -239,6 +240,7 @@ public class BasicStats {
 
     currentNumRows = rowCount;
     currentDataSize = rawDataSize;
+    currentFileSize = totalSize;
 
     if (currentNumRows > 0) {
       state = State.COMPLETE;
@@ -252,10 +254,12 @@ public class BasicStats {
     partish = null;
     List<Long> nrIn = Lists.newArrayList();
     List<Long> dsIn = Lists.newArrayList();
+    List<Long> fsIn = Lists.newArrayList();
     state = (partStats.size() == 0) ? State.COMPLETE : null;
     for (BasicStats ps : partStats) {
       nrIn.add(ps.getNumRows());
       dsIn.add(ps.getDataSize());
+      fsIn.add(ps.getTotalFileSize());
 
       if (state == null) {
         state = ps.getState();
@@ -265,6 +269,7 @@ public class BasicStats {
     }
     currentNumRows = StatsUtils.getSumIgnoreNegatives(nrIn);
     currentDataSize = StatsUtils.getSumIgnoreNegatives(dsIn);
+    currentFileSize = StatsUtils.getSumIgnoreNegatives(fsIn);
 
   }
 
@@ -292,8 +297,12 @@ public class BasicStats {
     currentDataSize = ds;
   }
 
-  protected long getTotalSize() {
-    return totalSize;
+  protected long getTotalFileSize() {
+    return currentFileSize;
+  }
+
+  public void setTotalFileSize(final long totalFileSize) {
+    this.currentFileSize = totalFileSize;
   }
 
   protected long getRawDataSize() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -147,7 +147,7 @@ public class StatsUtils {
    *          - hive configuration
    * @param partList
    *          - partition list
-   * @param tablebasicStats.getNumRows()
+   * @param table
    *          - table
    * @param tableScanOperator
    *          - table scan operator

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -147,7 +147,7 @@ public class StatsUtils {
    *          - hive configuration
    * @param partList
    *          - partition list
-   * @param table
+   * @param tablebasicStats.getNumRows()
    *          - table
    * @param tableScanOperator
    *          - table scan operator
@@ -276,6 +276,7 @@ public class StatsUtils {
       //      long nr = getNumRows(conf, schema, neededColumns, table, ds);
       long ds = basicStats.getDataSize();
       long nr = basicStats.getNumRows();
+      long fs = basicStats.getTotalFileSize();
       List<ColStatistics> colStats = Collections.emptyList();
 
       long numErasureCodedFiles = getErasureCodedFiles(table);
@@ -292,7 +293,7 @@ public class StatsUtils {
         }
       }
 
-      stats = new Statistics(nr, ds, numErasureCodedFiles);
+      stats = new Statistics(nr, ds, fs, numErasureCodedFiles);
       // infer if any column can be primary key based on column statistics
       inferAndSetPrimaryKey(stats.getNumRows(), colStats);
 
@@ -321,6 +322,7 @@ public class StatsUtils {
 
       long nr = bbs.getNumRows();
       long ds = bbs.getDataSize();
+      long fs = bbs.getTotalFileSize();
 
       List<Long> erasureCodedFiles = getBasicStatForPartitions(table, partList.getNotDeniedPartns(),
           StatsSetupConst.NUM_ERASURE_CODED_FILES);
@@ -329,7 +331,7 @@ public class StatsUtils {
       if (nr == 0) {
         nr = 1;
       }
-      stats = new Statistics(nr, ds, numErasureCodedFiles);
+      stats = new Statistics(nr, ds, fs, numErasureCodedFiles);
       stats.setBasicStatsState(bbs.getState());
       if (nr > 0) {
         // FIXME: this promotion process should be removed later

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestVectorMapJoinFastHashTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestVectorMapJoinFastHashTable.java
@@ -96,7 +96,7 @@ public class TestVectorMapJoinFastHashTable {
       dataSize += 8;
     }
 
-    Statistics stat = new Statistics(keyCount, dataSize, 0);
+    Statistics stat = new Statistics(keyCount, dataSize, 0, 0);
 
     Long realObjectSize = getObjectSize(container);
     Long executionEstimate = container.getEstimatedMemorySize();


### PR DESCRIPTION
Hive statistics annotation provide estimated Statistics for each operator. The data size provided in TableScanOperator is raw data size (after decompression and decoding), but there are some optimizations that can be performed based on total file size on disk (scan cost estimation).

