### PR TITLE
HIVE-23915: Improve Github PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,46 @@
-## NOTICE
+<!--
+Thanks for sending a pull request!  Here are some tips for you:
+  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
+  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
+  3. Ensure you have added or run the appropriate tests for your PR: 
+  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
+  5. Be sure to keep the PR description updated to reflect all changes.
+  6. Please write your PR title to summarize what this PR proposes.
+  7. If possible, provide a concise example to reproduce the issue for a faster review.
 
-Please create an issue in ASF JIRA before opening a pull request,
-and you need to set the title of the pull request which starts with
-the corresponding JIRA issue number. (e.g. HIVE-XXXXX: Fix a typo in YYY)
-For more details, please see https://cwiki.apache.org/confluence/display/Hive/HowToContribute
+-->
+
+### What changes were proposed in this pull request?
+<!--
+Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
+If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
+  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
+  2. If you fix some SQL features, you can provide some references of other DBMSes.
+  3. If there is design documentation, please add the link.
+  4. If there is a discussion in the mailing list, please add the link.
+-->
+
+
+### Why are the changes needed?
+<!--
+Please clarify why the changes are needed. For instance,
+  1. If you propose a new API, clarify the use case for a new API.
+  2. If you fix a bug, you can clarify why it is a bug.
+-->
+
+
+### Does this PR introduce _any_ user-facing change?
+<!--
+Note that it means *any* user-facing change including all aspects such as the documentation fix.
+If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
+If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
+If no, write 'No'.
+-->
+
+
+### How was this patch tested?
+<!--
+If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
+If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
+If tests were not added, please describe why they were not added and/or why it was difficult to add.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,8 +32,8 @@ Please clarify why the changes are needed. For instance,
 ### Does this PR introduce _any_ user-facing change?
 <!--
 Note that it means *any* user-facing change including all aspects such as the documentation fix.
-If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description and/or an example to show the behavior difference if possible.
-If possible, please also clarify if this is a user-facing change compared to the released Spark versions or within the unreleased branches such as master.
+If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
+If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
 If no, write 'No'.
 -->
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
The proposed change is an update to the github pull request template. I've copied the template from the Apache Spark project which seems to work pretty well.

### Why are the changes needed?
The project is now accepting PR's from github, which is great in that it should drastically increase the number of contributors. Consequently this also means an increase in the number of PR's which means that we need to make reviewing PR's as easy as possible for the people who have those permissions.

### Does this PR introduce _any_ user-facing change?
Yes, contributors who create a new PR will see the new PR template.

### How was this patch tested?
This patch was not tested.