### PR TITLE
HIVE-23175: Skip serializing hadoop and tez config on HS side

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4749,6 +4749,8 @@ public class HiveConf extends Configuration {
       "Merge adjacent joins into a single n-way join"),
     HIVE_LOG_N_RECORDS("hive.log.every.n.records", 0L, new RangeValidator(0L, null),
       "If value is greater than 0 logs in fixed intervals of size n rather than exponentially."),
+    HIVE_TEZ_SKIP_LOCAL_XML("hive.tez.skip.local.xml", false, "Hive excludes local xml files"
+        + " when sending configuration options to Tez AM when true"),
     /**
      * @deprecated Use MetastoreConf.MSCK_PATH_VALIDATION
      */

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -1381,7 +1381,8 @@ public class DagUtils {
     hiveConf.setBoolean("mapred.mapper.new-api", false);
 
     Predicate<String> findDefaults =
-        (s) -> ((s != null) && (s.endsWith(".xml") || (s.endsWith(".java") && !"HiveConf.java".equals(s))));
+        (s) -> ((s != null) && ((s.endsWith(".xml") && !s.endsWith("hive-site.xml")) ||
+            (s.endsWith(".java") && !"HiveConf.java".equals(s))));
 
     // since this is an inclusion filter, negate the predicate
     JobConf conf =

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -177,8 +177,9 @@ public class TezTask extends Task<TezWork> {
           ss.getHiveVariables().get("wmpool"), ss.getHiveVariables().get("wmapp"));
 
       WmContext wmContext = ctx.getWmContext();
+      boolean skipXmlConfs = conf.getBoolVar(HiveConf.ConfVars.HIVE_TEZ_SKIP_LOCAL_XML);
       // jobConf will hold all the configuration for hadoop, tez, and hive, which are not set in AM defaults
-      JobConf jobConf = utils.createConfiguration(conf, false);
+      JobConf jobConf = utils.createConfiguration(conf, skipXmlConfs);
 
 
       // Get all user jars from work (e.g. input format stuff).


### PR DESCRIPTION
Change-Id: I4dde8e25631fbb7243afa17d139f93b785206a46