### PR TITLE
HIVE-23874: Added debug line for fetchRequest in the HiveQueryResultSet

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
@@ -1,5 +1,4 @@
 /*
-
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
@@ -1,4 +1,5 @@
 /*
+
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -341,7 +342,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
       if (fetchedRows == null || !fetchedRowsItr.hasNext()) {
         TFetchResultsReq fetchReq = new TFetchResultsReq(stmtHandle,
             orientation, fetchSize);
-        LOG.debug(fetchReq.toString());
+        LOG.debug("HiveQueryResultsFetchReq: {}",fetchReq);
         TFetchResultsResp fetchResp;
         fetchResp = client.FetchResults(fetchReq);
         Utils.verifySuccessWithInfo(fetchResp.getStatus());
@@ -350,7 +351,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
         fetchedRows = RowSetFactory.create(results, protocol);
         fetchedRowsItr = fetchedRows.iterator();
       }
-      
+
       if (!fetchedRowsItr.hasNext()) {
         return false;
       }

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
@@ -341,7 +341,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
       if (fetchedRows == null || !fetchedRowsItr.hasNext()) {
         TFetchResultsReq fetchReq = new TFetchResultsReq(stmtHandle,
             orientation, fetchSize);
-        LOG.debug("HiveQueryResultsFetchReq: {}",fetchReq);
+        LOG.debug("HiveQueryResultsFetchReq: {}", fetchReq);
         TFetchResultsResp fetchResp;
         fetchResp = client.FetchResults(fetchReq);
         Utils.verifySuccessWithInfo(fetchResp.getStatus());

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
@@ -332,7 +332,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
     try {
       TFetchOrientation orientation = TFetchOrientation.FETCH_NEXT;
       if (fetchFirst) {
-        // If we are asked to start from begining, clear the current fetched resultset
+        // If we are asked to start from beginning, clear the current fetched resultset
         orientation = TFetchOrientation.FETCH_FIRST;
         fetchedRows = null;
         fetchedRowsItr = null;
@@ -341,6 +341,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
       if (fetchedRows == null || !fetchedRowsItr.hasNext()) {
         TFetchResultsReq fetchReq = new TFetchResultsReq(stmtHandle,
             orientation, fetchSize);
+        LOG.debug(fetchReq.toString());
         TFetchResultsResp fetchResp;
         fetchResp = client.FetchResults(fetchReq);
         Utils.verifySuccessWithInfo(fetchResp.getStatus());
@@ -349,7 +350,7 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
         fetchedRows = RowSetFactory.create(results, protocol);
         fetchedRowsItr = fetchedRows.iterator();
       }
-
+      
       if (!fetchedRowsItr.hasNext()) {
         return false;
       }


### PR DESCRIPTION
Debugging fetch request will help in troubleshooting client side requests to HS2.

hive-jdbc probably needs better logging overall, will likely be taking a look at that in the future.