### PR TITLE
HIVE-23619: Add new reexecute plugin to rerun queries in case AM is down due to lost node

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4983,10 +4983,11 @@ public class HiveConf extends Configuration {
 
     HIVE_QUERY_REEXECUTION_ENABLED("hive.query.reexecution.enabled", true,
         "Enable query reexecutions"),
-    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize",
+    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize,reexecutelostam",
         "comma separated list of plugin can be used:\n"
             + "  overlay: hiveconf subtree 'reexec.overlay' is used as an overlay in case of an execution errors out\n"
-            + "  reoptimize: collects operator statistics during execution and recompile the query after a failure"),
+            + "  reoptimize: collects operator statistics during execution and recompile the query after a failure\n"
+            + "  reexecutelostam: reexecutes query if it failed due to tez am node gets decommissioned"),
     HIVE_QUERY_REEXECUTION_STATS_PERSISTENCE("hive.query.reexecution.stats.persist.scope", "metastore",
         new StringSet("query", "hiveserver", "metastore"),
         "Sets the persistence scope of runtime statistics\n"

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4983,11 +4983,11 @@ public class HiveConf extends Configuration {
 
     HIVE_QUERY_REEXECUTION_ENABLED("hive.query.reexecution.enabled", true,
         "Enable query reexecutions"),
-    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize,reexecutelostam",
+    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize,reexecute_lost_am",
         "comma separated list of plugin can be used:\n"
             + "  overlay: hiveconf subtree 'reexec.overlay' is used as an overlay in case of an execution errors out\n"
             + "  reoptimize: collects operator statistics during execution and recompile the query after a failure\n"
-            + "  reexecutelostam: reexecutes query if it failed due to tez am node gets decommissioned"),
+            + "  reexecute_lost_am: reexecutes query if it failed due to tez am node gets decommissioned"),
     HIVE_QUERY_REEXECUTION_STATS_PERSISTENCE("hive.query.reexecution.stats.persist.scope", "metastore",
         new StringSet("query", "hiveserver", "metastore"),
         "Sets the persistence scope of runtime statistics\n"

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
@@ -75,7 +75,7 @@ public class TestReExecuteKilledTezAMQueryPlugin {
     public static void beforeTest() throws Exception {
         conf = defaultConf();
         conf.setVar(HiveConf.ConfVars.USERS_IN_ADMIN_ROLE, System.getProperty("user.name"));
-        conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecutelostam");
+        conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecute_lost_am");
         MiniHS2.cleanupLocalDir();
         Class.forName(MiniHS2.getJdbcDriverName());
         miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
@@ -39,7 +39,9 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 public class TestReExecuteKilledTezAMQueryPlugin {
@@ -71,10 +73,14 @@ public class TestReExecuteKilledTezAMQueryPlugin {
         conf.setVar(HiveConf.ConfVars.USERS_IN_ADMIN_ROLE, System.getProperty("user.name"));
         conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecutelostam");
         MiniHS2.cleanupLocalDir();
-        miniHS2 = BaseJdbcWithMiniLlap.beforeTest(conf);
+        Class.forName(MiniHS2.getJdbcDriverName());
+        miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
         dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
+        Map<String, String> confOverlay = new HashMap<String, String>();
+        miniHS2.start(confOverlay);
+        miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
-        Connection conDefault = BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(),
+        Connection conDefault = getConnection(miniHS2.getJdbcURL(),
                 System.getProperty("user.name"), "bar");
         Statement stmt = conDefault.createStatement();
         String tblName = testDbName + "." + tableName;

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
@@ -20,12 +20,9 @@ package org.apache.hadoop.hive.ql.reexec;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.llap.LlapBaseInputFormat;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
 import org.apache.hadoop.yarn.client.api.YarnClient;
-import org.apache.hive.jdbc.BaseJdbcWithMiniLlap;
 import org.apache.hive.jdbc.HiveStatement;
 import org.apache.hive.jdbc.TestJdbcWithMiniLlapArrow;
 import org.apache.hive.jdbc.miniHS2.MiniHS2;
@@ -43,165 +40,156 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-
 public class TestReExecuteKilledTezAMQueryPlugin {
-    protected static final Logger LOG = LoggerFactory.getLogger(TestJdbcWithMiniLlapArrow.class);
+  protected static final Logger LOG = LoggerFactory.getLogger(TestReExecuteKilledTezAMQueryPlugin.class);
 
-    private static MiniHS2 miniHS2 = null;
-    private static final String tableName = "testKillTezAmTbl";
-    private static String dataFileDir;
-    private static final String testDbName = "testKillTezAmDb";
-    protected static Connection hs2Conn = null;
-    private static HiveConf conf;
+  private static MiniHS2 miniHS2 = null;
+  private static final String tableName = "testKillTezAmTbl";
+  private static String dataFileDir;
+  private static final String testDbName = "testKillTezAmDb";
+  protected static Connection hs2Conn = null;
+  private static HiveConf conf;
 
-    private static class ExceptionHolder {
-        Throwable throwable;
+  private static class ExceptionHolder {
+    Throwable throwable;
+  }
+
+  static HiveConf defaultConf() throws Exception {
+    String confDir = "../../data/conf/llap/";
+    if (confDir != null && !confDir.isEmpty()) {
+      HiveConf.setHiveSiteLocation(new URL("file://"+ new File(confDir).toURI().getPath() + "/hive-site.xml"));
+      System.out.println("Setting hive-site: " + HiveConf.getHiveSiteLocation());
     }
+    HiveConf defaultConf = new HiveConf();
+    defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+    defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
+    defaultConf.addResource(new URL("file://" + new File(confDir).toURI().getPath() + "/tez-site.xml"));
+    return defaultConf;
+  }
 
-    static HiveConf defaultConf() throws Exception {
-        String confDir = "../../data/conf/llap/";
-        if (confDir != null && !confDir.isEmpty()) {
-            HiveConf.setHiveSiteLocation(new URL("file://"+ new File(confDir).toURI().getPath() + "/hive-site.xml"));
-            System.out.println("Setting hive-site: " + HiveConf.getHiveSiteLocation());
-        }
-        HiveConf defaultConf = new HiveConf();
-        defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
-        defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
-        defaultConf.addResource(new URL("file://" + new File(confDir).toURI().getPath() + "/tez-site.xml"));
-        return defaultConf;
-    }
-
-    @BeforeClass
+  @BeforeClass
     public static void beforeTest() throws Exception {
-        conf = defaultConf();
-        conf.setVar(HiveConf.ConfVars.USERS_IN_ADMIN_ROLE, System.getProperty("user.name"));
-        conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecute_lost_am");
-        MiniHS2.cleanupLocalDir();
-        Class.forName(MiniHS2.getJdbcDriverName());
-        miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
-        dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
-        Map<String, String> confOverlay = new HashMap<String, String>();
-        miniHS2.start(confOverlay);
-        miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
+      conf = defaultConf();
+      conf.setVar(HiveConf.ConfVars.USERS_IN_ADMIN_ROLE, System.getProperty("user.name"));
+      conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecute_lost_am");
+      MiniHS2.cleanupLocalDir();
+      Class.forName(MiniHS2.getJdbcDriverName());
+      miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.LLAP);
+      dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
+      Map<String, String> confOverlay = new HashMap<String, String>();
+      miniHS2.start(confOverlay);
+      miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));
 
-        Connection conDefault = getConnection(miniHS2.getJdbcURL(),
-                System.getProperty("user.name"), "bar");
-        Statement stmt = conDefault.createStatement();
-        String tblName = testDbName + "." + tableName;
-        Path dataFilePath = new Path(dataFileDir, "kv1.txt");
-        String udfName = TestJdbcWithMiniLlapArrow.SleepMsUDF.class.getName();
-        stmt.execute("drop database if exists " + testDbName + " cascade");
-        stmt.execute("create database " + testDbName);
-        stmt.execute("set role admin");
-        stmt.execute("dfs -put " + dataFilePath.toString() + " " + "kv1.txt");
-        stmt.execute("use " + testDbName);
-        stmt.execute("create table " + tblName + " (int_col int, value string) ");
-        stmt.execute("load data inpath 'kv1.txt' into table " + tblName);
-        stmt.execute("create function sleepMsUDF as '" + udfName + "'");
-        stmt.execute("grant select on table " + tblName + " to role public");
+      Connection conDefault = getConnection(miniHS2.getJdbcURL(),
+      System.getProperty("user.name"), "bar");
+      Statement stmt = conDefault.createStatement();
+      String tblName = testDbName + "." + tableName;
+      Path dataFilePath = new Path(dataFileDir, "kv1.txt");
+      String udfName = TestJdbcWithMiniLlapArrow.SleepMsUDF.class.getName();
+      stmt.execute("drop database if exists " + testDbName + " cascade");
+      stmt.execute("create database " + testDbName);
+      stmt.execute("set role admin");
+      stmt.execute("dfs -put " + dataFilePath.toString() + " " + "kv1.txt");
+      stmt.execute("use " + testDbName);
+      stmt.execute("create table " + tblName + " (int_col int, value string) ");
+      stmt.execute("load data inpath 'kv1.txt' into table " + tblName);
+      stmt.execute("create function sleepMsUDF as '" + udfName + "'");
+      stmt.execute("grant select on table " + tblName + " to role public");
 
-        stmt.close();
-        conDefault.close();
+      stmt.close();
+      conDefault.close();
     }
 
-    @AfterClass
+  @AfterClass
     public static void afterTest() {
-        if (miniHS2 != null && miniHS2.isStarted()) {
-            miniHS2.stop();
-        }
+      if (miniHS2 != null && miniHS2.isStarted()) {
+        miniHS2.stop();
+      }
     }
 
-    @Before
+  @Before
     public void setUp() throws Exception {
-        hs2Conn = getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");
+      hs2Conn = getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");
     }
 
-    public static Connection getConnection(String jdbcURL, String user, String pwd) throws SQLException {
-        Connection conn = DriverManager.getConnection(jdbcURL, user, pwd);
-        conn.createStatement().execute("set hive.support.concurrency = false");
-        return conn;
-    }
+  public static Connection getConnection(String jdbcURL, String user, String pwd) throws SQLException {
+    Connection conn = DriverManager.getConnection(jdbcURL, user, pwd);
+    conn.createStatement().execute("set hive.support.concurrency = false");
+    return conn;
+  }
 
-    @After
+  @After
     public void tearDown() throws Exception {
-        LlapBaseInputFormat.closeAll();
-        hs2Conn.close();
+      hs2Conn.close();
     }
-
-
 
     @Test
     public void testKillQueryById() throws Exception {
-        String user = System.getProperty("user.name");
-        Connection con1 = getConnection(miniHS2.getJdbcURL(testDbName),
-                user, "bar");
+      String user = System.getProperty("user.name");
+      Connection con1 = getConnection(miniHS2.getJdbcURL(testDbName), user, "bar");
 
-        final HiveStatement stmt = (HiveStatement)con1.createStatement();
-        final StringBuffer stmtQueryId = new StringBuffer();
-        ExceptionHolder originalQExHolder = new ExceptionHolder();
-        originalQExHolder.throwable = null;
+      final HiveStatement stmt = (HiveStatement)con1.createStatement();
+      final StringBuffer stmtQueryId = new StringBuffer();
+      ExceptionHolder originalQExHolder = new ExceptionHolder();
+      originalQExHolder.throwable = null;
 
-        // Thread executing the query
-        Thread tExecute = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    System.out.println("Executing query: ");
-                    stmt.execute("set hive.llap.execution.mode = none");
+      // Thread executing the query
+      Thread tExecute = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            System.out.println("Executing query: ");
+            stmt.execute("set hive.llap.execution.mode = none");
 
-                    // The test table has 500 rows, so total query time should be ~ 500*500ms
-                    stmt.executeAsync("select sleepMsUDF(t1.int_col, 100), t1.int_col, t2.int_col " +
-                            "from " + tableName + " t1 join " + tableName + " t2 on t1.int_col = t2.int_col");
-                    stmtQueryId.append(stmt.getQueryId());
-                    stmt.getUpdateCount();
-                } catch (SQLException e) {
-                    originalQExHolder.throwable = e;
-                }
-            }
-        });
-
-        tExecute.start();
-
-        // wait for other thread to create the stmt handle
-        int count = 0;
-        while (++count <= 10) {
-                Thread.sleep(2000);
-                String queryId;
-                if (stmtQueryId.length() != 0) {
-                    queryId = stmtQueryId.toString();
-                } else {
-                    continue;
-                }
-                System.out.println("Killing query: " + queryId);
-                killAMForQueryId(queryId);
-                break;
+            // The test table has 500 rows, so total query time should be ~ 500*100ms
+            stmt.executeAsync("select sleepMsUDF(t1.int_col, 100), t1.int_col, t2.int_col " +
+            "from " + tableName + " t1 join " + tableName + " t2 on t1.int_col = t2.int_col");
+            stmtQueryId.append(stmt.getQueryId());
+            stmt.getUpdateCount();
+          } catch (SQLException e) {
+            originalQExHolder.throwable = e;
+          }
         }
