### PR TITLE
HIVE-23168 Adding lookup functionality to VectorMapJoinHashTable interface

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastBytesHashTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastBytesHashTable.java
@@ -53,6 +53,12 @@ public abstract class VectorMapJoinFastBytesHashTable
     add(keyBytes, 0, keyLength, currentValue);
   }
 
+  @Override
+  public boolean containsLongKey(long currentKey) {
+    // Only supported for Long-Hash implementations
+    throw new RuntimeException("Not supported yet!");
+  }
+
   public abstract void add(byte[] keyBytes, int keyStart, int keyLength,
       BytesWritable currentValue);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMap.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMap.java
@@ -155,6 +155,11 @@ public class VectorMapJoinFastLongHashMap
     }
   }
 
+  @Override
+  public boolean containsLongKey(long currentKey) {
+    return containsKey(currentKey);
+  }
+
   /*
    * A Unit Test convenience method for putting key and value into the hash table using the
    * actual types.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashMultiSet.java
@@ -64,6 +64,11 @@ public class VectorMapJoinFastLongHashMultiSet
     }
   }
 
+  @Override
+  public boolean containsLongKey(long currentKey) {
+    return containsKey(currentKey);
+  }
+
   /*
    * A Unit Test convenience method for putting the key into the hash table using the
    * actual type.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSet.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashSet.java
@@ -56,6 +56,11 @@ public class VectorMapJoinFastLongHashSet
     adaptPutRow(currentKey, currentValue);
   }
 
+  @Override
+  public boolean containsLongKey(long currentKey) {
+    return containsKey(currentKey);
+  }
+
   /*
    * A Unit Test convenience method for putting the key into the hash table using the
    * actual type.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/VectorMapJoinFastLongHashTable.java
@@ -216,6 +216,11 @@ public abstract class VectorMapJoinFastLongHashTable
     metricExpands++;
   }
 
+  protected boolean containsKey(long key) {
+    long hashCode = HashCodeUtil.calculateLongHashCode(key);
+    return findReadSlot(key, hashCode) != -1;
+  }
+
   protected int findReadSlot(long key, long hashCode) {
 
     int intHashCode = (int) hashCode;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/hashtable/VectorMapJoinHashTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/hashtable/VectorMapJoinHashTable.java
@@ -42,6 +42,15 @@ public interface VectorMapJoinHashTable extends MemoryEstimate {
       throws SerDeException, HiveException, IOException;
 
   /**
+   *
+   * @param currentKey
+   *          The key to check for existence.
+   * @return true
+   *          If HashTable contains the given key.
+   */
+  boolean containsLongKey(long currentKey);
+
+  /**
    * Get hash table size
    */
   int size();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/optimized/VectorMapJoinOptimizedHashTable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/mapjoin/optimized/VectorMapJoinOptimizedHashTable.java
@@ -75,6 +75,12 @@ public abstract class VectorMapJoinOptimizedHashTable
     putRowInternal(currentKey, currentValue);
   }
 
+  @Override
+  public boolean containsLongKey(long currentKey) {
+    // Method only supported by FAST HashTable implementations
+    throw new RuntimeException("Not implemented");
+  }
+
   protected void putRowInternal(BytesWritable key, BytesWritable value)
       throws SerDeException, HiveException, IOException {
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/CheckFastRowHashMap.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/mapjoin/fast/CheckFastRowHashMap.java
@@ -361,7 +361,7 @@ public class CheckFastRowHashMap extends CheckFastHashTable {
               throw new RuntimeException("Unexpected hash table key type " + hashTableKeyType.name());
             }
             joinResult = longHashMap.lookup(longKey, hashMapResult);
-            if (joinResult != JoinUtil.JoinResult.MATCH) {
+            if (joinResult != JoinUtil.JoinResult.MATCH || !longHashMap.containsLongKey(longKey)) {
               assertTrue(false);
             }
           }


### PR DESCRIPTION
Currently supports only for longs to avoid type conversions

Change-Id: I94acefcec276466c5852a8369a015a46db9f6322