### PR TITLE
HIVE-23758: OrcInputFormat.getSargColumnNames might be more failsafe in case of schema mismatch

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -494,6 +494,13 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     // we go thru all the top level ORC file columns that are included, in order, they match
     // originalColumnNames. This way, we do not depend on names stored inside ORC for SARG leaf
     // column name resolution (see mapSargColumns method).
+    if (rootColumn > types.size() - 1) {
+      LOG.warn(
+          "possible schema mismatch, asked for column with index:{} but there is only {} types defined"
+              + " (isOriginal: {}, originalColumnNames.length: {}), cannot get sarg col names...",
+          rootColumn, types.size(), isOriginal, originalColumnNames.length);
+      return null;
+    }
     for(int columnId: types.get(rootColumn).getSubtypesList()) {
       if (includedColumns == null || includedColumns[columnId - rootColumn]) {
         // this is guaranteed to be positive because types only have children


### PR DESCRIPTION
## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HIVE-XXXXX: Fix a typo in YYY)
For more details, please see https://cwiki.apache.org/confluence/display/Hive/HowToContribute
