### PR TITLE
HIVE-23700: HiveConf static initialization fails when JAR URI is opaque

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -176,7 +176,15 @@ public class HiveConf extends Configuration {
             System.err.println("Cannot get jar URI: " + e.getMessage());
           }
           // From the jar file, the parent is /lib folder
-          File parent = new File(jarUri).getParentFile();
+          File parent = null;
+          if (jarUri != null) {
+            try {
+              parent = new File(jarUri).getParentFile();
+            } catch (IllegalArgumentException e) {
+              LOG.info("Cannot get File from jar URI " + jarUri, e);
+              System.err.println("Cannot get File from jar URI " + jarUri + ": " + e.getMessage());
+            }
+          }
           if (parent != null) {
             result = checkConfigFile(new File(parent.getParentFile(), nameInConf));
           }


### PR DESCRIPTION
Handle IllegalArgumentExceptions thrown by the File constructor when the
jar URI is not supported. This fixes the static initialization of the
HiveConf class when four conditions are met:

1. hive-site.xml is not present on the classpath
2. hive-site.xml is not present on the "HIVE_CONF_DIR" directory
3. hive-site.xml is not present on the "HIVE_HOME" directory
4. jar URI is not absolute, or is opaque, or URI scheme is null or not
   file, uri authority is not null, uri fragment is not null, uri query
   is not null and finally uri path is empty.