+      });
 
-        tExecute.join();
-        Assert.assertEquals(originalQExHolder.throwable, null);
-        try {
-            stmt.close();
-            con1.close();
-        } catch (Exception e) {
-            // ignore error
-            LOG.warn("Exception when close stmt and con", e);
+      tExecute.start();
+
+      // wait for other thread to create the stmt handle
+      int count = 0;
+      while (++count <= 10) {
+        Thread.sleep(2000);
+        if (stmtQueryId.length() != 0) {
+          String queryId = stmtQueryId.toString();
+          System.out.println("Killing query: " + queryId);
+          killAMForQueryId(queryId);
+          break;
         }
+      }
+
+      tExecute.join();try {
+        stmt.close();
+        con1.close();
+      } catch (Exception e) {
+        // ignore error
+        LOG.warn("Exception when close stmt and con", e);
+      }
+      Assert.assertEquals(originalQExHolder.throwable, null);
     }
 
-    private void killAMForQueryId(String queryId) throws Exception {
-        YarnClient yarnClient = YarnClient.createYarnClient();
-        yarnClient.init(conf);
-        yarnClient.start();
+  private void killAMForQueryId(String queryId) throws Exception {
+    YarnClient yarnClient = YarnClient.createYarnClient();
+    yarnClient.init(conf);
+    yarnClient.start();
 
-        List<ApplicationReport> applicationReports = yarnClient.getApplications();
-        String diagnosticsMessage = "AM Container for %s exited with exitCode: -100";
-        for (ApplicationReport ar : applicationReports) {
-            LOG.info("Killing application: " + ar.getApplicationId());
-            if (ar.getApplicationTags().contains(queryId)) {
-                yarnClient.killApplication(ar.getApplicationId(), String.format(diagnosticsMessage, ar.getCurrentApplicationAttemptId()));
-                ApplicationReport updated = yarnClient.getApplicationReport(ar.getApplicationId());
-                Assert.assertEquals(updated.getYarnApplicationState(), YarnApplicationState.KILLED);
-            }
-        }
+    List<ApplicationReport> applicationReports = yarnClient.getApplications();
+    String diagnosticsMessage = "AM Container for %s exited with exitCode: -100";
+    for (ApplicationReport ar : applicationReports) {
+      LOG.info("Killing application: " + ar.getApplicationId());
+      if (ar.getApplicationTags().contains(queryId)) {
+        yarnClient.killApplication(ar.getApplicationId(), String.format(diagnosticsMessage, ar.getCurrentApplicationAttemptId()));
+        ApplicationReport updated = yarnClient.getApplicationReport(ar.getApplicationId());
+        Assert.assertEquals(updated.getYarnApplicationState(), YarnApplicationState.KILLED);
+      }
     }
+  }
 }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/reexec/TestReExecuteKilledTezAMQueryPlugin.java
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-package org.apache.hive;
+package org.apache.hadoop.hive.ql.reexec;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -42,7 +42,7 @@ import java.sql.Statement;
 import java.util.List;
 
 
