### PR TITLE
HIVE-23689: Bump Tez version to 0.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <ST4.version>4.0.4</ST4.version>
     <storage-api.version>2.7.0-SNAPSHOT</storage-api.version>
-    <tez.version>0.9.1</tez.version>
+    <tez.version>0.9.2</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <spark.version>2.4.5</spark.version>
     <scala.binary.version>2.12</scala.binary.version>


### PR DESCRIPTION
Update the Tez version to 0.9.2

Local unit tests completed successfully.
