### PR TITLE
HIVE-23596: Encode guaranteed task information in containerId

### DIFF
--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/ContainerFactory.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/ContainerFactory.java
@@ -28,6 +28,29 @@ class ContainerFactory {
   final ApplicationAttemptId customAppAttemptId;
   AtomicLong nextId;
 
+  private static final int GUARANTEED_WIDTH = 1;
+
+  private static final long GUARANTEED_BIT_MASK = (1L << GUARANTEED_WIDTH) - 1;
+
+  /**
+   * This is a hack to pass initial guaranteed information from {@link LlapTaskSchedulerService}
+   * to {@link LlapTaskCommunicator}. Otherwise, we ended up synchronizing communication and
+   * scheduling. This workaround can be removed after TEZ-4192 and HIVE-23589 are merged.
+   *
+   * Note: This method is reliable only for initial allocation of the task. Guaranteed status
+   * may change via separate requests later. Therefore, do not rely on this method other
+   * than creating initial submit work request.
+   *
+   * Even containerId -> guaranteed
+   * Odd containerId -> not guaranteed
+   *
+   * @param containerId
+   * @return {@code true} if the task associated with container was guaranteed initially.
+   */
+  public static boolean isContainerInitializedAsGuaranteed(ContainerId containerId) {
+    return (containerId.getContainerId() & GUARANTEED_BIT_MASK) == 0;
+  }
+
   public ContainerFactory(ApplicationAttemptId appAttemptId, long appIdLong) {
     this.nextId = new AtomicLong(1);
     ApplicationId appId =
@@ -37,14 +60,28 @@ class ContainerFactory {
   }
 
   public Container createContainer(Resource capability, Priority priority, String hostname,
-      int port, String nodeHttpAddress) {
+      int port, String nodeHttpAddress, boolean isGuaranteed) {
     ContainerId containerId =
-        ContainerId.newContainerId(customAppAttemptId, nextId.getAndIncrement());
+        ContainerId.newContainerId(customAppAttemptId, nextContainerId(isGuaranteed));
     NodeId nodeId = NodeId.newInstance(hostname, port);
 
     Container container =
         Container.newInstance(containerId, nodeId, nodeHttpAddress, capability, priority, null);
 
     return container;
+  }
+
+  /**
+   * See {@link #isContainerInitializedAsGuaranteed(ContainerId)}
+   * @param isInitialGuaranteed
+   * @return
+   */
+  private long nextContainerId(boolean isInitialGuaranteed) {
+    long candidate = nextId.getAndIncrement();
+    candidate <<= GUARANTEED_WIDTH;
+    if (!isInitialGuaranteed) {
+      candidate |= 1;
+    }
+    return candidate;
   }
 }

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskCommunicator.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskCommunicator.java
@@ -858,10 +858,7 @@ public class LlapTaskCommunicator extends TezTaskCommunicatorImpl {
         taskSpec, currentQueryIdentifierProto, getTokenIdentifier(), user, hiveQueryId)).build());
     // Don't call builder.setWorkSpecSignature() - Tez doesn't sign fragments
     builder.setFragmentRuntimeInfo(fragmentRuntimeInfo);
-    if (scheduler != null) { // May be null in tests
-      // TODO: see javadoc
-      builder.setIsGuaranteed(scheduler.isInitialGuaranteed(taskSpec.getTaskAttemptID()));
-    }
+    builder.setIsGuaranteed(ContainerFactory.isContainerInitializedAsGuaranteed(containerId));
     return builder.build();
   }
 

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1334,35 +1334,6 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     handleUpdateResult(info, true);
   }
 
