### PR TITLE
HIVE-23269: Unsafe comparing bigints and (var)chars

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1636,7 +1636,7 @@ public class HiveConf extends Configuration {
         "Note that this check currently does not consider data size, only the query pattern."),
     HIVE_STRICT_CHECKS_TYPE_SAFETY("hive.strict.checks.type.safety", true,
         "Enabling strict type safety checks disallows the following:\n" +
-        "  Comparing bigints and strings.\n" +
+        "  Comparing bigints and strings/(var)chars.\n" +
         "  Comparing bigints and doubles."),
     HIVE_STRICT_CHECKS_CARTESIAN("hive.strict.checks.cartesian.product", false,
         "Enabling strict Cartesian join checks disallows the following:\n" +

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -1943,6 +1943,7 @@ minillaplocal.query.files=\
   union_null.q,\
   unionall_join_nullconstant.q,\
   unionall_lateralview1.q,\
+  unsafe_compare.q,\
   unset_table_view_property.q,\
   updateAccessTime.q,\
   update_after_multiple_inserts_special_characters.q,\

--- a/ql/src/test/queries/clientpositive/unsafe_compare.q
+++ b/ql/src/test/queries/clientpositive/unsafe_compare.q
@@ -1,0 +1,10 @@
+
+CREATE TABLE test_a (appid1 varchar(256),  appid2 char(20));
+
+INSERT INTO  test_a VALUES ('2882303761517473127', '2882303761517473127'), ('2882303761517473276','2882303761517473276');
+
+SET hive.strict.checks.type.safety=false;
+
+SELECT appid1 FROM test_a WHERE appid1 = 2882303761517473127;
+
+SELECT appid2 FROM test_a WHERE appid2 = 2882303761517473127;

--- a/ql/src/test/results/clientpositive/llap/unsafe_compare.q.out
+++ b/ql/src/test/results/clientpositive/llap/unsafe_compare.q.out
@@ -1,0 +1,40 @@
+PREHOOK: query: CREATE TABLE test_a (appid1 varchar(256),  appid2 char(20))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_a
+POSTHOOK: query: CREATE TABLE test_a (appid1 varchar(256),  appid2 char(20))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_a
+PREHOOK: query: INSERT INTO  test_a VALUES ('2882303761517473127', '2882303761517473127'), ('2882303761517473276','2882303761517473276')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_a
+POSTHOOK: query: INSERT INTO  test_a VALUES ('2882303761517473127', '2882303761517473127'), ('2882303761517473276','2882303761517473276')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_a
+POSTHOOK: Lineage: test_a.appid1 SCRIPT []
+POSTHOOK: Lineage: test_a.appid2 SCRIPT []
+WARNING: Comparing a bigint and a varchar(256) may result in a loss of precision.
+PREHOOK: query: SELECT appid1 FROM test_a WHERE appid1 = 2882303761517473127
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_a
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT appid1 FROM test_a WHERE appid1 = 2882303761517473127
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_a
+#### A masked pattern was here ####
+2882303761517473127
+2882303761517473276
+WARNING: Comparing a bigint and a char(20) may result in a loss of precision.
+PREHOOK: query: SELECT appid2 FROM test_a WHERE appid2 = 2882303761517473127
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_a
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT appid2 FROM test_a WHERE appid2 = 2882303761517473127
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_a
+#### A masked pattern was here ####
+2882303761517473127 
+2882303761517473276 


### PR DESCRIPTION
Comparing bigints and (var)chars may result to wrong result