### PR TITLE
Fixing empty count result for parquet files with nested schema

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ProjectionPusher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ProjectionPusher.java
@@ -17,8 +17,9 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -83,7 +84,7 @@ public class ProjectionPusher {
       return;
     }
 
-    final Set<String> aliases = new HashSet<String>();
+    final Set<String> aliases = new LinkedHashSet<String>();
     try {
       List<String> a = HiveFileFormatUtils.getFromPathRecursively(
           mapWork.getPathToAliases(), new Path(splitPath), null, false, true);
@@ -101,10 +102,10 @@ public class ProjectionPusher {
     // expression for the table.
     boolean allColumnsNeeded = false;
     boolean noFilters = false;
-    Set<Integer> neededColumnIDs = new HashSet<Integer>();
+    Set<Integer> neededColumnIDs = new LinkedHashSet<Integer>();
     // To support nested column pruning, we need to track the path from the top to the nested
     // fields
-    Set<String> neededNestedColumnPaths = new HashSet<String>();
+    Set<String> neededNestedColumnPaths = new LinkedHashSet<String>();
     List<ExprNodeGenericFuncDesc> filterExprs = new ArrayList<ExprNodeGenericFuncDesc>();
     RowSchema rowSchema = null;
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hive.serde2;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -196,7 +196,7 @@ public final class ColumnProjectionUtils {
   public static Set<String> getNestedColumnPaths(Configuration conf) {
     String skips =
       conf.get(READ_NESTED_COLUMN_PATH_CONF_STR, READ_NESTED_COLUMN_PATH_CONF_STR_DEFAULT);
-    return new HashSet<>(Arrays.asList(StringUtils.split(skips)));
+    return new LinkedHashSet<>(Arrays.asList(StringUtils.split(skips)));
   }
 
   public static String[] getReadColumnNames(Configuration conf) {


### PR DESCRIPTION
This PR fixes the bug HIVE-21709 -- https://issues.apache.org/jira/browse/HIVE-21709

Due to column order mismatch, Hive fails to parse parquet file with nested schema. The reason for the mismatch happens in these two files because using HashSet changes the order of the columns from the actual table definition. As a result we read wrong values for the wrong columns leading to the bug