### PR TITLE
HIVE-23443: LLAP speculative task pre-emption seems to be not working

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -867,7 +867,8 @@ public class TaskExecutorService extends AbstractService
     return sc;
   }
 
-  private void finishableStateUpdated(TaskWrapper taskWrapper, boolean newFinishableState) {
+  @VisibleForTesting
+  void finishableStateUpdated(TaskWrapper taskWrapper, boolean newFinishableState) {
     synchronized (lock) {
       LOG.debug("Fragment {} guaranteed state changed to {}; finishable {}, in wait queue {}, "
           + "in preemption queue {}", taskWrapper.getRequestId(), taskWrapper.isGuaranteed(),

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -907,6 +907,9 @@ public class TaskExecutorService extends AbstractService
   }
 
   private void addToPreemptionQueue(TaskWrapper taskWrapper) {
+    if (taskWrapper.isInPreemptionQueue()) {
+      return;
+    }
     synchronized (lock) {
       insertIntoPreemptionQueueOrFailUnlocked(taskWrapper);
       taskWrapper.setIsInPreemptableQueue(true);

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestTaskExecutorService.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestTaskExecutorService.java
@@ -236,6 +236,128 @@ public class TestTaskExecutorService {
     }
   }
 
+  @Test(timeout = 10000)
+  public void testPreemptionQueueOnFinishableStateUpdates() throws InterruptedException {
+
+    long r1WorkTime = 1000L;
+    long r2WorkTime = 2000L;
+    long r3WorkTime = 2000L;
+    // all tasks start with non-finishable state
+    MockRequest r1 = createMockRequest(1, 2, 100, 200, false, r1WorkTime, false);
+    MockRequest r2 = createMockRequest(2, 1, 100, 200, false, r2WorkTime, false);
+    MockRequest r3 = createMockRequest(3, 3, 50, 200, false, r3WorkTime, false);
+
+
+    TaskExecutorServiceForTest taskExecutorService =
+      new TaskExecutorServiceForTest(3, 2, ShortestJobFirstComparator.class.getName(), true, mockMetrics);
+    taskExecutorService.init(new Configuration());
+    taskExecutorService.start();
+
+    try {
+      String fragmentId1 = r1.getRequestId();
+      Scheduler.SubmissionState submissionState1 = taskExecutorService.schedule(r1);
+      assertEquals(Scheduler.SubmissionState.ACCEPTED, submissionState1);
+      awaitStartAndSchedulerRun(r1, taskExecutorService);
+
+      String fragmentId2 = r2.getRequestId();
+      Scheduler.SubmissionState submissionState2 = taskExecutorService.schedule(r2);
+      assertEquals(Scheduler.SubmissionState.ACCEPTED, submissionState2);
+      awaitStartAndSchedulerRun(r2, taskExecutorService);
+
+      String fragmentId3 = r3.getRequestId();
+      Scheduler.SubmissionState submissionState3 = taskExecutorService.schedule(r3);
+      assertEquals(Scheduler.SubmissionState.ACCEPTED, submissionState3);
+      awaitStartAndSchedulerRun(r3, taskExecutorService);
+
+      TaskWrapper taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // all tasks are non-finishables, r2 has min tasks
+      assertEquals(fragmentId2, taskWrapper.getRequestId());
+      assertEquals(3, taskExecutorService.preemptionQueue.size());
+
+      // to let us set the finishable state for tests
+      r1.setCanUpdateFinishable();
+      r2.setCanUpdateFinishable();
+      r3.setCanUpdateFinishable();
+
+      TaskWrapper taskWrapper1 = taskExecutorService.knownTasks.get(fragmentId1);
+      TaskWrapper taskWrapper2 = taskExecutorService.knownTasks.get(fragmentId2);
+      TaskWrapper taskWrapper3 = taskExecutorService.knownTasks.get(fragmentId3);
+
+      // r2 is finishable now, so it should go to back of pre-emption queue.
+      taskExecutorService.finishableStateUpdated(taskWrapper2, true);
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // r1 is smallest among non-finishables, so should be first in queue
+      assertEquals(fragmentId1, taskWrapper.getRequestId());
+      assertFalse(taskWrapper.canFinishForPriority());
+      assertEquals(3, taskExecutorService.preemptionQueue.size());
+
+      // r1 is finishable now, so it should go to back of pre-emption queue.
+      taskExecutorService.finishableStateUpdated(taskWrapper1, true);
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // r3 is the only non-finishable
+      assertEquals(fragmentId3, taskWrapper.getRequestId());
+      assertFalse(taskWrapper.canFinishForPriority());
+      assertEquals(3, taskExecutorService.preemptionQueue.size());
+
+      // r3 is finishable now, so it should go to back of pre-emption queue.
+      taskExecutorService.finishableStateUpdated(taskWrapper3, true);
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // no more non-finishables left, r2 is smallest among the finishables
+      assertEquals(fragmentId2, taskWrapper.getRequestId());
+      assertTrue(taskWrapper.canFinishForPriority());
+      assertEquals(3, taskExecutorService.preemptionQueue.size());
+
+      // remove r2 from scheduler
+      taskExecutorService.killFragment(fragmentId2);
+
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // no more non-finishables left, r1 is the smallest among the finishables
+      assertEquals(fragmentId1, taskWrapper.getRequestId());
+      assertTrue(taskWrapper.canFinishForPriority());
+      assertEquals(2, taskExecutorService.preemptionQueue.size());
+
+      // make r3 as non-finishable and make sure its at top of queue
+      taskExecutorService.finishableStateUpdated(taskWrapper3, false);
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // r3 is non-finishable and should be at top
+      assertEquals(fragmentId3, taskWrapper.getRequestId());
+      assertFalse(taskWrapper.canFinishForPriority());
+      assertEquals(2, taskExecutorService.preemptionQueue.size());
+
+      // remove r3 from scheduler
+      taskExecutorService.killFragment(fragmentId3);
+
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNotNull(taskWrapper);
+      assertTrue(taskWrapper.isInPreemptionQueue());
+      // r1 is the only one left in queue and is finishable
+      assertEquals(fragmentId1, taskWrapper.getRequestId());
+      assertTrue(taskWrapper.canFinishForPriority());
+      assertEquals(1, taskExecutorService.preemptionQueue.size());
+
+      // remove r1 from scheduler
+      taskExecutorService.killFragment(fragmentId1);
+
+      // no more left in queue
+      taskWrapper = taskExecutorService.preemptionQueue.peek();
+      assertNull(taskWrapper);
+    } finally {
+      taskExecutorService.shutDown(false);
+    }
+  }
+
   // Tests wait queue behaviour for fragments which have reported to the AM, but have not given up their executor slot.
   @Test (timeout = 10000)
   public void testWaitQueueAcceptAfterAMTaskReport() throws


### PR DESCRIPTION
I think after HIVE-23210 we are getting a stable sort order and it is causing pre-emption to not work in certain cases.

```
"attempt_1589167813851_0000_119_01_000008_0 (hive_20200511055921_89598f09-19f1-4969-ab7a-82e2dd796273-119/Map 1, started at 2020-05-11 05:59:22, in preemption queue, can finish)", 
"attempt_1589167813851_0008_84_01_000008_1 (hive_20200511055928_7ae29ca3-e67d-4d1f-b193-05651023b503-84/Map 1, started at 2020-05-11 06:00:23, in preemption queue, can finish)" 
```

Scheduler only peek's at the pre-emption queue and looks at whether it is non-finishable. 

https://github.com/apache/hive/blob/master/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java#L420

In the above case, all tasks are speculative but state change is not triggering pre-emption queue re-ordering so peek() always returns canFinish task even though non-finishable tasks are in the queue. 