### PR TITLE
HIVE-23911: CBO fails when query has distinct in function and having clause

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4850,7 +4850,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
                     expr, columnList, excludedColumns, inputRR, starRR, pos,
                     outputRR, qb.getAliases(), true);
           } else if (ParseUtils.containsTokenOfType(expr, HiveParser.TOK_FUNCTIONDI)
-                  && !(srcRel instanceof HiveAggregate)) {
+                  && !(srcRel instanceof HiveAggregate ||
+              (srcRel.getInputs().size() == 1 && srcRel.getInput(0) instanceof HiveAggregate))) {
             // Likely a malformed query eg, select hash(distinct c1) from t1;
             throw new CalciteSemanticException("Distinct without an aggregation.",
                     UnsupportedFeature.Distinct_without_an_aggreggation);

--- a/ql/src/test/queries/clientpositive/having_distinct_function.q
+++ b/ql/src/test/queries/clientpositive/having_distinct_function.q
@@ -1,0 +1,19 @@
+create table t (col0 int, col1 int);
+
+insert into t(col0, col1) values
+(1, 1),
+(1, 2), (1, 2), (1, 2),
+(1, 3), (1, 3),
+(2, 4),
+(2, 5),
+(3, 10)
+;
+
+explain cbo
+select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1;
+
+select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1;

--- a/ql/src/test/results/clientpositive/llap/having_distinct_function.q.out
+++ b/ql/src/test/results/clientpositive/llap/having_distinct_function.q.out
@@ -1,0 +1,65 @@
+PREHOOK: query: create table t (col0 int, col1 int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t
+POSTHOOK: query: create table t (col0 int, col1 int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t
+PREHOOK: query: insert into t(col0, col1) values
+(1, 1),
+(1, 2), (1, 2), (1, 2),
+(1, 3), (1, 3),
+(2, 4),
+(2, 5),
+(3, 10)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t
+POSTHOOK: query: insert into t(col0, col1) values
+(1, 1),
+(1, 2), (1, 2), (1, 2),
+(1, 3), (1, 3),
+(2, 4),
+(2, 5),
+(3, 10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t
+POSTHOOK: Lineage: t.col0 SCRIPT []
+POSTHOOK: Lineage: t.col1 SCRIPT []
+PREHOOK: query: explain cbo
+select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t
+#### A masked pattern was here ####
+CBO PLAN:
+HiveFilter(condition=[>($1, 1)])
+  HiveAggregate(group=[{0}], agg#0=[count($1)])
+    HiveProject(col0=[$0], col1=[$1])
+      HiveAggregate(group=[{0, 1}])
+        HiveTableScan(table=[[default, t]], table:alias=[t])
+
+PREHOOK: query: select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t
+#### A masked pattern was here ####
+POSTHOOK: query: select col0, count(distinct col1) from t
+group by col0
+having count(distinct col1) > 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t
+#### A masked pattern was here ####
+1	3
+2	2


### PR DESCRIPTION
Testing done:
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=having_distinct_function.q -pl itests/qtest -Pitests
```