### PR TITLE
HIVE-23738: DBLockManager::lock() : Move lock request to debug level

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbLockManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbLockManager.java
@@ -99,7 +99,8 @@ public final class DbLockManager implements HiveLockManager{
     MAX_SLEEP = Math.max(15000, conf.getTimeVar(HiveConf.ConfVars.HIVE_LOCK_SLEEP_BETWEEN_RETRIES, TimeUnit.MILLISECONDS));
     int maxNumWaits = Math.max(0, conf.getIntVar(HiveConf.ConfVars.HIVE_LOCK_NUMRETRIES));
     try {
-      LOG.info("Requesting: queryId=" + queryId + " " + lock);
+      LOG.info("Requesting lock for queryId=" + queryId);
+      LOG.debug("Requested lock= " + lock);
       LockResponse res = txnManager.getMS().lock(lock);
       //link lockId to queryId
       LOG.info("Response to queryId=" + queryId + " " + res);


### PR DESCRIPTION
Moving the logging of lock request object to debug, since it prints out the lock request for ALL partitions, which can be huge.
