### PR TITLE
HIVE-23586: load data overwrite into bucket table not overwrite HIVE-23586

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -518,7 +518,11 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     // Step 2 : create the Insert query
     StringBuilder rewrittenQueryStr = new StringBuilder();
 
-    rewrittenQueryStr.append("insert into table ");
+    if (isOverWrite) {
+      rewrittenQueryStr.append("insert overwrite table ");
+    } else {
+      rewrittenQueryStr.append("insert into table ");
+    }
     rewrittenQueryStr.append(getFullTableNameForSQL((ASTNode)(tableTree.getChild(0))));
     addPartitionColsToInsert(table.getPartCols(), inpPartSpec, rewrittenQueryStr);
     rewrittenQueryStr.append(" select * from ");


### PR DESCRIPTION
load data overwrite into bucket table is failed if filename is not like 000000_0, but insert new data in the table. this is fixed by modify insert sql