### PR TITLE
HIVE-23615: Null pointers should not be dereferenced

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -211,7 +211,7 @@ public class Commands {
         return def;
       }
       throw new IllegalArgumentException(beeLine.loc("arg-usage",
-          new Object[] {ret.length == 0 ? "" : ret[0],
+          new Object[] {ret == null || ret.length == 0 ? "" : ret[0],
               paramname}));
     }
     return ret[1];


### PR DESCRIPTION
Beeline: Null pointers should not be dereferenced