### PR TITLE
HIVE-23735: Reducer misestimate for export command

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -6866,7 +6866,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     int numFiles = 1;
     int totalFiles = 1;
 
-    if (dest_tab.getNumBuckets() > 0) {
+    if (dest_tab.getNumBuckets() > 0 && !dest_tab.getBucketCols().isEmpty()) {
       enforceBucketing = true;
       if (updating(dest) || deleting(dest)) {
         partnCols = getPartitionColsFromBucketColsForUpdateDelete(input, true);


### PR DESCRIPTION
HIVE-23735: Reducer misestimate for export command

SemanticAnalyzer::genBucketingSortingDest checks for number of buckets for enforceBucketing and based on this number of reducers are determined. Patch adds one more check for bucketCols to ensure that only valid tables gets the reducer sink.
