### PR TITLE
HIVE-23698: Filter PPD for probe-decode

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapRecordReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapRecordReader.java
@@ -203,7 +203,7 @@ class LlapRecordReader implements RecordReader<NullWritable, VectorizedRowBatch>
     this.probeDecodeEnabled = HiveConf.getBoolVar(jobConf, ConfVars.HIVE_OPTIMIZE_SCAN_PROBEDECODE);
     if (this.probeDecodeEnabled) {
       includes.setProbeDecodeContext(mapWork.getProbeDecodeContext());
-      LOG.info("LlapRecordReader ProbeDecode is enabled");
+      LOG.info("LlapRecordReader ProbeDecode is enabled {} ", mapWork.getProbeDecodeContext());
     }
 
     // Create the consumer of encoded data; it will coordinate decoding to CVBs.

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/OrcEncodedDataConsumer.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/OrcEncodedDataConsumer.java
@@ -81,8 +81,7 @@ public class OrcEncodedDataConsumer
     super(consumer, includes.getPhysicalColumnIds().size(), ioMetrics, counters);
     this.includes = includes;
     if (includes.isProbeDecodeEnabled()) {
-      LlapIoImpl.LOG.info("OrcEncodedDataConsumer probeDecode is enabled with cacheKey {} colIndex {} and colName {}",
-              this.includes.getProbeCacheKey(), this.includes.getProbeColIdx(), this.includes.getProbeColName());
+      LlapIoImpl.LOG.info("OrcEncodedDataConsumer probeDecode is enabled");
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -135,9 +135,9 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
 
     @Override
     public String toString() {
-      return "dynFilter {CKey:" + mjSmallTableCacheKey + ", bigTColName:" + mjBigTableKeyColName +
+      return "dynFilter={CKey:" + mjSmallTableCacheKey + ", bigTColName:" + mjBigTableKeyColName +
           ", smallTPos:" + mjSmallTablePos + ", KRatio:" + keyRatio +
-           "}, staticFilter {Expr: " + staticFilterExpr + "}";
+           "}, staticFilter={Expr: " + staticFilterExpr + "}";
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -21,10 +21,8 @@ package org.apache.hadoop.hive.ql.exec;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -38,6 +36,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizationContextRegion;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
@@ -93,10 +92,14 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
    */
   public static class ProbeDecodeContext {
 
-    private final String mjSmallTableCacheKey;
-    private final String mjBigTableKeyColName;
-    private final byte mjSmallTablePos;
-    private final double keyRatio;
+    private String mjSmallTableCacheKey;
+    private String mjBigTableKeyColName;
+    private byte mjSmallTablePos;
+    private double keyRatio;
+
+    private ExprNodeDesc staticFilterExpr;
+
+    public  ProbeDecodeContext() { }
 
     public ProbeDecodeContext(String mjSmallTableCacheKey, byte mjSmallTablePos, String mjBigTableKeyColName,
         double keyRatio) {
@@ -104,6 +107,14 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
       this.mjSmallTablePos = mjSmallTablePos;
       this.mjBigTableKeyColName = mjBigTableKeyColName;
       this.keyRatio = keyRatio;
+    }
+
+    public ExprNodeDesc getStaticFilterExpr() {
+      return staticFilterExpr;
+    }
+
+    public void setStaticFilterExpr(ExprNodeDesc staticFilterExpr) {
+      this.staticFilterExpr = staticFilterExpr;
     }
 
     public String getMjSmallTableCacheKey() {
@@ -125,7 +136,8 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
     @Override
     public String toString() {
       return "cacheKey:" + mjSmallTableCacheKey + ", bigKeyColName:" + mjBigTableKeyColName +
-          ", smallTablePos:" + mjSmallTablePos + ", keyRatio:" + keyRatio;
+          ", smallTablePos:" + mjSmallTablePos + ", keyRatio:" + keyRatio  + "\n" +
+           ", staticFilterExpr: " + staticFilterExpr;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -136,7 +136,7 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
     @Override
     public String toString() {
       return "cacheKey:" + mjSmallTableCacheKey + ", bigKeyColName:" + mjBigTableKeyColName +
-          ", smallTablePos:" + mjSmallTablePos + ", keyRatio:" + keyRatio  + "\n" +
+          ", smallTablePos:" + mjSmallTablePos + ", keyRatio:" + keyRatio +
            ", staticFilterExpr: " + staticFilterExpr;
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/TableScanOperator.java
@@ -135,9 +135,9 @@ public class TableScanOperator extends Operator<TableScanDesc> implements
 
     @Override
     public String toString() {
-      return "cacheKey:" + mjSmallTableCacheKey + ", bigKeyColName:" + mjBigTableKeyColName +
-          ", smallTablePos:" + mjSmallTablePos + ", keyRatio:" + keyRatio +
-           ", staticFilterExpr: " + staticFilterExpr;
+      return "dynFilter {CKey:" + mjSmallTableCacheKey + ", bigTColName:" + mjBigTableKeyColName +
+          ", smallTPos:" + mjSmallTablePos + ", KRatio:" + keyRatio +
+           "}, staticFilter {Expr: " + staticFilterExpr + "}";
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ColumnPrunerProcFactory.java
@@ -495,6 +495,14 @@ public final class ColumnPrunerProcFactory {
 
       cppCtx.getPrunedColLists().put((Operator<? extends OperatorDesc>) nd, cols);
       RowSchema inputRS = scanOp.getSchema();
+      // TODO [PANOS] is this the best way to do it?
+      if (cols != null && scanOp.getProbeDecodeContext() != null &&
+              scanOp.getProbeDecodeContext().getStaticFilterExpr() != null) {
+        for (String colName: scanOp.getProbeDecodeContext().getStaticFilterExpr().getCols()) {
+          if (!cols.contains(colName))
+            cols.add( new FieldNode(colName));
+        }
+      }
       setupNeededColumns(scanOp, inputRS, cols);
 
       return null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -1516,6 +1516,10 @@ public class TezCompiler extends TaskCompiler {
           LOG.debug("ProbeDecode MJ for TS {}  with CacheKey {} MJ Pos {} ColName {} with Ratio {}",
               probeTsMap.getKey().getName(), tsCntx.getMjSmallTableCacheKey(), tsCntx.getMjSmallTablePos(),
               tsCntx.getMjBigTableKeyColName(), tsCntx.getKeyRatio());
+          // FilterPPD already pushed a staticPred we can utilize
+          if (probeTsMap.getKey().getProbeDecodeContext() != null) {
+            tsCntx.setStaticFilterExpr(probeTsMap.getKey().getProbeDecodeContext().getStaticFilterExpr());
+          }
           probeTsMap.getKey().setProbeDecodeContext(tsCntx);
           probeTsMap.getKey().getConf().setProbeDecodeContext(tsCntx);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hive.ql.exec.RowSchema;
 import org.apache.hadoop.hive.ql.exec.SelectOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.lib.SemanticNodeProcessor;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
@@ -785,7 +786,7 @@ public final class OpProcFactory {
           exprs.addAll(finalCandidates);
         }
       }
-      
+
       if (!nonFinalCandidates.isEmpty()) {
         createFilter((Operator) nd, nonFinalCandidates, owi);
       }
@@ -1006,9 +1007,10 @@ public final class OpProcFactory {
       HiveConf hiveConf = owi.getParseContext().getConf();
       pushFilterToStorage =
         hiveConf.getBoolVar(HiveConf.ConfVars.HIVEOPTPPD_STORAGE);
+      TableScanOperator tsOp = (TableScanOperator) op;
       if (pushFilterToStorage) {
         condn = pushFilterToStorageHandler(
-          (TableScanOperator) op,
+          tsOp,
           (ExprNodeGenericFuncDesc)condn,
           owi,
           hiveConf);
@@ -1016,6 +1018,18 @@ public final class OpProcFactory {
           // we pushed the whole thing down
           return null;
         }
+      }
+
+      // TODO [PANOS] maybe have static PPD vs MJ filter in different conf?
+      if (hiveConf.getBoolVar(HiveConf.ConfVars.HIVE_OPTIMIZE_SCAN_PROBEDECODE)
+              && OrcInputFormat.class.isAssignableFrom(tsOp.getConf().getTableMetadata().getInputFormatClass())) {
+        if (tsOp.getProbeDecodeContext() == null) {
+          tsOp.setProbeDecodeContext(new TableScanOperator.ProbeDecodeContext());
+        }
+        tsOp.getProbeDecodeContext().setStaticFilterExpr(condn);
+        LOG.info("ProbeDecode pushing RowFiler {}", condn);
+        // Whole filter can be applied so FilterOp can be removed.
+        return null;
       }
     }
 

--- a/ql/src/test/queries/clientpositive/probedecode_mapjoin_simple.q
+++ b/ql/src/test/queries/clientpositive/probedecode_mapjoin_simple.q
@@ -25,7 +25,7 @@ INSERT INTO orders_fact values(67891, 110, '2006-06-30 00:00:00');
 
 SET hive.optimize.scan.probedecode=true;
 
-EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1);
+EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100;
 
 -- two keys match, the remaining rows can be skipped
-select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1);
+select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100;

--- a/ql/src/test/queries/clientpositive/probedecode_static_simple.q
+++ b/ql/src/test/queries/clientpositive/probedecode_static_simple.q
@@ -1,0 +1,43 @@
+-- Simple static filter attempt
+SET hive.stats.column.autogather=true;
+SET hive.vectorized.execution.enabled=true;
+SET hive.explain.user=false;
+
+SET hive.optimize.scan.probedecode=true;
+
+DROP TABLE IF EXISTS orders;
+DROP TABLE IF EXISTS orders_all;
+--
+dfs -mkdir ${system:test.tmp.dir}/orc_split;
+dfs -cp /Users/panosgarefalakis/IdeaProjects/hive/data/files/orc_split_compressed ${system:test.tmp.dir}/orc_split/;
+--
+CREATE TABLE orders (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp) stored as orc;
+--
+CREATE EXTERNAL TABLE orders_all (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp)
+stored as orc
+LOCATION '${system:test.tmp.dir}/orc_split';
+
+FROM orders_all ss
+INSERT OVERWRITE TABLE orders
+SELECT *;
+--
+-- -- Distinct keys -> Cardinality (25k rows)
+-- -- 5 -> 1
+-- -- 13 -> 1
+-- -- 29 -> 1
+-- -- 2 -> 1
+-- -- 70 -> 1
+-- -- 100 -> 24995
+--
+-- set hive.exec.post.hooks=org.apache.hadoop.hive.ql.hooks.PostExecTezSummaryPrinter;
+
+EXPLAIN VECTORIZATION DETAIL
+SELECT * from orders where orders.key2 <> 100;
+-- 
+EXPLAIN VECTORIZATION DETAIL SELECT key2, doubleval, stringval, tsval
+FROM orders
+WHERE key2 + 1 <> bround(101.1);
+--
+EXPLAIN VECTORIZATION SELECT SUM(key2 * doubleval)
+FROM orders
+WHERE key2 <> 100;

--- a/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_simple.q.out
@@ -131,7 +131,7 @@ STAGE PLANS:
                 TableScan
                   alias: orders_fact
                   filterExpr: ((nokey <> 100) and key2 is not null) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:_col0, smallTablePos:1, keyRatio:1.0, staticFilterExpr: GenericUDFOPAnd(GenericUDFOPNotEqual(Column[nokey], Const int 100), GenericUDFOPNotNull(Column[key2]))
+                  probeDecodeDetails: dynFilter={CKey:HASH_MAP_MAPJOIN_25_container, bigTColName:_col0, smallTPos:1, KRatio:1.0}, staticFilter={Expr: GenericUDFOPAnd(GenericUDFOPNotEqual(Column[nokey], Const int 100), GenericUDFOPNotNull(Column[key2]))}
                   Statistics: Num rows: 6 Data size: 336 Basic stats: COMPLETE Column stats: NONE
                   TableScan Vectorization:
                       native: true
@@ -212,7 +212,7 @@ STAGE PLANS:
                 TableScan
                   alias: item_dim
                   filterExpr: key1 is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotNull(Column[key1])
+                  probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotNull(Column[key1])}
                   Statistics: Num rows: 2 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                   TableScan Vectorization:
                       native: true

--- a/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_simple.q.out
@@ -100,12 +100,12 @@ POSTHOOK: Output: default@orders_fact
 POSTHOOK: Lineage: orders_fact.dt SCRIPT []
 POSTHOOK: Lineage: orders_fact.key2 SCRIPT []
 POSTHOOK: Lineage: orders_fact.nokey SCRIPT []
-PREHOOK: query: EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1)
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100
 PREHOOK: type: QUERY
 PREHOOK: Input: default@item_dim
 PREHOOK: Input: default@orders_fact
 #### A masked pattern was here ####
-POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1)
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@item_dim
 POSTHOOK: Input: default@orders_fact
@@ -130,9 +130,9 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: orders_fact
-                  filterExpr: key2 is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:_col0, smallTablePos:1, keyRatio:1.0
-                  Statistics: Num rows: 6 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                  filterExpr: ((nokey <> 100) and key2 is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:_col0, smallTablePos:1, keyRatio:1.0, staticFilterExpr: GenericUDFOPAnd(GenericUDFOPNotEqual(Column[nokey], Const int 100), GenericUDFOPNotNull(Column[key2]))
+                  Statistics: Num rows: 6 Data size: 336 Basic stats: COMPLETE Column stats: NONE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:nokey:int, 1:key2:int, 2:dt:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
@@ -140,9 +140,9 @@ STAGE PLANS:
                     Filter Vectorization:
                         className: VectorFilterOperator
                         native: true
-                        predicateExpression: SelectColumnIsNotNull(col 1:int)
-                    predicate: key2 is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                        predicateExpression: FilterExprAndExpr(children: FilterLongColNotEqualLongScalar(col 0:int, val 100), SelectColumnIsNotNull(col 1:int))
+                    predicate: ((nokey <> 100) and key2 is not null) (type: boolean)
+                    Statistics: Num rows: 6 Data size: 336 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: key2 (type: int), dt (type: timestamp)
                       outputColumnNames: _col0, _col1
@@ -150,7 +150,7 @@ STAGE PLANS:
                           className: VectorSelectOperator
                           native: true
                           projectedOutputColumnNums: [1, 2]
-                      Statistics: Num rows: 6 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 6 Data size: 336 Basic stats: COMPLETE Column stats: NONE
                       Map Join Operator
                         condition map:
                              Inner Join 0 to 1
@@ -171,7 +171,7 @@ STAGE PLANS:
                         outputColumnNames: _col0, _col1, _col2, _col3
                         input vertices:
                           1 Map 2
-                        Statistics: Num rows: 6 Data size: 290 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 6 Data size: 369 Basic stats: COMPLETE Column stats: NONE
                         Select Operator
                           expressions: _col2 (type: int), _col0 (type: int), _col3 (type: string), _col1 (type: timestamp)
                           outputColumnNames: _col0, _col1, _col2, _col3
@@ -179,13 +179,13 @@ STAGE PLANS:
                               className: VectorSelectOperator
                               native: true
                               projectedOutputColumnNums: [1, 1, 4, 2]
-                          Statistics: Num rows: 6 Data size: 290 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 6 Data size: 369 Basic stats: COMPLETE Column stats: NONE
                           File Output Operator
                             compressed: false
                             File Sink Vectorization:
                                 className: VectorFileSinkOperator
                                 native: false
-                            Statistics: Num rows: 6 Data size: 290 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 6 Data size: 369 Basic stats: COMPLETE Column stats: NONE
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -203,7 +203,7 @@ STAGE PLANS:
                 vectorized: true
                 rowBatchContext:
                     dataColumnCount: 3
-                    includeColumns: [1, 2]
+                    includeColumns: [0, 1, 2]
                     dataColumns: nokey:int, key2:int, dt:timestamp
                     partitionColumnCount: 0
                     scratchColumnTypeNames: [string]
@@ -212,7 +212,8 @@ STAGE PLANS:
                 TableScan
                   alias: item_dim
                   filterExpr: key1 is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: NONE
+                  probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotNull(Column[key1])
+                  Statistics: Num rows: 2 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:key1:int, 1:name:string, 2:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
@@ -222,7 +223,7 @@ STAGE PLANS:
                         native: true
                         predicateExpression: SelectColumnIsNotNull(col 0:int)
                     predicate: key1 is not null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 2 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: key1 (type: int), name (type: string)
                       outputColumnNames: _col0, _col1
@@ -230,7 +231,7 @@ STAGE PLANS:
                           className: VectorSelectOperator
                           native: true
                           projectedOutputColumnNums: [0, 1]
-                      Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 2 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
@@ -242,7 +243,7 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             valueColumns: 1:string
-                        Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 2 Data size: 384 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -268,12 +269,12 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-PREHOOK: query: select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1)
+PREHOOK: query: select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100
 PREHOOK: type: QUERY
 PREHOOK: Input: default@item_dim
 PREHOOK: Input: default@orders_fact
 #### A masked pattern was here ####
-POSTHOOK: query: select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1)
+POSTHOOK: query: select key1, key2, name, dt from orders_fact join item_dim on (orders_fact.key2 = item_dim.key1) where orders_fact.nokey <> 100
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@item_dim
 POSTHOOK: Input: default@orders_fact

--- a/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_stats.q.out
@@ -191,8 +191,8 @@ STAGE PLANS:
                 TableScan
                   alias: orders_fact
                   filterExpr: (key2 is not null and key3 is not null) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_46_container, bigKeyColName:_col0, smallTablePos:1, keyRatio:0.16666666666666666
-                  Statistics: Num rows: 6 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                  probeDecodeDetails: dynFilter={CKey:HASH_MAP_MAPJOIN_46_container, bigTColName:_col0, smallTPos:1, KRatio:0.16666666666666666}, staticFilter={Expr: GenericUDFOPAnd(GenericUDFOPNotNull(Column[key2]), GenericUDFOPNotNull(Column[key3]))}
+                  Statistics: Num rows: 6 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:key3:int, 1:key2:int, 2:dt:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
@@ -293,7 +293,8 @@ STAGE PLANS:
                 TableScan
                   alias: item_dim
                   filterExpr: key1 is not null (type: boolean)
-                  Statistics: Num rows: 5 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                  probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotNull(Column[key1])}
+                  Statistics: Num rows: 5 Data size: 500 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:key1:int, 1:name:string, 2:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
@@ -347,7 +348,8 @@ STAGE PLANS:
                 TableScan
                   alias: seller_dim
                   filterExpr: key4 is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotNull(Column[key4])}
