### PR TITLE
HIVE-23882: Compiler should skip MJ keyExpr for probe optimization

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -43,6 +43,7 @@ import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.llap.LlapHiveUtils;
 import org.apache.hadoop.hive.ql.Context;
 import org.apache.hadoop.hive.ql.QueryState;
 import org.apache.hadoop.hive.ql.exec.AppMasterEventOperator;
@@ -143,8 +144,7 @@ import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.ql.stats.OperatorStats;
 import org.apache.hadoop.hive.ql.stats.StatsUtils;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFBloomFilter.GenericUDAFBloomFilterEvaluator;
-import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
-import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1525,15 +1525,14 @@ public class TezCompiler extends TaskCompiler {
         }
       }
     }
-    if (procCtx.conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_SCAN_PROBEDECODE)) {
+    if (LlapHiveUtils.isLlapMode(procCtx.conf) && procCtx.conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_SCAN_PROBEDECODE)) {
       if (probeDecodeMJoins.size() > 0) {
         // When multiple MJ, select one based on a policy
         for (Map.Entry<TableScanOperator, List<MapJoinOperator>> probeTsMap : probeDecodeMJoins.entrySet()){
           TableScanOperator.ProbeDecodeContext tsCntx = null;
           // Currently supporting: LowestRatio policy
           // TODO: Add more policies and make the selection a conf property
-          tsCntx = selectLowestRatioProbeDecodeMapJoin(probeTsMap.getKey(), probeTsMap.getValue(),
-                  procCtx.conf.getBoolVar(ConfVars.HIVE_IN_TEST));
+          tsCntx = selectLowestRatioProbeDecodeMapJoin(probeTsMap.getKey(), probeTsMap.getValue());
           if (tsCntx != null) {
             LOG.debug("ProbeDecode MJ for TS {}  with CacheKey {} MJ Pos {} ColName {} with Ratio {}",
                     probeTsMap.getKey().getName(), tsCntx.getMjSmallTableCacheKey(), tsCntx.getMjSmallTablePos(),
@@ -1547,7 +1546,7 @@ public class TezCompiler extends TaskCompiler {
   }
 
   private static TableScanOperator.ProbeDecodeContext selectLowestRatioProbeDecodeMapJoin(TableScanOperator tsOp,
-      List<MapJoinOperator> mjOps, boolean inTestMode){
+      List<MapJoinOperator> mjOps) throws SemanticException {
     MapJoinOperator selectedMJOp = null;
     double selectedMJOpRatio = 0;
     for (MapJoinOperator currMJOp : mjOps) {
@@ -1589,13 +1588,17 @@ public class TezCompiler extends TaskCompiler {
 
       List<ExprNodeDesc> keyDesc = selectedMJOp.getConf().getKeys().get(posBigTable);
       ExprNodeColumnDesc keyCol = (ExprNodeColumnDesc) keyDesc.get(0);
-      String realTSColName = OperatorUtils.findTableColNameOf(selectedMJOp, keyCol.getColumn());
-      if (realTSColName != null) {
+      ExprNodeColumnDesc originTSColExpr = OperatorUtils.findTableOriginColExpr(keyCol, selectedMJOp, tsOp);
+      if (originTSColExpr == null) {
+        LOG.warn("ProbeDecode could not find origTSCol for mjCol: {} with MJ Schema: {}",
+            keyCol, selectedMJOp.getSchema());
+      } else if (!TypeInfoUtils.doPrimitiveCategoriesMatch(keyCol.getTypeInfo(), originTSColExpr.getTypeInfo())) {
+        // src Col -> HT key Col needs explicit or implicit (Casting) conversion
+        // as a result we cannot perform direct lookups on the HT
+        LOG.warn("ProbeDecode origTSCol {} type missmatch mjCol {}", originTSColExpr, keyCol);
+      } else {
         tsProbeDecodeCtx = new TableScanOperator.ProbeDecodeContext(mjCacheKey, mjSmallTablePos,
-                realTSColName, selectedMJOpRatio);
-      } else if (inTestMode){
-        throw new RuntimeException("ProbeDecode could not find TSColName for ColKey: " + keyCol + " with MJ Schema: " +
-                selectedMJOp.getSchema());
+            originTSColExpr.getColumn(), selectedMJOpRatio);
       }
     }
     return tsProbeDecodeCtx;
@@ -1614,32 +1617,34 @@ public class TezCompiler extends TaskCompiler {
 
     // Single Key MJ at this point
     List<ExprNodeDesc> tsKeyDesc = mjOp.getConf().getKeys().get(mjBigTablePos);
-    ExprNodeColumnDesc tsKeyCol = (ExprNodeColumnDesc) tsKeyDesc.get(0);
-
     List<ExprNodeDesc> mjKeyDesc = mjOp.getConf().getKeys().get(mjSmallTablePos);
-    ExprNodeColumnDesc mjKeyCol = (ExprNodeColumnDesc) mjKeyDesc.get(0);
+    if (mjKeyDesc.get(0) instanceof ExprNodeColumnDesc) {
+      ExprNodeColumnDesc tsKeyCol = (ExprNodeColumnDesc) tsKeyDesc.get(0);
+      ExprNodeColumnDesc mjKeyCol = (ExprNodeColumnDesc) mjKeyDesc.get(0);
 
-    ColStatistics mjStats = mjOp.getStatistics().getColumnStatisticsFromColName(mjKeyCol.getColumn());
-    ColStatistics tsStats = tsOp.getStatistics().getColumnStatisticsFromColName(tsKeyCol.getColumn());
+      ColStatistics mjStats = mjOp.getStatistics().getColumnStatisticsFromColName(mjKeyCol.getColumn());
+      ColStatistics tsStats = tsOp.getStatistics().getColumnStatisticsFromColName(tsKeyCol.getColumn());
 
-    if (canUseNDV(mjStats)) {
-      mjKeyCardinality = mjStats.getCountDistint();
-    }
-    if (canUseNDV(tsStats)) {
-      tsKeyCardinality = tsStats.getCountDistint();
+      if (canUseNDV(mjStats)) {
+        mjKeyCardinality = mjStats.getCountDistint();
+      }
+      if (canUseNDV(tsStats)) {
+        tsKeyCardinality = tsStats.getCountDistint();
+      }
     }
     return mjKeyCardinality / (double) tsKeyCardinality;
   }
 
-  // Valid MapJoin with a single Key of Number type (Long/Int/Short)
+  /**
+   * Returns true for a MapJoin operator that can be used for ProbeDecode.
+   * MapJoin should be a single Key join, where the bigTable keyCol is only a ExprNodeColumnDesc
+   * @param mapJoinOp
+   * @return true for a valid MapJoin
+   */
   private static boolean isValidProbeDecodeMapJoin(MapJoinOperator mapJoinOp) {
     Map<Byte, List<ExprNodeDesc>> keyExprs = mapJoinOp.getConf().getKeys();
     List<ExprNodeDesc> bigTableKeyExprs = keyExprs.get( (byte) mapJoinOp.getConf().getPosBigTable());
-    return (bigTableKeyExprs.size() == 1)
-        && !(((PrimitiveTypeInfo) bigTableKeyExprs.get(0).getTypeInfo()).getPrimitiveCategory().
-        equals(PrimitiveObjectInspector.PrimitiveCategory.STRING) ||
-        ((PrimitiveTypeInfo) bigTableKeyExprs.get(0).getTypeInfo()).getPrimitiveCategory().
-            equals(PrimitiveObjectInspector.PrimitiveCategory.BYTE));
+    return (bigTableKeyExprs.size() == 1) && (bigTableKeyExprs.get(0) instanceof ExprNodeColumnDesc);
   }
 
   private static boolean canUseNDV(ColStatistics colStats) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ExprNodeDescUtils.java
@@ -367,9 +367,14 @@ public class ExprNodeDescUtils {
 
   public static ArrayList<ExprNodeDesc> backtrack(List<ExprNodeDesc> sources,
       Operator<?> current, Operator<?> terminal, boolean foldExpr) throws SemanticException {
-    ArrayList<ExprNodeDesc> result = new ArrayList<ExprNodeDesc>();
+    return backtrack(sources, current, terminal, foldExpr, false);
+  }
+
+  public static ArrayList<ExprNodeDesc> backtrack(List<ExprNodeDesc> sources,
+      Operator<?> current, Operator<?> terminal, boolean foldExpr, boolean stayInSameVertex) throws SemanticException {
+    ArrayList<ExprNodeDesc> result = new ArrayList<>();
     for (ExprNodeDesc expr : sources) {
-      result.add(backtrack(expr, current, terminal, foldExpr));
+      result.add(backtrack(expr, current, terminal, foldExpr, stayInSameVertex));
     }
     return result;
   }
@@ -381,7 +386,12 @@ public class ExprNodeDescUtils {
 
   public static ExprNodeDesc backtrack(ExprNodeDesc source, Operator<?> current,
       Operator<?> terminal, boolean foldExpr) throws SemanticException {
-    Operator<?> parent = getSingleParent(current, terminal);
+    return backtrack(source, current, terminal, foldExpr, false);
+  }
+
+  public static ExprNodeDesc backtrack(ExprNodeDesc source, Operator<?> current,
+      Operator<?> terminal, boolean foldExpr, boolean stayInSameVertex) throws SemanticException {
+    Operator<?> parent = stayInSameVertex ? getSameVertexParent(current, terminal) : getSingleParent(current, terminal);
     if (parent == null) {
       return source;
     }
@@ -392,7 +402,7 @@ public class ExprNodeDescUtils {
     if (source instanceof ExprNodeGenericFuncDesc) {
       // all children expression should be resolved
       ExprNodeGenericFuncDesc function = (ExprNodeGenericFuncDesc) source.clone();
-      List<ExprNodeDesc> children = backtrack(function.getChildren(), current, terminal, foldExpr);
+      List<ExprNodeDesc> children = backtrack(function.getChildren(), current, terminal, foldExpr, stayInSameVertex);
       for (ExprNodeDesc child : children) {
         if (child == null) {
           // Could not resolve all of the function children, fail
@@ -411,12 +421,12 @@ public class ExprNodeDescUtils {
     }
     if (source instanceof ExprNodeColumnDesc) {
       ExprNodeColumnDesc column = (ExprNodeColumnDesc) source;
-      return backtrack(column, parent, terminal);
+      return backtrack(column, parent, terminal, stayInSameVertex);
     }
     if (source instanceof ExprNodeFieldDesc) {
       // field expression should be resolved
       ExprNodeFieldDesc field = (ExprNodeFieldDesc) source.clone();
-      ExprNodeDesc fieldDesc = backtrack(field.getDesc(), current, terminal, foldExpr);
+      ExprNodeDesc fieldDesc = backtrack(field.getDesc(), current, terminal, foldExpr, stayInSameVertex);
       if (fieldDesc == null) {
         return null;
       }
@@ -429,13 +439,13 @@ public class ExprNodeDescUtils {
 
   // Resolve column expression to input expression by using expression mapping in current operator
   private static ExprNodeDesc backtrack(ExprNodeColumnDesc column, Operator<?> current,
-      Operator<?> terminal) throws SemanticException {
+      Operator<?> terminal, boolean stayInSameVertex) throws SemanticException {
     Map<String, ExprNodeDesc> mapping = current.getColumnExprMap();
     if (mapping == null) {
-      return backtrack((ExprNodeDesc)column, current, terminal);
+      return backtrack(column, current, terminal, false, stayInSameVertex);
     }
     ExprNodeDesc mapped = mapping.get(column.getColumn());
-    return mapped == null ? null : backtrack(mapped, current, terminal);
+    return mapped == null ? null : backtrack(mapped, current, terminal, false, stayInSameVertex);
   }
 
   public static Operator<?> getSingleParent(Operator<?> current, Operator<?> terminal)
@@ -457,6 +467,30 @@ public class ExprNodeDescUtils {
       return terminal;
     }
     throw new SemanticException("Met multiple parent operators");
+  }
+
+  /**
+   * When Multi-Parent backtrack to the same Vertex (non-RS) branch and return the found parent.
+   * @param current Parent OP
+   * @param terminal End Op
+   * @return parent Op or Null when not found
+   */
+  public static Operator<?> getSameVertexParent(Operator<?> current, Operator<?> terminal) {
+    if (current == terminal) {
+      return null;
+    }
+    List<Operator<?>> parents = current.getParentOperators();
+    if (parents == null || parents.isEmpty()) {
+      return null;
+    }
+    if (parents.size() == 1) {
+      return parents.get(0);
+    }
+    if (terminal != null && parents.contains(terminal)) {
+      return terminal;
+    }
+    // When multi-parent, backtrack to non-RS parent branches looking for the src Expr
+    return parents.stream().filter(op -> !(op instanceof ReduceSinkOperator)).findFirst().get();
   }
 
   public static List<ExprNodeDesc> resolveJoinKeysAsRSColumns(List<ExprNodeDesc> sourceList,

--- a/ql/src/test/queries/clientpositive/probedecode_mapjoin_keyexpr.q
+++ b/ql/src/test/queries/clientpositive/probedecode_mapjoin_keyexpr.q
@@ -1,0 +1,61 @@
+set hive.stats.column.autogather=true;
+set hive.mapred.mode=nonstrict;
+set hive.explain.user=false;
+SET hive.auto.convert.join=true;
+SET hive.auto.convert.join.noconditionaltask=true;
+SET hive.auto.convert.join.noconditionaltask.size=10000000000;
+SET hive.vectorized.execution.enabled=true;
+set hive.fetch.task.conversion=none;
+
+SET mapred.min.split.size=10000;
+SET mapred.max.split.size=50000;
+
+SET hive.optimize.scan.probedecode=true;
+
+CREATE TABLE lineitem_trs (
+   l_orderkey BIGINT,
+   l_partkey BIGINT,
+   l_suppkey BIGINT,
+   l_linenumber INT,
+   l_quantity DECIMAL(12,2),
+   l_extendedprice DECIMAL(12,2),
+   l_discount DECIMAL(12,2),
+   l_tax DECIMAL(12,2),
+   l_returnflag STRING,
+   l_linestatus STRING,
+   l_shipdate STRING,
+   l_commitdate STRING,
+   l_receiptdate STRING,
+   l_shipinstruct STRING,
+   l_shipmode STRING,
+   l_comment STRING
+) STORED AS ORC;
+
+
+CREATE TABLE unique_lineitem_stage (
+  l_orderkey STRING,
+  l_partkey BIGINT,
+  l_suppkey BIGINT,
+  l_linenumber INT,
+  l_quantity DECIMAL(12,2),
+  l_extendedprice DECIMAL(12,2),
+  l_discount DECIMAL(12,2),
+  l_tax DECIMAL(12,2),
+  l_returnflag STRING,
+  l_linestatus STRING,
+  l_shipdate STRING,
+  l_commitdate STRING,
+  l_receiptdate STRING,
+  l_shipinstruct STRING,
+  l_shipmode STRING,
+  l_comment STRING
+) STORED AS ORC;
+
+
+
+-- l_orderkey Key types missmatch thus will be converted (from String and Bigint to Double) using a UDF Expr
+-- Probe compiler optimization will SKIP such MJs with keys defined as Exprs (each expr will need to be evaluated before probe)
+EXPLAIN VECTORIZATION DETAIL
+SELECT * FROM
+unique_lineitem_stage, lineitem_trs
+where unique_lineitem_stage.L_ORDERKEY = lineitem_trs.L_ORDERKEY;

--- a/ql/src/test/results/clientpositive/llap/auto_join1.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join1.q.out
@@ -59,6 +59,7 @@ STAGE PLANS:
                 TableScan
                   alias: src2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join10.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join10.q.out
@@ -57,6 +57,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.582
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join11.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join11.q.out
@@ -57,6 +57,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: (UDFToDouble(key) < 100.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 100.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join12.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join12.q.out
@@ -43,6 +43,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: (UDFToDouble(key) < 80.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 80.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join13.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join13.q.out
@@ -43,6 +43,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: (UDFToDouble(key) < 100.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_42_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 100.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join14.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join14.q.out
@@ -65,6 +65,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart
                   filterExpr: (UDFToDouble(key) > 100.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.166
                   Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) > 100.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join15.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join15.q.out
@@ -36,6 +36,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join17.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join17.q.out
@@ -38,6 +38,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join19.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join19.q.out
@@ -50,6 +50,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.158
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join19_inclause.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join19_inclause.q.out
@@ -50,6 +50,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.158
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join2.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join2.q.out
@@ -39,6 +39,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: (key is not null and UDFToDouble(key) is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and UDFToDouble(key) is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join20.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join20.q.out
@@ -37,6 +37,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: (UDFToDouble(key) < 10.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_43_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 10.0D) (type: boolean)
@@ -205,6 +206,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: (UDFToDouble(key) < 10.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_43_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 10.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join22.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join22.q.out
@@ -27,6 +27,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join24.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join24.q.out
@@ -46,6 +46,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 309 Data size: 28119 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join26.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join26.q.out
@@ -62,6 +62,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_37_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join27.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join27.q.out
@@ -46,6 +46,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: (UDFToDouble(key) < 200.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_41_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.664
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 200.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join29.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join29.q.out
@@ -3435,6 +3435,7 @@ STAGE PLANS:
                 TableScan
                   alias: src3
                   filterExpr: (UDFToDouble(key) < 10.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_47_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.002
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 10.0D) (type: boolean)
@@ -3737,6 +3738,7 @@ STAGE PLANS:
                 TableScan
                   alias: src3
                   filterExpr: (UDFToDouble(key) < 10.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_47_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.002
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 10.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join3.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join3.q.out
@@ -39,6 +39,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_56_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join30.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join30.q.out
@@ -57,6 +57,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.582
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -441,6 +442,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1178,6 +1180,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_43_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join31.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join31.q.out
@@ -43,6 +43,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join32.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join32.q.out
@@ -69,6 +69,7 @@ STAGE PLANS:
                 TableScan
                   alias: v
                   filterExpr: name is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_34_container, bigKeyColName:name, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: name is not null (type: boolean)
@@ -216,6 +217,7 @@ STAGE PLANS:
                 TableScan
                   alias: v
                   filterExpr: name is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_34_container, bigKeyColName:name, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: name is not null (type: boolean)
@@ -379,6 +381,7 @@ STAGE PLANS:
                 TableScan
                   alias: v
                   filterExpr: name is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_34_container, bigKeyColName:name, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: name is not null (type: boolean)
@@ -543,6 +546,7 @@ STAGE PLANS:
                 TableScan
                   alias: s
                   filterExpr: ((p = 'bar') and name is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_34_container, bigKeyColName:name, smallTablePos:1, keyRatio:0.0
                   Statistics: Num rows: 1 Data size: 268 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p = 'bar') and name is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join9.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join9.q.out
@@ -63,6 +63,7 @@ STAGE PLANS:
                 TableScan
                   alias: src2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/auto_join_stats2.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join_stats2.q.out
@@ -199,6 +199,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: (key is not null and UDFToDouble(key) is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_51_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and UDFToDouble(key) is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/bucket_map_join_tez2.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_map_join_tez2.q.out
@@ -503,7 +503,6 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: UDFToDouble(key) is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.764
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(key) is not null (type: boolean)
@@ -595,7 +594,6 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: UDFToDouble(key) is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.764
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(key) is not null (type: boolean)
@@ -2400,6 +2398,7 @@ STAGE PLANS:
                 TableScan
                   alias: my_dim
                   filterExpr: ((filter_col) IN ('VAL1', 'VAL2') and join_col is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:join_col, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 4 Data size: 1472 Basic stats: COMPLETE Column stats: NONE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/cbo_rp_auto_join17.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_rp_auto_join17.q.out
@@ -38,6 +38,7 @@ STAGE PLANS:
                 TableScan
                   alias: src1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/cbo_rp_cross_product_check_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_rp_cross_product_check_2.q.out
@@ -149,6 +149,7 @@ STAGE PLANS:
                 TableScan
                   alias: d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 10 Data size: 1760 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -289,6 +290,7 @@ STAGE PLANS:
                 TableScan
                   alias: od1:d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -578,6 +580,7 @@ STAGE PLANS:
                 TableScan
                   alias: od1:d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_36_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/comments.q.out
+++ b/ql/src/test/results/clientpositive/llap/comments.q.out
@@ -104,6 +104,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (UDFToDouble(key) > 0.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.332
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer1.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer1.q.out
@@ -380,6 +380,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_34_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer3.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer3.q.out
@@ -551,6 +551,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_87_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer6.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer6.q.out
@@ -568,6 +568,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_85_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.64
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -3974,6 +3975,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_85_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.64
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer7.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer7.q.out
@@ -38,6 +38,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -212,6 +213,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -386,6 +388,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -560,6 +563,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/cross_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_join.q.out
@@ -410,6 +410,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/cross_prod_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_prod_3.q.out
@@ -58,6 +58,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_48_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.1
                   Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -112,6 +113,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.1
                   Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/cross_product_check_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/cross_product_check_2.q.out
@@ -137,6 +137,7 @@ STAGE PLANS:
                 TableScan
                   alias: d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
                   Statistics: Num rows: 10 Data size: 1760 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -277,6 +278,7 @@ STAGE PLANS:
                 TableScan
                   alias: d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_35_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -558,6 +560,7 @@ STAGE PLANS:
                 TableScan
                   alias: d1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_39_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.5
                   Statistics: Num rows: 10 Data size: 860 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction.q.out
@@ -2213,6 +2213,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -2342,6 +2343,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: (key is not null and key BETWEEN DynamicValue(RS_7_srcpart_small_n3_key1_min) AND DynamicValue(RS_7_srcpart_small_n3_key1_max) and in_bloom_filter(key, DynamicValue(RS_7_srcpart_small_n3_key1_bloom_filter))) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and key BETWEEN DynamicValue(RS_7_srcpart_small_n3_key1_min) AND DynamicValue(RS_7_srcpart_small_n3_key1_max) and in_bloom_filter(key, DynamicValue(RS_7_srcpart_small_n3_key1_bloom_filter))) (type: boolean)
@@ -2665,6 +2667,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -2717,6 +2720,7 @@ STAGE PLANS:
                 TableScan
                   alias: alltypesorc_int_n1
                   filterExpr: cstring is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_50_container, bigKeyColName:cstring, smallTablePos:0, keyRatio:0.8212076822916666
                   Statistics: Num rows: 12288 Data size: 862450 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: cstring is not null (type: boolean)
@@ -2831,6 +2835,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: (key is not null and value is not null and key BETWEEN DynamicValue(RS_10_srcpart_small_n3_key1_min) AND DynamicValue(RS_10_srcpart_small_n3_key1_max) and in_bloom_filter(key, DynamicValue(RS_10_srcpart_small_n3_key1_bloom_filter))) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null and key BETWEEN DynamicValue(RS_10_srcpart_small_n3_key1_min) AND DynamicValue(RS_10_srcpart_small_n3_key1_max) and in_bloom_filter(key, DynamicValue(RS_10_srcpart_small_n3_key1_bloom_filter))) (type: boolean)
@@ -2913,6 +2918,7 @@ STAGE PLANS:
                 TableScan
                   alias: alltypesorc_int_n1
                   filterExpr: (cstring is not null and cstring BETWEEN DynamicValue(RS_12_srcpart_date_n7_value_min) AND DynamicValue(RS_12_srcpart_date_n7_value_max) and in_bloom_filter(cstring, DynamicValue(RS_12_srcpart_date_n7_value_bloom_filter))) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_50_container, bigKeyColName:cstring, smallTablePos:0, keyRatio:0.8212076822916666
                   Statistics: Num rows: 12288 Data size: 862450 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (cstring is not null and cstring BETWEEN DynamicValue(RS_12_srcpart_date_n7_value_min) AND DynamicValue(RS_12_srcpart_date_n7_value_max) and in_bloom_filter(cstring, DynamicValue(RS_12_srcpart_date_n7_value_bloom_filter))) (type: boolean)
@@ -3238,6 +3244,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.13
                   Statistics: Num rows: 2000 Data size: 550000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -3620,6 +3627,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_small_n3
                   filterExpr: (key1 is not null and key1 BETWEEN DynamicValue(RS_10_srcpart_small10_key1_min) AND DynamicValue(RS_10_srcpart_small10_key1_max) and in_bloom_filter(key1, DynamicValue(RS_10_srcpart_small10_key1_bloom_filter))) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key1, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 20 Data size: 5420 Basic stats: PARTIAL Column stats: PARTIAL
                   Filter Operator
                     predicate: (key1 is not null and key1 BETWEEN DynamicValue(RS_10_srcpart_small10_key1_min) AND DynamicValue(RS_10_srcpart_small10_key1_max) and in_bloom_filter(key1, DynamicValue(RS_10_srcpart_small10_key1_bloom_filter))) (type: boolean)
@@ -3826,6 +3834,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_small_n3
                   filterExpr: (key1 is not null and key1 BETWEEN DynamicValue(RS_10_srcpart_small10_key1_min) AND DynamicValue(RS_10_srcpart_small10_key1_max) and in_bloom_filter(key1, DynamicValue(RS_10_srcpart_small10_key1_bloom_filter))) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key1, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 20 Data size: 5420 Basic stats: PARTIAL Column stats: PARTIAL
                   Filter Operator
                     predicate: (key1 is not null and key1 BETWEEN DynamicValue(RS_10_srcpart_small10_key1_min) AND DynamicValue(RS_10_srcpart_small10_key1_max) and in_bloom_filter(key1, DynamicValue(RS_10_srcpart_small10_key1_bloom_filter))) (type: boolean)
@@ -4010,6 +4019,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_small_n3
                   filterExpr: key1 is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key1, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 20 Data size: 5420 Basic stats: PARTIAL Column stats: PARTIAL
                   Filter Operator
                     predicate: key1 is not null (type: boolean)
@@ -4286,6 +4296,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n7
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.3665
                   Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_1.q.out
@@ -839,6 +839,7 @@ STAGE PLANS:
                 TableScan
                   alias: p1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0438095238095237
                   Statistics: Num rows: 525 Data size: 92000 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -973,6 +974,7 @@ STAGE PLANS:
                 TableScan
                   alias: p1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0438095238095237
                   Statistics: Num rows: 525 Data size: 92000 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
@@ -77,6 +77,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_50_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -238,6 +239,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_50_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -401,6 +403,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_77_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000/2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -428,6 +431,7 @@ STAGE PLANS:
                 TableScan
                   alias: w
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_78_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.05063291139240506
                   Statistics: Num rows: 2000/2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -601,6 +605,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_77_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -628,6 +633,7 @@ STAGE PLANS:
                 TableScan
                   alias: w
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_78_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.05063291139240506
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -794,6 +800,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_77_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -821,6 +828,7 @@ STAGE PLANS:
                 TableScan
                   alias: w
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_78_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.05063291139240506
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1013,6 +1021,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_106_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1054,6 +1063,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_108_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.5276872964169381
                   Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -1295,6 +1305,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_106_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.5
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1336,6 +1347,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_108_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.5276872964169381
                   Statistics: Num rows: 2000 Data size: 182000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -1578,6 +1590,7 @@ STAGE PLANS:
                 TableScan
                   alias: z1
                   filterExpr: (key < 'zzzzzzzz') (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_97_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.0379746835443038
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key < 'zzzzzzzz') (type: boolean)
@@ -1819,6 +1832,7 @@ STAGE PLANS:
                 TableScan
                   alias: z1
                   filterExpr: (key < 'zzzzzzzz') (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_97_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.0379746835443038
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key < 'zzzzzzzz') (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join25.q.out
+++ b/ql/src/test/results/clientpositive/llap/join25.q.out
@@ -64,6 +64,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join26.q.out
+++ b/ql/src/test/results/clientpositive/llap/join26.q.out
@@ -59,6 +59,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_55_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -200,6 +201,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_56_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/join27.q.out
+++ b/ql/src/test/results/clientpositive/llap/join27.q.out
@@ -64,6 +64,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.038
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join28.q.out
+++ b/ql/src/test/results/clientpositive/llap/join28.q.out
@@ -53,6 +53,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_55_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -105,6 +106,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_56_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join30.q.out
+++ b/ql/src/test/results/clientpositive/llap/join30.q.out
@@ -62,6 +62,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_37_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join32.q.out
+++ b/ql/src/test/results/clientpositive/llap/join32.q.out
@@ -59,6 +59,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -201,6 +202,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.126
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/join32_lessSize.q.out
+++ b/ql/src/test/results/clientpositive/llap/join32_lessSize.q.out
@@ -67,6 +67,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -209,6 +210,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.126
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -567,6 +569,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: (value is not null and key is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_76_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.64
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -709,6 +712,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_77_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -786,6 +790,7 @@ STAGE PLANS:
                 TableScan
                   alias: w
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_78_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.198
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -1135,6 +1140,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -1277,6 +1283,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.038
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -1762,6 +1769,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_47_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.038
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -2144,6 +2152,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -2198,6 +2207,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.038
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -2445,6 +2455,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -2499,6 +2510,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.038
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join33.q.out
+++ b/ql/src/test/results/clientpositive/llap/join33.q.out
@@ -59,6 +59,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.078
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -201,6 +202,7 @@ STAGE PLANS:
                 TableScan
                   alias: z
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.126
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/join34.q.out
+++ b/ql/src/test/results/clientpositive/llap/join34.q.out
@@ -64,6 +64,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: (UDFToDouble(key) NOT BETWEEN 20.0D AND 100.0D and (UDFToDouble(key) < 20.0D)) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_40_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.092
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/join37.q.out
+++ b/ql/src/test/results/clientpositive/llap/join37.q.out
@@ -64,6 +64,7 @@ STAGE PLANS:
                 TableScan
                   alias: y
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.032
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join38.q.out
+++ b/ql/src/test/results/clientpositive/llap/join38.q.out
@@ -72,6 +72,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (UDFToDouble(key) = 111.0D) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.002
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) = 111.0D) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join40.q.out
+++ b/ql/src/test/results/clientpositive/llap/join40.q.out
@@ -3870,6 +3870,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.582
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join_max_hashtable.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_max_hashtable.q.out
@@ -27,6 +27,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/join_on_varchar.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_on_varchar.q.out
@@ -103,7 +103,7 @@ STAGE PLANS:
                 TableScan
                   alias: tbl2_n2
                   filterExpr: c2 is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:c1, smallTablePos:0, keyRatio:1.0
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:c2, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 2 Data size: 194 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: c2 is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/mapjoin_hint.q.out
+++ b/ql/src/test/results/clientpositive/llap/mapjoin_hint.q.out
@@ -302,6 +302,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart_date_n5
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 174000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/mapjoin_mapjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/mapjoin_mapjoin.q.out
@@ -45,6 +45,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart
                   filterExpr: (value is not null and key is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 21248 Basic stats: COMPLETE Column stats: NONE
                   GatherStats: false
                   Filter Operator
@@ -435,6 +436,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart
                   filterExpr: ((value > 'val_450') and key is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.366
                   Statistics: Num rows: 2000 Data size: 21248 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: ((value > 'val_450') and key is not null) (type: boolean)
@@ -560,6 +562,7 @@ STAGE PLANS:
                 TableScan
                   alias: srcpart
                   filterExpr: (value is not null and key is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:value, smallTablePos:1, keyRatio:1.1
                   Statistics: Num rows: 2000 Data size: 21248 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (value is not null and key is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/mrr.q.out
+++ b/ql/src/test/results/clientpositive/llap/mrr.q.out
@@ -890,6 +890,7 @@ STAGE PLANS:
                 TableScan
                   alias: s2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_36_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.582
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/multiMapJoin1.q.out
+++ b/ql/src/test/results/clientpositive/llap/multiMapJoin1.q.out
@@ -201,6 +201,7 @@ STAGE PLANS:
                 TableScan
                   alias: bigtbl
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.99
                   Statistics: Num rows: 5000 Data size: 1748368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -375,6 +376,7 @@ STAGE PLANS:
                 TableScan
                   alias: bigtbl
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.99
                   Statistics: Num rows: 5000 Data size: 1748368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -551,6 +553,7 @@ STAGE PLANS:
                 TableScan
                   alias: bigtbl
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.99
                   Statistics: Num rows: 5000 Data size: 1748368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -871,6 +874,7 @@ STAGE PLANS:
                 TableScan
                   alias: bigtbl
                   filterExpr: (key1 is not null and value is not null and key2 is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_96_container, bigKeyColName:key1, smallTablePos:1, keyRatio:0.935
                   Statistics: Num rows: 5000 Data size: 2622552 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key1 is not null and value is not null and key2 is not null) (type: boolean)
@@ -1218,6 +1222,7 @@ STAGE PLANS:
                 TableScan
                   alias: bigtbl
                   filterExpr: (key1 is not null and value is not null and key2 is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_96_container, bigKeyColName:key1, smallTablePos:1, keyRatio:0.935
                   Statistics: Num rows: 5000 Data size: 2622552 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key1 is not null and value is not null and key2 is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/multiMapJoin2.q.out
+++ b/ql/src/test/results/clientpositive/llap/multiMapJoin2.q.out
@@ -38,6 +38,7 @@ STAGE PLANS:
                 TableScan
                   alias: x1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -68,6 +69,7 @@ STAGE PLANS:
                 TableScan
                   alias: x2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_54_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -590,6 +592,7 @@ STAGE PLANS:
                 TableScan
                   alias: x2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_35_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.004
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1730,6 +1733,7 @@ STAGE PLANS:
                 TableScan
                   alias: x
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.336
                   Statistics: Num rows: 125 Data size: 10875 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1868,6 +1872,7 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_106_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1919,6 +1924,7 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_108_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/multi_join_union.q.out
+++ b/ql/src/test/results/clientpositive/llap/multi_join_union.q.out
@@ -85,6 +85,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -146,6 +147,7 @@ STAGE PLANS:
                 TableScan
                   alias: src13
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_54_container, bigKeyColName:value, smallTablePos:0, keyRatio:0.614
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_keyexpr.q.out
+++ b/ql/src/test/results/clientpositive/llap/probedecode_mapjoin_keyexpr.q.out
@@ -1,0 +1,260 @@
+PREHOOK: query: CREATE TABLE lineitem_trs (
+   l_orderkey BIGINT,
+   l_partkey BIGINT,
+   l_suppkey BIGINT,
+   l_linenumber INT,
+   l_quantity DECIMAL(12,2),
+   l_extendedprice DECIMAL(12,2),
+   l_discount DECIMAL(12,2),
+   l_tax DECIMAL(12,2),
+   l_returnflag STRING,
+   l_linestatus STRING,
+   l_shipdate STRING,
+   l_commitdate STRING,
+   l_receiptdate STRING,
+   l_shipinstruct STRING,
+   l_shipmode STRING,
+   l_comment STRING
+) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@lineitem_trs
+POSTHOOK: query: CREATE TABLE lineitem_trs (
+   l_orderkey BIGINT,
+   l_partkey BIGINT,
+   l_suppkey BIGINT,
+   l_linenumber INT,
+   l_quantity DECIMAL(12,2),
+   l_extendedprice DECIMAL(12,2),
+   l_discount DECIMAL(12,2),
+   l_tax DECIMAL(12,2),
+   l_returnflag STRING,
+   l_linestatus STRING,
+   l_shipdate STRING,
+   l_commitdate STRING,
+   l_receiptdate STRING,
+   l_shipinstruct STRING,
+   l_shipmode STRING,
+   l_comment STRING
+) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@lineitem_trs
+PREHOOK: query: CREATE TABLE unique_lineitem_stage (
+  l_orderkey STRING,
+  l_partkey BIGINT,
+  l_suppkey BIGINT,
+  l_linenumber INT,
+  l_quantity DECIMAL(12,2),
+  l_extendedprice DECIMAL(12,2),
+  l_discount DECIMAL(12,2),
+  l_tax DECIMAL(12,2),
+  l_returnflag STRING,
+  l_linestatus STRING,
+  l_shipdate STRING,
+  l_commitdate STRING,
+  l_receiptdate STRING,
+  l_shipinstruct STRING,
+  l_shipmode STRING,
+  l_comment STRING
+) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@unique_lineitem_stage
+POSTHOOK: query: CREATE TABLE unique_lineitem_stage (
+  l_orderkey STRING,
+  l_partkey BIGINT,
+  l_suppkey BIGINT,
+  l_linenumber INT,
+  l_quantity DECIMAL(12,2),
+  l_extendedprice DECIMAL(12,2),
+  l_discount DECIMAL(12,2),
+  l_tax DECIMAL(12,2),
+  l_returnflag STRING,
+  l_linestatus STRING,
+  l_shipdate STRING,
+  l_commitdate STRING,
+  l_receiptdate STRING,
+  l_shipinstruct STRING,
+  l_shipmode STRING,
+  l_comment STRING
+) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@unique_lineitem_stage
+WARNING: Comparing string and bigint may result in loss of information.
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL
+SELECT * FROM
+unique_lineitem_stage, lineitem_trs
+where unique_lineitem_stage.L_ORDERKEY = lineitem_trs.L_ORDERKEY
+PREHOOK: type: QUERY
+PREHOOK: Input: default@lineitem_trs
+PREHOOK: Input: default@unique_lineitem_stage
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL
+SELECT * FROM
+unique_lineitem_stage, lineitem_trs
+where unique_lineitem_stage.L_ORDERKEY = lineitem_trs.L_ORDERKEY
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@lineitem_trs
+POSTHOOK: Input: default@unique_lineitem_stage
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Map 2 (BROADCAST_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: unique_lineitem_stage
+                  filterExpr: UDFToDouble(l_orderkey) is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 2124 Basic stats: COMPLETE Column stats: NONE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:l_orderkey:string, 1:l_partkey:bigint, 2:l_suppkey:bigint, 3:l_linenumber:int, 4:l_quantity:decimal(12,2)/DECIMAL_64, 5:l_extendedprice:decimal(12,2)/DECIMAL_64, 6:l_discount:decimal(12,2)/DECIMAL_64, 7:l_tax:decimal(12,2)/DECIMAL_64, 8:l_returnflag:string, 9:l_linestatus:string, 10:l_shipdate:string, 11:l_commitdate:string, 12:l_receiptdate:string, 13:l_shipinstruct:string, 14:l_shipmode:string, 15:l_comment:string, 16:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: SelectColumnIsNotNull(col 17:double)(children: CastStringToDouble(col 0:string) -> 17:double)
+                    predicate: UDFToDouble(l_orderkey) is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 2124 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: l_orderkey (type: string), l_partkey (type: bigint), l_suppkey (type: bigint), l_linenumber (type: int), l_quantity (type: decimal(12,2)), l_extendedprice (type: decimal(12,2)), l_discount (type: decimal(12,2)), l_tax (type: decimal(12,2)), l_returnflag (type: string), l_linestatus (type: string), l_shipdate (type: string), l_commitdate (type: string), l_receiptdate (type: string), l_shipinstruct (type: string), l_shipmode (type: string), l_comment (type: string), UDFToDouble(l_orderkey) (type: double)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18]
+                          selectExpressions: CastStringToDouble(col 0:string) -> 18:double
+                      Statistics: Num rows: 1 Data size: 2124 Basic stats: COMPLETE Column stats: NONE
+                      Map Join Operator
+                        condition map:
+                             Inner Join 0 to 1
+                        keys:
+                          0 _col16 (type: double)
+                          1 _col16 (type: double)
+                        Map Join Vectorization:
+                            bigTableKeyColumns: 18:double
+                            bigTableRetainColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+                            bigTableValueColumns: 0:string, 1:bigint, 2:bigint, 3:int, 4:decimal(12,2), 5:decimal(12,2), 6:decimal(12,2), 7:decimal(12,2), 8:string, 9:string, 10:string, 11:string, 12:string, 13:string, 14:string, 15:string
+                            className: VectorMapJoinInnerMultiKeyOperator
+                            native: true
+                            nativeConditionsMet: hive.mapjoin.optimized.hashtable IS true, hive.vectorized.execution.mapjoin.native.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, One MapJoin Condition IS true, No nullsafe IS true, Small table vectorizes IS true, Optimized Table and Supports Key Types IS true
+                            nonOuterSmallTableKeyMapping: []
+                            projectedOutput: 0:string, 1:bigint, 2:bigint, 3:int, 4:decimal(12,2), 5:decimal(12,2), 6:decimal(12,2), 7:decimal(12,2), 8:string, 9:string, 10:string, 11:string, 12:string, 13:string, 14:string, 15:string, 19:bigint, 20:bigint, 21:bigint, 22:int, 23:decimal(12,2), 24:decimal(12,2), 25:decimal(12,2), 26:decimal(12,2), 27:string, 28:string, 29:string, 30:string, 31:string, 32:string, 33:string, 34:string
+                            smallTableValueMapping: 19:bigint, 20:bigint, 21:bigint, 22:int, 23:decimal(12,2), 24:decimal(12,2), 25:decimal(12,2), 26:decimal(12,2), 27:string, 28:string, 29:string, 30:string, 31:string, 32:string, 33:string, 34:string
+                            hashTableImplementationType: OPTIMIZED
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31, _col32
+                        input vertices:
+                          1 Map 2
+                        Statistics: Num rows: 1 Data size: 2336 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: string), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: int), _col4 (type: decimal(12,2)), _col5 (type: decimal(12,2)), _col6 (type: decimal(12,2)), _col7 (type: decimal(12,2)), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: string), _col13 (type: string), _col14 (type: string), _col15 (type: string), _col17 (type: bigint), _col18 (type: bigint), _col19 (type: bigint), _col20 (type: int), _col21 (type: decimal(12,2)), _col22 (type: decimal(12,2)), _col23 (type: decimal(12,2)), _col24 (type: decimal(12,2)), _col25 (type: string), _col26 (type: string), _col27 (type: string), _col28 (type: string), _col29 (type: string), _col30 (type: string), _col31 (type: string), _col32 (type: string)
+                          outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26, _col27, _col28, _col29, _col30, _col31
+                          Select Vectorization:
+                              className: VectorSelectOperator
+                              native: true
+                              projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34]
+                          Statistics: Num rows: 1 Data size: 2336 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            File Sink Vectorization:
+                                className: VectorFileSinkOperator
+                                native: false
+                            Statistics: Num rows: 1 Data size: 2336 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 16
+                    includeColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+                    dataColumns: l_orderkey:string, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:decimal(12,2)/DECIMAL_64, l_extendedprice:decimal(12,2)/DECIMAL_64, l_discount:decimal(12,2)/DECIMAL_64, l_tax:decimal(12,2)/DECIMAL_64, l_returnflag:string, l_linestatus:string, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [double, double, bigint, bigint, bigint, bigint, decimal(12,2), decimal(12,2), decimal(12,2), decimal(12,2), string, string, string, string, string, string, string, string]
+        Map 2 
+            Map Operator Tree:
+                TableScan
+                  alias: lineitem_trs
+                  filterExpr: UDFToDouble(l_orderkey) is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 1948 Basic stats: COMPLETE Column stats: NONE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:l_orderkey:bigint, 1:l_partkey:bigint, 2:l_suppkey:bigint, 3:l_linenumber:int, 4:l_quantity:decimal(12,2)/DECIMAL_64, 5:l_extendedprice:decimal(12,2)/DECIMAL_64, 6:l_discount:decimal(12,2)/DECIMAL_64, 7:l_tax:decimal(12,2)/DECIMAL_64, 8:l_returnflag:string, 9:l_linestatus:string, 10:l_shipdate:string, 11:l_commitdate:string, 12:l_receiptdate:string, 13:l_shipinstruct:string, 14:l_shipmode:string, 15:l_comment:string, 16:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: SelectColumnIsNotNull(col 17:double)(children: CastLongToDouble(col 0:bigint) -> 17:double)
+                    predicate: UDFToDouble(l_orderkey) is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 1948 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: l_orderkey (type: bigint), l_partkey (type: bigint), l_suppkey (type: bigint), l_linenumber (type: int), l_quantity (type: decimal(12,2)), l_extendedprice (type: decimal(12,2)), l_discount (type: decimal(12,2)), l_tax (type: decimal(12,2)), l_returnflag (type: string), l_linestatus (type: string), l_shipdate (type: string), l_commitdate (type: string), l_receiptdate (type: string), l_shipinstruct (type: string), l_shipmode (type: string), l_comment (type: string), UDFToDouble(l_orderkey) (type: double)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 18]
+                          selectExpressions: CastLongToDouble(col 0:bigint) -> 18:double
+                      Statistics: Num rows: 1 Data size: 1948 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col16 (type: double)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col16 (type: double)
+                        Reduce Sink Vectorization:
+                            className: VectorReduceSinkMultiKeyOperator
+                            keyColumns: 18:double
+                            native: true
+                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                            valueColumns: 0:bigint, 1:bigint, 2:bigint, 3:int, 4:decimal(12,2), 5:decimal(12,2), 6:decimal(12,2), 7:decimal(12,2), 8:string, 9:string, 10:string, 11:string, 12:string, 13:string, 14:string, 15:string
+                        Statistics: Num rows: 1 Data size: 1948 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: int), _col4 (type: decimal(12,2)), _col5 (type: decimal(12,2)), _col6 (type: decimal(12,2)), _col7 (type: decimal(12,2)), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: string), _col13 (type: string), _col14 (type: string), _col15 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 16
+                    includeColumns: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+                    dataColumns: l_orderkey:bigint, l_partkey:bigint, l_suppkey:bigint, l_linenumber:int, l_quantity:decimal(12,2)/DECIMAL_64, l_extendedprice:decimal(12,2)/DECIMAL_64, l_discount:decimal(12,2)/DECIMAL_64, l_tax:decimal(12,2)/DECIMAL_64, l_returnflag:string, l_linestatus:string, l_shipdate:string, l_commitdate:string, l_receiptdate:string, l_shipinstruct:string, l_shipmode:string, l_comment:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [double, double]
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin1.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin1.q.out
@@ -63,6 +63,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -268,6 +269,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin11.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin11.q.out
@@ -63,6 +63,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin2.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin2.q.out
@@ -63,6 +63,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin3.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin3.q.out
@@ -63,6 +63,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin4.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin4.q.out
@@ -81,6 +81,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_48_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin5.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin5.q.out
@@ -74,6 +74,7 @@ STAGE PLANS:
                 TableScan
                   alias: t1_n87
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:1, keyRatio:2.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin6.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin6.q.out
@@ -82,6 +82,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:0, keyRatio:6.0
                   Statistics: Num rows: 6 Data size: 12624 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin7.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin7.q.out
@@ -73,6 +73,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_51_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -109,6 +110,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin8.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin8.q.out
@@ -85,6 +85,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (key is not null and val is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and val is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin9.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin9.q.out
@@ -87,6 +87,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (key is not null and val is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_45_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and val is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/subq_where_serialization.q.out
+++ b/ql/src/test/results/clientpositive/llap/subq_where_serialization.q.out
@@ -23,6 +23,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
@@ -814,6 +814,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: (key > '8') (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.21
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '8') (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/tez_join_result_complex.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_join_result_complex.q.out
@@ -256,6 +256,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: cnctevn_id is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:cnctevn_id, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 4944 Basic stats: COMPLETE Column stats: NONE
                   GatherStats: false
                   Filter Operator
@@ -1237,6 +1238,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: cnctevn_id is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:cnctevn_id, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 4944 Basic stats: COMPLETE Column stats: NONE
                   GatherStats: false
                   Filter Operator

--- a/ql/src/test/results/clientpositive/llap/tez_smb_main.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_smb_main.q.out
@@ -818,6 +818,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:value, smallTablePos:1, keyRatio:1.0991735537190082
                   Statistics: Num rows: 242 Data size: 2566 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -1403,6 +1404,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:value, smallTablePos:0, keyRatio:1.1
                   Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -1508,6 +1510,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: value is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:value, smallTablePos:0, keyRatio:1.1
                   Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -1610,6 +1613,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:value, smallTablePos:1, keyRatio:1.0991735537190082
                   Statistics: Num rows: 242 Data size: 2566 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -1750,6 +1754,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: (key is not null and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_49_container, bigKeyColName:value, smallTablePos:1, keyRatio:1.0991735537190082
                   Statistics: Num rows: 242 Data size: 2566 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/tez_union.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_union.q.out
@@ -30,6 +30,7 @@ STAGE PLANS:
                 TableScan
                   alias: s1
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -412,6 +413,7 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -578,6 +580,7 @@ STAGE PLANS:
                 TableScan
                   alias: s2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_140_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -633,6 +636,7 @@ STAGE PLANS:
                 TableScan
                   alias: s6
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_142_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -688,6 +692,7 @@ STAGE PLANS:
                 TableScan
                   alias: s4
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_141_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1052,6 +1057,7 @@ STAGE PLANS:
                 TableScan
                   alias: s2
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_51_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1084,6 +1090,7 @@ STAGE PLANS:
                 TableScan
                   alias: s4
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_52_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/union34.q.out
+++ b/ql/src/test/results/clientpositive/llap/union34.q.out
@@ -103,6 +103,7 @@ STAGE PLANS:
                 TableScan
                   alias: src10_1_n0
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_31_container, bigKeyColName:key, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/union_remove_12.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_remove_12.q.out
@@ -96,6 +96,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/union_remove_13.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_remove_13.q.out
@@ -103,6 +103,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_37_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/union_remove_14.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_remove_14.q.out
@@ -96,6 +96,7 @@ STAGE PLANS:
                 TableScan
                   alias: b
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_33_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.0
                   Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: key is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/llap/vector_inner_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_inner_join.q.out
@@ -695,7 +695,7 @@ STAGE PLANS:
                 TableScan
                   alias: t2
                   filterExpr: (c > 2) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:v1, smallTablePos:0, keyRatio:0.4
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:c, smallTablePos:0, keyRatio:0.4
                   Statistics: Num rows: 5 Data size: 460 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -1413,7 +1413,7 @@ STAGE PLANS:
                 TableScan
                   alias: t2
                   filterExpr: (c > 2) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:v1, smallTablePos:0, keyRatio:0.4
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:c, smallTablePos:0, keyRatio:0.4
                   Statistics: Num rows: 5 Data size: 460 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -1594,7 +1594,7 @@ STAGE PLANS:
                 TableScan
                   alias: t2
                   filterExpr: (c > 2) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:v1, smallTablePos:0, keyRatio:0.4
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_25_container, bigKeyColName:c, smallTablePos:0, keyRatio:0.4
                   Statistics: Num rows: 5 Data size: 460 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true

--- a/ql/src/test/results/clientpositive/llap/vector_join30.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_join30.q.out
@@ -104,6 +104,7 @@ STAGE PLANS:
                 TableScan
                   alias: orcsrc_n0
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_30_container, bigKeyColName:key, smallTablePos:0, keyRatio:1.582
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -926,6 +927,7 @@ STAGE PLANS:
                 TableScan
                   alias: orcsrc_n0
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_53_container, bigKeyColName:key, smallTablePos:1, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -2198,6 +2200,7 @@ STAGE PLANS:
                 TableScan
                   alias: orcsrc_n0
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_43_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -2445,6 +2448,7 @@ STAGE PLANS:
                 TableScan
                   alias: orcsrc_n0
                   filterExpr: key is not null (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_35_container, bigKeyColName:key, smallTablePos:0, keyRatio:0.632
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true

--- a/ql/src/test/results/clientpositive/llap/vector_leftsemi_mapjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_leftsemi_mapjoin.q.out
@@ -3365,6 +3365,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: ((key > 100) and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.045454545454545456
                   Statistics: Num rows: 22 Data size: 2046 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((key > 100) and value is not null) (type: boolean)
@@ -6472,6 +6473,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: ((key > 100) and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.045454545454545456
                   Statistics: Num rows: 22 Data size: 2046 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((key > 100) and value is not null) (type: boolean)
@@ -14370,6 +14372,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: ((key > 100) and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.045454545454545456
                   Statistics: Num rows: 22 Data size: 2046 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -19055,6 +19058,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: ((key > 100) and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.045454545454545456
                   Statistics: Num rows: 22 Data size: 2046 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -23764,6 +23768,7 @@ STAGE PLANS:
                 TableScan
                   alias: a
                   filterExpr: ((key > 100) and value is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_27_container, bigKeyColName:value, smallTablePos:1, keyRatio:0.045454545454545456
                   Statistics: Num rows: 22 Data size: 2046 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query11.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query11.q.out
@@ -252,7 +252,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: customer
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_302_container, bigKeyColName:$f00, smallTablePos:0, keyRatio:0.1111111125
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_302_container, bigKeyColName:c_customer_id, smallTablePos:0, keyRatio:0.1111111125
                   Statistics: Num rows: 80000000 Data size: 29760000000 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: c_customer_id (type: char(16)), c_first_name (type: char(20)), c_last_name (type: char(30)), c_birth_country (type: varchar(20))

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query24.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query24.q.out
@@ -47,7 +47,7 @@ STAGE PLANS:
                 TableScan
                   alias: customer
                   filterExpr: c_current_addr_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_323_container, bigKeyColName:ca_state, smallTablePos:0, keyRatio:0.0997652625
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_323_container, bigKeyColName:c_current_addr_sk, smallTablePos:0, keyRatio:0.0997652625
                   Statistics: Num rows: 80000000 Data size: 23040000000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: c_current_addr_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query4.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query4.q.out
@@ -429,7 +429,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: customer
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_486_container, bigKeyColName:$f00, smallTablePos:0, keyRatio:0.083333325
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_486_container, bigKeyColName:c_customer_id, smallTablePos:0, keyRatio:0.083333325
                   Statistics: Num rows: 80000000 Data size: 29760000000 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: c_customer_id (type: char(16)), c_first_name (type: char(20)), c_last_name (type: char(30)), c_birth_country (type: varchar(20))

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query5.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query5.q.out
@@ -25,7 +25,7 @@ STAGE PLANS:
                 TableScan
                   alias: store_sales
                   filterExpr: ss_store_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_231_container, bigKeyColName:store_sk, smallTablePos:1, keyRatio:1.0756178660512734
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_231_container, bigKeyColName:ss_store_sk, smallTablePos:1, keyRatio:1.0756178660512734
                   Statistics: Num rows: 82510879939 Data size: 19351122693824 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ss_store_sk is not null (type: boolean)
@@ -149,7 +149,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_web_site_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_235_container, bigKeyColName:wsr_web_site_sk, smallTablePos:1, keyRatio:2.1438795429601423
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_235_container, bigKeyColName:ws_web_site_sk, smallTablePos:1, keyRatio:2.1438795429601423
                   Statistics: Num rows: 21594638446 Data size: 5182388988880 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_web_site_sk is not null (type: boolean)
@@ -485,7 +485,7 @@ STAGE PLANS:
                 TableScan
                   alias: catalog_sales
                   filterExpr: cs_catalog_page_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_233_container, bigKeyColName:page_sk, smallTablePos:1, keyRatio:1.0959547352990346
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_233_container, bigKeyColName:cs_catalog_page_sk, smallTablePos:1, keyRatio:1.0959547352990346
                   Statistics: Num rows: 43005109025 Data size: 10308315074584 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: cs_catalog_page_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query54.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query54.q.out
@@ -188,7 +188,7 @@ STAGE PLANS:
                 TableScan
                   alias: catalog_sales
                   filterExpr: cs_bill_customer_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_289_container, bigKeyColName:item_sk, smallTablePos:1, keyRatio:2.3199545882327872E-5
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_289_container, bigKeyColName:cs_item_sk, smallTablePos:1, keyRatio:2.3199545882327872E-5
                   Statistics: Num rows: 43005109025 Data size: 1031276889552 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: cs_bill_customer_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query59.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query59.q.out
@@ -21,6 +21,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_162_container, bigKeyColName:s_store_id, smallTablePos:1, keyRatio:0.5158450704225352
                   Statistics: Num rows: 1704 Data size: 333984 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: s_store_sk (type: bigint), s_store_id (type: string), s_store_name (type: varchar(50))

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query71.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query71.q.out
@@ -22,7 +22,7 @@ STAGE PLANS:
                 TableScan
                   alias: web_sales
                   filterExpr: ws_sold_time_sk is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_119_container, bigKeyColName:time_sk, smallTablePos:1, keyRatio:4.3992401279400425E-9
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_119_container, bigKeyColName:ws_sold_time_sk, smallTablePos:1, keyRatio:4.3992401279400425E-9
                   Statistics: Num rows: 21594638446 Data size: 2936546600912 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ws_sold_time_sk is not null (type: boolean)

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_1.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_1.q.out
@@ -45,7 +45,6 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: (cint < 2000000000) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:cint, smallTablePos:1, keyRatio:2.0131022135416665
                   Statistics: Num rows: 12288 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (cint < 2000000000) (type: boolean)
@@ -174,7 +173,6 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: (cint < 2000000000) (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:cint, smallTablePos:1, keyRatio:2.0131022135416665
                   Statistics: Num rows: 12288 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (cint < 2000000000) (type: boolean)
@@ -302,7 +300,6 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: cint is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:cint, smallTablePos:1, keyRatio:1.121826171875
                   Statistics: Num rows: 12288 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: cint is not null (type: boolean)
@@ -427,7 +424,6 @@ STAGE PLANS:
                 TableScan
                   alias: c
                   filterExpr: cint is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_29_container, bigKeyColName:cint, smallTablePos:1, keyRatio:1.121826171875
                   Statistics: Num rows: 12288 Data size: 36696 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: cint is not null (type: boolean)


### PR DESCRIPTION
Extend probedecode compiler logic:

* Validate that MJ is a single Key join, where the bigTable keyCol is only a ExprNodeColumnDesc
* For the selected MJ use backtracking logic to find the orignal TS key it maps to (on the same vertex) - this actually revealed several missed or wrong optimizations (updated q outs)
* Finally, extended the optimization logic to check if there a type Cast between src and destination (as the types have to match in the probe case) and only use it on the LLAP mode for now
