### PR TITLE
HIVE-23736: Disable topn in ReduceSinkOp if a TNK is introduced

### DIFF
--- a/kudu-handler/src/test/results/positive/kudu_complex_queries.q.out
+++ b/kudu-handler/src/test/results/positive/kudu_complex_queries.q.out
@@ -145,7 +145,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 488 Data size: 86864 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
@@ -327,7 +326,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 121 Data size: 22748 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: vectorized

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyProcessor.java
@@ -98,6 +98,7 @@ public class TopNKeyProcessor implements SemanticNodeProcessor {
 
 
     copyDown(reduceSinkOperator, topNKeyDesc);
+    reduceSinkDesc.setTopN(-1);
     return null;
   }
 

--- a/ql/src/test/results/clientpositive/druid/druidmini_expressions.q.out
+++ b/ql/src/test/results/clientpositive/druid/druidmini_expressions.q.out
@@ -381,7 +381,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -485,7 +484,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1300,7 +1298,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1385,7 +1382,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1867,7 +1863,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 9173 Data size: 1499152 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col2 (type: date), _col3 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -2343,7 +2338,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -2428,7 +2422,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/druid/druidmini_test1.q.out
+++ b/ql/src/test/results/clientpositive/druid/druidmini_test1.q.out
@@ -299,7 +299,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -397,7 +396,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -497,7 +495,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -599,7 +596,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -701,7 +697,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -803,7 +798,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 9173 Data size: 348640 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/autoColumnStats_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/autoColumnStats_4.q.out
@@ -89,7 +89,6 @@ STAGE PLANS:
                           null sort order: z
                           sort order: +
                           Statistics: Num rows: 9173 Data size: 977184 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/auto_join_without_localtask.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join_without_localtask.q.out
@@ -86,7 +86,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -288,7 +287,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 1288 Data size: 229264 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -490,7 +488,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 270 Data size: 48060 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/bucket_groupby.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_groupby.q.out
@@ -93,7 +93,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -111,7 +110,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -236,7 +234,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -254,7 +251,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -353,7 +349,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -449,7 +444,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -546,7 +540,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -564,7 +557,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -664,7 +656,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -682,7 +673,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -1301,7 +1291,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1319,7 +1308,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -1419,7 +1407,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1437,7 +1424,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -1645,7 +1631,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1663,7 +1648,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -1763,7 +1747,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1785,7 +1768,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/bucketmapjoin7.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketmapjoin7.q.out
@@ -257,8 +257,6 @@ STAGE PLANS:
                       sort order: ++
                       Statistics: Num rows: 72 Data size: 29216 Basic stats: PARTIAL Column stats: NONE
                       tag: -1
-                      TopN: 1
-                      TopN Hash Memory Usage: 0.1
                       auto parallelism: false
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
@@ -253,7 +253,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 20 Data size: 1740 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -276,7 +275,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 20 Data size: 1740 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 3 
@@ -782,7 +780,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 5 
@@ -805,7 +802,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -829,7 +825,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -868,7 +863,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Union 3 
             Vertex: Union 3
 

--- a/ql/src/test/results/clientpositive/llap/cbo_input26.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_input26.q.out
@@ -52,7 +52,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -216,7 +215,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -379,7 +377,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -1474,7 +1474,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 103500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(5,2)), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1794,7 +1793,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 73500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: int), _col3 (type: decimal(5,2))
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1816,7 +1814,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 250 Data size: 73500 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: int), _col1 (type: decimal(5,2))
         Reducer 3 
             Execution mode: vectorized, llap
@@ -3575,7 +3572,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/constraints_optimization.q.out
+++ b/ql/src/test/results/clientpositive/llap/constraints_optimization.q.out
@@ -202,7 +202,6 @@ STAGE PLANS:
                           null sort order: z
                           sort order: +
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -277,7 +276,6 @@ STAGE PLANS:
                           null sort order: z
                           sort order: +
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -361,7 +359,6 @@ STAGE PLANS:
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: bigint), _col1 (type: bigint)
                             Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -383,7 +380,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -628,7 +624,6 @@ STAGE PLANS:
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: bigint), _col1 (type: string)
                             Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-                            TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -648,7 +643,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/cp_sel.q.out
+++ b/ql/src/test/results/clientpositive/llap/cp_sel.q.out
@@ -45,7 +45,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/ctas.q.out
+++ b/ql/src/test/results/clientpositive/llap/ctas.q.out
@@ -61,7 +61,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -85,7 +84,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -276,7 +274,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -300,7 +297,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -491,7 +487,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 96000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -515,7 +510,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 10 Data size: 1920 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -770,7 +764,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -794,7 +787,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -987,7 +979,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1011,7 +1002,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/decimal_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/decimal_stats.q.out
@@ -101,7 +101,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 56112 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(5,0)), _col2 (type: decimal(10,0))
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/distinct_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/distinct_windowing.q.out
@@ -139,7 +139,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -153,7 +152,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -298,7 +296,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -312,7 +309,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -466,7 +462,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: tinyint)
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -480,7 +475,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/distinct_windowing_no_cbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/distinct_windowing_no_cbo.q.out
@@ -139,7 +139,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -153,7 +152,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -298,7 +296,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -312,7 +309,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -466,7 +462,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: tinyint)
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -480,7 +475,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -693,7 +687,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: float)
         Reducer 4 
             Execution mode: vectorized, llap
@@ -880,7 +873,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: smallint), _col1 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -894,7 +886,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_opt_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_opt_vectorization.q.out
@@ -1857,7 +1857,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 1049 Data size: 25136 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col3 (type: bigint), _col4 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization.q.out
@@ -1786,7 +1786,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col3 (type: bigint), _col4 (type: float)
             Execution mode: llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -3019,7 +3019,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 103500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(5,2)), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -3174,7 +3173,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 44500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3194,7 +3192,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 73500 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: int), _col1 (type: decimal(5,2)), _col2 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -6298,7 +6295,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/external_jdbc_table_perf.q.out
+++ b/ql/src/test/results/clientpositive/llap/external_jdbc_table_perf.q.out
@@ -1939,7 +1939,6 @@ GROUP BY "t0"."cs_ship_customer_sk"
                           sort order: +++++
                           Map-reduce partition columns: _col0 (type: char(1)), _col1 (type: char(1)), _col2 (type: char(20)), _col3 (type: int), _col4 (type: char(10))
                           Statistics: Num rows: 1 Data size: 499 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col5 (type: bigint)
         Reducer 5 
             Execution mode: vectorized, llap
@@ -1959,7 +1958,6 @@ GROUP BY "t0"."cs_ship_customer_sk"
                     null sort order: zzzzz
                     sort order: +++++
                     Statistics: Num rows: 1 Data size: 499 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col3 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