-public class TestKillTezAM {
+public class TestReExecuteKilledTezAMQueryPlugin {
     protected static final Logger LOG = LoggerFactory.getLogger(TestJdbcWithMiniLlapArrow.class);
 
     private static MiniHS2 miniHS2 = null;

--- a/itests/hive-unit/src/test/java/org/apache/hive/TestKillTezAM.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/TestKillTezAM.java
@@ -1,0 +1,199 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.LlapBaseInputFormat;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.yarn.api.records.ApplicationReport;
+import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.hadoop.yarn.client.api.YarnClient;
+import org.apache.hive.jdbc.BaseJdbcWithMiniLlap;
+import org.apache.hive.jdbc.HiveStatement;
+import org.apache.hive.jdbc.TestJdbcWithMiniLlapArrow;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.junit.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.net.URL;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+
+
+public class TestKillTezAM {
+    protected static final Logger LOG = LoggerFactory.getLogger(TestJdbcWithMiniLlapArrow.class);
+
+    private static MiniHS2 miniHS2 = null;
+    private static final String tableName = "testKillTezAmTbl";
+    private static String dataFileDir;
+    private static final String testDbName = "testKillTezAmDb";
+    protected static Connection hs2Conn = null;
+    private static HiveConf conf;
+
+    static HiveConf defaultConf() throws Exception {
+        String confDir = "../../data/conf/llap/";
+        if (confDir != null && !confDir.isEmpty()) {
+            HiveConf.setHiveSiteLocation(new URL("file://"+ new File(confDir).toURI().getPath() + "/hive-site.xml"));
+            System.out.println("Setting hive-site: " + HiveConf.getHiveSiteLocation());
+        }
+        HiveConf defaultConf = new HiveConf();
+        defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+        defaultConf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, false);
+        defaultConf.addResource(new URL("file://" + new File(confDir).toURI().getPath() + "/tez-site.xml"));
+        return defaultConf;
+    }
+
+    @BeforeClass
+    public static void beforeTest() throws Exception {
+        conf = defaultConf();
+        conf.setVar(HiveConf.ConfVars.USERS_IN_ADMIN_ROLE, System.getProperty("user.name"));
+        conf.set(HiveConf.ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname, "reexecutelostam");
+        MiniHS2.cleanupLocalDir();
+        miniHS2 = BaseJdbcWithMiniLlap.beforeTest(conf);
+        dataFileDir = conf.get("test.data.files").replace('\\', '/').replace("c:", "");
+
+        Connection conDefault = BaseJdbcWithMiniLlap.getConnection(miniHS2.getJdbcURL(),
+                System.getProperty("user.name"), "bar");
+        Statement stmt = conDefault.createStatement();
+        String tblName = testDbName + "." + tableName;
+        Path dataFilePath = new Path(dataFileDir, "kv1.txt");
+        String udfName = TestJdbcWithMiniLlapArrow.SleepMsUDF.class.getName();
+        stmt.execute("drop database if exists " + testDbName + " cascade");
+        stmt.execute("create database " + testDbName);
+        stmt.execute("set role admin");
+        stmt.execute("dfs -put " + dataFilePath.toString() + " " + "kv1.txt");
+        stmt.execute("use " + testDbName);
+        stmt.execute("create table " + tblName + " (int_col int, value string) ");
+        stmt.execute("load data inpath 'kv1.txt' into table " + tblName);
+        stmt.execute("create function sleepMsUDF as '" + udfName + "'");
+        stmt.execute("grant select on table " + tblName + " to role public");
+
+        stmt.close();
+        conDefault.close();
+    }
+
+    @AfterClass
+    public static void afterTest() {
+        if (miniHS2 != null && miniHS2.isStarted()) {
+            miniHS2.stop();
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        hs2Conn = getConnection(miniHS2.getJdbcURL(), System.getProperty("user.name"), "bar");
+    }
+
+    public static Connection getConnection(String jdbcURL, String user, String pwd) throws SQLException {
+        Connection conn = DriverManager.getConnection(jdbcURL, user, pwd);
+        conn.createStatement().execute("set hive.support.concurrency = false");
+        return conn;
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        LlapBaseInputFormat.closeAll();
+        hs2Conn.close();
+    }
+
+
+
+    @Test
+    public void testKillQueryById() throws Exception {
+        String user = System.getProperty("user.name");
+        Connection con1 = getConnection(miniHS2.getJdbcURL(testDbName),
+                user, "bar");
+
+        final HiveStatement stmt = (HiveStatement)con1.createStatement();
+        final StringBuffer stmtQueryId = new StringBuffer();
+
+        // Thread executing the query
+        Thread tExecute = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    System.out.println("Executing query: ");
+                    stmt.execute("set hive.llap.execution.mode = none");
+
+                    // The test table has 500 rows, so total query time should be ~ 500*500ms
+                    stmt.executeAsync("select sleepMsUDF(t1.int_col, 100), t1.int_col, t2.int_col " +
+                            "from " + tableName + " t1 join " + tableName + " t2 on t1.int_col = t2.int_col");
+                    stmtQueryId.append(stmt.getQueryId());
+                    stmt.getUpdateCount();
+                } catch (SQLException e) {
+                    Assert.fail();
+                }
+            }
+        });
+
+        tExecute.start();
+
+        // wait for other thread to create the stmt handle
+        int count = 0;
+        while (++count <= 10) {
+            try {
+                Thread.sleep(2000);
+                String queryId;
+                if (stmtQueryId.length() != 0) {
+                    queryId = stmtQueryId.toString();
+                } else {
+                    continue;
+                }
+                System.out.println("Killing query: " + queryId);
+                killAMForQueryId(queryId);
+                break;
+            } catch (HiveException e) {
+                LOG.warn("Exception when kill query", e);
+                Assert.fail();
+            }
+        }
+
+        tExecute.join();
+        try {
+            stmt.close();
+            con1.close();
+        } catch (Exception e) {
+            // ignore error
+            LOG.warn("Exception when close stmt and con", e);
+        }
+    }
+
+    private void killAMForQueryId(String queryId) throws Exception {
+        YarnClient yarnClient = YarnClient.createYarnClient();
+        yarnClient.init(conf);
+        yarnClient.start();
+
+        List<ApplicationReport> applicationReports = yarnClient.getApplications();
+        String diagnosticsMessage = "AM Container for %s exited with exitCode: -100";
+        for (ApplicationReport ar : applicationReports) {
+            LOG.info("Killing application: " + ar.getApplicationId());
+            if (ar.getApplicationTags().contains(queryId)) {
+                yarnClient.killApplication(ar.getApplicationId(), String.format(diagnosticsMessage, ar.getCurrentApplicationAttemptId()));
+                ApplicationReport updated = yarnClient.getApplicationReport(ar.getApplicationId());
+                Assert.assertEquals(updated.getYarnApplicationState(), YarnApplicationState.KILLED);
+            }
+        }
+    }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
@@ -65,7 +65,7 @@ public class DriverFactory {
     if (name.equals("reoptimize")) {
       return new ReOptimizePlugin();
     }
-    if(name.equals("reexecutelostam")) {
+    if(name.equals("reexecute_lost_am")) {
       return new ReExecuteLostAMQueryPlugin();
     }
     throw new RuntimeException(

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.reexec.IReExecutionPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReExecDriver;
+import org.apache.hadoop.hive.ql.reexec.ReExecuteLostAMQueryPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReExecutionOverlayPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReOptimizePlugin;
 
@@ -63,6 +64,9 @@ public class DriverFactory {
     }
     if (name.equals("reoptimize")) {
       return new ReOptimizePlugin();
+    }
+    if(name.equals("reexecutelostam")) {
+      return new ReExecuteLostAMQueryPlugin();
     }
     throw new RuntimeException(
         "Unknown re-execution plugin: " + name + " (" + ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname + ")");

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -1,0 +1,60 @@
+package org.apache.hadoop.hive.ql.reexec;
+
+import com.cronutils.utils.VisibleForTesting;
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.regex.Pattern;
+
+public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
+    private static final Logger LOG = LoggerFactory.getLogger(ReExecuteLostAMQueryPlugin.class);
+    private boolean retryPossible;
+
+    // Lost am container have exit code -100, due to node failures.
+    private Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+
+    class LocalHook implements ExecuteWithHookContext {
+
+        @Override
+        public void run(HookContext hookContext) throws Exception {
+            if (hookContext.getHookType() == HookContext.HookType.ON_FAILURE_HOOK) {
+                Throwable exception = hookContext.getException();
+
+                if (exception != null && exception.getMessage() != null
+                        && lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()) {
+                    retryPossible = true;
+                }
+            }
+        }
+    }
+    @Override
+    public void initialize(Driver driver) {
+        driver.getHookRunner().addOnFailureHook(new LocalHook());
+    }
+
+    @Override
+    public void beforeExecute(int executionIndex, boolean explainReOptimization) {
+    }
+
+    @Override
+    public boolean shouldReExecute(int executionNum) {
+        return retryPossible;
+    }
+
+    @Override
+    public void prepareToReExecute() {
+    }
+
+    @Override
+    public boolean shouldReExecute(int executionNum, PlanMapper oldPlanMapper, PlanMapper newPlanMapper) {
+        return retryPossible;
+    }
+
+    @Override
+    public void afterExecute(PlanMapper planMapper, boolean successfull) {
+    }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -26,50 +26,50 @@ import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
 import java.util.regex.Pattern;
 
 public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
-    private boolean retryPossible;
+  private boolean retryPossible;
 
-    // Lost am container have exit code -100, due to node failures.
-    private Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+  // Lost am container have exit code -100, due to node failures.
+  private Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
 
-    class LocalHook implements ExecuteWithHookContext {
+  class LocalHook implements ExecuteWithHookContext {
 
-        @Override
-        public void run(HookContext hookContext) throws Exception {
-            if (hookContext.getHookType() == HookContext.HookType.ON_FAILURE_HOOK) {
-                Throwable exception = hookContext.getException();
+    @Override
+    public void run(HookContext hookContext) throws Exception {
+      if (hookContext.getHookType() == HookContext.HookType.ON_FAILURE_HOOK) {
+        Throwable exception = hookContext.getException();
 
-                if (exception != null && exception.getMessage() != null
-                        && lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()) {
-                    retryPossible = true;
-                }
-            }
+        if (exception != null && exception.getMessage() != null
+            && lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()) {
+          retryPossible = true;
         }
+      }
     }
+  }
 
-    @Override
-    public void initialize(Driver driver) {
-        driver.getHookRunner().addOnFailureHook(new LocalHook());
-    }
+  @Override
+  public void initialize(Driver driver) {
+    driver.getHookRunner().addOnFailureHook(new LocalHook());
+  }
 
-    @Override
-    public void beforeExecute(int executionIndex, boolean explainReOptimization) {
-    }
+  @Override
+  public void beforeExecute(int executionIndex, boolean explainReOptimization) {
+  }
 
-    @Override
-    public boolean shouldReExecute(int executionNum) {
-        return retryPossible;
-    }
+  @Override
+  public boolean shouldReExecute(int executionNum) {
+    return retryPossible;
+  }
 
-    @Override
-    public void prepareToReExecute() {
-    }
+  @Override
+  public void prepareToReExecute() {
+  }
 
-    @Override
-    public boolean shouldReExecute(int executionNum, PlanMapper oldPlanMapper, PlanMapper newPlanMapper) {
-        return retryPossible;
-    }
+  @Override
+  public boolean shouldReExecute(int executionNum, PlanMapper oldPlanMapper, PlanMapper newPlanMapper) {
+    return retryPossible;
+  }
 
-    @Override
-    public void afterExecute(PlanMapper planMapper, boolean successfull) {
-    }
+  @Override
+  public void afterExecute(PlanMapper planMapper, boolean successfull) {
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -45,6 +45,7 @@ public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
             }
         }
     }
+
     @Override
     public void initialize(Driver driver) {
         driver.getHookRunner().addOnFailureHook(new LocalHook());

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -1,17 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.reexec;
 
-import com.cronutils.utils.VisibleForTesting;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.util.regex.Pattern;
 
 public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
-    private static final Logger LOG = LoggerFactory.getLogger(ReExecuteLostAMQueryPlugin.class);
     private boolean retryPossible;
 
     // Lost am container have exit code -100, due to node failures.


### PR DESCRIPTION
If the AM running the query is killed due to node going down, the query is killed. This plugin checks the error message received and matches with lost node exception. If yes, the query is re-run.