### PR TITLE
HIVE-23839: Use LongAdder instead of AtomicLong

### DIFF
--- a/llap-client/src/java/org/apache/hadoop/hive/llap/tezplugins/helpers/LlapTaskUmbilicalServer.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/tezplugins/helpers/LlapTaskUmbilicalServer.java
@@ -19,10 +19,8 @@ package org.apache.hadoop.hive.llap.tezplugins.helpers;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeysPublic;

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
@@ -29,7 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.atomic.AtomicReference;
 
 import javax.management.ObjectName;
@@ -106,7 +106,7 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
   private final LlapRegistryService registry;
   private final LlapWebServices webServices;
   private final LlapLoadGeneratorService llapLoadGeneratorService;
-  private final AtomicLong numSubmissions = new AtomicLong(0);
+  private final LongAdder numSubmissions = new LongAdder();
   private final JvmPauseMonitor pauseMonitor;
   private final ObjectName llapDaemonInfoBean;
   private final LlapDaemonExecutorMetrics metrics;
@@ -612,7 +612,7 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
   @Override
   public SubmitWorkResponseProto submitWork(
       SubmitWorkRequestProto request) throws IOException {
-    numSubmissions.incrementAndGet();
+    numSubmissions.increment();
     return containerRunner.submitWork(request);
   }
 
@@ -655,7 +655,7 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
 
   @VisibleForTesting
   public long getNumSubmissions() {
-    return numSubmissions.get();
+    return numSubmissions.longValue();
   }
 
   public InetSocketAddress getListenerAddress() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -69,7 +69,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadLocalRandom;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.Deflater;