@@ -2429,7 +2427,6 @@ GROUP BY "t0"."cs_ship_customer_sk"
                           sort order: +++++
                           Map-reduce partition columns: _col0 (type: char(1)), _col1 (type: char(1)), _col2 (type: char(20)), _col3 (type: int), _col4 (type: char(10))
                           Statistics: Num rows: 1 Data size: 499 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col5 (type: bigint)
         Reducer 5 
             Execution mode: vectorized, llap
@@ -2449,7 +2446,6 @@ GROUP BY "t0"."cs_ship_customer_sk"
                     null sort order: zzzzz
                     sort order: +++++
                     Statistics: Num rows: 1 Data size: 499 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col3 (type: bigint)
         Reducer 6 
             Execution mode: vectorized, llap
@@ -3167,7 +3163,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: char(16))
         Reducer 4 
             Execution mode: vectorized, llap
@@ -3998,7 +3993,6 @@ WHERE "d_week_seq" IS NOT NULL AND "d_date" IS NOT NULL
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col2 (type: double), _col3 (type: bigint), _col4 (type: double), _col5 (type: bigint), _col6 (type: double), _col7 (type: decimal(25,6))
         Reducer 7 
             Execution mode: vectorized, llap
@@ -4320,7 +4314,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: vectorized, llap
@@ -5683,7 +5676,6 @@ GROUP BY "t2"."r_reason_desc"
                         null sort order: zzzz
                         sort order: ++++
                         Statistics: Num rows: 1 Data size: 440 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/gby_star.q.out
+++ b/ql/src/test/results/clientpositive/llap/gby_star.q.out
@@ -49,7 +49,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -67,7 +66,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col2 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -162,7 +160,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 83 Data size: 15438 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -180,7 +177,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 83 Data size: 15438 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col2 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -275,7 +271,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -293,7 +288,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -435,7 +429,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -451,7 +444,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: double)
         Reducer 4 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/gen_udf_example_add10.q.out
+++ b/ql/src/test/results/clientpositive/llap/gen_udf_example_add10.q.out
@@ -60,7 +60,6 @@ STAGE PLANS:
                         null sort order: az
                         sort order: -+
                         Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized
         Reducer 2 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby1_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby1_limit.q.out
@@ -59,7 +59,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/groupby2_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby2_limit.q.out
@@ -49,7 +49,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -67,7 +66,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby7_noskew_multi_single_reducer.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby7_noskew_multi_single_reducer.q.out
@@ -90,7 +90,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: double)
                 Group By Operator
                   aggregations: sum(VALUE._col0)
@@ -103,7 +102,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 316 Data size: 30020 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby_complex_types_multi_single_reducer.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_complex_types_multi_single_reducer.q.out
@@ -77,7 +77,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: array<string>)
                           Statistics: Num rows: 250 Data size: 482000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
                   Select Operator
                     expressions: key (type: string), value (type: string)
@@ -102,7 +101,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: map<string,string>)
                           Statistics: Num rows: 250 Data size: 232000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -120,7 +118,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 482000 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -154,7 +151,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 232000 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 5 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby_duplicate_key.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_duplicate_key.q.out
@@ -317,7 +317,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 113750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -339,7 +338,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 113750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: string), _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby_grouping_sets_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_grouping_sets_limit.q.out
@@ -65,7 +65,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: bigint)
                           Statistics: Num rows: 4 Data size: 1472 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -87,7 +86,6 @@ STAGE PLANS:
                     null sort order: zzz
                     sort order: +++
                     Statistics: Num rows: 2 Data size: 736 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -182,7 +180,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: bigint)
                           Statistics: Num rows: 4 Data size: 1472 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -204,7 +201,6 @@ STAGE PLANS:
                     null sort order: zzz
                     sort order: +++
                     Statistics: Num rows: 2 Data size: 736 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -299,7 +295,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: bigint)
                           Statistics: Num rows: 2 Data size: 736 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -321,7 +316,6 @@ STAGE PLANS:
                     null sort order: zzz
                     sort order: +++
                     Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -415,7 +409,6 @@ STAGE PLANS:
                           sort order: ++++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: string), _col3 (type: bigint)
                           Statistics: Num rows: 3 Data size: 1656 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -435,7 +428,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 1 Data size: 552 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -528,7 +520,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -544,7 +535,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -633,7 +623,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: double)
                           Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -655,7 +644,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/groupby_multi_single_reducer.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_multi_single_reducer.q.out
@@ -481,7 +481,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 146500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col2 (type: string), _col3 (type: double), _col4 (type: bigint)
         Reducer 4 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/input14_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/input14_limit.q.out
@@ -71,7 +71,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: string), _col1 (type: string)
         Reducer 2 
             Execution mode: vectorized, llap
@@ -95,7 +94,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 20 Data size: 3560 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/input22.q.out
+++ b/ql/src/test/results/clientpositive/llap/input22.q.out
@@ -62,7 +62,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/input26.q.out
+++ b/ql/src/test/results/clientpositive/llap/input26.q.out
@@ -52,7 +52,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/input3_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/input3_limit.q.out
@@ -91,7 +91,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/input4_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/input4_limit.q.out
@@ -41,7 +41,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -66,7 +65,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/insert1_overwrite_partitions.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert1_overwrite_partitions.q.out
@@ -80,7 +80,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -285,7 +284,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -463,7 +461,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/insert2_overwrite_partitions.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert2_overwrite_partitions.q.out
@@ -91,7 +91,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 124 Data size: 40480 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -251,7 +250,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 124 Data size: 40480 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/insert_into1.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into1.q.out
@@ -53,7 +53,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -230,7 +229,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -407,7 +405,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/insert_into2.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into2.q.out
@@ -57,7 +57,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -283,7 +282,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -474,7 +472,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/insert_into3.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into3.q.out
@@ -73,7 +73,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                   Top N Key Operator
                     sort order: ++
                     keys: key (type: string), value (type: string)
