### PR TITLE
HIVE-23477: [LLAP] mmap allocation interruptions fails to notify other threads

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cache/BuddyAllocator.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cache/BuddyAllocator.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.llap.cache;
 
+import java.nio.channels.ClosedByInterruptException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -217,7 +218,11 @@ public final class BuddyAllocator
     }
     int initCount = doPreallocate && !isMapped ? maxArenas : 1;
     for (int i = 0; i < initCount; ++i) {
-      arenas[i].init(i);
+      try {
+        arenas[i].init(i);
+      } catch (ClosedByInterruptException e) {
+        throw new RuntimeException("Failed pre-allocating buddy allocator arena. ", e);
+      }
       metrics.incrAllocatedArena();
     }
     allocatedArenas.set(initCount);
@@ -851,7 +856,7 @@ public final class BuddyAllocator
     return isDirect;
   }
 
-  private ByteBuffer preallocateArenaBuffer(int arenaSize) {
+  private ByteBuffer preallocateArenaBuffer(int arenaSize) throws ClosedByInterruptException {
     if (isMapped) {
       RandomAccessFile rwf = null;
       File rf = null;
@@ -863,6 +868,15 @@ public final class BuddyAllocator
         // Use RW, not PRIVATE because the copy-on-write is irrelevant for a deleted file
         // see discussion in YARN-5551 for the memory accounting discussion
         return rwf.getChannel().map(MapMode.READ_WRITE, 0, arenaSize);
+      } catch (ClosedByInterruptException cbi) {
+        LlapIoImpl.LOG.warn("Interrupted while trying to allocate memory mapped arena", cbi);
+        // finally may not execute on thread interrupts so cleanup the arena file as it may be unmapped
+        IOUtils.closeQuietly(rwf);
+        if (rf != null) {
+          rf.delete();
+          rf = null;
+        }
+        throw cbi;
       } catch (IOException ioe) {
         LlapIoImpl.LOG.warn("Failed trying to allocate memory mapped arena", ioe);
         // fail similarly when memory allocations fail
@@ -892,7 +906,7 @@ public final class BuddyAllocator
     private byte[] headers; // Free list indices of each unallocated block, for quick lookup.
     private FreeList[] freeLists;
 
-    void init(int arenaIx) {
+    void init(int arenaIx) throws ClosedByInterruptException {
       this.arenaIx = arenaIx;
       try {
         data = preallocateArenaBuffer(arenaSize);
@@ -1453,13 +1467,24 @@ public final class BuddyAllocator
           continue; // CAS race, look again.
         }
         assert data == null;
-        init(arenaIx);
-        boolean isCommited = allocatedArenas.compareAndSet(-arenaCount - 1, arenaCount + 1);
-        assert isCommited;
+        try {
+          init(arenaIx);
+          // if init did not throw interrupt exception then allocation succeeded and so increment and commit the arena
+          boolean isCommited = allocatedArenas.compareAndSet(-arenaCount - 1, arenaCount + 1);
+          assert isCommited;
+          metrics.incrAllocatedArena();
+        } catch (ClosedByInterruptException e) {
+          LlapIoImpl.LOG.info("Received interrupt during arena {} allocation.. Ignoring..", arenaIx);
+          // not doing the notify in finally() block as thread interruptions may not execute finally
+          synchronized (this) {
+            this.notifyAll();
+          }
+          continue;
+        }
+
         synchronized (this) {
           this.notifyAll();
         }
-        metrics.incrAllocatedArena();
         return allocateWithSplit(freeListIx, dest, null, ix, dest.length, size, -1);
       }
     }


### PR DESCRIPTION
BuddyAllocator always uses lazy allocation is mmap is enabled. If query fragment is interrupted at the time of arena allocation ClosedByInterruptionException is thrown. This exception artificially triggers allocator OutOfMemoryError and fails to notify other threads waiting to allocate arenas. 

```
2020-05-15 00:03:23.254  WARN [TezTR-128417_1_3_1_1_0] LlapIoImpl: Failed trying to allocate memory mapped arena
java.nio.channels.ClosedByInterruptException
        at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:202)
        at sun.nio.ch.FileChannelImpl.map(FileChannelImpl.java:970)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.preallocateArenaBuffer(BuddyAllocator.java:867)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.access$1100(BuddyAllocator.java:69)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.init(BuddyAllocator.java:900)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.allocateWithExpand(BuddyAllocator.java:1458)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.access$800(BuddyAllocator.java:884)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.allocateWithExpand(BuddyAllocator.java:740)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.allocateMultiple(BuddyAllocator.java:330)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.wrapBbForFile(MetadataCache.java:257)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.putFileMetadata(MetadataCache.java:216)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.putFileMetadata(MetadataCache.java:49)
        at org.apache.hadoop.hive.ql.io.parquet.vector.VectorizedParquetRecordReader.readSplitFooter(VectorizedParquetRecordReader.java:343)
        at org.apache.hadoop.hive.ql.io.parquet.vector.VectorizedParquetRecordReader.initialize(VectorizedParquetRecordReader.java:238)
        at org.apache.hadoop.hive.ql.io.parquet.vector.VectorizedParquetRecordReader.<init>(VectorizedParquetRecordReader.java:160)
        at org.apache.hadoop.hive.ql.io.parquet.VectorizedParquetInputFormat.getRecordReader(VectorizedParquetInputFormat.java:50)
        at org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat.getRecordReader(MapredParquetInputFormat.java:87)
        at org.apache.hadoop.hive.ql.io.HiveInputFormat.getRecordReader(HiveInputFormat.java:427)
        at org.apache.hadoop.mapred.split.TezGroupedSplitsInputFormat$TezGroupedSplitsRecordReader.initNextRecordReader(TezGroupedSplitsInputFormat.java:203)
        at org.apache.hadoop.mapred.split.TezGroupedSplitsInputFormat$TezGroupedSplitsRecordReader.<init>(TezGroupedSplitsInputFormat.java:145)
        at org.apache.hadoop.mapred.split.TezGroupedSplitsInputFormat.getRecordReader(TezGroupedSplitsInputFormat.java:111)
        at org.apache.tez.mapreduce.lib.MRReaderMapred.setupOldRecordReader(MRReaderMapred.java:156)
        at org.apache.tez.mapreduce.lib.MRReaderMapred.setSplit(MRReaderMapred.java:82)
        at org.apache.tez.mapreduce.input.MRInput.initFromEventInternal(MRInput.java:703)
        at org.apache.tez.mapreduce.input.MRInput.initFromEvent(MRInput.java:662)
        at org.apache.tez.mapreduce.input.MRInputLegacy.checkAndAwaitRecordReaderInitialization(MRInputLegacy.java:150)
        at org.apache.tez.mapreduce.input.MRInputLegacy.init(MRInputLegacy.java:114)
        at org.apache.hadoop.hive.ql.exec.tez.MapRecordProcessor.getMRInput(MapRecordProcessor.java:532)
        at org.apache.hadoop.hive.ql.exec.tez.MapRecordProcessor.init(MapRecordProcessor.java:178)
        at org.apache.hadoop.hive.ql.exec.tez.TezProcessor.initializeAndRunProcessor(TezProcessor.java:266)
        at org.apache.hadoop.hive.ql.exec.tez.TezProcessor.run(TezProcessor.java:250)
        at org.apache.tez.runtime.LogicalIOProcessorRuntimeTask.run(LogicalIOProcessorRuntimeTask.java:374)
        at org.apache.tez.runtime.task.TaskRunner2Callable$1.run(TaskRunner2Callable.java:75)
        at org.apache.tez.runtime.task.TaskRunner2Callable$1.run(TaskRunner2Callable.java:62)
        at java.security.AccessController.doPrivileged(Native Method)
        at javax.security.auth.Subject.doAs(Subject.java:422)
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1876)
        at org.apache.tez.runtime.task.TaskRunner2Callable.callInternal(TaskRunner2Callable.java:62)
        at org.apache.tez.runtime.task.TaskRunner2Callable.callInternal(TaskRunner2Callable.java:38)
        at org.apache.tez.common.CallableWithNdc.call(CallableWithNdc.java:36)
        at org.apache.hadoop.hive.llap.daemon.impl.StatsRecordingThreadPool$WrappedCallable.call(StatsRecordingThreadPool.java:118)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
2020-05-15 00:03:23.254 ERROR [TezTR-128417_1_3_1_1_0] vector.VectorizedParquetRecordReader: Failed to create the vectorized reader due to exception java.lang.OutOfMemoryError: Cannot allocate 1073741824 bytes: Failed trying to allocate memory mapped arena: null; make sure your xmx and process size are set correctly. 

```
 
```
"TezTR-128417_1_3_1_18_0" #319 daemon prio=5 os_prio=0 tid=0x00007f5880004000 nid=0x3c8 runnable [0x00007f57a1846000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Throwable.fillInStackTrace(Native Method)
        at java.lang.Throwable.fillInStackTrace(Throwable.java:784)
        - locked <0x00007f5c93915e98> (a java.lang.InterruptedException)
        at java.lang.Throwable.<init>(Throwable.java:251)
        at java.lang.Exception.<init>(Exception.java:54)
        at java.lang.InterruptedException.<init>(InterruptedException.java:57)
        at java.lang.Object.wait(Native Method)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.allocateWithExpand(BuddyAllocator.java:1443)
        - locked <0x00007f598859f188> (a org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.access$800(BuddyAllocator.java:884)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.allocateWithExpand(BuddyAllocator.java:740)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator.allocateMultiple(BuddyAllocator.java:330)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.wrapBbForFile(MetadataCache.java:257)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.putFileMetadata(MetadataCache.java:216)
        at org.apache.hadoop.hive.llap.io.metadata.MetadataCache.putFileMetadata(MetadataCache.java:49)
        at org.apache.hadoop.hive.ql.io.parquet.vector.VectorizedParquetRecordReader.readSplitFooter(VectorizedParquetRecordReader.java:343) 
 ```

```
"TezTR-128417_1_4_1_18_0" #588 daemon prio=5 os_prio=0 tid=0x00007f57d0004000 nid=0x43a3 in Object.wait() [0x00007f56f8681000]
   java.lang.Thread.State: TIMED_WAITING (on object monitor)
        at java.lang.Object.wait(Native Method)
        at org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena.allocateWithExpand(BuddyAllocator.java:1443)
        - locked <0x00007f598859f188> (a org.apache.hadoop.hive.llap.cache.BuddyAllocator$Arena) 
 ```

TezTR-128417_1_3_1_18_0 got interrupted, it threw OOM but failed to notify other threads. TezTR-128417_1_4_1_18_0 thread is stuck forever waiting to allocate.