+                  Statistics: Num rows: 2 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:key4:int, 1:sellername:string, 2:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]

--- a/ql/src/test/results/clientpositive/llap/probedecode_static_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_static_simple.q.out
@@ -70,7 +70,7 @@ STAGE PLANS:
         TableScan
           alias: orders
           filterExpr: (key2 <> 100) (type: boolean)
-          probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(Column[key2], Const int 100)
+          probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotEqual(Column[key2], Const int 100)}
           Select Operator
             expressions: key2 (type: int), stringval (type: string), doubleval (type: double), decival (type: decimal(38,0)), tsval (type: timestamp)
             outputColumnNames: _col0, _col1, _col2, _col3, _col4
@@ -103,7 +103,7 @@ STAGE PLANS:
         TableScan
           alias: orders
           filterExpr: (CAST( (key2 + 1) AS decimal(10,0)) <> 101) (type: boolean)
-          probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(GenericUDFToDecimal(GenericUDFOPPlus(Column[key2], Const int 1)), Const decimal(3,0) 101)
+          probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotEqual(GenericUDFToDecimal(GenericUDFOPPlus(Column[key2], Const int 1)), Const decimal(3,0) 101)}
           Select Operator
             expressions: key2 (type: int), doubleval (type: double), stringval (type: string), tsval (type: timestamp)
             outputColumnNames: _col0, _col1, _col2, _col3