@@ -89,7 +88,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/join45.q.out
+++ b/ql/src/test/results/clientpositive/llap/join45.q.out
@@ -101,7 +101,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 2 Data size: 706 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -247,7 +246,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 39 Data size: 13767 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -400,7 +398,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 110 Data size: 38830 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -545,7 +542,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 12500 Data size: 4412500 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -698,7 +694,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 1388 Data size: 489964 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -845,7 +840,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 8332 Data size: 2941196 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -994,7 +988,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 7 Data size: 2471 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1166,7 +1159,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4491 Data size: 2312973 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1350,7 +1342,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4491 Data size: 2312973 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1527,7 +1518,6 @@ STAGE PLANS:
                     null sort order: zzzzzz
                     sort order: ++++++
                     Statistics: Num rows: 354 Data size: 178440 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1712,7 +1702,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 533 Data size: 278754 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1875,7 +1864,6 @@ STAGE PLANS:
                     null sort order: zzzzzz
                     sort order: ++++++
                     Statistics: Num rows: 4520 Data size: 174240 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -2056,7 +2044,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4700 Data size: 2358403 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -2278,7 +2265,6 @@ STAGE PLANS:
                       null sort order: zzzzzzzzzzzzzzzzzzzzzzzzz
                       sort order: +++++++++++++++++++++++++
                       Statistics: Num rows: 303750 Data size: 555861675 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col5 (type: string), _col11 (type: string), _col17 (type: string), _col23 (type: string), _col29 (type: string)
         Reducer 5 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/join47.q.out
+++ b/ql/src/test/results/clientpositive/llap/join47.q.out
@@ -101,7 +101,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 2 Data size: 706 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -247,7 +246,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 39 Data size: 13767 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -400,7 +398,6 @@ STAGE PLANS:
                     null sort order: zzzz
                     sort order: ++++
                     Statistics: Num rows: 110 Data size: 38830 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -545,7 +542,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 12500 Data size: 4412500 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -698,7 +694,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 1388 Data size: 489964 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -845,7 +840,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 8332 Data size: 2941196 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -994,7 +988,6 @@ STAGE PLANS:
                       null sort order: zzzz
                       sort order: ++++
                       Statistics: Num rows: 7 Data size: 2471 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1166,7 +1159,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4491 Data size: 2312973 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1350,7 +1342,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4491 Data size: 2312973 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1527,7 +1518,6 @@ STAGE PLANS:
                     null sort order: zzzzzz
                     sort order: ++++++
                     Statistics: Num rows: 354 Data size: 178440 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1712,7 +1702,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 533 Data size: 278754 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1875,7 +1864,6 @@ STAGE PLANS:
                     null sort order: zzzzzz
                     sort order: ++++++
                     Statistics: Num rows: 4520 Data size: 174240 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -2056,7 +2044,6 @@ STAGE PLANS:
                       null sort order: zzzzzz
                       sort order: ++++++
                       Statistics: Num rows: 4700 Data size: 2358403 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -2278,7 +2265,6 @@ STAGE PLANS:
                       null sort order: zzzzzzzzzzzzzzzzzzzzzzzzz
                       sort order: +++++++++++++++++++++++++
                       Statistics: Num rows: 303750 Data size: 555861675 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col5 (type: string), _col11 (type: string), _col17 (type: string), _col23 (type: string), _col29 (type: string)
         Reducer 5 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/lateral_view.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view.q.out
@@ -65,7 +65,6 @@ STAGE PLANS:
                               null sort order: zz
                               sort order: ++
                               Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
-                              TopN Hash Memory Usage: 0.1
                               value expressions: _col1 (type: string)
                     Select Operator
                       expressions: array(1,2,3) (type: array<int>)
@@ -92,7 +91,6 @@ STAGE PLANS:
                                 null sort order: zz
                                 sort order: ++
                                 Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
-                                TopN Hash Memory Usage: 0.1
                                 value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -117,7 +115,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 1 Data size: 178 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/lateral_view_explode2.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_explode2.q.out
@@ -54,7 +54,6 @@ STAGE PLANS:
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                               Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                              TopN Hash Memory Usage: 0.1
                     Select Operator
                       expressions: array(1,2,3) (type: array<int>)
                       outputColumnNames: _col0
@@ -83,7 +82,6 @@ STAGE PLANS:
                                 sort order: ++
                                 Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                                TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/lateral_view_onview.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_onview.q.out
@@ -84,7 +84,6 @@ STAGE PLANS:
                               null sort order: zz
                               sort order: ++
                               Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
-                              TopN Hash Memory Usage: 0.1
                               value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
                       Select Operator
                         expressions: array(1,2,3) (type: array<int>)
@@ -107,7 +106,6 @@ STAGE PLANS:
                                 null sort order: zz
                                 sort order: ++
                                 Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
-                                TopN Hash Memory Usage: 0.1
                                 value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
             Execution mode: llap
             LLAP IO: no inputs
@@ -132,7 +130,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
         Reducer 3 
             Execution mode: vectorized, llap
@@ -626,7 +623,6 @@ STAGE PLANS:
                             null sort order: zz
                             sort order: ++
                             Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
                     Select Operator
                       expressions: _col12 (type: array<int>)
@@ -649,7 +645,6 @@ STAGE PLANS:
                               null sort order: zz
                               sort order: ++
                               Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
-                              TopN Hash Memory Usage: 0.1
                               value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -672,7 +667,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
         Reducer 4 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/limit_join_transpose.q.out
+++ b/ql/src/test/results/clientpositive/llap/limit_join_transpose.q.out
@@ -777,7 +777,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -824,7 +823,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: string)
         Reducer 3 
             Execution mode: llap
@@ -886,7 +884,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 6 
             Execution mode: llap
@@ -1776,7 +1773,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1823,7 +1819,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: string)
         Reducer 3 
             Execution mode: llap
@@ -1887,7 +1882,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 2 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 6 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/limit_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/limit_pushdown.q.out
@@ -40,7 +40,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -138,7 +137,6 @@ STAGE PLANS:
                         null sort order: a
                         sort order: -
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -244,7 +242,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -355,7 +352,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -466,7 +462,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: double)
                           Statistics: Num rows: 5528 Data size: 21816 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -964,7 +959,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
                     value expressions: _col0 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1079,7 +1073,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: bigint)
                   Top N Key Operator
                     sort order: +
