### PR TITLE
HIVE-16490. Hive should not use getKeyProvider from DFSClient directly.

### DIFF
--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1225,29 +1225,8 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     public HdfsEncryptionShim(URI uri, Configuration conf) throws IOException {
       this.conf = conf;
       this.hdfsAdmin = new HdfsAdmin(uri, conf);
-      this.keyProvider = getKeyProvider();
-    }
-
-    private KeyProvider getKeyProvider() throws IOException {
-      if (isMethodExist(HdfsAdmin.class, "getKeyProvider")) {
-        // HDFS-11687 added getKeyProvider method in hdfsAdmin from Hadoop-2.9.0
-        return this.hdfsAdmin.getKeyProvider();
-      } else {
-        // Once Hive sets it's minimum Hadoop version to >2.9.0, this else part
-        // of the code can be removed.
-        DistributedFileSystem dfs =
-            (DistributedFileSystem) FileSystem.get(this.conf);
-        return dfs.getClient().getKeyProvider();
-      }
-    }
-
-    private boolean isMethodExist(final Class clazz, final String methodName) {
-      try {
-        clazz.getMethod(methodName);
-        return true;
-      } catch (NoSuchMethodException e) {
-        return false;
-      }
+      // HDFS-11687 added getKeyProvider method in hdfsAdmin from Hadoop-2.9.0
+      this.keyProvider = this.hdfsAdmin.getKeyProvider();
     }
 
     @Override

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1225,7 +1225,6 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     public HdfsEncryptionShim(URI uri, Configuration conf) throws IOException {
       this.conf = conf;
       this.hdfsAdmin = new HdfsAdmin(uri, conf);
-      // HDFS-11687 added getKeyProvider method in hdfsAdmin from Hadoop-2.9.0
       this.keyProvider = this.hdfsAdmin.getKeyProvider();
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-16490