### PR TITLE
HIVE-23877: Hive on Spark incorrect partition pruning ANALYZE TABLE

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/metainfo/annotation/OpTraitsRulesProcFactory.java
@@ -213,8 +213,9 @@ public class OpTraitsRulesProcFactory {
       Table table = ts.getConf().getTableMetadata();
       PrunedPartitionList prunedPartList = null;
       try {
+        boolean analyzeCommand = opTraitsCtx.getParseContext().getQueryProperties().isAnalyzeCommand();
         prunedPartList =
-            opTraitsCtx.getParseContext().getPrunedPartitions(ts.getConf().getAlias(), ts);
+            opTraitsCtx.getParseContext().getPrunedPartitions(ts, analyzeCommand);
       } catch (HiveException e) {
         prunedPartList = null;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -133,7 +133,8 @@ public class StatsRulesProcFactory {
         Object... nodeOutputs) throws SemanticException {
       TableScanOperator tsop = (TableScanOperator) nd;
       AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
-      PrunedPartitionList partList = aspCtx.getParseContext().getPrunedPartitions(tsop);
+      boolean analyzeCommand = aspCtx.getParseContext().getQueryProperties().isAnalyzeCommand();
+      PrunedPartitionList partList = aspCtx.getParseContext().getPrunedPartitions(tsop, analyzeCommand);
       ColumnStatsList colStatsCached = aspCtx.getParseContext().getColStatsCached(partList);
       Table table = tsop.getConf().getTableMetadata();
 


### PR DESCRIPTION
Fixes  [HIVE-23877](https://issues.apache.org/jira/browse/HIVE-23877)

Partitions are pruned based on the partition specification in ANALYZE TABLE command and cached in TableSpec.
When compiling, It's unnecessary to use PartitionPruner.prune() to get partitions again. And PartitionPruner can not prune partitions for ANALYZE TABLE command, so it will get all partitions.