@@ -1104,7 +1097,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1242,7 +1234,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: value (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: key (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1345,7 +1336,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 407500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 2.0E-5
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1546,7 +1536,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 2.0E-5
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/limit_pushdown2.q.out
+++ b/ql/src/test/results/clientpositive/llap/limit_pushdown2.q.out
@@ -52,7 +52,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -172,7 +171,6 @@ STAGE PLANS:
                           sort order: +-
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -292,7 +290,6 @@ STAGE PLANS:
                           sort order: -+
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -412,7 +409,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -532,7 +528,6 @@ STAGE PLANS:
                           sort order: -+
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -652,7 +647,6 @@ STAGE PLANS:
                           sort order: -+
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 48500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: double), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -773,7 +767,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -797,7 +790,6 @@ STAGE PLANS:
                     null sort order: zzz
                     sort order: +++
                     Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -909,7 +901,6 @@ STAGE PLANS:
                           sort order: -+
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -933,7 +924,6 @@ STAGE PLANS:
                     null sort order: azz
                     sort order: -++
                     Statistics: Num rows: 250 Data size: 46500 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1066,7 +1056,6 @@ STAGE PLANS:
                       null sort order: za
                       sort order: +-
                       Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1200,7 +1189,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 750 Data size: 139500 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
                       value expressions: _col2 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1303,7 +1291,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 750 Data size: 139500 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
                       value expressions: _col2 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/limit_pushdown3.q.out
+++ b/ql/src/test/results/clientpositive/llap/limit_pushdown3.q.out
@@ -40,7 +40,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -138,7 +137,6 @@ STAGE PLANS:
                         null sort order: a
                         sort order: -
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -245,7 +243,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -263,7 +260,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.3
                   value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -368,7 +364,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -390,7 +385,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
                     value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -494,7 +488,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: double)
                           Statistics: Num rows: 5528 Data size: 21816 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -510,7 +503,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 5528 Data size: 21816 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -634,7 +626,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 131 Data size: 1312 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -759,7 +750,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 131 Data size: 1312 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -888,7 +878,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 131 Data size: 2360 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
                       value expressions: _col1 (type: bigint), _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1038,7 +1027,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
                     value expressions: _col0 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1136,7 +1124,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: value (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: key (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1154,7 +1141,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 307 Data size: 30393 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.3
                   value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1250,7 +1236,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 407500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 2.0E-5
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1451,7 +1436,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 2.0E-5
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/llap_decimal64_reader.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_decimal64_reader.q.out
@@ -153,7 +153,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: decimal(10,2)), _col1 (type: decimal(38,5))
                           Statistics: Num rows: 1 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -261,7 +260,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: decimal(10,2)), _col1 (type: decimal(38,5))
                           Statistics: Num rows: 1 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_8.q.out
@@ -264,7 +264,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 1 Data size: 159 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: bigint), _col1 (type: date), _col3 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/offset_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/offset_limit.q.out
@@ -49,7 +49,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -67,7 +66,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: double)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/offset_limit_ppd_optimizer.q.out
+++ b/ql/src/test/results/clientpositive/llap/offset_limit_ppd_optimizer.q.out
@@ -40,7 +40,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -139,7 +138,6 @@ STAGE PLANS:
                         null sort order: a
                         sort order: -
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -246,7 +244,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: no inputs
@@ -358,7 +355,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -470,7 +466,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: double)
                           Statistics: Num rows: 5528 Data size: 21816 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
@@ -972,7 +967,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 250 Data size: 24750 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1069,7 +1063,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: value (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.3
                         value expressions: key (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1173,7 +1166,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 407500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 2.0E-5
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -1345,7 +1337,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 2.0E-5
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1503,7 +1494,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: key (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 2.0E-5
                   Top N Key Operator
                     sort order: +
                     keys: key (type: string)
@@ -1520,7 +1510,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: key (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 2.0E-5
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/orc_createas1.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_createas1.q.out
@@ -208,7 +208,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/orc_predicate_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_predicate_pushdown.q.out
@@ -851,7 +851,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 25 Data size: 2825 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs
@@ -941,7 +940,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 25 Data size: 2825 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs
@@ -1097,7 +1095,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 44 Data size: 4972 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs
@@ -1122,7 +1119,6 @@ STAGE PLANS:
                       null sort order: a
                       sort order: -
                       Statistics: Num rows: 3 Data size: 339 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
         Reducer 3 
             Execution mode: llap
@@ -1215,7 +1211,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 44 Data size: 4972 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs
@@ -1240,7 +1235,6 @@ STAGE PLANS:
                       null sort order: a
                       sort order: -
                       Statistics: Num rows: 3 Data size: 339 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/orc_struct_type_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_struct_type_vectorization.q.out
@@ -281,7 +281,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 341 Data size: 76542 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/order.q.out
+++ b/ql/src/test/results/clientpositive/llap/order.q.out
@@ -40,7 +40,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -128,7 +127,6 @@ STAGE PLANS:
                         null sort order: a
                         sort order: -
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/order3.q.out
+++ b/ql/src/test/results/clientpositive/llap/order3.q.out
@@ -71,7 +71,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -91,7 +90,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -176,7 +174,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -198,7 +195,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 4 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: int)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -284,7 +280,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 4 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -306,7 +301,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -391,7 +385,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -407,7 +400,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 4 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -492,7 +484,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -510,7 +501,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: int)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -596,7 +586,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: int), 'AAA' (type: string)
                           Statistics: Num rows: 4 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -618,7 +607,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 4 Data size: 396 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/parquet_complex_types_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_complex_types_vectorization.q.out
@@ -257,7 +257,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 341 Data size: 38920 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -310,7 +309,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 170 Data size: 19402 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -567,7 +565,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 341 Data size: 38921 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -620,7 +617,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 170 Data size: 19403 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -877,7 +873,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 341 Data size: 38923 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -930,7 +925,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 170 Data size: 19404 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/parquet_map_type_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_map_type_vectorization.q.out
@@ -273,7 +273,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 511 Data size: 995378 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint), _col2 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -326,7 +325,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 255 Data size: 496715 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: bigint), _col1 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/parquet_predicate_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_predicate_pushdown.q.out
@@ -785,7 +785,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 25 Data size: 2825 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs (cache only)
@@ -875,7 +874,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 25 Data size: 2825 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs (cache only)
@@ -1076,7 +1074,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 44 Data size: 4972 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs (cache only)
@@ -1101,7 +1098,6 @@ STAGE PLANS:
                       null sort order: a
                       sort order: -
                       Statistics: Num rows: 3 Data size: 339 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
         Reducer 3 
             Execution mode: llap
@@ -1194,7 +1190,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 44 Data size: 4972 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
             Execution mode: llap
             LLAP IO: all inputs (cache only)
@@ -1219,7 +1214,6 @@ STAGE PLANS:
                       null sort order: a
                       sort order: -
                       Statistics: Num rows: 3 Data size: 339 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: tinyint), _col1 (type: smallint), _col2 (type: double)
         Reducer 3 
             Execution mode: llap
@@ -1324,7 +1318,6 @@ STAGE PLANS:
                           null sort order: a
                           sort order: -
                           Statistics: Num rows: 911 Data size: 14576 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: int), _col2 (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs (cache only)
@@ -1349,7 +1342,6 @@ STAGE PLANS:
                       null sort order: a
                       sort order: -
                       Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: int), _col2 (type: bigint)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/parquet_struct_type_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_struct_type_vectorization.q.out
