### PR TITLE
HIVE-21939: Bump protoc version in standalone metadata

### DIFF
--- a/standalone-metastore/metastore-common/pom.xml
+++ b/standalone-metastore/metastore-common/pom.xml
@@ -491,7 +491,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>${protobuf.group}:protoc:${protobuf-exc.version}</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/standalone-metastore/metastore-server/pom.xml
+++ b/standalone-metastore/metastore-server/pom.xml
@@ -479,7 +479,7 @@
               <goal>run</goal>
             </goals>
             <configuration>
-              <protocArtifact>com.google.protobuf:protoc:2.5.0</protocArtifact>
+              <protocArtifact>${protobuf.group}:protoc:${protobuf-exc.version}</protocArtifact>
               <addSources>none</addSources>
               <inputDirectories>
                 <include>${basedir}/src/main/protobuf/org/apache/hadoop/hive/metastore</include>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -92,7 +92,10 @@
     <log4j2.version>2.12.1</log4j2.version>
     <mockito-core.version>1.10.19</mockito-core.version>
     <orc.version>1.5.1</orc.version>
-    <protobuf.version>2.5.0</protobuf.version>
+    <!-- com.google repo will be used except on Aarch64 platform. -->
+    <protobuf.group>com.google.protobuf</protobuf.group>
+    <protobuf.version>2.6.1</protobuf.version>
+    <protobuf-exc.version>2.6.1</protobuf-exc.version>
     <sqlline.version>1.9.0</sqlline.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>
@@ -460,4 +463,20 @@
     </plugins>
   </build>
 
+  <profiles>
+  <!-- use com.github.os72 on aarch64 platform -->
+  <profile>
+    <id>aarch64</id>
+    <properties>
+      <protobuf.group>com.github.os72</protobuf.group>
+      <protobuf-exc.version>2.6.1-build3</protobuf-exc.version>
+    </properties>
+    <activation>
+      <os>
+        <family>linux</family>
+        <arch>aarch64</arch>
+      </os>
+    </activation>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Standalone metadata package currently depends on proroc 2.5.0 which does not support Aarch64 platform and blocks building Hive on Aarch64. This patch proposed to bump  protoc used in standalone metadata to 2.6.1, and also added a new profile that detacts hardware architecture, override the default protoc package with package from com.github.os72(it has aarch64 support) if the hardware arch is Aarch64. By doing this, we will keep the affects to current X86 users to the minimum.