### PR TITLE
HIVE-23737: Reuse dagDelete Feature Of Tez Custom Shuffle Handler Instead Of LLAP's dagDelete

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryInfo.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryInfo.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.tez.common.security.JobTokenIdentifier;
+import org.apache.tez.runtime.library.common.Constants;
 
 public class QueryInfo {
   private final QueryIdentifier queryIdentifier;
@@ -199,7 +200,7 @@ public class QueryInfo {
     // May work via YARN Service - since the directory would already exist. Otherwise may need a custom shuffle handler.
     // TODO This should be the process user - and not the user on behalf of whom the query is being submitted.
     return baseDir + File.separator + "usercache" + File.separator + user + File.separator +
-        "appcache" + File.separator + applicationIdString + File.separator + dagIdentifier;
+        "appcache" + File.separator + applicationIdString + File.separator + Constants.DAG_PREFIX + dagIdentifier;
   }
 
   /**

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/QueryTracker.java
@@ -305,7 +305,9 @@ public class QueryTracker extends AbstractService {
       queryInfoMap.remove(queryIdentifier);
       if (!isExternalQuery) {
         rememberCompletedDag(queryIdentifier);
-        cleanupLocalDirs(queryInfo, deleteDelay);
+        // DAG Directory clean up will be taken care by LLAP Shuffle Handler
+        //todo: Properly remove all dag directory clean up code.
+        //cleanupLocalDirs(queryInfo, deleteDelay);
         handleLogOnQueryCompletion(queryInfo.getHiveQueryIdString(), queryInfo.getDagIdString());
       } else {
         // If there's no pending fragments, queue some of the cleanup for a later point - locks, log rolling.

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
@@ -895,7 +895,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
             unregisterDag(dagPath.toString(), jobQ.get(0), Integer.parseInt(dagIdQ.get(0)));
           }
         } catch (IOException e) {
-          LOG.warn("Encountered exception during dag delete "+ e);
+          LOG.warn("Encountered exception during dag delete ", e);
         }
         evt.getChannel().write(new DefaultHttpResponse(HTTP_1_1, OK));
         evt.getChannel().close();

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/shufflehandler/TestShuffleHandler.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/shufflehandler/TestShuffleHandler.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.llap.shufflehandler;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeysPublic;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.hadoop.util.PureJavaCrc32;
+import org.apache.hadoop.util.StringUtils;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.apache.hadoop.yarn.conf.YarnConfiguration;
+import org.apache.tez.common.security.JobTokenIdentifier;
+import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
+import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
+import org.apache.tez.runtime.library.common.sort.impl.TezSpillRecord;
+import org.jboss.netty.channel.ChannelHandlerContext;
+import org.jboss.netty.handler.codec.http.HttpResponseStatus;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.EOFException;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.Checksum;
+
+public class TestShuffleHandler {
+
+  @Test(timeout = 5000)
+  public void testDagDelete() throws Exception {
+    final ArrayList<Throwable> failures = new ArrayList<Throwable>(1);
+    Configuration conf = new Configuration();
+    conf.setInt(ShuffleHandler.MAX_SHUFFLE_CONNECTIONS, 3);
+    conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, ShuffleHandler.DEFAULT_SHUFFLE_PORT);
+    conf.set(CommonConfigurationKeysPublic.HADOOP_SECURITY_AUTHENTICATION,
+        "simple");
+    UserGroupInformation.setConfiguration(conf);
+    File absLogDir = new File("target", TestShuffleHandler.class.
+        getSimpleName() + "LocDir").getAbsoluteFile();
+    conf.set(ShuffleHandler.SHUFFLE_HANDLER_LOCAL_DIRS, absLogDir.getAbsolutePath());
+    ApplicationId appId = ApplicationId.newInstance(12345, 1);
+    String appAttemptId = "attempt_12345_1_m_1_0";
+    String user = "randomUser";
+    List<File> fileMap = new ArrayList<File>();
+    createShuffleHandlerFiles(absLogDir, user, appId.toString(), appAttemptId,
+        conf, fileMap);
+    ShuffleHandler shuffleHandler = new ShuffleHandler(conf) {
+      @Override
+      protected Shuffle getShuffle(Configuration conf) {
+        // replace the shuffle handler with one stubbed for testing
+        return new Shuffle(conf) {
+          @Override
+          protected void sendError(ChannelHandlerContext ctx, String message,
+                                   HttpResponseStatus status) {
+            if (failures.size() == 0) {
+              failures.add(new Error(message));
+              ctx.getChannel().close();
+            }
+          }
+        };
+      }
+    };
+    try {
+      shuffleHandler.start();
+      DataOutputBuffer outputBuffer = new DataOutputBuffer();
+      outputBuffer.reset();
+      Token<JobTokenIdentifier> jt =
+          new Token<JobTokenIdentifier>("identifier".getBytes(),
+              "password".getBytes(), new Text(user), new Text("shuffleService"));
+      jt.write(outputBuffer);
+      shuffleHandler.registerDag(appId.toString(), 1, jt, user, null);
+      URL url =
+          new URL(
+              "http://127.0.0.1:"
+                  + conf.get(
+                  ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY)
+                  + "/mapOutput?dagAction=delete&job=job_12345_0001&dag=1");
+      HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
+          ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
+      conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
+          ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
+      String dagDirStr =
+          StringUtils.join(Path.SEPARATOR,
+              new String[] { absLogDir.getAbsolutePath(),
+                  ShuffleHandler.USERCACHE, user,
+                  ShuffleHandler.APPCACHE, appId.toString(),"dag_1/"});
+      File dagDir = new File(dagDirStr);
+      Assert.assertTrue("Dag Directory does not exist!", dagDir.exists());
+      conn.connect();
+      try {
+        DataInputStream is = new DataInputStream(conn.getInputStream());
+        is.close();
+        Assert.assertFalse("Dag Directory was not deleted!", dagDir.exists());
+      } catch (EOFException e) {
+        // ignore
+      }
+      Assert.assertEquals("sendError called due to shuffle error",
+          0, failures.size());
+    } finally {
+      shuffleHandler.stop();
+      FileUtil.fullyDelete(absLogDir);
+    }
+  }
+
+  private static void createShuffleHandlerFiles(File logDir, String user,
+                                                String appId, String appAttemptId, Configuration conf,
+                                                List<File> fileMap) throws IOException {
+    String attemptDir =
+        StringUtils.join(Path.SEPARATOR,
+            new String[] { logDir.getAbsolutePath(),
+                ShuffleHandler.USERCACHE, user,
+                ShuffleHandler.APPCACHE, appId,"dag_1/" + "output",
+                appAttemptId });
+    File appAttemptDir = new File(attemptDir);
+    appAttemptDir.mkdirs();
+    System.out.println(appAttemptDir.getAbsolutePath());
+    File indexFile = new File(appAttemptDir, "file.out.index");
+    fileMap.add(indexFile);
+    createIndexFile(indexFile, conf);
+    File mapOutputFile = new File(appAttemptDir, "file.out");
+    fileMap.add(mapOutputFile);
+    createMapOutputFile(mapOutputFile, conf);
+  }
+
+  private static void
+  createMapOutputFile(File mapOutputFile, Configuration conf)
+      throws IOException {
+    FileOutputStream out = new FileOutputStream(mapOutputFile);
+    out.write("Creating new dummy map output file. Used only for testing"
+        .getBytes());
+    out.flush();
+    out.close();
+  }
+
+  private static void createIndexFile(File indexFile, Configuration conf)
+      throws IOException {
+    if (indexFile.exists()) {
+      System.out.println("Deleting existing file");
+      indexFile.delete();
+    }
+    Checksum crc = new PureJavaCrc32();
+    TezSpillRecord tezSpillRecord = new TezSpillRecord(2);
+    tezSpillRecord.putIndex(new TezIndexRecord(0, 10, 10), 0);
+    tezSpillRecord.putIndex(new TezIndexRecord(10, 10, 10), 1);
+    tezSpillRecord.writeToFile(new Path(indexFile.getAbsolutePath()), conf, crc);
+  }
+}

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapContainerLauncher.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapContainerLauncher.java
@@ -14,20 +14,49 @@
 
 package org.apache.hadoop.hive.llap.tezplugins;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.tez.common.DagContainerLauncher;
+import org.apache.tez.common.ReflectionUtils;
+import org.apache.tez.common.TezUtils;
+import org.apache.tez.common.security.JobTokenSecretManager;
+import org.apache.tez.dag.api.TezConfiguration;
+import org.apache.tez.dag.api.TezReflectionException;
+import org.apache.tez.dag.api.TezUncheckedException;
+import org.apache.tez.dag.app.launcher.DeletionTracker;
+import org.apache.tez.dag.records.TezDAGID;
 import org.apache.tez.serviceplugins.api.ContainerLaunchRequest;
-import org.apache.tez.serviceplugins.api.ContainerLauncher;
 import org.apache.tez.serviceplugins.api.ContainerLauncherContext;
 import org.apache.tez.serviceplugins.api.ContainerStopRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class LlapContainerLauncher extends ContainerLauncher {
+import java.io.IOException;
+
+public class LlapContainerLauncher extends DagContainerLauncher {
   private static final Logger LOG = LoggerFactory.getLogger(LlapContainerLauncher.class);
+  private Configuration conf;
+  private DeletionTracker deletionTracker;
 
   public LlapContainerLauncher(ContainerLauncherContext containerLauncherContext) {
     super(containerLauncherContext);
-  }
+    try {
+      conf = TezUtils.createConfFromUserPayload(containerLauncherContext.getInitialUserPayload());
+    } catch (IOException e) {
+      throw new TezUncheckedException(
+          "Failed to parse user payload for " + LlapContainerLauncher.class.getSimpleName(), e);
+    }
 
+    try {
+      //todo: Do we need to put this behind the flag?
+      String deletionTrackerClassName = conf.get(TezConfiguration.TEZ_AM_DELETION_TRACKER_CLASS,
+          TezConfiguration.TEZ_AM_DELETION_TRACKER_CLASS_DEFAULT);
+      deletionTracker = ReflectionUtils.createClazzInstance(
+          deletionTrackerClassName, new Class[]{Configuration.class}, new Object[]{conf});
+    } catch (TezReflectionException e) {
+      LOG.warn("Unable to initialize dag deletionTracker class. Dag deletion on completion won't work", e);
+    }
+  }
   @Override
   public void launchContainer(ContainerLaunchRequest containerLaunchRequest) {
     if (LOG.isDebugEnabled()) {
@@ -36,6 +65,11 @@ public class LlapContainerLauncher extends ContainerLauncher {
           " succeeded on host: " + containerLaunchRequest.getNodeId());
     }
     getContext().containerLaunched(containerLaunchRequest.getContainerId());
+
+    if (deletionTracker != null) {
+      deletionTracker.addNodeShufflePort(containerLaunchRequest.getNodeId(),
+          HiveConf.getIntVar(conf, HiveConf.ConfVars.LLAP_DAEMON_YARN_SHUFFLE_PORT));
+    }
   }
 
   @Override
@@ -45,5 +79,12 @@ public class LlapContainerLauncher extends ContainerLauncher {
           containerStopRequest.getContainerId());
     }
     // Nothing to do here.
+  }
+
+  @Override
+  public void dagComplete(TezDAGID dag, JobTokenSecretManager jobTokenSecretManager) {
+    if (deletionTracker != null) {
+      deletionTracker.dagComplete(dag, jobTokenSecretManager);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -332,7 +332,7 @@ public class TezSessionState {
           new TaskSchedulerDescriptor[] { TaskSchedulerDescriptor.create(
               LLAP_SERVICE, LLAP_SCHEDULER).setUserPayload(servicePluginPayload) },
           new ContainerLauncherDescriptor[] { ContainerLauncherDescriptor.create(
-              LLAP_SERVICE, LLAP_LAUNCHER) },
+              LLAP_SERVICE, LLAP_LAUNCHER).setUserPayload(servicePluginPayload)  },
           new TaskCommunicatorDescriptor[] { TaskCommunicatorDescriptor.create(
               LLAP_SERVICE, LLAP_TASK_COMMUNICATOR).setUserPayload(servicePluginPayload) });
     } else {


### PR DESCRIPTION
LLAP have a dagDelete feature added as part of HIVE-9911, But now that Tez have added support for dagDelete in custom shuffle handler (TEZ-3362) we could re-use that feature in LLAP.
There are some added advantages of using Tez's dagDelete feature rather than the current LLAP's dagDelete feature.

1) We can easily extend this feature to accommodate the upcoming features such as vertex and failed task attempt shuffle data clean up. Refer TEZ-3363 and TEZ-4129

2) It will be more easier to maintain this feature by separating it out from the Hive's code path.