### PR TITLE
HIVE-23597: VectorizedOrcAcidRowBatchReader::ColumnizedDeleteEventReg…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -59,6 +59,7 @@ import org.apache.orc.impl.OrcTail;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-23597 has more details on the issue.

HIVE-23597: VectorizedOrcAcidRowBatchReader::ColumnizedDeleteEventRegistry reads delete delta directories multiple times.

Patch reduces the number of times delete delta files needs to be scanned. For delta_x, it need not look at delete delta's which are lesser than its write ids. Also, caching the orcTail of delete delta reduces the lookup & scan cost in cloud storage.

In a small cluster, simple select query took "35-40 seconds" without the patch.  With the patch, it takes "6-7" seconds.