-  /**
-   * A hacky way for communicator and scheduler to share per-task info. Scheduler should be able
-   * to include this with task allocation to be passed to the communicator, instead. TEZ-3866.
-   * @param attemptId Task attempt ID.
-   * @return The initial value of the guaranteed flag to send with the task.
-   */
-  boolean isInitialGuaranteed(TezTaskAttemptID attemptId) {
-    if (!workloadManagementEnabled) {
-      return false;
-    }
-    TaskInfo info = null;
-    readLock.lock();
-    try {
-      info = tasksById.get(attemptId);
-    } finally {
-      readLock.unlock();
-    }
-    if (info == null) {
-      WM_LOG.warn("Status requested for an unknown task " + attemptId);
-      return false;
-    }
-    synchronized (info) {
-      if (info.isGuaranteed == null) return false; // TODO: should never happen?
-      assert info.lastSetGuaranteed == null;
-      info.requestedValue = info.isGuaranteed;
-      return info.isGuaranteed;
-    }
-  }
-
   // Must be called under the epic lock.
   private TaskInfo distributeGuaranteedOnTaskCompletion() {
     List<TaskInfo> toUpdate = new ArrayList<>(1);
@@ -2005,12 +1976,14 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     if (selectHostResult.scheduleResult != ScheduleResult.SCHEDULED) {
       return selectHostResult.scheduleResult;
     }
+    boolean isGuaranteed = false;
     if (unusedGuaranteed > 0) {
       boolean wasGuaranteed = false;
       synchronized (taskInfo) {
         assert !taskInfo.isPendingUpdate; // No updates before it's running.
         wasGuaranteed = taskInfo.isGuaranteed;
         taskInfo.isGuaranteed = true;
+        isGuaranteed = true;
       }
       if (wasGuaranteed) {
         // This should never happen - we only schedule one attempt once.
@@ -2032,6 +2005,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         synchronized (taskInfo) {
           assert !taskInfo.isPendingUpdate; // No updates before it's running.
           taskInfo.isGuaranteed = true;
+          isGuaranteed = true;
         }
         // Note: after this, the caller MUST send the downgrade message to downgradedTask
         //       (outside of the writeLock, preferably), before exiting.
@@ -2043,7 +2017,8 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         containerFactory.createContainer(nodeInfo.getResourcePerExecutor(), taskInfo.priority,
             nodeInfo.getHost(),
             nodeInfo.getRpcPort(),
-            nodeInfo.getServiceAddress());
+            nodeInfo.getServiceAddress(),
+            isGuaranteed);
     writeLock.lock(); // While updating local structures
     // Note: this is actually called under the epic writeLock in schedulePendingTasks
     try {

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
@@ -1925,6 +1925,33 @@ public class TestLlapTaskSchedulerService {
     }
   }
 
+  @Test
+  public void testInitialGuaranteedInfoIsEncodedInContainerId() {
+    ApplicationAttemptId appAttemptId = ApplicationAttemptId.newInstance(ApplicationId.newInstance(1000, 1), 1);
+    ContainerFactory containerFactory = new ContainerFactory(appAttemptId, 15);
+    Container c1 = createDummyContainer(containerFactory, false);
+    Container c2 = createDummyContainer(containerFactory, true);
+    Container c3 = createDummyContainer(containerFactory, true);
+    Container c4 = createDummyContainer(containerFactory, false);
+    Container c5 = createDummyContainer(containerFactory, true);
+    Container c6 = createDummyContainer(containerFactory, false);
+    Container c7 = createDummyContainer(containerFactory, false);
+    Container c8 = createDummyContainer(containerFactory, true);
+
+    assertFalse(ContainerFactory.isContainerInitializedAsGuaranteed(c1.getId()));
+    assertTrue(ContainerFactory.isContainerInitializedAsGuaranteed(c2.getId()));
+    assertTrue(ContainerFactory.isContainerInitializedAsGuaranteed(c3.getId()));
+    assertFalse(ContainerFactory.isContainerInitializedAsGuaranteed(c4.getId()));
+    assertTrue(ContainerFactory.isContainerInitializedAsGuaranteed(c5.getId()));
+    assertFalse(ContainerFactory.isContainerInitializedAsGuaranteed(c6.getId()));
+    assertFalse(ContainerFactory.isContainerInitializedAsGuaranteed(c7.getId()));
+    assertTrue(ContainerFactory.isContainerInitializedAsGuaranteed(c8.getId()));
+  }
+
+  private Container createDummyContainer(ContainerFactory containerFactory, boolean isGuaranteed) {
+    return containerFactory.createContainer(mock(Resource.class), mock(Priority.class), "hostname", 0, null, isGuaranteed);
+  }
+
   private static class TestTaskSchedulerServiceWrapper {
     static final Resource resource = Resource.newInstance(1024, 1);
     Configuration conf;


### PR DESCRIPTION
We should avoid calling LlapTaskScheduler to get initial isguaranteed flag for all the tasks. It causes arbitrary delays in sending tasks out. Since communicator is a single thread, any blocking there delays all the tasks.

There is https://jira.apache.org/jira/browse/HIVE-23589 for a proper solution to this. However, that requires a Tez release which seems far right now. We can replace the current hack with another hack that does not require locking.

Change-Id: If08961fcb0e5ea3b2772c619be1a26068afe1327