### PR TITLE
HIVE-23935. Fetching primaryKey through beeline fails with NPE.

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -10721,7 +10721,8 @@ public class ObjectStore implements RawStore, Configurable {
                                                      final String db_name_input,
                                                      final String tbl_name_input)
   throws MetaException, NoSuchObjectException {
-    final String db_name = normalizeIdentifier(db_name_input);
+    final String db_name =
+        db_name_input != null ? normalizeIdentifier(db_name_input) : null;
     final String tbl_name = normalizeIdentifier(tbl_name_input);
     return new GetListHelper<SQLPrimaryKey>(catName, db_name, tbl_name, true, true) {
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -107,6 +107,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
+import static org.junit.Assert.assertEquals;
 
 @Category(MetastoreUnitTest.class)
 public class TestObjectStore {
@@ -1122,6 +1123,40 @@ public class TestObjectStore {
   @Test
   public void testEmptyTrustStoreProps() {
     setAndCheckSSLProperties(true, "", "", "jks");
+  }
+
+  /**
+   * Tests getPrimaryKeys() when db_name isn't specified.
+   */
+  @Test
+  public void testGetPrimaryKeys() throws Exception {
+    Database db1 =
+        new DatabaseBuilder().setName(DB1).setDescription("description")
+            .setLocation("locationurl").build(conf);
+    objectStore.createDatabase(db1);
+    StorageDescriptor sd1 = new StorageDescriptor(
+        ImmutableList.of(new FieldSchema("pk_col", "double", null)), "location",
+        null, null, false, 0,
+        new SerDeInfo("SerDeName", "serializationLib", null), null, null, null);
+    HashMap<String, String> params = new HashMap<>();
+    params.put("EXTERNAL", "false");
+    Table tbl1 =
+        new Table(TABLE1, DB1, "owner", 1, 2, 3, sd1, null, params, null, null,
+            "MANAGED_TABLE");
+    objectStore.createTable(tbl1);
+
+    SQLPrimaryKey pk =
+        new SQLPrimaryKey(DB1, TABLE1, "pk_col", 1, "pk_const_1", false, false,
+            false);
+    pk.setCatName(DEFAULT_CATALOG_NAME);
+    objectStore.addPrimaryKeys(ImmutableList.of(pk));
+
+    // Primary key retrieval should be success, even if db_name isn't specified.
+    assertEquals("pk_col",
+        objectStore.getPrimaryKeys(DEFAULT_CATALOG_NAME, null, TABLE1).get(0)
+            .getColumn_name());
+    objectStore.dropTable(DEFAULT_CATALOG_NAME, DB1, TABLE1);
+    objectStore.dropDatabase(db1.getCatalogName(), DB1);
   }
 
   /**


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-23935

Entire Trace -

```
0: jdbc:hive2://localhost:10000> !primarykeys Persons
Error: MetaException(message:java.lang.NullPointerException) (state=,code=0)
org.apache.hive.service.cli.HiveSQLException: MetaException(message:java.lang.NullPointerException)
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:360)
	at org.apache.hive.jdbc.Utils.verifySuccess(Utils.java:351)
	at org.apache.hive.jdbc.HiveDatabaseMetaData.getPrimaryKeys(HiveDatabaseMetaData.java:573)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hive.beeline.Reflector.invoke(Reflector.java:89)
	at org.apache.hive.beeline.Commands.metadata(Commands.java:125)
	at org.apache.hive.beeline.Commands.primarykeys(Commands.java:231)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hive.beeline.ReflectiveCommandHandler.execute(ReflectiveCommandHandler.java:57)
	at org.apache.hive.beeline.BeeLine.execCommandWithPrefix(BeeLine.java:1465)
	at org.apache.hive.beeline.BeeLine.dispatch(BeeLine.java:1504)
	at org.apache.hive.beeline.BeeLine.execute(BeeLine.java:1364)
	at org.apache.hive.beeline.BeeLine.begin(BeeLine.java:1134)
	at org.apache.hive.beeline.BeeLine.begin(BeeLine.java:1082)
	at org.apache.hive.beeline.BeeLine.mainWithInputRedirection(BeeLine.java:546)
	at org.apache.hive.beeline.BeeLine.main(BeeLine.java:528)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.util.RunJar.run(RunJar.java:323)
	at org.apache.hadoop.util.RunJar.main(RunJar.java:236)
Caused by: org.apache.hive.service.cli.HiveSQLException: MetaException(message:java.lang.NullPointerException)
	at org.apache.hive.service.cli.operation.GetPrimaryKeysOperation.runInternal(GetPrimaryKeysOperation.java:120)
	at org.apache.hive.service.cli.operation.Operation.run(Operation.java:277)
	at org.apache.hive.service.cli.session.HiveSessionImpl.getPrimaryKeys(HiveSessionImpl.java:997)
	at org.apache.hive.service.cli.CLIService.getPrimaryKeys(CLIService.java:416)
	at org.apache.hive.service.cli.thrift.ThriftCLIService.GetPrimaryKeys(ThriftCLIService.java:838)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$GetPrimaryKeys.getResult(TCLIService.java:1717)
	at org.apache.hive.service.rpc.thrift.TCLIService$Processor$GetPrimaryKeys.getResult(TCLIService.java:1702)
	at org.apache.thrift.ProcessFunction.process(ProcessFunction.java:39)
	at org.apache.thrift.TBaseProcessor.process(TBaseProcessor.java:39)
	at org.apache.hive.service.auth.TSetIpAddressProcessor.process(TSetIpAddressProcessor.java:56)
	at org.apache.thrift.server.TThreadPoolServer$WorkerProcess.run(TThreadPoolServer.java:286)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: MetaException(message:java.lang.NullPointerException)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.newMetaException(HiveMetaStore.java:7921)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.throwMetaException(HiveMetaStore.java:9105)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.get_primary_keys(HiveMetaStore.java:9067)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invokeInternal(RetryingHMSHandler.java:147)
	at org.apache.hadoop.hive.metastore.RetryingHMSHandler.invoke(RetryingHMSHandler.java:108)
	at com.sun.proxy.$Proxy44.get_primary_keys(Unknown Source)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.getPrimaryKeys(HiveMetaStoreClient.java:2617)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RetryingMetaStoreClient.invoke(RetryingMetaStoreClient.java:215)
	at com.sun.proxy.$Proxy45.getPrimaryKeys(Unknown Source)
	at org.apache.hive.service.cli.operation.GetPrimaryKeysOperation.runInternal(GetPrimaryKeysOperation.java:94)
	... 13 more
Caused by: java.lang.NullPointerException: null
	at org.apache.hadoop.hive.metastore.utils.StringUtils.normalizeIdentifier(StringUtils.java:94)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPrimaryKeysInternal(ObjectStore.java:10723)
	at org.apache.hadoop.hive.metastore.ObjectStore.getPrimaryKeys(ObjectStore.java:10713)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.hadoop.hive.metastore.RawStoreProxy.invoke(RawStoreProxy.java:97)
	at com.sun.proxy.$Proxy42.getPrimaryKeys(Unknown Source)
	at org.apache.hadoop.hive.metastore.HiveMetaStore$HMSHandler.get_primary_keys(HiveMetaStore.java:9064)
	... 28 more
```
Post Fix
```
: jdbc:hive2://localhost:10000> !primarykeys persons
+------------+--------------+-------------+--------------+----------+-------------------------------+
| TABLE_CAT  | TABLE_SCHEM  | TABLE_NAME  | COLUMN_NAME  | KEY_SEQ  |            PK_NAME            |
+------------+--------------+-------------+--------------+----------+-------------------------------+
|            | default      | persons     | id           | 1        | pk_250096773_1595006111286_0  |
+------------+--------------+-------------+--------------+----------+-------------------------------+
```

