### PR TITLE
HIVE-23026: Allow for custom YARN application name for TEZ queries (branch-2)

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1500,7 +1500,7 @@ public class HiveConf extends Configuration {
     HIVEQUERYNAME ("hive.query.name", null,
         "This named is used by Tez to set the dag name. This name in turn will appear on \n" +
         "the Tez UI representing the work that was done."),
-    HIVETEZJOBNAME("tez.job.name", null,
+    HIVETEZJOBNAME("tez.job.name", "HIVE-%s",
         "This named is used by Tez to set the job name. This name in turn will appear on \n" +
         "the Yarn UI representing the Yarn Application Name."),
 

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1500,6 +1500,9 @@ public class HiveConf extends Configuration {
     HIVEQUERYNAME ("hive.query.name", null,
         "This named is used by Tez to set the dag name. This name in turn will appear on \n" +
         "the Tez UI representing the work that was done."),
+    HIVETEZJOBNAME("tez.job.name", null,
+        "This named is used by Tez to set the job name. This name in turn will appear on \n" +
+        "the Yarn UI representing the Yarn Application Name."),
 
     HIVEOPTIMIZEBUCKETINGSORTING("hive.optimize.bucketingsorting", true,
         "Don't create a reducer for enforcing \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1502,7 +1502,8 @@ public class HiveConf extends Configuration {
         "the Tez UI representing the work that was done."),
     HIVETEZJOBNAME("tez.job.name", "HIVE-%s",
         "This named is used by Tez to set the job name. This name in turn will appear on \n" +
-        "the Yarn UI representing the Yarn Application Name."),
+        "the Yarn UI representing the Yarn Application Name And The job name may be a \n" +
+        "Java String.format() string, to which the session ID will be supplied as the single parameter."),
 
     HIVEOPTIMIZEBUCKETINGSORTING("hive.optimize.bucketingsorting", true,
         "Don't create a reducer for enforcing \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1502,7 +1502,7 @@ public class HiveConf extends Configuration {
         "the Tez UI representing the work that was done."),
     HIVETEZJOBNAME("tez.job.name", "HIVE-%s",
         "This named is used by Tez to set the job name. This name in turn will appear on \n" +
-        "the Yarn UI representing the Yarn Application Name And The job name may be a \n" +
+        "the Yarn UI representing the Yarn Application Name. And The job name may be a \n" +
         "Java String.format() string, to which the session ID will be supplied as the single parameter."),
 
     HIVEOPTIMIZEBUCKETINGSORTING("hive.optimize.bucketingsorting", true,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -317,8 +317,8 @@ public class TezSessionState {
 
     setupSessionAcls(tezConfig, conf);
 
-    String tezJobName = HiveConf.getVar(conf, ConfVars.HIVETEZJOBNAME, sessionId);
-    final TezClient session = TezClient.newBuilder(String.format("HIVE-%s", tezJobName), tezConfig)
+    String tezJobNameFormat = HiveConf.getVar(conf, ConfVars.HIVETEZJOBNAME);
+    final TezClient session = TezClient.newBuilder(String.format(tezJobNameFormat, sessionId), tezConfig)
         .setIsSession(true).setLocalResources(commonLocalResources)
         .setCredentials(llapCredentials).setServicePluginDescriptor(servicePluginsDescriptor)
         .build();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -317,7 +317,8 @@ public class TezSessionState {
 
     setupSessionAcls(tezConfig, conf);
 
-    final TezClient session = TezClient.newBuilder("HIVE-" + sessionId, tezConfig)
+    String tezJobName = HiveConf.getVar(conf, ConfVars.HIVETEZJOBNAME, sessionId);
+    final TezClient session = TezClient.newBuilder(String.format("HIVE-%s", tezJobName), tezConfig)
         .setIsSession(true).setLocalResources(commonLocalResources)
         .setCredentials(llapCredentials).setServicePluginDescriptor(servicePluginsDescriptor)
         .build();


### PR DESCRIPTION
### What is this PR for?
- add a configuration item to support setting tez job name

### What type of PR is it?
- feature

### What is the Jira issue?
- https://issues.apache.org/jira/browse/HIVE-23026

### How to use?
- We can use 'set tez.job.name=<customized_job_name>;' or '--hiveconf ez.job.name=<customized_job_name>' to use this function to customize Yarn application name when we run a sql. 
- We recommend setting  the 'customized_job_name' to a Java String.format() string that can accept the hive session ID as a single parameter.