### PR TITLE
HIVE-23853: CRUD based compaction also should update ACID file version metadata

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtil.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.io.AcidInputFormat;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.RecordIdentifier;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
@@ -94,8 +95,8 @@ class CompactorTestUtil {
       throws IOException {
     Path path = partitionName == null ? new Path(table.getSd().getLocation(), deltaName) : new Path(
         new Path(table.getSd().getLocation()), new Path(partitionName, deltaName));
-    return Arrays.stream(fs.listStatus(path)).map(FileStatus::getPath).map(Path::getName).sorted()
-        .collect(Collectors.toList());
+    return Arrays.stream(fs.listStatus(path, AcidUtils.hiddenFileFilter)).map(FileStatus::getPath).map(Path::getName)
+        .sorted().collect(Collectors.toList());
   }
 
   /**

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -67,6 +67,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   @Test
   public void testMajorCompactionNotPartitionedWithoutBuckets() throws Exception {
+    boolean originalEnableVersionFile = conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE, true);
+
     String dbName = "default";
     String tblName = "testMajorCompaction";
     TestDataProvider testDataProvider = new TestDataProvider();
@@ -122,6 +125,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         testDataProvider.getBucketData(tblName, "536870912"));
     // Check bucket file contents
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs, true,
+        new String[] { AcidUtils.BASE_PREFIX});
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE, originalEnableVersionFile);
   }
 
   /**
@@ -130,6 +137,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
    */
   @Test
   public void testMajorCompactionNotPartitioned4Buckets() throws Exception {
+    boolean originalEnableVersionFile = conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE);
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE, false);
+
     String dbName = "default";
     String tblName = "testMajorCompaction";
     executeStatementOnDriver("drop table if exists " + tblName, driver);
@@ -208,6 +218,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 1);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 2);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs, false,
+        new String[] { AcidUtils.BASE_PREFIX});
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE, originalEnableVersionFile);
   }
 
   @Test
@@ -294,6 +308,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     checkBucketIdAndRowIdInAcidFile(fs, new Path(todayPath, "base_0000005_v0000009"), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(tomorrowPath, "base_0000005_v0000013"), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(yesterdayPath, "base_0000005_v0000017"), 0);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE), new String[] { AcidUtils.BASE_PREFIX});
   }
 
   @Test public void testMajorCompactionPartitionedWithBuckets() throws Exception {
@@ -401,6 +418,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionTomorrow), expectedBaseTomorrow), 1);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionYesterday), expectedBaseYesterday), 0);
     checkBucketIdAndRowIdInAcidFile(fs, new Path(new Path(tablePath, partitionYesterday), expectedBaseYesterday), 1);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE), new String[] { AcidUtils.BASE_PREFIX});
   }
 
   @Test
@@ -468,6 +488,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
     // Clean up
     dataProvider.dropTable(tableName);
   }
@@ -541,6 +566,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
     // Clean up
     dataProvider.dropTable(tableName);
   }
@@ -603,6 +633,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
     // Clean up
     dataProvider.dropTable(tableName);
   }
@@ -685,6 +720,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
     // Clean up
     dataProvider.dropTable(tableName);
   }
@@ -738,6 +778,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     // Verify all contents
     List<String> actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
     // Clean up
     dataProvider.dropTable(tableName);
   }
@@ -788,6 +833,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     Assert.assertEquals("Delete delta directories does not match after compaction",
         Collections.singletonList("delete_delta_0000001_0000015_v0000044"), actualDeleteDeltasAfterComp);
 
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX, AcidUtils.DELETE_DELTA_PREFIX});
+
   }
 
   @Test
@@ -822,6 +871,9 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
           new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000005_v0000009")}, "a,b", "int:string",
           0, 1L, 4L, null, 1);
 
+      CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+          conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+          new String[] { AcidUtils.DELTA_PREFIX });
     } finally {
       if (connection != null) {
         connection.close();
@@ -853,6 +905,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     CompactorTestUtil.checkExpectedTxnsPresent(null,
         new Path[] {new Path(table.getSd().getLocation(), "delta_0000001_0000006_v0000009")}, "a,b", "int:string", 0,
         1L, 4L, Lists.newArrayList(5, 6), 1);
+
+    CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs,
+        conf.getBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE),
+        new String[] { AcidUtils.DELTA_PREFIX });
   }
 
   @Test
@@ -868,7 +924,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         .newArrayList(new CompactorTestUtil.StreamingConnectionOption(false, false),
             new CompactorTestUtil.StreamingConnectionOption(true, false),
             new CompactorTestUtil.StreamingConnectionOption(false, false)));
-    // Now, copact
+    // Now, compact
     CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
     // Find the location of the table
     IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -292,6 +292,9 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
             }
         }
       }