@@ -281,7 +281,6 @@ STAGE PLANS:
                                 native: true
                                 nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             Statistics: Num rows: 341 Data size: 76542 Basic stats: COMPLETE Column stats: NONE
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_13.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_13.q.out
@@ -207,7 +207,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 693 Data size: 142976 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -565,7 +564,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 693 Data size: 142976 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_7.q.out
@@ -115,7 +115,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 11033 Data size: 1323416 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:
@@ -365,7 +364,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 11033 Data size: 1323416 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_8.q.out
@@ -111,7 +111,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3059 Data size: 410040 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:
@@ -348,7 +347,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3059 Data size: 410040 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_div0.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_div0.q.out
@@ -250,7 +250,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3215 Data size: 411520 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: decimal(22,21))
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -484,7 +483,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 20 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: double), _col4 (type: double), _col5 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_limit.q.out
@@ -47,7 +47,6 @@ STAGE PLANS:
                           null sort order: zz
                           sort order: ++
                           Statistics: Num rows: 2048 Data size: 16176 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:
@@ -173,7 +172,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9173 Data size: 72384 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:
@@ -330,7 +328,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 131 Data size: 2360 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
                           value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -500,7 +497,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 131 Data size: 264 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:
@@ -922,7 +918,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 4586 Data size: 64088 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_offset_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_offset_limit.q.out
@@ -141,7 +141,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9173 Data size: 72384 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: smallint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_part_project.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_part_project.q.out
@@ -94,7 +94,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 200 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/pcr.q.out
+++ b/ql/src/test/results/clientpositive/llap/pcr.q.out
@@ -4181,8 +4181,6 @@ STAGE PLANS:
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: -1
-                        TopN: 10
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
                         auto parallelism: false
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/q93_with_constraints.q.out
+++ b/ql/src/test/results/clientpositive/llap/q93_with_constraints.q.out
@@ -367,7 +367,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 285117845 Data size: 34670330027 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
         Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/regex_col.q.out
+++ b/ql/src/test/results/clientpositive/llap/regex_col.q.out
@@ -521,7 +521,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/select_as_omitted.q.out
+++ b/ql/src/test/results/clientpositive/llap/select_as_omitted.q.out
@@ -48,7 +48,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/select_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/select_column_pruning.q.out
@@ -79,7 +79,6 @@ STAGE PLANS:
                                 null sort order: zz
                                 sort order: ++
                                 Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
-                                TopN Hash Memory Usage: 0.1
                                 value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
                       Select Operator
                         expressions: array(1,2,3) (type: array<int>)
@@ -106,7 +105,6 @@ STAGE PLANS:
                                   null sort order: zz
                                   sort order: ++
                                   Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
-                                  TopN Hash Memory Usage: 0.1
                                   value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
@@ -131,7 +129,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/semijoin_reddedup.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin_reddedup.q.out
@@ -448,7 +448,6 @@ STAGE PLANS:
                       sort order: -++++
                       Map-reduce partition columns: _col0 (type: double), _col1 (type: string), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: string)
                       Statistics: Num rows: 6269989391 Data size: 95303838902 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col5 (type: double)
         Reducer 5 
             Execution mode: vectorized, llap
@@ -468,7 +467,6 @@ STAGE PLANS:
                     null sort order: az
                     sort order: -+
                     Statistics: Num rows: 3134994695 Data size: 47651919443 Basic stats: COMPLETE Column stats: NONE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: string), _col1 (type: bigint), _col2 (type: bigint), _col5 (type: double)
         Reducer 6 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/skewjoin_noskew.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_noskew.q.out
@@ -92,7 +92,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/smb_mapjoin_15.q.out
+++ b/ql/src/test/results/clientpositive/llap/smb_mapjoin_15.q.out
@@ -159,8 +159,6 @@ STAGE PLANS:
                             sort order: +
                             Statistics: Num rows: ###Masked### Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                             tag: -1
-                            TopN: 10
-                            TopN Hash Memory Usage: 0.1
                             value expressions: _col1 (type: string), _col2 (type: int), _col3 (type: string)
                             auto parallelism: false
             Execution mode: llap
@@ -520,8 +518,6 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: ###Masked### Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                     tag: -1
-                    TopN: 10
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: int), _col4 (type: int), _col5 (type: string)
                     auto parallelism: false
         Reducer 3 
@@ -787,8 +783,6 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: ###Masked### Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                     tag: -1
-                    TopN: 10
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: int), _col4 (type: int), _col5 (type: string)
                     auto parallelism: false
         Reducer 3 
@@ -1054,8 +1048,6 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: ###Masked### Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                     tag: -1
-                    TopN: 10
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: int), _col4 (type: int), _col5 (type: string)
                     auto parallelism: false
         Reducer 3 

--- a/ql/src/test/results/clientpositive/llap/subquery_in.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_in.q.out
@@ -335,7 +335,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: p_mfgr (type: string)
                       Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -530,7 +529,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3459,7 +3457,6 @@ STAGE PLANS:
                     null sort order: z
                     sort order: +
                     Statistics: Num rows: 7 Data size: 4333 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/subquery_notin.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_notin.q.out
@@ -378,7 +378,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: p_name (type: string)
                   Filter Operator
                     predicate: p_mfgr is not null (type: boolean)
@@ -396,7 +395,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: p_name (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -694,7 +692,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: p_mfgr (type: string)
                       Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1003,7 +1000,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -4658,7 +4654,6 @@ STAGE PLANS:
                           null sort order: zz
                           sort order: ++
                           Statistics: Num rows: 33 Data size: 20427 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
         Reducer 4 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/subquery_scalar.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_scalar.q.out
@@ -1139,7 +1139,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
         Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/subquery_select.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_select.q.out
@@ -3130,7 +3130,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3823,7 +3822,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                 Top N Key Operator
                   sort order: +
                   keys: _col1 (type: int)
@@ -3839,7 +3837,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/subquery_unqualcolumnrefs.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_unqualcolumnrefs.q.out
@@ -400,7 +400,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: p_name (type: string)
                   Filter Operator
                     predicate: p_mfgr is not null (type: boolean)
@@ -418,7 +417,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: p_mfgr (type: string)
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: p_name (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/temp_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/temp_table.q.out
@@ -238,7 +238,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 247 Data size: 86848 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -328,7 +327,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 175904 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -352,7 +350,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 175904 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/temp_table_insert1_overwrite_partitions.q.out
+++ b/ql/src/test/results/clientpositive/llap/temp_table_insert1_overwrite_partitions.q.out
@@ -80,7 +80,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -284,7 +283,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -424,7 +422,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 99 Data size: 31648 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/temp_table_insert2_overwrite_partitions.q.out
+++ b/ql/src/test/results/clientpositive/llap/temp_table_insert2_overwrite_partitions.q.out
@@ -91,7 +91,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 124 Data size: 40480 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -251,7 +250,6 @@ STAGE PLANS:
                         null sort order: aa
                         sort order: --
                         Statistics: Num rows: 124 Data size: 40480 Basic stats: PARTIAL Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/tez_fixed_bucket_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_fixed_bucket_pruning.q.out
@@ -565,8 +565,6 @@ STAGE PLANS:
                                     sort order: ++
                                     Statistics: Num rows: 30 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
                                     tag: -1
-                                    TopN: 5
-                                    TopN Hash Memory Usage: 0.1
                                     auto parallelism: false
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -1027,8 +1025,6 @@ STAGE PLANS:
                                     sort order: ++
                                     Statistics: Num rows: 30 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
                                     tag: -1
-                                    TopN: 5
-                                    TopN Hash Memory Usage: 0.1
                                     auto parallelism: false
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/topnkey.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey.q.out
@@ -49,7 +49,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: llap
             LLAP IO: no inputs
@@ -67,7 +66,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -217,7 +215,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                       Statistics: Num rows: 395 Data size: 70310 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -231,7 +228,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 395 Data size: 70310 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: string)
         Reducer 4 
             Execution mode: llap
@@ -375,7 +371,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                       Statistics: Num rows: 395 Data size: 70310 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -389,7 +384,6 @@ STAGE PLANS:
                   null sort order: a
                   sort order: +
                   Statistics: Num rows: 395 Data size: 70310 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: string)
         Reducer 4 
             Execution mode: llap
