### PR TITLE
HIVE-23676: Test to cover wildcard partVals in listPartitionNames

### DIFF
--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -1197,7 +1197,7 @@ public interface IMetaStoreClient {
    * @param tbl_name table name.
    * @param part_vals partial list of partition values.  These must be given in the order of the
    *                  partition keys.  If you wish to accept any value for a particular key you
-   *                  can pass ".*" for that value in this list.
+   *                  can pass empty string "" for that value in this list.
    * @param max_parts maximum number of partition names to return, or -1 to return all that are
    *                  found.
    * @return list of matching partition names.

--- a/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
+++ b/standalone-metastore/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
@@ -1038,6 +1038,31 @@ public class TestListPartitions extends MetaStoreClientTest {
 
   }
 
+  @Test
+  public void testListPartitionNamesByEmptyStringPartVal() throws Exception {
+    Table t = createTestTable(client, DB_NAME, TABLE_NAME, Lists.newArrayList("yyyy", "mm", "dd"), false);
+    List<List<String>> testValuesWithRepeatedDayNumber = Lists.newArrayList(
+            Lists.newArrayList("1999", "01", "02"),
+            Lists.newArrayList("1999", "02", "02"),
+            Lists.newArrayList("1999", "03", "02"),
+            Lists.newArrayList("2009", "02", "10"),
+            Lists.newArrayList("2017", "10", "26"),
+            Lists.newArrayList("2017", "11", "27"));
+
+    for(List<String> vals : testValuesWithRepeatedDayNumber) {
+      addPartition(client, t, vals);
+    }
+
+    List<String> partitionNames = client.listPartitionNames(DB_NAME, TABLE_NAME,
+            Lists.newArrayList("", "", "02"), (short) -1);
+    assertEquals(3, partitionNames.size());
+    assertCorrectPartitionNames(partitionNames, testValuesWithRepeatedDayNumber.subList(0, 3),
+            Lists.newArrayList("yyyy", "mm", "dd"));
+    partitionNames = client.listPartitionNames(DB_NAME, TABLE_NAME,
+            Lists.newArrayList(".*", ".*", "02"), (short) -1);
+    assertEquals(0, partitionNames.size());
+  }
+
   @Test(expected = NoSuchObjectException.class)
   public void testListPartitionNamesNoDbName() throws Exception {
     createTable4PartColsParts(client);


### PR DESCRIPTION
Incorrect documentation for MetaStoreClient method

`List<String> listPartitionNames(String db_name, String tbl_name, List<String> part_vals, short max_parts)`
Saying `If you wish to accept any value for a particular key you can pass ".*" for that value in this list`

Any value wildcard behaviour is achieved with empty string `""`. Documentation have been changed and test added to reflect this.