### PR TITLE
HIVE-23791: Optimize ACID stats generation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1344,8 +1344,8 @@ public class AcidUtils {
       // Okay, we're going to need these originals.  
       // Recurse through them and figure out what we really need.
       // If we already have the original list, do nothing
-      // If dirSnapshots != null, we would have already populated "original"
-      if (dirSnapshots == null) {
+      // If childrenWithId != null, we would have already populated "original"
+      if (childrenWithId != null) {
         for (Path origDir : originalDirectories) {
           findOriginals(fs, origDir, original, useFileIds, ignoreEmptyFiles, true);
         }


### PR DESCRIPTION
Run AcidUtils.getHdfsDirSnapshots to collect the relevant files, and use that for stats generation