@@ -518,7 +512,6 @@ STAGE PLANS:
                         null sort order: zz
                         sort order: ++
                         Statistics: Num rows: 8 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -617,7 +610,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                           Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -633,7 +625,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets.q.out
@@ -93,7 +93,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -113,7 +112,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 26 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -211,7 +209,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -228,7 +225,6 @@ STAGE PLANS:
                   null sort order: zz
                   sort order: ++
                   Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -355,7 +351,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 26 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -468,7 +463,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 26 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -577,7 +571,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 13 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -682,7 +675,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -699,7 +691,6 @@ STAGE PLANS:
                   null sort order: az
                   sort order: -+
                   Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -804,7 +795,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -821,7 +811,6 @@ STAGE PLANS:
                   null sort order: az
                   sort order: -+
                   Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -926,7 +915,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -943,7 +931,6 @@ STAGE PLANS:
                   null sort order: az
                   sort order: -+
                   Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1048,7 +1035,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1065,7 +1051,6 @@ STAGE PLANS:
                   null sort order: az
                   sort order: -+
                   Statistics: Num rows: 13 Data size: 152 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -1198,7 +1183,6 @@ STAGE PLANS:
                       sort order: -++
                       Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                       Statistics: Num rows: 6 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col3 (type: int)
         Reducer 3 
             Execution mode: llap
@@ -1219,7 +1203,6 @@ STAGE PLANS:
                     null sort order: az
                     sort order: -+
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: int)
         Reducer 4 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets_functions.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets_functions.q.out
@@ -116,7 +116,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: llap
@@ -245,7 +244,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 26 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col2 (type: int)
         Reducer 3 
             Execution mode: llap
@@ -374,7 +372,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 26 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col2 (type: int)
         Reducer 3 
             Execution mode: llap

--- a/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets_order.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_grouping_sets_order.q.out
@@ -109,7 +109,6 @@ STAGE PLANS:
                     null sort order: az
                     sort order: ++
                     Statistics: Num rows: 26 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -230,7 +229,6 @@ STAGE PLANS:
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 26 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -335,7 +333,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -352,7 +349,6 @@ STAGE PLANS:
                   null sort order: az
                   sort order: -+
                   Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -457,7 +453,6 @@ STAGE PLANS:
                           sort order: -++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: bigint)
                           Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -474,7 +469,6 @@ STAGE PLANS:
                   null sort order: aa
                   sort order: -+
                   Statistics: Num rows: 26 Data size: 296 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/topnkey_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_windowing.q.out
@@ -118,7 +118,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: tw_code (type: string)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -248,7 +247,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: tw_code (type: string)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -413,8 +411,6 @@ STAGE PLANS:
                       Map-reduce partition columns: 0 (type: int)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
                       tag: -1
-                      TopN: 4
-                      TopN Hash Memory Usage: 0.1
                       value expressions: tw_code (type: string)
                       auto parallelism: true
             Execution mode: llap
@@ -602,8 +598,6 @@ STAGE PLANS:
                       Map-reduce partition columns: 0 (type: int)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
                       tag: -1
-                      TopN: 4
-                      TopN Hash Memory Usage: 0.1
                       value expressions: tw_code (type: string)
                       auto parallelism: true
             Execution mode: vectorized, llap
@@ -805,7 +799,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: tw_code (type: string)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/topnkey_windowing_order.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_windowing_order.q.out
@@ -120,7 +120,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: tw_a (type: string)
                       Statistics: Num rows: 26 Data size: 1969 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -280,7 +279,6 @@ STAGE PLANS:
                       sort order: ++-
                       Map-reduce partition columns: tw_a (type: string)
                       Statistics: Num rows: 26 Data size: 2153 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -438,7 +436,6 @@ STAGE PLANS:
                       sort order: +++
                       Map-reduce partition columns: tw_a (type: string), tw_b (type: string)
                       Statistics: Num rows: 26 Data size: 3924 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/udf_case_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_case_column_pruning.q.out
@@ -104,7 +104,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 791 Data size: 3164 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/udtf_explode.q.out
+++ b/ql/src/test/results/clientpositive/llap/udtf_explode.q.out
@@ -282,7 +282,6 @@ STAGE PLANS:
                             null sort order: zz
                             sort order: ++
                             Statistics: Num rows: 500 Data size: 4000 Basic stats: COMPLETE Column stats: COMPLETE
-                            TopN Hash Memory Usage: 0.1
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/union_top_level.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_top_level.q.out
@@ -310,7 +310,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -355,7 +354,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 791 Data size: 140798 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: string)
         Reducer 6 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_case_when_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_case_when_2.q.out
