### PR TITLE
HIVE-20817: Reading Timestamp datatype via HiveServer2 gives errors

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/ColumnValue.java
+++ b/service/src/java/org/apache/hive/service/cli/ColumnValue.java
@@ -19,14 +19,14 @@
 package org.apache.hive.service.cli;
 
 import java.math.BigDecimal;
-import java.sql.Date;
-import java.sql.Timestamp;
 
+import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.HiveChar;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
+import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.common.type.TimestampTZ;
 import org.apache.hadoop.hive.serde2.thrift.Type;
 import org.apache.hive.service.rpc.thrift.TBoolValue;


### PR DESCRIPTION
HIVE-20817: Reading Timestamp datatype via HiveServer2 gives errors
(cherry picked from commit 132a10459e8348707b014215509727f563dbd57a)
https://issues.apache.org/jira/browse/HIVE-20817

This issue has been already fixed in Hive 4.0, however, not in Hive 3.1. 
This pull request is to backport the fix to Hive 3.1 branch.