### PR TITLE
HIVE-23829: Compute Stats Incorrect for Binary Columns

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2209,10 +2209,10 @@ public class HiveConf extends Configuration {
         "'1', and '0' as extended, legal boolean literal, in addition to 'TRUE' and 'FALSE'.\n" +
         "The default is false, which means only 'TRUE' and 'FALSE' are treated as legal\n" +
         "boolean literal."),
-    HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64("hive.lazysimple.decode_binary_as_base64", false,
+    HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64("hive.lazysimple.decode_binary_as_base64", true,
     	"LazySimpleSerde uses this property to determine if data in binary column types should\n" +
     	"be decoded as base64. If true and value is not valid base64 then original value will be used.\n" +
-    	"The default for this option is false."),
+    	"The default for this option is true."),
 
     HIVESKEWJOIN("hive.optimize.skewjoin", false,
         "Whether to enable skew join optimization. \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2209,10 +2209,6 @@ public class HiveConf extends Configuration {
         "'1', and '0' as extended, legal boolean literal, in addition to 'TRUE' and 'FALSE'.\n" +
         "The default is false, which means only 'TRUE' and 'FALSE' are treated as legal\n" +
         "boolean literal."),
-    HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64("hive.lazysimple.decode_binary_as_base64", true,
-    	"LazySimpleSerde uses this property to determine if data in binary column types should\n" +
-    	"be decoded as base64. If true and value is not valid base64 then original value will be used.\n" +
-    	"The default for this option is true."),
 
     HIVESKEWJOIN("hive.optimize.skewjoin", false,
         "Whether to enable skew join optimization. \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2211,7 +2211,8 @@ public class HiveConf extends Configuration {
         "boolean literal."),
     HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64("hive.lazysimple.decode_binary_as_base64", false,
     	"LazySimpleSerde uses this property to determine if data in binary column types should\n" +
-    	"be decoded as base64. If true and row is not valid base64 then original value will be used."),
+    	"be decoded as base64. If true and value is not valid base64 then original value will be used.\n" +
+    	"The default for this option is false."),
 
     HIVESKEWJOIN("hive.optimize.skewjoin", false,
         "Whether to enable skew join optimization. \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2209,6 +2209,9 @@ public class HiveConf extends Configuration {
         "'1', and '0' as extended, legal boolean literal, in addition to 'TRUE' and 'FALSE'.\n" +
         "The default is false, which means only 'TRUE' and 'FALSE' are treated as legal\n" +
         "boolean literal."),
