### PR TITLE
HIVE-23300 Fix closing function name for alter_partitions

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -5539,7 +5539,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         ex = e;
         throw newMetaException(e);
       } finally {
-        endFunction("alter_partition", oldParts != null, ex, tbl_name);
+        endFunction("alter_partitions", oldParts != null, ex, tbl_name);
       }
     }
 


### PR DESCRIPTION
As described in the JIRA, this made it hard to view the number of active api calls correctly for alter_paritions.