### PR TITLE
HIVE-21624: LLAP: Cpu metrics at thread level is broken

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -91,7 +91,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class TaskExecutorService extends AbstractService
     implements Scheduler<TaskRunnerCallable>, SchedulerFragmentCompletingListener {
   private static final Logger LOG = LoggerFactory.getLogger(TaskExecutorService.class);
-  private static final String TASK_EXECUTOR_THREAD_NAME_FORMAT = "Task-Executor-%d";
+  public static final String TASK_EXECUTOR_THREAD_NAME_FORMAT_PREFIX = "Task-Executor-";
+  private static final String TASK_EXECUTOR_THREAD_NAME_FORMAT = TASK_EXECUTOR_THREAD_NAME_FORMAT_PREFIX + "%d";
   private static final String WAIT_QUEUE_SCHEDULER_THREAD_NAME_FORMAT = "Wait-Queue-Scheduler-%d";
   private static final long PREEMPTION_KILL_GRACE_MS = 500; // 500ms
   private static final int PREEMPTION_KILL_GRACE_SLEEP_MS = 50; // 50ms

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorMetrics.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorMetrics.java
@@ -71,6 +71,7 @@ import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
 import org.apache.commons.math3.stat.descriptive.SynchronizedDescriptiveStatistics;
 import org.apache.hadoop.hive.common.JvmMetrics;
 import org.apache.hadoop.hive.llap.daemon.impl.ContainerRunnerImpl;
+import org.apache.hadoop.hive.llap.daemon.impl.TaskExecutorService;
 import org.apache.hadoop.metrics2.MetricsCollector;
 import org.apache.hadoop.metrics2.MetricsInfo;
 import org.apache.hadoop.metrics2.MetricsRecordBuilder;
@@ -213,7 +214,7 @@ public class LlapDaemonExecutorMetrics implements MetricsSource {
       this.userMetricsInfoMap.put(i, miu);
       this.executorThreadCpuTime[i] = registry.newGauge(mic, 0L);
       this.executorThreadUserTime[i] = registry.newGauge(miu, 0L);
-      this.executorNames.put(ContainerRunnerImpl.THREAD_NAME_FORMAT_PREFIX + i, i);
+      this.executorNames.put(TaskExecutorService.TASK_EXECUTOR_THREAD_NAME_FORMAT_PREFIX + i, i);
     }
 
     if (timedWindowAverageDataPoints > 0) {


### PR DESCRIPTION
ExecutorThreadCPUTime and ExecutorThreadUserTime relies on thread mx bean cpu metrics when available. At some point, the thread name which the metrics publisher looks for has changed causing no metrics to be published for these counters.  

The above counters looks for thread with name starting with "ContainerExecutor" but the llap task executor thread got changed to "Task-Executor"