### PR TITLE
HIVE-23210: Update ShortestJobFirstComparator

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/comparator/ShortestJobFirstComparator.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/comparator/ShortestJobFirstComparator.java
@@ -44,12 +44,15 @@ public class ShortestJobFirstComparator extends LlapQueueComparatorBase {
     // it's parent hierarchy. selfAndUpstreamComplete indicates how many of these have completed.
     int knownPending1 = fri1.getNumSelfAndUpstreamTasks() - fri1.getNumSelfAndUpstreamCompletedTasks();
     int knownPending2 = fri2.getNumSelfAndUpstreamTasks() - fri2.getNumSelfAndUpstreamCompletedTasks();
-    // WaitTime: multi-task vertex attempt with longer wait-time wrt to its start time -> higher priority
-    // WaitTime: single-task vertex attempt with earlier start-time -> higher priority
-    long waitTime1 = fri1.getNumSelfAndUpstreamTasks() == 1 ?
-            -1 * fri1.getCurrentAttemptStartTime() : fri1.getCurrentAttemptStartTime() - fri1.getFirstAttemptStartTime();
-    long waitTime2 = fri2.getNumSelfAndUpstreamTasks() == 1 ?
-            -1 * fri2.getCurrentAttemptStartTime() : fri2.getCurrentAttemptStartTime() - fri2.getFirstAttemptStartTime();
+    // Multi-task vertex attempt: longer wait-time wrt to its start time -> higher priority
+    long waitTime1 = fri1.getCurrentAttemptStartTime() - fri1.getFirstAttemptStartTime();
+    long waitTime2 = fri2.getCurrentAttemptStartTime() - fri2.getFirstAttemptStartTime();
+
+    // Single-task vertex attempt: earlier start-time -> higher priority
+    if (fri1.getNumSelfAndUpstreamTasks() == fri2.getNumSelfAndUpstreamTasks() &&
+            fri1.getNumSelfAndUpstreamTasks() == 1) {
+      return (int) (fri1.getCurrentAttemptStartTime() - fri2.getCurrentAttemptStartTime());
+    }
 
     if (waitTime1 == 0 || waitTime2 == 0) {
       return knownPending1 - knownPending2;

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/comparator/ShortestJobFirstComparator.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/comparator/ShortestJobFirstComparator.java
@@ -73,6 +73,7 @@ public class ShortestJobFirstComparator extends LlapQueueComparatorBase {
       return 1;
     }
 
-    return 0;
+    // when ratio is the same, pick the one which has waited the longest
+    return Long.compare(fri1.getCurrentAttemptStartTime(), fri2.getCurrentAttemptStartTime());
   }
 }

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
@@ -114,17 +114,24 @@ public class TaskExecutorTestHelpers {
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
+          int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
+          long currentAttemptStartTime, String dagName, int numCompletedTasks) {
+    return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
+            currentAttemptStartTime, 1, dagName, false, numCompletedTasks);
+  }
+
+  public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
       long currentAttemptStartTime, String dagName) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, 1, dagName, false);
+        currentAttemptStartTime, 1, dagName, false, 0);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
       long currentAttemptStartTime, String dagName, boolean isGuaranteed) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, 1, dagName, isGuaranteed);
+        currentAttemptStartTime, 1, dagName, isGuaranteed, 0);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
@@ -132,7 +139,7 @@ public class TaskExecutorTestHelpers {
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, withinDagPriority, "MockDag", false);
+        currentAttemptStartTime, withinDagPriority, "MockDag", false, 0);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
@@ -140,14 +147,14 @@ public class TaskExecutorTestHelpers {
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority, boolean isGuaranteed) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, withinDagPriority, "MockDag", isGuaranteed);
+        currentAttemptStartTime, withinDagPriority, "MockDag", isGuaranteed, 0);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism,
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority, String dagName,
-      boolean isGuaranteed) {
+      boolean isGuaranteed, int numCompletedTasks) {
     ApplicationId appId = ApplicationId.newInstance(9999, 72);
     TezDAGID dagId = TezDAGID.getInstance(appId, 1);
     TezVertexID vId = TezVertexID.getInstance(dagId, 35);
@@ -186,6 +193,7 @@ public class TaskExecutorTestHelpers {
             .setNumSelfAndUpstreamTasks(selfAndUpstreamParallelism)
             .setNumSelfAndUpstreamCompletedTasks(selfAndUpstreamComplete)
             .setWithinDagPriority(withinDagPriority)
+            .setNumSelfAndUpstreamCompletedTasks(numCompletedTasks)
             .build())
         .build();
   }

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
@@ -114,32 +114,25 @@ public class TaskExecutorTestHelpers {
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
-          int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
-          long currentAttemptStartTime, String dagName, int numCompletedTasks) {
-    return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-            currentAttemptStartTime, 1, dagName, false, numCompletedTasks);
-  }
-
-  public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
       long currentAttemptStartTime, String dagName) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, 1, dagName, false, 0);
