### PR TITLE
HIVE-23700: HiveConf static initialization fails when JAR URI is opaque

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -173,7 +173,16 @@ public class HiveConf extends Configuration {
             }
             System.err.println("Cannot get jar URI: " + e.getMessage());
           }
-          result = checkConfigFile(new File(new File(jarUri).getParentFile(), nameInConf));
+          if (jarUri != null) {
+            try {
+              result = checkConfigFile(new File(new File(jarUri).getParentFile(), nameInConf));
+            } catch (IllegalArgumentException e) {
+              if (l4j.isInfoEnabled()) {
+                l4j.info("Cannot get File from jar URI " + jarUri, e);
+              }
+              System.err.println("Cannot get File from jar URI " + jarUri + ": " + e.getMessage());
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
Handle IllegalArgumentExceptions thrown by the File constructor when the
jar URI is not supported. This fixes the static initialization of the
HiveConf class when four conditions are met:

1. hive-site.xml is not present in the classpath
2. hive-site.xml is not present on the "HIVE_CONF_DIR" directory
3. hive-site.xml is not present on the "HIVE_HOME" directory
4. jar URI is not absolute, or is opaque, or URI scheme is null or not
   file, uri authority is not null, uri fragment is not null, uri query
   is not null and finally uri path is empty.