@@ -142,7 +142,7 @@ STAGE PLANS:
                 TableScan
                   alias: orders
                   filterExpr: (key2 <> 100) (type: boolean)
-                  probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(Column[key2], Const int 100)
+                  probeDecodeDetails: dynFilter={CKey:null, bigTColName:null, smallTPos:0, KRatio:0.0}, staticFilter={Expr: GenericUDFOPNotEqual(Column[key2], Const int 100)}
                   Statistics: Num rows: 25000 Data size: 400000 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: (UDFToDouble(key2) * doubleval) (type: double)

--- a/ql/src/test/results/clientpositive/llap/probedecode_static_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_static_simple.q.out
@@ -1,0 +1,200 @@
+PREHOOK: query: DROP TABLE IF EXISTS orders
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS orders
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: DROP TABLE IF EXISTS orders_all
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS orders_all
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE orders (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orders
+POSTHOOK: query: CREATE TABLE orders (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orders
+PREHOOK: query: CREATE EXTERNAL TABLE orders_all (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp)
+stored as orc
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@orders_all
+POSTHOOK: query: CREATE EXTERNAL TABLE orders_all (key2 int, stringval string, doubleval double, decival decimal(38,0), tsval timestamp)
+stored as orc
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@orders_all
+PREHOOK: query: FROM orders_all ss
+INSERT OVERWRITE TABLE orders
+SELECT *
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orders_all
+PREHOOK: Output: default@orders
+POSTHOOK: query: FROM orders_all ss
+INSERT OVERWRITE TABLE orders
+SELECT *
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orders_all
+POSTHOOK: Output: default@orders
+POSTHOOK: Lineage: orders.decival SIMPLE [(orders_all)ss.FieldSchema(name:decival, type:decimal(38,0), comment:null), ]
+POSTHOOK: Lineage: orders.doubleval SIMPLE [(orders_all)ss.FieldSchema(name:doubleval, type:double, comment:null), ]
+POSTHOOK: Lineage: orders.key2 SIMPLE [(orders_all)ss.FieldSchema(name:key2, type:int, comment:null), ]
+POSTHOOK: Lineage: orders.stringval SIMPLE [(orders_all)ss.FieldSchema(name:stringval, type:string, comment:null), ]
+POSTHOOK: Lineage: orders.tsval SIMPLE [(orders_all)ss.FieldSchema(name:tsval, type:timestamp, comment:null), ]
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL
+SELECT * from orders where orders.key2 <> 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orders
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL
+SELECT * from orders where orders.key2 <> 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orders
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: orders
+          filterExpr: (key2 <> 100) (type: boolean)
+          probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(Column[key2], Const int 100)
+          Select Operator
+            expressions: key2 (type: int), stringval (type: string), doubleval (type: double), decival (type: decimal(38,0)), tsval (type: timestamp)
+            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+            ListSink
+
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT key2, doubleval, stringval, tsval
+FROM orders
+WHERE key2 + 1 <> bround(101.1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orders
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT key2, doubleval, stringval, tsval
+FROM orders
+WHERE key2 + 1 <> bround(101.1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orders
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: orders
+          filterExpr: (CAST( (key2 + 1) AS decimal(10,0)) <> 101) (type: boolean)
+          probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(GenericUDFToDecimal(GenericUDFOPPlus(Column[key2], Const int 1)), Const decimal(3,0) 101)
+          Select Operator
+            expressions: key2 (type: int), doubleval (type: double), stringval (type: string), tsval (type: timestamp)
+            outputColumnNames: _col0, _col1, _col2, _col3
+            ListSink
+
+PREHOOK: query: EXPLAIN VECTORIZATION SELECT SUM(key2 * doubleval)
+FROM orders
+WHERE key2 <> 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@orders
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION SELECT SUM(key2 * doubleval)
+FROM orders
+WHERE key2 <> 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@orders
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: orders
+                  filterExpr: (key2 <> 100) (type: boolean)
+                  probeDecodeDetails: cacheKey:null, bigKeyColName:null, smallTablePos:0, keyRatio:0.0, staticFilterExpr: GenericUDFOPNotEqual(Column[key2], Const int 100)
+                  Statistics: Num rows: 25000 Data size: 400000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: (UDFToDouble(key2) * doubleval) (type: double)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 25000 Data size: 400000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(_col0)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+


### PR DESCRIPTION
Similar to what we currently do for StorageHandlers, we pushdown expression for row-level filtering when the file-format supports the feature (ORC).

As we can support any type of filterExpr, the operator is then removed for the pipeline.
To make sure the filter columns are not prunned, they are then added to needed columns (as part of ColumnPrunerTableScanProc).

Change-Id: Ia36920b44d83ce932b2020ba9fdd30a0366a8cd8

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HIVE-XXXXX: Fix a typo in YYY)
For more details, please see https://cwiki.apache.org/confluence/display/Hive/HowToContribute