+        currentAttemptStartTime, 1, dagName, false);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism, long firstAttemptStartTime,
       long currentAttemptStartTime, String dagName, boolean isGuaranteed) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, 1, dagName, isGuaranteed, 0);
+        currentAttemptStartTime, 1, dagName, isGuaranteed);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism,
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority) {
-    return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, withinDagPriority, "MockDag", false, 0);
+    return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, selfAndUpstreamComplete, firstAttemptStartTime,
+        currentAttemptStartTime, withinDagPriority, "MockDag", false);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
@@ -147,14 +140,14 @@ public class TaskExecutorTestHelpers {
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority, boolean isGuaranteed) {
     return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, 0, firstAttemptStartTime,
-        currentAttemptStartTime, withinDagPriority, "MockDag", isGuaranteed, 0);
+        currentAttemptStartTime, withinDagPriority, "MockDag", isGuaranteed);
   }
 
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism,
       int selfAndUpstreamComplete, long firstAttemptStartTime,
       long currentAttemptStartTime, int withinDagPriority, String dagName,
-      boolean isGuaranteed, int numCompletedTasks) {
+      boolean isGuaranteed) {
     ApplicationId appId = ApplicationId.newInstance(9999, 72);
     TezDAGID dagId = TezDAGID.getInstance(appId, 1);
     TezVertexID vId = TezVertexID.getInstance(dagId, 35);
@@ -193,7 +186,6 @@ public class TaskExecutorTestHelpers {
             .setNumSelfAndUpstreamTasks(selfAndUpstreamParallelism)
             .setNumSelfAndUpstreamCompletedTasks(selfAndUpstreamComplete)
             .setWithinDagPriority(withinDagPriority)
-            .setNumSelfAndUpstreamCompletedTasks(numCompletedTasks)
             .build())
         .build();
   }

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
@@ -346,14 +346,14 @@ public class TestShortestJobFirstComparator {
 
     // Single task DAG with different start and attempt time
     r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 1, 800, 1000, "q11"), true, 1000);
-    // Multi-task DAG with 10 out of 12
-    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 1000, 1500, "q12", 10), true, 1000);
+    // Multi-task DAG with 5 out of 12
+    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 1000, 1500, "q12", 5), true, 1000);
 
-    // pending/wait-time -> r2 has again priority
+    // pending/wait-time -> r2 has lower priority because it has more pending tasks!
     assertNull(queue.offer(r1, 0));
     assertEquals(r1, queue.peek()); // Task1 ratio = 1/200 = 0.005
     assertNull(queue.offer(r2, 0));
-    assertEquals(r2, queue.peek()); // Task2 ratio = 2/500 = 0.004
+    assertEquals(r1, queue.peek()); // Task2 ratio = 7/500 = 0.014
   }
 
   @Test(timeout = 60000)

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
@@ -92,7 +92,7 @@ public class TestShortestJobFirstComparator {
     assertNull(queue.offer(r4, 0));
     // q4 can not finish thus q1 remains in top
     assertEquals(r1, queue.peek());
-    // offer accepted and r2 gets evicted (later start-time than q4)
+    // offer accepted and r4 gets evicted (later start-time than q4)
     assertEquals(r4, queue.offer(r5, 0));
     assertEquals(r1, queue.take());
     assertEquals(r3, queue.take());


### PR DESCRIPTION
Update ShortestJobFirstComparator to take into account single-task vertices.

Single-task vertices with earlier start-time have higher priority, while the ones with the latest start-times are the first candidates for eviction.

Change-Id: I94715d194ec8b3a6919aa56d4fae8a0b529ae23e