### PR TITLE
HIVE-23841: Field writers is an HashSet, i.e., not thread-safe.  Field writers is typically protected by synchronization on lock, but not in 1 location.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java
+++ b/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java
@@ -245,7 +245,7 @@ public class LlapOutputFormatService {
     @Override
     public void operationComplete(ChannelFuture future) throws Exception {
       RecordWriter<?, ?> writer = null;
-      synchronized (INSTANCE) {
+      synchronized (lock) {
         writer = writers.remove(id);
       }
 


### PR DESCRIPTION
I also submitted a bug report on JIRA at:

https://issues.apache.org/jira/browse/HIVE-23841

# Description

Field `writers` is a `HashMap` ([line 70](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L70)), i.e., not thread-safe. 

Accesses to field `writers` are protected by synchronization on `lock`, e.g., at lines: [141-144](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L141-L144), [212-213](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L212-L213), and [212-215](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L212-L215).

However, the `writers.remove()` at  [line 249](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L249) is protected by synchronization on `INSTANCE`, **not** on `lock`.

Synchronizing on 2 different objects does not ensure mutual exclusion.  This is because 2 threads synchronizing on different objects can still execute in parallel at the same time.

Note that lines [215](https://github.com/apache/hive/blob/c93d7797329103d6c509bada68b6da7f907b3dee/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L215) and [249](https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/llap/LlapOutputFormatService.java#L249) are modifying `writers` with `put()` and `remove()`, respectively. 


# The Code for This Fix

This fix is very simple: just change `synchronized (INSTANCE)` to `synchronized (lock)`, just like the methods containing the other lines listed above.
