### PR TITLE
HIVE-23870: Optimise multiple text conversions in HiveCharWritable/WritableHiveCharObjectInspector

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveBaseCharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveBaseCharWritable.java
@@ -27,12 +27,17 @@ import org.apache.hive.common.util.HiveStringUtils;
 
 public abstract class HiveBaseCharWritable {
   protected Text value = new Text();
+  protected int charLength = -1;
 
   public HiveBaseCharWritable() {
   }
 
   public int getCharacterLength() {
-    return HiveStringUtils.getTextUtfLength(value);
+    if (charLength != -1) {
+      return charLength;
+    }
+    charLength = HiveStringUtils.getTextUtfLength(value);
+    return charLength;
   }
 
   /**
@@ -45,6 +50,7 @@ public abstract class HiveBaseCharWritable {
 
   public void readFields(DataInput in) throws IOException {
     value.readFields(in);
+    charLength = -1;
   }
 
   public void write(DataOutput out) throws IOException {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
@@ -53,6 +53,7 @@ public class HiveCharWritable extends HiveBaseCharWritable
 
   public void set(HiveCharWritable val) {
     value.set(val.value);
+    charLength = -1;
   }
 
   public void set(HiveCharWritable val, int maxLength) {
@@ -65,6 +66,7 @@ public class HiveCharWritable extends HiveBaseCharWritable
 
   public void set(String val, int maxLength) {
     value.set(HiveBaseChar.getPaddedValue(val, maxLength));
+    charLength = maxLength;
   }
 
   public HiveChar getHiveChar() {
@@ -78,6 +80,9 @@ public class HiveCharWritable extends HiveBaseCharWritable
   }
 
   public Text getStrippedValue() {
+    if (value.charAt(value.getLength() - 1) != ' ') {
+      return value;
+    }
     // A lot of these methods could be done more efficiently by operating on the Text value
     // directly, rather than converting to HiveChar.
     return new Text(getHiveChar().getStrippedValue());
@@ -88,7 +93,11 @@ public class HiveCharWritable extends HiveBaseCharWritable
   }
 
   public int getCharacterLength() {
-    return HiveStringUtils.getTextUtfLength(getStrippedValue());
+    if (charLength != -1) {
+      return charLength;
+    }
+    charLength = HiveStringUtils.getTextUtfLength(getStrippedValue());
+    return charLength;
   }
 
   public int compareTo(HiveCharWritable rhs) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
@@ -66,7 +66,6 @@ public class HiveCharWritable extends HiveBaseCharWritable
 
   public void set(String val, int maxLength) {
     value.set(HiveBaseChar.getPaddedValue(val, maxLength));
-    charLength = maxLength;
   }
 
   public HiveChar getHiveChar() {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveVarcharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveVarcharWritable.java
@@ -45,6 +45,7 @@ public class HiveVarcharWritable extends HiveBaseCharWritable
 
   public void set(HiveVarcharWritable val) {
     value.set(val.value);
+    charLength = val.charLength;
   }
 
   public void set(HiveVarcharWritable val, int maxLength) {
@@ -57,6 +58,7 @@ public class HiveVarcharWritable extends HiveBaseCharWritable
 
   public void set(String val, int maxLength) {
     value.set(HiveBaseChar.enforceMaxLength(val, maxLength));
+    charLength = maxLength;
   }
 
   public HiveVarchar getHiveVarchar() {


### PR DESCRIPTION
Observed runtime dropping from "7600s --> 4800s" in internal cluster, when running a job which creates materialized view on warehouse/inventory/date_dim (where warehouse had char/varchar).

