### PR TITLE
HIVE-23929: Run compaction as partition owner

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -520,7 +520,7 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         if (runJobAsSelf(ci.runAs)) {
           mr.run(conf, jobName.toString(), t, p, sd, tblValidWriteIds, ci, su, msc, dir);
         } else {
-          UserGroupInformation ugi = UserGroupInformation.createProxyUser(t.getOwner(),
+          UserGroupInformation ugi = UserGroupInformation.createProxyUser(ci.runAs,
               UserGroupInformation.getLoginUser());
           final Partition fp = p;
           final CompactionInfo fci = ci;


### PR DESCRIPTION
While using Nifi to stream data into Hive tables, it can happen that the newly created partitions have a different owner than the table itself. Running compaction on these partitions will fail with AccessControlException. 
Change compaction to use partition owner as base for proxy user.