+    HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64("hive.lazysimple.decode_binary_as_base64", false,
+    	"LazySimpleSerde uses this property to determine if data in binary column types should\n" +
+    	"be decoded as base64. If true and row is not valid base64 then original value will be used."),
 
     HIVESKEWJOIN("hive.optimize.skewjoin", false,
         "Whether to enable skew join optimization. \n" +

--- a/ql/src/test/queries/clientpositive/acid_vectorization_original_tez.q
+++ b/ql/src/test/queries/clientpositive/acid_vectorization_original_tez.q
@@ -37,7 +37,8 @@ CREATE TABLE over10k_n9(t tinyint,
            `dec` decimal(4,2),
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
-STORED AS TEXTFILE;
+STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 --oddly this has 9999 rows not > 10K
 LOAD DATA LOCAL INPATH '../../data/files/over1k' OVERWRITE INTO TABLE over10k_n9;

--- a/ql/src/test/queries/clientpositive/avro_nullable_fields.q
+++ b/ql/src/test/queries/clientpositive/avro_nullable_fields.q
@@ -17,7 +17,8 @@ CREATE TABLE test_serializer(string1 STRING,
                              bytes1 BINARY,
                              fixed1 BINARY)
  ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' COLLECTION ITEMS TERMINATED BY ':' MAP KEYS TERMINATED BY '#' LINES TERMINATED BY '\n'
- STORED AS TEXTFILE;
+ STORED AS TEXTFILE
+ TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 LOAD DATA LOCAL INPATH '../../data/files/csv.txt' INTO TABLE test_serializer;
 

--- a/ql/src/test/queries/clientpositive/llap_text.q
+++ b/ql/src/test/queries/clientpositive/llap_text.q
@@ -26,7 +26,8 @@ CREATE TABLE text_llap(
 row format serde 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 -- stored as inputformat "org.apache.hadoop.hive.llap.io.decode.LlapTextInputFormat" 
- outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat";
+outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 insert into table text_llap
 select ctinyint, csmallint, cint, cbigint, cfloat, cdouble, cstring1, cstring2, ctimestamp1, ctimestamp2, cboolean1, cboolean2 from alltypesorc 
@@ -47,7 +48,8 @@ create table text_llap2(
 row format delimited fields terminated by '|'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 -- stored as inputformat "org.apache.hadoop.hive.llap.io.decode.LlapTextInputFormat" 
-outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat";
+outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k.gz' into table text_llap2;
 

--- a/ql/src/test/queries/clientpositive/metadata_only_queries.q
+++ b/ql/src/test/queries/clientpositive/metadata_only_queries.q
@@ -16,7 +16,8 @@ create table over10k_n12(
            `dec` decimal,  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n12;
 

--- a/ql/src/test/queries/clientpositive/metadata_only_queries_with_filters.q
+++ b/ql/src/test/queries/clientpositive/metadata_only_queries_with_filters.q
@@ -15,7 +15,8 @@ create table over10k_n23(
            `dec` decimal,  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n23;
 

--- a/ql/src/test/queries/clientpositive/orc_llap_counters.q
+++ b/ql/src/test/queries/clientpositive/orc_llap_counters.q
@@ -20,7 +20,8 @@ CREATE TABLE staging_n6(t tinyint,
            `dec` decimal(4,2),
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
-STORED AS TEXTFILE;
+STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 LOAD DATA LOCAL INPATH '../../data/files/over1k' OVERWRITE INTO TABLE staging_n6;
 LOAD DATA LOCAL INPATH '../../data/files/over1k' INTO TABLE staging_n6;

--- a/ql/src/test/queries/clientpositive/orc_llap_counters1.q
+++ b/ql/src/test/queries/clientpositive/orc_llap_counters1.q
@@ -19,7 +19,8 @@ CREATE TABLE staging(t tinyint,
            `dec` decimal(4,2),
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
-STORED AS TEXTFILE;
+STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 LOAD DATA LOCAL INPATH '../../data/files/over1k' OVERWRITE INTO TABLE staging;
 LOAD DATA LOCAL INPATH '../../data/files/over1k' INTO TABLE staging;

--- a/ql/src/test/queries/clientpositive/vector_binary_join_groupby.q
+++ b/ql/src/test/queries/clientpositive/vector_binary_join_groupby.q
@@ -22,7 +22,8 @@ CREATE TABLE over1k_n7(t tinyint,
            `dec` decimal(4,2),
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
-STORED AS TEXTFILE;
+STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 LOAD DATA LOCAL INPATH '../../data/files/over1k' OVERWRITE INTO TABLE over1k_n7;
 

--- a/ql/src/test/queries/clientpositive/vector_windowing_multipartitioning.q
+++ b/ql/src/test/queries/clientpositive/vector_windowing_multipartitioning.q
@@ -20,7 +20,8 @@ create table over10k_n6(
            `dec` decimal(4,2),  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n6;
 

--- a/ql/src/test/queries/clientpositive/vector_windowing_navfn.q
+++ b/ql/src/test/queries/clientpositive/vector_windowing_navfn.q
@@ -21,7 +21,8 @@ create table over10k_n7(
            `dec` decimal(4,2),  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n7;
 

--- a/ql/src/test/queries/clientpositive/windowing_distinct.q
+++ b/ql/src/test/queries/clientpositive/windowing_distinct.q
@@ -14,7 +14,8 @@ create table windowing_distinct(
            `dec` decimal,
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/windowing_distinct.txt' into table windowing_distinct;
 

--- a/ql/src/test/queries/clientpositive/windowing_multipartitioning.q
+++ b/ql/src/test/queries/clientpositive/windowing_multipartitioning.q
@@ -15,7 +15,8 @@ create table over10k_n11(
            `dec` decimal(4,2),  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n11;
 

--- a/ql/src/test/queries/clientpositive/windowing_navfn.q
+++ b/ql/src/test/queries/clientpositive/windowing_navfn.q
@@ -14,7 +14,8 @@ create table over10k_n19(
            `dec` decimal(4,2),  
            bin binary)
        row format delimited
-       fields terminated by '|';
+       fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false");
 
 load data local inpath '../../data/files/over10k' into table over10k_n19;
 

--- a/ql/src/test/results/clientpositive/llap/avro_nullable_fields.q.out
+++ b/ql/src/test/results/clientpositive/llap/avro_nullable_fields.q.out
@@ -15,6 +15,7 @@ PREHOOK: query: CREATE TABLE test_serializer(string1 STRING,
                              fixed1 BINARY)
  ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' COLLECTION ITEMS TERMINATED BY ':' MAP KEYS TERMINATED BY '#' LINES TERMINATED BY '\n'
  STORED AS TEXTFILE
+ TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@test_serializer
@@ -35,6 +36,7 @@ POSTHOOK: query: CREATE TABLE test_serializer(string1 STRING,
                              fixed1 BINARY)
  ROW FORMAT DELIMITED FIELDS TERMINATED BY ',' COLLECTION ITEMS TERMINATED BY ':' MAP KEYS TERMINATED BY '#' LINES TERMINATED BY '\n'
  STORED AS TEXTFILE
+ TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@test_serializer

--- a/ql/src/test/results/clientpositive/llap/llap_text.q.out
+++ b/ql/src/test/results/clientpositive/llap/llap_text.q.out
@@ -18,7 +18,8 @@ PREHOOK: query: CREATE TABLE text_llap(
 row format serde 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 
- outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@text_llap
@@ -38,7 +39,8 @@ POSTHOOK: query: CREATE TABLE text_llap(
 row format serde 'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 
- outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@text_llap
@@ -82,6 +84,7 @@ row format delimited fields terminated by '|'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 
 outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@text_llap2
@@ -101,6 +104,7 @@ row format delimited fields terminated by '|'
 stored as inputformat "org.apache.hadoop.mapred.TextInputFormat" 
 
 outputformat "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@text_llap2

--- a/ql/src/test/results/clientpositive/llap/metadata_only_queries.q.out
+++ b/ql/src/test/results/clientpositive/llap/metadata_only_queries.q.out
@@ -12,6 +12,7 @@ PREHOOK: query: create table over10k_n12(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n12
@@ -29,6 +30,7 @@ POSTHOOK: query: create table over10k_n12(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n12

--- a/ql/src/test/results/clientpositive/llap/metadata_only_queries_with_filters.q.out
+++ b/ql/src/test/results/clientpositive/llap/metadata_only_queries_with_filters.q.out
@@ -12,6 +12,7 @@ PREHOOK: query: create table over10k_n23(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n23
@@ -29,6 +30,7 @@ POSTHOOK: query: create table over10k_n23(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n23

--- a/ql/src/test/results/clientpositive/llap/orc_llap_counters.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_llap_counters.q.out
@@ -11,6 +11,7 @@ PREHOOK: query: CREATE TABLE staging_n6(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@staging_n6
@@ -27,6 +28,7 @@ POSTHOOK: query: CREATE TABLE staging_n6(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@staging_n6

--- a/ql/src/test/results/clientpositive/llap/orc_llap_counters1.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_llap_counters1.q.out
@@ -11,6 +11,7 @@ PREHOOK: query: CREATE TABLE staging(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@staging
@@ -27,6 +28,7 @@ POSTHOOK: query: CREATE TABLE staging(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@staging

--- a/ql/src/test/results/clientpositive/llap/vector_binary_join_groupby.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_binary_join_groupby.q.out
@@ -19,6 +19,7 @@ PREHOOK: query: CREATE TABLE over1k_n7(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over1k_n7
@@ -35,6 +36,7 @@ POSTHOOK: query: CREATE TABLE over1k_n7(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over1k_n7

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_multipartitioning.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_multipartitioning.q.out
@@ -16,6 +16,7 @@ PREHOOK: query: create table over10k_n6(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n6
@@ -33,6 +34,7 @@ POSTHOOK: query: create table over10k_n6(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n6

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_navfn.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_navfn.q.out
@@ -16,6 +16,7 @@ PREHOOK: query: create table over10k_n7(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n7
@@ -33,6 +34,7 @@ POSTHOOK: query: create table over10k_n7(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n7

--- a/ql/src/test/results/clientpositive/llap/windowing_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/windowing_distinct.q.out
@@ -17,6 +17,7 @@ PREHOOK: query: create table windowing_distinct(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@windowing_distinct
@@ -35,6 +36,7 @@ POSTHOOK: query: create table windowing_distinct(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@windowing_distinct

--- a/ql/src/test/results/clientpositive/llap/windowing_multipartitioning.q.out
+++ b/ql/src/test/results/clientpositive/llap/windowing_multipartitioning.q.out
@@ -16,6 +16,7 @@ PREHOOK: query: create table over10k_n11(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n11
@@ -33,6 +34,7 @@ POSTHOOK: query: create table over10k_n11(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n11

--- a/ql/src/test/results/clientpositive/llap/windowing_navfn.q.out
+++ b/ql/src/test/results/clientpositive/llap/windowing_navfn.q.out
@@ -16,6 +16,7 @@ PREHOOK: query: create table over10k_n19(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n19
@@ -33,6 +34,7 @@ POSTHOOK: query: create table over10k_n19(
            bin binary)
        row format delimited
        fields terminated by '|'
+       TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n19

--- a/ql/src/test/results/clientpositive/tez/acid_vectorization_original_tez.q.out
+++ b/ql/src/test/results/clientpositive/tez/acid_vectorization_original_tez.q.out
@@ -34,6 +34,7 @@ PREHOOK: query: CREATE TABLE over10k_n9(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@over10k_n9
@@ -50,6 +51,7 @@ POSTHOOK: query: CREATE TABLE over10k_n9(t tinyint,
            bin binary)
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|'
 STORED AS TEXTFILE
+TBLPROPERTIES ("hive.serialization.decode.binary.as.base64"="false")
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@over10k_n9

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyBinary.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyBinary.java
@@ -52,7 +52,7 @@ public class LazyBinary extends LazyPrimitive<LazyBinaryObjectInspector, BytesWr
     data.set(decoded, 0, decoded.length);
   }
 
-  // decodes binary columns as base64 if the conf value HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64 is set to true.
+  // todo this should be configured in serde
   public static byte[] decodeIfNeeded(byte[] recv) {
     try {
       return Base64.getDecoder().decode(recv);

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyBinary.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazyBinary.java
@@ -52,7 +52,7 @@ public class LazyBinary extends LazyPrimitive<LazyBinaryObjectInspector, BytesWr
     data.set(decoded, 0, decoded.length);
   }
 
-  // todo this should be configured in serde
+  // decodes binary columns as base64 if the conf value HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64 is set to true.
   public static byte[] decodeIfNeeded(byte[] recv) {
     try {
       return Base64.getDecoder().decode(recv);

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -53,7 +53,9 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
   	= "hive.serialization.extend.nesting.levels";
   public static final String SERIALIZATION_EXTEND_ADDITIONAL_NESTING_LEVELS
 	= "hive.serialization.extend.additional.nesting.levels";
-
+  public static final String SERIALIZATION_DECODE_BINARY_AS_BASE64
+  	= "hive.serialization.decode.binary.as.base.64";
+  
   private Properties tableProperties;
   private String serdeName;
 
@@ -90,6 +92,8 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     lastColumnTakesRest = (lastColumnTakesRestString != null && lastColumnTakesRestString
         .equalsIgnoreCase("true"));
 
+    decodeBinaryAsBase64 = Boolean.parseBoolean(tableProperties.getProperty(SERIALIZATION_DECODE_BINARY_AS_BASE64, "true"));
+
     extractColumnInfo(job);
 
     // Create the LazyObject for storing the rows
@@ -117,10 +121,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
 
     extendedBooleanLiteral = (job == null ? false :
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
-    
-    decodeBinaryAsBase64 = (job == null ? false :
-    	job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64.varname, true));
-    		
+
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));
     if (timestampFormatsArray != null) {
@@ -254,7 +255,8 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     boolean extendedNesting = extendNestingValue != null && extendNestingValue.equalsIgnoreCase("true");
     boolean extendedAdditionalNesting = extendAdditionalNestingValue != null 
     		&& extendAdditionalNestingValue.equalsIgnoreCase("true");
-
+    
+    
     separatorCandidates.add(LazyUtils.getByte(tableProperties.getProperty(serdeConstants.FIELD_DELIM,
         tableProperties.getProperty(serdeConstants.SERIALIZATION_FORMAT)), DefaultSeparators[0]));
     separatorCandidates.add(LazyUtils.getByte(tableProperties

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -127,7 +127,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     if (timestampFormatsArray != null) {
       timestampFormats = Arrays.asList(timestampFormatsArray);
     }
-    
+
     LOG.debug(serdeName + " initialized with: columnNames="
         + columnNames + " columnTypes=" + columnTypes
         + " separator=" + Arrays.asList(separators)

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -54,7 +54,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
   public static final String SERIALIZATION_EXTEND_ADDITIONAL_NESTING_LEVELS
 	= "hive.serialization.extend.additional.nesting.levels";
   public static final String SERIALIZATION_DECODE_BINARY_AS_BASE64
-  	= "hive.serialization.decode.binary.as.base.64";
+  	= "hive.serialization.decode.binary.as.base64";
   
   private Properties tableProperties;
   private String serdeName;
@@ -121,7 +121,6 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
 
     extendedBooleanLiteral = (job == null ? false :
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
-
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));
     if (timestampFormatsArray != null) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -128,8 +128,11 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     }
     
 
-    LOG.debug("{} initialized with: columnNames={} columnTypes={} separator={} nullString={} lastColumnTakesRest={} timestampFormats={}",
-    		serdeName, columnNames, columnTypes, Arrays.asList(separators), nullString, lastColumnTakesRest, timestampFormats);
+    LOG.debug(serdeName + " initialized with: columnNames="
+            + columnNames + " columnTypes=" + columnTypes
+            + " separator=" + Arrays.asList(separators)
+            + " nullstring=" + nullString + " lastColumnTakesRest="
+            + lastColumnTakesRest + " timestampFormats=" + timestampFormats);
   }
 
   /**

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -121,6 +121,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
 
     extendedBooleanLiteral = (job == null ? false :
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
+
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));
     if (timestampFormatsArray != null) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -119,7 +119,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
     
     decodeBinaryAsBase64 = (job == null ? false :
-    	job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64.varname, false));
+    	job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64.varname, true));
     		
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -127,12 +127,11 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
       timestampFormats = Arrays.asList(timestampFormatsArray);
     }
     
-
     LOG.debug(serdeName + " initialized with: columnNames="
-            + columnNames + " columnTypes=" + columnTypes
-            + " separator=" + Arrays.asList(separators)
-            + " nullstring=" + nullString + " lastColumnTakesRest="
-            + lastColumnTakesRest + " timestampFormats=" + timestampFormats);
+        + columnNames + " columnTypes=" + columnTypes
+        + " separator=" + Arrays.asList(separators)
+        + " nullstring=" + nullString + " lastColumnTakesRest="
+        + lastColumnTakesRest + " timestampFormats=" + timestampFormats);
   }
 
   /**

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -255,8 +255,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     boolean extendedNesting = extendNestingValue != null && extendNestingValue.equalsIgnoreCase("true");
     boolean extendedAdditionalNesting = extendAdditionalNestingValue != null 
     		&& extendAdditionalNestingValue.equalsIgnoreCase("true");
-    
-    
+
     separatorCandidates.add(LazyUtils.getByte(tableProperties.getProperty(serdeConstants.FIELD_DELIM,
         tableProperties.getProperty(serdeConstants.SERIALIZATION_FORMAT)), DefaultSeparators[0]));
     separatorCandidates.add(LazyUtils.getByte(tableProperties

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -121,7 +121,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
 
     extendedBooleanLiteral = (job == null ? false :
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
-
+    
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));
     if (timestampFormatsArray != null) {

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/LazySerDeParameters.java
@@ -74,6 +74,7 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
   private boolean[] needsEscape = new boolean[256];  // A flag for each byte to indicate if escape is needed.
 
   private boolean extendedBooleanLiteral;
+  private boolean decodeBinaryAsBase64;
   List<String> timestampFormats;
   
   public LazySerDeParameters(Configuration job, Properties tbl, String serdeName) throws SerDeException {
@@ -117,17 +118,18 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     extendedBooleanLiteral = (job == null ? false :
         job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_EXTENDED_BOOLEAN_LITERAL.varname, false));
     
+    decodeBinaryAsBase64 = (job == null ? false :
+    	job.getBoolean(ConfVars.HIVE_LAZYSIMPLE_DECODE_BINARY_AS_BASE64.varname, false));
+    		
     String[] timestampFormatsArray =
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS));
     if (timestampFormatsArray != null) {
       timestampFormats = Arrays.asList(timestampFormatsArray);
     }
+    
 
-    LOG.debug(serdeName + " initialized with: columnNames="
-        + columnNames + " columnTypes=" + columnTypes
-        + " separator=" + Arrays.asList(separators)
-        + " nullstring=" + nullString + " lastColumnTakesRest="
-        + lastColumnTakesRest + " timestampFormats=" + timestampFormats);
+    LOG.debug("{} initialized with: columnNames={} columnTypes={} separator={} nullString={} lastColumnTakesRest={} timestampFormats={}",
+    		serdeName, columnNames, columnTypes, Arrays.asList(separators), nullString, lastColumnTakesRest, timestampFormats);
   }
 
   /**
@@ -218,6 +220,10 @@ public class LazySerDeParameters implements LazyObjectInspectorParameters {
     return extendedBooleanLiteral;
   }
 
+  public boolean isDecodeBinaryAsBase64() {
+    return decodeBinaryAsBase64;
+  }
+  
   public List<String> getTimestampFormats() {
     return timestampFormats;
   }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/lazy/fast/LazySimpleDeserializeRead.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/lazy/fast/LazySimpleDeserializeRead.java
@@ -26,7 +26,6 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 
-
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.slf4j.Logger;
@@ -35,7 +34,6 @@ import org.apache.hadoop.hive.common.type.DataTypePhysicalVariation;
 import org.apache.hadoop.hive.common.type.HiveIntervalDayTime;
 import org.apache.hadoop.hive.common.type.HiveIntervalYearMonth;
 import org.apache.hadoop.hive.serde2.fast.DeserializeRead;
-import org.apache.hadoop.hive.serde2.lazy.LazyBinary;
 import org.apache.hadoop.hive.serde2.lazy.LazyByte;
 import org.apache.hadoop.hive.serde2.lazy.LazyInteger;
 import org.apache.hadoop.hive.serde2.lazy.LazyLong;
@@ -56,7 +54,6 @@ import org.apache.hadoop.io.Text;
 import org.apache.hive.common.util.TimestampParser;
 
 import com.google.common.base.Preconditions;
-import com.sun.jersey.core.util.Base64;
 
 /*
  * Directly deserialize with the caller reading field-by-field the LazySimple (text)
@@ -784,10 +781,11 @@ public final class LazySimpleDeserializeRead extends DeserializeRead {
           return true;
         case BINARY:
           {
-          	ByteBuffer bb = ByteBuffer.wrap(bytes, fieldStart, fieldLength);
-        	final ByteBuffer b64bb = isDecodeBinaryAsBase64 ? Base64.getDecoder().decode(bb) : bb;
-        	currentBytes = new byte[b64bb.remaining()];
-        	b64bb.get(currentBytes);
+            ByteBuffer bb = ByteBuffer.wrap(bytes, fieldStart, fieldLength);
+            // Base64 or raw value: Throws IllegalArgumentException on invalid decode
+            final ByteBuffer b64bb = isDecodeBinaryAsBase64 ? Base64.getDecoder().decode(bb) : bb;
+            currentBytes = new byte[b64bb.remaining()];
+            b64bb.get(currentBytes);
             currentBytesStart = 0;
             currentBytesLength = currentBytes.length;
           }


### PR DESCRIPTION
Updated the LazySimple SerDe to no longer attempt to auto-detect if Binary columns were Base64 and instead use a table property. The previous way this was done was expensive and did not correctly check if the values were valid Base64 which in niche cases could result in statistics being computed incorrectly.