### PR TITLE
HIVE-23509: MapJoin AssertionError: Capacity must be power of 2

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/BytesBytesMultiHashMap.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/persistence/BytesBytesMultiHashMap.java
@@ -608,7 +608,7 @@ public final class BytesBytesMultiHashMap implements MemoryEstimate {
     int newRefsCount = oldRefsCount + estimateNewRowCount;
     if (resizeThreshold <= newRefsCount) {
       newRefsCount =
-          (Long.bitCount(newRefsCount) == 1) ? estimateNewRowCount : nextHighestPowerOfTwo(newRefsCount);
+          (Long.bitCount(newRefsCount) == 1) ? newRefsCount : nextHighestPowerOfTwo(newRefsCount);
       expandAndRehashImpl(newRefsCount);
       LOG.info("Expand and rehash to " + newRefsCount + " from " + oldRefsCount);
     }
@@ -616,7 +616,7 @@ public final class BytesBytesMultiHashMap implements MemoryEstimate {
 
   private static void validateCapacity(long capacity) {
     if (Long.bitCount(capacity) != 1) {
-      throw new AssertionError("Capacity must be a power of two");
+      throw new AssertionError("Capacity must be a power of two but got " + capacity);
     }
     if (capacity <= 0) {
       throw new AssertionError("Invalid capacity " + capacity);

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/persistence/TestBytesBytesMultiHashMap.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/persistence/TestBytesBytesMultiHashMap.java
@@ -49,6 +49,13 @@ public class TestBytesBytesMultiHashMap {
   }
 
   @Test
+  public void testExpandAndRehashToTarget() {
+    BytesBytesMultiHashMap map = new BytesBytesMultiHashMap(CAPACITY, LOAD_FACTOR, WB_SIZE);
+    map.expandAndRehashToTarget(24);
+    assertEquals(32, map.getCapacity());
+  }
+
+  @Test
   public void testPutGetOne() throws Exception {
     BytesBytesMultiHashMap map = new BytesBytesMultiHashMap(CAPACITY, LOAD_FACTOR, WB_SIZE);
     RandomKvSource kv = new RandomKvSource(0, 0);


### PR DESCRIPTION
Observed that MapJoin is failing when row count is provided as (2^x)+(2^(x+1)). Fixing it and added a unit test to check against such case