@@ -2610,9 +2610,9 @@ public final class Utilities {
     Preconditions.checkNotNull(executor);
 
     List<Future<?>> futures = new ArrayList<Future<?>>(pathNeedProcess.size());
-    final AtomicLong totalLength = new AtomicLong(0L);
-    final AtomicLong totalFileCount = new AtomicLong(0L);
-    final AtomicLong totalDirectoryCount = new AtomicLong(0L);
+    final LongAdder totalLength = new LongAdder();
+    final LongAdder totalFileCount = new LongAdder();
+    final LongAdder totalDirectoryCount = new LongAdder();
 
     HiveInterruptCallback interrup = HiveInterruptUtils.add(new HiveInterruptCallback() {
       @Override
@@ -2704,9 +2704,9 @@ public final class Utilities {
             final long csFileCount = cs.getFileCount();
             final long csDirectoryCount = cs.getDirectoryCount();
 
-            totalLength.addAndGet(csLength);
-            totalFileCount.addAndGet(csFileCount);
-            totalDirectoryCount.addAndGet(csDirectoryCount);
+            totalLength.add(csLength);
+            totalFileCount.add(csFileCount);
+            totalDirectoryCount.add(csDirectoryCount);
 
             ctx.addCS(p.toString(), cs);
 
@@ -2735,9 +2735,9 @@ public final class Utilities {
 
       HiveInterruptUtils.checkInterrupted();
 
-      summary[0] += totalLength.get();
-      summary[1] += totalFileCount.get();
-      summary[2] += totalDirectoryCount.get();
+      summary[0] += totalLength.longValue();
+      summary[1] += totalFileCount.longValue();
+      summary[2] += totalDirectoryCount.longValue();
     } finally {
       executor.shutdownNow();
       HiveInterruptUtils.remove(interrup);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkMetricUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/SparkMetricUtils.java
@@ -26,7 +26,7 @@ import org.slf4j.Logger;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 
 /**
@@ -47,17 +47,17 @@ public final class SparkMetricUtils {
 
   public static void updateSparkBytesWrittenMetrics(Logger log, FileSystem fs, Path[]
           commitPaths) {
-    AtomicLong bytesWritten = new AtomicLong();
+    LongAdder bytesWritten = new LongAdder();
     Arrays.stream(commitPaths).parallel().forEach(path -> {
       try {
-        bytesWritten.addAndGet(fs.getFileStatus(path).getLen());
+        bytesWritten.add(fs.getFileStatus(path).getLen());
       } catch (IOException e) {
         log.debug("Unable to collect stats for file: " + path + " output metrics may be inaccurate",
                 e);
       }
     });
-    if (bytesWritten.get() > 0) {
-      TaskContext.get().taskMetrics().outputMetrics().setBytesWritten(bytesWritten.get());
+    if (bytesWritten.longValue() > 0) {
+      TaskContext.get().taskMetrics().outputMetrics().setBytesWritten(bytesWritten.longValue());
     }
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AggregateStatsCache.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/AggregateStatsCache.java
@@ -35,7 +35,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -69,8 +69,8 @@ public class AggregateStatsCache {
   private final double maxVariance;
   // Used to determine if cleaner thread is already running
   private boolean isCleaning = false;
-  private final AtomicLong cacheHits = new AtomicLong(0);
-  private final AtomicLong cacheMisses = new AtomicLong(0);
+  private final LongAdder cacheHits = new LongAdder();
+  private final LongAdder cacheMisses = new LongAdder();
   // To track cleaner metrics
   int numRemovedTTL = 0, numRemovedLRU = 0;
 
@@ -182,12 +182,12 @@ public class AggregateStatsCache {
       if (match != null) {
         // Ok to not lock the list for this and use a volatile lastAccessTime instead
         candidateList.updateLastAccessTime();
-        cacheHits.incrementAndGet();
+        cacheHits.increment();
         LOG.info("Returning aggregate stats from the cache; total hits: " + cacheHits.longValue()
             + ", total misses: " + cacheMisses.longValue() + ", hit ratio: " + getHitRatio());
       }
       else {
-        cacheMisses.incrementAndGet();
+        cacheMisses.increment();
       }
     } catch (InterruptedException e) {
       LOG.debug("Interrupted Exception ignored ",e);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/SharedCache.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/SharedCache.java
@@ -36,7 +36,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
@@ -109,7 +109,7 @@ public class SharedCache {
   private Map<ByteArrayWrapper, StorageDescriptorWrapper> sdCache = new HashMap<>();
   private static MessageDigest md;
   private static final Logger LOG = LoggerFactory.getLogger(SharedCache.class.getName());
-  private AtomicLong cacheUpdateCount = new AtomicLong(0);
+  private LongAdder cacheUpdateCount = new LongAdder();
   private long maxCacheSizeInBytes = -1;
   private HashMap<Class<?>, ObjectEstimator> sizeEstimators = null;
   private Set<String> tableToUpdateSize = new ConcurrentHashSet<>();
@@ -2552,10 +2552,10 @@ public class SharedCache {
   }
 
   public long getUpdateCount() {
-    return cacheUpdateCount.get();
+    return cacheUpdateCount.longValue();
   }
 
   public void incrementUpdateCount() {
-    cacheUpdateCount.incrementAndGet();
+    cacheUpdateCount.increment();
   }
 }

--- a/testutils/ptest2/src/main/java/org/apache/hive/ptest/execution/HostExecutor.java
+++ b/testutils/ptest2/src/main/java/org/apache/hive/ptest/execution/HostExecutor.java
@@ -28,7 +28,7 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
 
 import com.google.common.base.Stopwatch;
 import org.apache.commons.lang3.StringUtils;
@@ -71,7 +71,7 @@ class HostExecutor {
   private volatile boolean mShutdown;
   private int numParallelBatchesProcessed = 0;
   private int numIsolatedBatchesProcessed = 0;
-  private AtomicLong totalElapsedTimeInRsync = new AtomicLong(0L);
+  private LongAdder totalElapsedTimeInRsync = new LongAdder();
   
   HostExecutor(Host host, String privateKey, ListeningExecutorService executor,
       SSHCommandExecutor sshCommandExecutor,
@@ -143,7 +143,7 @@ class HostExecutor {
   }
 
   long getTotalRsyncTimeInMs() {
-    return totalElapsedTimeInRsync.get();
+    return totalElapsedTimeInRsync.longValue();
   }
   /**
    * Executes parallel test until the parallel work queue is empty. Then
@@ -317,7 +317,7 @@ class HostExecutor {
     if(result.getException() != null || result.getExitCode() != 0) {
       throw new SSHExecutionException(result);
     }
-    totalElapsedTimeInRsync.getAndAdd(result.getElapsedTimeInMs());
+    totalElapsedTimeInRsync.add(result.getElapsedTimeInMs());
     return result;
   }
   /**
@@ -387,7 +387,7 @@ class HostExecutor {
     if(result.getException() != null || result.getExitCode() != Constants.EXIT_CODE_SUCCESS) {
       throw new SSHExecutionException(result);
     }
-    totalElapsedTimeInRsync.getAndAdd(result.getElapsedTimeInMs());
+    totalElapsedTimeInRsync.add(result.getElapsedTimeInMs());
     return result;
   }
   /**


### PR DESCRIPTION
LongAdder performs better than AtomicLong in high concurrent environment
