### PR TITLE
HIVE-23480: use the JsonPropertyOrder annotation 

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/StatsSetupConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/StatsSetupConst.java
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -167,6 +168,7 @@ public class StatsSetupConst {
       COLUMN_STATS_ACCURATE, NUM_FILES, TOTAL_SIZE, ROW_COUNT, RAW_DATA_SIZE, NUM_PARTITIONS,
       NUM_ERASURE_CODED_FILES);
 
+  @JsonPropertyOrder({"basicStats", "columnStats"})
   private static class ColumnStatsAccurate {
     private static ObjectReader objectReader;
     private static ObjectWriter objectWriter;


### PR DESCRIPTION
use the JsonPropertyOrder annotation to ensure the ordering of serialized properties.

Change-Id: I2f2b3f1d9eec1e26b5b6e445efe6f0106f4ea15d