### PR TITLE
HIVE-23814: Clean up Driver (Miklos Gergely)

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHiveAuthorizerCheckInvocation.java
@@ -302,7 +302,7 @@ public class TestHiveAuthorizerCheckInvocation {
     assertTrue("db name", dbName.equalsIgnoreCase(dbObj.getDbname()));
 
     // actually create the permanent function
-    driver.run(null, true);
+    driver.run();
 
     // Verify privilege objects
     reset(mockedAuthorizer);

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
@@ -34,7 +34,11 @@ import com.google.common.base.Strings;
 /**
  * Constructs a driver for ql clients.
  */
-public class DriverFactory {
+public final class DriverFactory {
+
+  private DriverFactory() {
+    throw new UnsupportedOperationException("DriverFactory should not be instantiated!");
+  }
 
   public static IDriver newDriver(HiveConf conf) {
     return newDriver(getNewQueryState(conf), null);
@@ -62,13 +66,13 @@ public class DriverFactory {
   }
 
   private static IReExecutionPlugin buildReExecPlugin(String name) throws RuntimeException {
-    if (name.equals("overlay")) {
+    if ("overlay".equals(name)) {
       return new ReExecutionOverlayPlugin();
     }
-    if (name.equals("reoptimize")) {
+    if ("reoptimize".equals(name)) {
       return new ReOptimizePlugin();
     }
-    if(name.equals("reexecute_lost_am")) {
+    if("reexecute_lost_am".equals(name)) {
       return new ReExecuteLostAMQueryPlugin();
     }
     throw new RuntimeException(

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverState.java
@@ -129,8 +129,13 @@ public class DriverState {
     return driverState == State.EXECUTING;
   }
 
-  public void executionFinished(boolean wasError) {
-    driverState = wasError ? State.ERROR : State.EXECUTED;
+  public void executionFinishedWithLocking(boolean wasError) {
+    lock();
+    try {
+      driverState = wasError ? State.ERROR : State.EXECUTED;
+    } finally {
+      unlock();
+    }
   }
 
   public boolean isExecuted() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Executor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Executor.java
@@ -550,12 +550,7 @@ public class Executor {
       SessionState.get().getSparkSession().onQueryCompletion(driverContext.getQueryId());
     }
 
-    driverState.lock();
-    try {
-      driverState.executionFinished(executionError);
-    } finally {
-      driverState.unlock();
-    }
+    driverState.executionFinishedWithLocking(executionError);
 
     if (driverState.isAborted()) {
       LOG.info("Executing command(queryId={}) has been interrupted after {} seconds", driverContext.getQueryId(),

--- a/ql/src/java/org/apache/hadoop/hive/ql/HiveDriverRunHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/HiveDriverRunHook.java
@@ -38,13 +38,11 @@ public interface HiveDriverRunHook extends Hook {
    * Invoked before Hive begins any processing of a command in the Driver,
    * notably before compilation and any customizable performance logging.
    */
-  public void preDriverRun(
-    HiveDriverRunHookContext hookContext) throws Exception;
+  void preDriverRun(HiveDriverRunHookContext hookContext) throws Exception;
 
   /**
    * Invoked after Hive performs any processing of a command, just before a
    * response is returned to the entity calling the Driver.
    */
-  public void postDriverRun(
-    HiveDriverRunHookContext hookContext) throws Exception;
+  void postDriverRun(HiveDriverRunHookContext hookContext) throws Exception;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/HiveDriverRunHookContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/HiveDriverRunHookContext.java
@@ -29,6 +29,6 @@ import org.apache.hadoop.hive.common.classification.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public interface HiveDriverRunHookContext extends Configurable{
-  public String getCommand();
-  public void setCommand(String command);
+  String getCommand();
+  void setCommand(String command);
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/IDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/IDriver.java
@@ -31,7 +31,7 @@ import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorResponse;
 
 /**
- * Hive query executer driver
+ * Hive query executer driver.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Unstable
@@ -53,6 +53,7 @@ public interface IDriver extends CommandProcessor {
   CommandProcessorResponse run(String command) throws CommandProcessorException;
 
   // create some "cover" to the result?
+  @SuppressWarnings("rawtypes")
   boolean getResults(List res) throws IOException;
 
   void setMaxRows(int maxRows);
@@ -65,7 +66,8 @@ public interface IDriver extends CommandProcessor {
 
   void resetFetch() throws IOException;
 
-  // close&destroy is used in seq coupling most of the time - the difference is either not clear; or not relevant - remove?
+  // close&destroy is used in seq coupling most of the time - the difference is either not clear; or not relevant
+  // remove?
   @Override
   void close();
   void destroy();

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
@@ -350,7 +350,7 @@ public class GenericUDTFGetSplits extends GenericUDTF {
         driver.releaseResources();
         HiveConf.setVar(conf, ConfVars.HIVE_EXECUTION_MODE, originalMode);
         try {
-          driver.run(ctas, false);
+          driver.run(ctas);
         } catch (CommandProcessorException e) {
           throw new HiveException("Failed to create temp table [" + tableName + "]", e);
         }


### PR DESCRIPTION
Driver is now cut down to it's minimal size by extracting all of it's sub tasks to separate classes. The rest should be cleaned up by

- moving out some smaller parts of the code to sub task and utility classes wherever it is still possible
- fix checkstyle issues
- add missing javadocs