### PR TITLE
HIVE-23856: Beeline Should Print Binary Data in Base64

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/Rows.java
+++ b/beeline/src/java/org/apache/hive/beeline/Rows.java
@@ -22,12 +22,14 @@
  */
 package org.apache.hive.beeline;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Iterator;
 
 import org.apache.hadoop.hive.common.cli.EscapeCRLFHelper;
@@ -41,7 +43,7 @@ abstract class Rows implements Iterator {
   final ResultSetMetaData rsMeta;
   final Boolean[] primaryKeys;
   final NumberFormat numberFormat;
-  private boolean convertBinaryArray;
+  private boolean convertBinaryArrayToString;
   private final String nullStr;
 
   Rows(BeeLine beeLine, ResultSet rs) throws SQLException {
@@ -55,7 +57,7 @@ abstract class Rows implements Iterator {
     } else {
       numberFormat = new DecimalFormat(beeLine.getOpts().getNumberFormat());
     }
-    this.convertBinaryArray = beeLine.getOpts().getConvertBinaryArrayToString();
+    this.convertBinaryArrayToString = beeLine.getOpts().getConvertBinaryArrayToString();
   }
 
   @Override
@@ -162,7 +164,7 @@ abstract class Rows implements Iterator {
         } else if (o instanceof Number) {
           value = numberFormat != null ? numberFormat.format(o) : o.toString();
         } else if (o instanceof byte[]) {
-          value = convertBinaryArray ? new String((byte[])o) : Arrays.toString((byte[])o);
+          value = convertBinaryArrayToString ? new String((byte[])o, StandardCharsets.UTF_8) : Base64.getEncoder().withoutPadding().encodeToString((byte[])o);
         } else {
           value = o.toString();
         }

--- a/beeline/src/test/org/apache/hive/beeline/TestIncrementalRows.java
+++ b/beeline/src/test/org/apache/hive/beeline/TestIncrementalRows.java
@@ -94,7 +94,7 @@ public class TestIncrementalRows {
 
     convertedIr.next();
     String row = convertedIr.next().toString();
-    Assert.assertEquals("[[77, 77, 77]]", row);
+    Assert.assertEquals("[TU1N]", row);
   }
 
   public void initNrOfResultSetCalls(final int iter) throws SQLException {


### PR DESCRIPTION
Fixed Binary data type in beeline rows to encode to Base64

https://issues.apache.org/jira/browse/HIVE-23856