@@ -1005,7 +1005,6 @@ STAGE PLANS:
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             valueColumns: 16:decimal(11,1)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(11,1))
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1150,7 +1149,6 @@ STAGE PLANS:
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             valueColumns: 9:decimal(11,1)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(11,1))
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1295,7 +1293,6 @@ STAGE PLANS:
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             valueColumns: 16:decimal(11,1)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(11,1))
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -1440,7 +1437,6 @@ STAGE PLANS:
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                             valueColumns: 8:decimal(11,1)
                         Statistics: Num rows: 6 Data size: 24 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: decimal(11,1))
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/vector_cast_constant.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_cast_constant.q.out
@@ -180,7 +180,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 257 Data size: 40092 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint), _col2 (type: bigint), _col3 (type: double), _col4 (type: bigint), _col5 (type: decimal(12,0)), _col6 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -234,7 +233,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 257 Data size: 33924 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col1 (type: double), _col2 (type: double), _col3 (type: decimal(6,4))
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_char_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_char_2.q.out
@@ -141,7 +141,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -186,7 +185,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -354,7 +352,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -399,7 +396,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 250 Data size: 26750 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_data_types.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_data_types.q.out
@@ -154,7 +154,6 @@ STAGE PLANS:
                         null sort order: zzz
                         sort order: +++
                         Statistics: Num rows: 1050 Data size: 357661 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col3 (type: bigint), _col4 (type: float), _col5 (type: double), _col6 (type: boolean), _col7 (type: string), _col8 (type: timestamp), _col9 (type: decimal(4,2)), _col10 (type: binary)
             Execution mode: llap
             LLAP IO: all inputs
@@ -279,7 +278,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 1050 Data size: 357661 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col3 (type: bigint), _col4 (type: float), _col5 (type: double), _col6 (type: boolean), _col7 (type: string), _col8 (type: timestamp), _col9 (type: decimal(4,2)), _col10 (type: binary)
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/vector_decimal_expressions.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_decimal_expressions.q.out
@@ -103,7 +103,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 1 Data size: 220 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -291,7 +290,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 1 Data size: 220 Basic stats: COMPLETE Column stats: NONE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vector_groupby_grouping_sets_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_groupby_grouping_sets_limit.q.out
@@ -109,7 +109,6 @@ STAGE PLANS:
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               valueColumns: 3:bigint
                           Statistics: Num rows: 12 Data size: 2232 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -178,7 +177,6 @@ STAGE PLANS:
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         valueColumns: 2:bigint
                     Statistics: Num rows: 12 Data size: 2136 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -327,7 +325,6 @@ STAGE PLANS:
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               valueColumns: 3:bigint
                           Statistics: Num rows: 12 Data size: 2232 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -396,7 +393,6 @@ STAGE PLANS:
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         valueColumns: 2:bigint
                     Statistics: Num rows: 12 Data size: 2136 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -545,7 +541,6 @@ STAGE PLANS:
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               valueColumns: 3:bigint
                           Statistics: Num rows: 6 Data size: 1116 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -614,7 +609,6 @@ STAGE PLANS:
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         valueColumns: 2:bigint
                     Statistics: Num rows: 6 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
                     value expressions: _col2 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -760,7 +754,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9 Data size: 2367 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -825,7 +818,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 9 Data size: 765 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -970,7 +962,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3 Data size: 255 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -1026,7 +1017,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 3 Data size: 255 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -1170,7 +1160,6 @@ STAGE PLANS:
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               valueColumns: 1:bigint
                           Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -1230,7 +1219,6 @@ STAGE PLANS:
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       valueColumns: 1:bigint
                   Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_identity_reuse.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_identity_reuse.q.out
@@ -257,7 +257,6 @@ STAGE PLANS:
                                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                                         valueColumns: 8:int, 6:int
                                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                                    TopN Hash Memory Usage: 0.1
                                     value expressions: _col1 (type: int), _col2 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/vector_llap_text_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_llap_text_1.q.out
@@ -276,7 +276,6 @@ STAGE PLANS:
                                   native: true
                                   nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               Statistics: Num rows: 399 Data size: 74214 Basic stats: COMPLETE Column stats: COMPLETE
-                              TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vector_mr_diff_schema_alias.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_mr_diff_schema_alias.q.out
@@ -399,7 +399,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col1 (type: bigint)
             MergeJoin Vectorization:
                 enabled: false
@@ -424,7 +423,6 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col1 (type: bigint)
         Reducer 5 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_partitioned_date_time.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_partitioned_date_time.q.out
@@ -305,7 +305,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39456 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: timestamp), _col4 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -360,7 +359,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7200 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: timestamp), _col4 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -1296,7 +1294,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39593 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: timestamp), _col3 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -1351,7 +1348,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7225 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: timestamp), _col3 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -2359,7 +2355,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39593 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: date), _col3 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -2414,7 +2409,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7225 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: date), _col3 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -2978,7 +2972,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39456 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: timestamp), _col4 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -3033,7 +3026,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7200 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col3 (type: timestamp), _col4 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -3969,7 +3961,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39593 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: timestamp), _col3 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -4024,7 +4015,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7225 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: timestamp), _col3 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -5032,7 +5022,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 137 Data size: 39593 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: date), _col3 (type: float)
             Execution mode: vectorized, llap
             LLAP IO: all inputs (cache only)
@@ -5087,7 +5076,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 25 Data size: 7225 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: date), _col3 (type: float)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_reduce_groupby_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_reduce_groupby_decimal.q.out
@@ -99,7 +99,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 6102 Data size: 2123496 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col4 (type: decimal(20,10))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -144,7 +143,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 6102 Data size: 2123496 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
                   value expressions: _col4 (type: decimal(20,10))
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/vector_string_concat.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_string_concat.q.out
@@ -393,7 +393,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 1000 Data size: 184000 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -435,7 +434,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 500 Data size: 92000 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vector_topnkey.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_topnkey.q.out
@@ -129,7 +129,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 5 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: no inputs
             Map Vectorization:
@@ -185,7 +184,6 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 5 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                  TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vector_varchar_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_varchar_simple.q.out
@@ -95,7 +95,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 500 Data size: 94248 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: varchar(20))
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -226,7 +225,6 @@ STAGE PLANS:
                         null sort order: a
                         sort order: -
                         Statistics: Num rows: 500 Data size: 94248 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: varchar(20))
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_streaming.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_streaming.q.out
@@ -249,12 +249,12 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: p_mfgr (type: string)
                       Reduce Sink Vectorization:
-                          className: VectorReduceSinkOperator
-                          native: false
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                          nativeConditionsNotMet: No PTF TopN IS false
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:string, 1:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          partitionColumns: 2:string
                       Statistics: Num rows: 26 Data size: 5694 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.8
             Execution mode: vectorized, llap
             LLAP IO: no inputs
             Map Vectorization:
@@ -263,7 +263,7 @@ STAGE PLANS:
                 inputFormatFeatureSupport: [DECIMAL_64]
                 featureSupportInUse: [DECIMAL_64]
                 inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
+                allNative: true
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
@@ -473,12 +473,12 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: t (type: tinyint)
                         Reduce Sink Vectorization:
