### PR TITLE
[HIVE-23496] Adding a flag to disable materialized views cache warm up

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2313,6 +2313,8 @@ public class HiveConf extends Configuration {
         "Setting it to 0s disables the timeout."),
     HIVE_SERVER2_PARALLEL_OPS_IN_SESSION("hive.server2.parallel.ops.in.session", true,
         "Whether to allow several parallel operations (such as SQL statements) in one session."),
+    HIVE_SERVER2_MATERIALIZED_VIEWS_CACHE_AT_STARTUP("hive.server2.materializedviews.cache.at.startup", true,
+        "Whether to cache the materialized views in the registry at startup."),
 
     // HiveServer2 WebUI
     HIVE_SERVER2_WEBUI_BIND_HOST("hive.server2.webui.host", "0.0.0.0", "The host address the HiveServer2 WebUI will listen on"),


### PR DESCRIPTION
At start-up, HiveServer2 will do a full DB & Table scan. For large Hive Metastores, this operation could take 10+ minutes to complete. The goal of this task is to make this “verification” optional if possible.

It seems that <= Hive 2.3.x && >= Hive 3.0 *does not* have this behavior.

This changes introduces a new flag, `hive.server2.materializedviews.cache.at.startup` that by setting it to false the cache warmup is disabled. 