+      if (conf.isCompactionTable() && HiveConf.getBoolVar(hconf, HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE)) {
+        AcidUtils.OrcAcidVersion.writeVersionFile(finalPaths[idx].getParent(), fs);
+      }
       updateProgress();
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -292,9 +292,6 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
             }
         }
       }
-      if (conf.isCompactionTable() && HiveConf.getBoolVar(hconf, HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE)) {
-        AcidUtils.OrcAcidVersion.writeVersionFile(finalPaths[idx].getParent(), fs);
-      }
       updateProgress();
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
@@ -163,7 +163,7 @@ public final class OrcFile extends org.apache.orc.OrcFile {
         LlapProxy.isDaemon()) {
         memory(getThreadLocalOrcLlapMemoryManager(conf));
       }
-      isCompaction = tableProperties != null && "true".equals(tableProperties.getProperty(AcidUtils.COMPACTOR_TABLE_PROPERTY));
+      isCompaction = AcidUtils.isCompactionTable(tableProperties);
     }
 
    /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFile.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.llap.LlapDaemonInfo;
 import org.apache.hadoop.hive.llap.LlapUtil;
 import org.apache.hadoop.hive.llap.io.api.LlapProxy;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.orc.FileMetadata;
@@ -153,6 +154,7 @@ public final class OrcFile extends org.apache.orc.OrcFile {
     // the smallest stripe size would be 5120 rows, which changes the output
     // of some of the tests.)
     private int batchSize = 1000;
+    private boolean isCompaction;
 
     WriterOptions(Properties tableProperties, Configuration conf) {
       super(tableProperties, conf);
@@ -161,6 +163,7 @@ public final class OrcFile extends org.apache.orc.OrcFile {
         LlapProxy.isDaemon()) {
         memory(getThreadLocalOrcLlapMemoryManager(conf));
       }
+      isCompaction = tableProperties != null && "true".equals(tableProperties.getProperty(AcidUtils.COMPACTOR_TABLE_PROPERTY));
     }
 
    /**
@@ -348,6 +351,10 @@ public final class OrcFile extends org.apache.orc.OrcFile {
 
     int getBatchSize() {
       return batchSize;
+    }
+
+    boolean isCompaction() {
+      return isCompaction;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcOutputFormat.java
@@ -82,8 +82,7 @@ public class OrcOutputFormat extends FileOutputFormat<NullWritable, OrcSerdeRow>
     public void write(NullWritable nullWritable,
                       OrcSerdeRow row) throws IOException {
       if (writer == null) {
-        options.inspector(row.getInspector());
-        writer = OrcFile.createWriter(path, options);
+        init(row);
       }
       writer.addRow(row.getRow());
     }
@@ -92,8 +91,7 @@ public class OrcOutputFormat extends FileOutputFormat<NullWritable, OrcSerdeRow>
     public void write(Writable row) throws IOException {
       OrcSerdeRow serdeRow = (OrcSerdeRow) row;
       if (writer == null) {
-        options.inspector(serdeRow.getInspector());
-        writer = OrcFile.createWriter(path, options);
+        init(serdeRow);
       }
       writer.addRow(serdeRow.getRow());
     }
@@ -120,6 +118,14 @@ public class OrcOutputFormat extends FileOutputFormat<NullWritable, OrcSerdeRow>
       stats.setRawDataSize(null == writer ? 0 : writer.getRawDataSize());
       stats.setRowCount(null == writer ? 0 : writer.getNumberOfRows());
       return stats;
+    }
+
+    private void init(OrcSerdeRow serdeRow) throws IOException {
+      options.inspector(serdeRow.getInspector());
+      writer = OrcFile.createWriter(path, options);
+      if (options.isCompaction()) {
+        AcidUtils.OrcAcidVersion.setAcidVersionInDataFile(writer);
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -4145,6 +4145,10 @@ private void constructOneLBLocationMap(FileStatus fSta,
             }
           }
           files = fileStatuses.toArray(new FileStatus[files.length]);
+
+          if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE)) {
+            AcidUtils.OrcAcidVersion.writeVersionFile(destf, destFs);
+          }
         } catch (IOException e) {
           if (null != pool) {
             pool.shutdownNow();

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -18,18 +18,13 @@
 package org.apache.hadoop.hive.ql;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
-import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
@@ -39,7 +34,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
@@ -72,8 +66,6 @@ import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
-import org.apache.hadoop.hive.ql.io.orc.OrcFile;
-import org.apache.hadoop.hive.ql.io.orc.Reader;
 import org.apache.hadoop.hive.ql.lockmgr.TestDbTxnManager2;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.io.orc.OrcFile;
+import org.apache.hadoop.hive.ql.io.orc.Reader;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+public class CompactorTestUtilities {
+  private static final Logger LOG = LoggerFactory.getLogger(CompactorTestUtilities.class);
+
+  private static final Charset UTF8 = Charset.forName("UTF-8");
+  private static final int ORC_ACID_VERSION_DEFAULT = 0;
+
+  /**
+   * This is smart enough to handle streaming ingest where there could be a
+   * {@link AcidUtils#DELTA_SIDE_FILE_SUFFIX} side file.
+   * @param dataFile - ORC acid data file
+   * @return version property from file if there,
+   *          {@link #ORC_ACID_VERSION_DEFAULT} otherwise
+   */
+  private static int getAcidVersionFromDataFile(Path dataFile, FileSystem fs) throws IOException {
+    FileStatus fileStatus = fs.getFileStatus(dataFile);
+    Reader orcReader = OrcFile.createReader(dataFile,
+        OrcFile.readerOptions(fs.getConf())
+            .filesystem(fs)
+            //make sure to check for side file in case streaming ingest died
+            .maxLength(AcidUtils.getLogicalLength(fs, fileStatus)));
+    if (orcReader.hasMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)) {
+      char[] versionChar =
+          UTF8.decode(orcReader.getMetadataValue(AcidUtils.OrcAcidVersion.ACID_VERSION_KEY)).array();
+      String version = new String(versionChar);
+      return Integer.valueOf(version);
+    }
+    return ORC_ACID_VERSION_DEFAULT;
+  }
+
+  private static int getAcidVersionFromMetaFile(Path deltaOrBaseDir, FileSystem fs)
+      throws IOException {
+    Path formatFile = AcidUtils.OrcAcidVersion.getVersionFilePath(deltaOrBaseDir);
+    try (FSDataInputStream inputStream = fs.open(formatFile)) {
+      byte[] bytes = new byte[1];
+      int read = inputStream.read(bytes);
+      if (read != -1) {
+        String version = new String(bytes, UTF8);
+        return Integer.valueOf(version);
+      }
+      return ORC_ACID_VERSION_DEFAULT;
+    } catch (FileNotFoundException fnf) {
+      LOG.debug(formatFile + " not found, returning default: " + ORC_ACID_VERSION_DEFAULT);
+      return ORC_ACID_VERSION_DEFAULT;
+    } catch(IOException ex) {
+      LOG.error(formatFile + " is unreadable due to: " + ex.getMessage(), ex);
+      throw ex;
+    }
+  }
+
+  public static void checkAcidVersion(RemoteIterator<LocatedFileStatus> files, FileSystem fs, boolean hasVersionFile,
+      String[] expectedTypes) throws IOException
+  {
+    Set<String> foundPrefixes = new HashSet<>(expectedTypes.length);
+    Set<String> foundDirectories = new HashSet<>(expectedTypes.length);
+    while(files.hasNext()) {
+      LocatedFileStatus file = files.next();
+      Path path = file.getPath();
+      if (!path.getName().equals(AcidUtils.OrcAcidVersion.ACID_FORMAT)) {
+        int version = getAcidVersionFromDataFile(path, fs);
+        //check that files produced by compaction still have the version marker
+        Assert.assertEquals("Unexpected version marker in " + path.getName(),
+            AcidUtils.OrcAcidVersion.ORC_ACID_VERSION, version);
+      }
+      Path parent = path.getParent();
+      if (!foundDirectories.contains(parent)) {
+        if (parent.getName().startsWith(AcidUtils.BASE_PREFIX)) {
+          foundPrefixes.add(AcidUtils.BASE_PREFIX);
+        } else if (parent.getName().startsWith(AcidUtils.DELTA_PREFIX)) {
+          foundPrefixes.add(AcidUtils.DELTA_PREFIX);
+        } else if (parent.getName().startsWith(AcidUtils.DELETE_DELTA_PREFIX)) {
+          foundPrefixes.add(AcidUtils.DELETE_DELTA_PREFIX);
+        }
+        // It is a directory
+        if (hasVersionFile) {
+          Assert.assertTrue("Version marker should exists",
+              fs.exists(AcidUtils.OrcAcidVersion.getVersionFilePath(parent)));
+          int versionFromMetaFile = getAcidVersionFromMetaFile(parent, fs);
+          Assert.assertEquals("Unexpected version marker in " + parent,
+              AcidUtils.OrcAcidVersion.ORC_ACID_VERSION, versionFromMetaFile);
+        } else {
+          Assert.assertFalse("Version marker should not exists",
+              fs.exists(AcidUtils.OrcAcidVersion.getVersionFilePath(parent)));
+        }
+      }
+    }
+    Assert.assertEquals("Did not found all types of directories", new HashSet<>(Arrays.asList(expectedTypes)),
+        foundPrefixes);
+  }
+}


### PR DESCRIPTION
Made sure that the version metadata is update at file creation, and the version file is created.
Updated tests as well