-                            className: VectorReduceSinkOperator
-                            native: false
-                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                            nativeConditionsNotMet: No PTF TopN IS false
+                            className: VectorReduceSinkObjectHashOperator
+                            keyColumns: 0:tinyint, 4:float
+                            native: true
+                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                            partitionColumns: 0:tinyint
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                        TopN Hash Memory Usage: 0.8
             Execution mode: vectorized, llap
             LLAP IO: no inputs
             Map Vectorization:
@@ -487,7 +487,7 @@ STAGE PLANS:
                 inputFormatFeatureSupport: [DECIMAL_64]
                 featureSupportInUse: [DECIMAL_64]
                 inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: false
+                allNative: true
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
@@ -718,7 +718,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: ctinyint (type: tinyint)
                       Statistics: Num rows: 12288 Data size: 110096 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.8
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
@@ -869,12 +868,12 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: ctinyint (type: tinyint)
                       Reduce Sink Vectorization:
-                          className: VectorReduceSinkOperator
-                          native: false
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                          nativeConditionsNotMet: No PTF TopN IS false
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:tinyint, 5:double
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          partitionColumns: 0:tinyint
                       Statistics: Num rows: 12288 Data size: 110096 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.8
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -883,7 +882,7 @@ STAGE PLANS:
                 inputFormatFeatureSupport: [DECIMAL_64]
                 featureSupportInUse: [DECIMAL_64]
                 inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: false
+                allNative: true
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:

--- a/ql/src/test/results/clientpositive/llap/vectorization_13.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_13.q.out
@@ -224,7 +224,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 693 Data size: 142976 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -589,7 +588,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 693 Data size: 142976 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_7.q.out
@@ -117,7 +117,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 11033 Data size: 1323416 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -380,7 +379,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 11033 Data size: 1323416 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_8.q.out
@@ -113,7 +113,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3059 Data size: 410040 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -363,7 +362,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3059 Data size: 410040 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_div0.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_div0.q.out
@@ -62,7 +62,6 @@ STAGE PLANS:
                             native: true
                             nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                         Statistics: Num rows: 12288 Data size: 538648 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
                         value expressions: _col1 (type: double), _col3 (type: double), _col5 (type: double), _col7 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -298,7 +297,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3215 Data size: 411520 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -533,7 +531,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 20 Data size: 960 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -768,7 +765,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3378 Data size: 161792 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_limit.q.out
@@ -49,7 +49,6 @@ STAGE PLANS:
                           null sort order: zz
                           sort order: ++
                           Statistics: Num rows: 2048 Data size: 16176 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -177,7 +176,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9173 Data size: 72384 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -428,7 +426,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 131 Data size: 1048 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -581,7 +578,6 @@ STAGE PLANS:
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                               partitionColumns: 0:tinyint
                           Statistics: Num rows: 131 Data size: 264 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.3
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -842,7 +838,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 131 Data size: 1312 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -1088,7 +1083,6 @@ STAGE PLANS:
                         native: true
                         nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                     Statistics: Num rows: 4586 Data size: 64088 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.3
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_offset_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_offset_limit.q.out
@@ -141,7 +141,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9173 Data size: 72384 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: smallint)
             Execution mode: vectorized, llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/vectorization_part_project.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_part_project.q.out
@@ -94,7 +94,6 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 200 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
-                        TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:

--- a/ql/src/test/results/clientpositive/llap/vectorization_short_regress.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_short_regress.q.out
@@ -1153,7 +1153,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 9898 Data size: 4905318 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -1466,7 +1465,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 8194 Data size: 2713706 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized, llap
             LLAP IO: all inputs
             Map Vectorization:
@@ -1728,7 +1726,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 4778 Data size: 1318066 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -2048,7 +2045,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 3828 Data size: 547232 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col0 (type: timestamp)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
@@ -2389,7 +2385,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 321 Data size: 55196 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -3023,7 +3018,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 5980 Data size: 2333226 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Vectorization:

--- a/ql/src/test/results/clientpositive/llap/view_cbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/view_cbo.q.out
@@ -75,7 +75,6 @@ STAGE PLANS:
                       null sort order: zz
                       sort order: ++
                       Statistics: Num rows: 750 Data size: 139500 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
                       value expressions: _col2 (type: double)
         Reducer 3 
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/windowing_filter.q.out
+++ b/ql/src/test/results/clientpositive/llap/windowing_filter.q.out
@@ -120,7 +120,6 @@ STAGE PLANS:
                     sort order: +-
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 5 Data size: 470 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/windowing_streaming.q.out
+++ b/ql/src/test/results/clientpositive/llap/windowing_streaming.q.out
@@ -171,7 +171,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: p_mfgr (type: string)
                       Statistics: Num rows: 26 Data size: 5694 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.8
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -393,7 +392,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: ctinyint (type: tinyint)
                       Statistics: Num rows: 12288 Data size: 110096 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.8
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query1b.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query1b.q.out
@@ -339,7 +339,6 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Statistics: Num rows: 816091 Data size: 81609100 Basic stats: COMPLETE Column stats: COMPLETE
-                      TopN Hash Memory Usage: 0.1
         Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/perf/tez/query1b.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query1b.q.out
@@ -340,7 +340,6 @@ STAGE PLANS:
                           null sort order: z
                           sort order: +
                           Statistics: Num rows: 816091 Data size: 81609100 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
         Reducer 6 
             Execution mode: vectorized
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
+++ b/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
@@ -711,7 +711,7 @@ Stage-0
       File Output Operator [FS_12]
         Limit [LIM_11] (rows=5/5 width=178)
           Number of rows:5
-          Select Operator [SEL_10] (rows=500/5 width=178)
+          Select Operator [SEL_10] (rows=500/36 width=178)
             Output:["_col0","_col1"]
           <-Map 1 [SIMPLE_EDGE] vectorized
             SHUFFLE [RS_9]

--- a/ql/src/test/results/clientpositive/tez/vector_non_string_partition.q.out
+++ b/ql/src/test/results/clientpositive/tez/vector_non_string_partition.q.out
@@ -95,7 +95,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 1537 Data size: 12296 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
                           value expressions: _col1 (type: tinyint)
             Execution mode: vectorized
             Map Vectorization:
@@ -235,7 +234,6 @@ STAGE PLANS:
                               native: true
                               nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                           Statistics: Num rows: 1537 Data size: 156774 Basic stats: COMPLETE Column stats: COMPLETE
-                          TopN Hash Memory Usage: 0.1
             Execution mode: vectorized
             Map Vectorization:
                 enabled: true


### PR DESCRIPTION
Testing done:
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=vector_topnkey.q,topnkey_grouping_sets_order.q,topnkey_windowing_order.q,topnkey_grouping_sets_functions.q,topnkey_order_null.q,topnkey_grouping_sets.q,topnkey_windowing.q -pl itests/qtest -Pitests
```