### PR TITLE
HIVE-23939: SharedWorkOptimizer: take the union of columns in mergeable TableScans

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2535,6 +2535,10 @@ public class HiveConf extends Configuration {
         "Whether to enable shared work extended optimizer for semijoins. The optimizer tries to merge\n" +
         "scan operators if one of them reads the full table, even if the other one is the target for\n" +
         "one or more semijoin edges. Tez only."),
+    HIVE_SHARED_WORK_MERGE_TS_SCHEMA("hive.optimize.shared.work.merge.ts.schema", true,
+        "Whether to enable merging scan operators over the same table but with different schema." +
+            "The optimizer tries to merge the scan operators by taking the union of needed columns from " +
+            "all scan operators. Requires hive.optimize.shared.work to be set to true. Tez only."),
     HIVE_SHARED_WORK_REUSE_MAPJOIN_CACHE("hive.optimize.shared.work.mapjoin.cache.reuse", true,
         "When shared work optimizer is enabled, whether we should reuse the cache for the broadcast side\n" +
         "of mapjoin operators that share same broadcast input. Requires hive.optimize.shared.work\n" +

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_join_pkfk.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_join_pkfk.q.out
@@ -1148,7 +1148,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1176,7 +1176,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: s
-                  filterExpr: ((s_floor_space > 1000) and s_store_sk is not null) (type: boolean)
+                  filterExpr: (((s_floor_space > 1000) and s_store_sk is not null) or s_store_sk is not null) (type: boolean)
                   Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((s_floor_space > 1000) and s_store_sk is not null) (type: boolean)
@@ -1191,14 +1191,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 12 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: s_store_sk is not null (type: boolean)
-                  Statistics: Num rows: 12 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: s_store_sk is not null (type: boolean)
                     Statistics: Num rows: 12 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/auto_join_reordering_values.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join_reordering_values.q.out
@@ -113,16 +113,16 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 8 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Map 9 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 7 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: orderpayment
-                  filterExpr: (date is not null and dealid is not null and cityid is not null and userid is not null) (type: boolean)
+                  filterExpr: ((date is not null and dealid is not null and cityid is not null and userid is not null) or dealid is not null or cityid is not null) (type: boolean)
                   Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -143,6 +143,42 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 106 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: 0
                         value expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                        auto parallelism: true
+                  Filter Operator
+                    isSamplingPred: false
+                    predicate: dealid is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: dealid (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        bucketingVersion: 2
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        numBuckets: -1
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
+                        auto parallelism: true
+                  Filter Operator
+                    isSamplingPred: false
+                    predicate: cityid is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: cityid (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        bucketingVersion: 2
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        numBuckets: -1
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 1
                         auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: no inputs
@@ -248,134 +284,6 @@ STAGE PLANS:
             Truncated Path -> Alias:
               /orderpayment_small [dim_pay_date]
         Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: deal
-                  filterExpr: dealid is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: dealid is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: dealid (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        bucketingVersion: 2
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        numBuckets: -1
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                        tag: 1
-                        auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: orderpayment_small
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    bucket_count -1
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns dealid,date,time,cityid,userid
-                    columns.types int:string:string:int:int
-#### A masked pattern was here ####
-                    name default.orderpayment_small
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns dealid,date,time,cityid,userid
-                      columns.comments 
-                      columns.types int:string:string:int:int
-#### A masked pattern was here ####
-                      name default.orderpayment_small
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.orderpayment_small
-                  name: default.orderpayment_small
-            Truncated Path -> Alias:
-              /orderpayment_small [deal]
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: order_city
-                  filterExpr: cityid is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: cityid is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: cityid (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        bucketingVersion: 2
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        numBuckets: -1
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                        tag: 1
-                        auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: orderpayment_small
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    bucket_count -1
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns dealid,date,time,cityid,userid
-                    columns.types int:string:string:int:int
-#### A masked pattern was here ####
-                    name default.orderpayment_small
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns dealid,date,time,cityid,userid
-                      columns.comments 
-                      columns.types int:string:string:int:int
-#### A masked pattern was here ####
-                      name default.orderpayment_small
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.orderpayment_small
-                  name: default.orderpayment_small
-            Truncated Path -> Alias:
-              /orderpayment_small [order_city]
-        Map 9 
             Map Operator Tree:
                 TableScan
                   alias: user

--- a/ql/src/test/results/clientpositive/llap/auto_join_without_localtask.q.out
+++ b/ql/src/test/results/clientpositive/llap/auto_join_without_localtask.q.out
@@ -179,7 +179,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -187,7 +187,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: a
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -203,6 +203,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                  Filter Operator
+                    predicate: value is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: value (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: no inputs
         Map 5 
@@ -224,27 +237,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: value (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
@@ -380,33 +372,11 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((UDFToDouble(key) > 100.0D) and value is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((UDFToDouble(key) > 100.0D) and value is not null) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: b
@@ -427,11 +397,11 @@ STAGE PLANS:
                         Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: c
-                  filterExpr: value is not null (type: boolean)
+                  filterExpr: (value is not null or ((UDFToDouble(key) > 100.0D) and value is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -446,6 +416,20 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((UDFToDouble(key) > 100.0D) and value is not null) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/bucket_map_join_tez2.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_map_join_tez2.q.out
@@ -184,14 +184,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: a
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or key is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -207,6 +207,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -229,27 +242,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -319,14 +311,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: a
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or key is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -342,6 +334,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -364,27 +369,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1391,14 +1375,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: tab_n10
-                  filterExpr: UDFToDouble(value) is not null (type: boolean)
+                  filterExpr: (UDFToDouble(value) is not null or UDFToDouble(key) is not null) (type: boolean)
                   Statistics: Num rows: 242 Data size: 22022 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(value) is not null (type: boolean)
@@ -1415,14 +1399,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 121 Data size: 11011 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: UDFToDouble(key) is not null (type: boolean)
-                  Statistics: Num rows: 242 Data size: 22990 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(key) is not null (type: boolean)
                     Statistics: Num rows: 242 Data size: 22990 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1507,14 +1483,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: tab_n10
-                  filterExpr: UDFToDouble(value) is not null (type: boolean)
+                  filterExpr: (UDFToDouble(value) is not null or UDFToDouble(key) is not null) (type: boolean)
                   Statistics: Num rows: 242 Data size: 22022 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(value) is not null (type: boolean)
@@ -1531,14 +1507,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 121 Data size: 11011 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: UDFToDouble(key) is not null (type: boolean)
-                  Statistics: Num rows: 242 Data size: 22990 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(key) is not null (type: boolean)
                     Statistics: Num rows: 242 Data size: 22990 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2100,14 +2068,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: a
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or key is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -2123,6 +2091,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -2145,27 +2126,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -2236,14 +2196,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: a
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or key is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -2259,6 +2219,19 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -2281,27 +2254,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
+++ b/ql/src/test/results/clientpositive/llap/cbo_SortUnionTransposeRule.q.out
@@ -913,18 +913,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src2
-                  filterExpr: key is not null (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -947,13 +946,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src1
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: string)
                     outputColumnNames: _col0
@@ -1057,7 +1049,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer10.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer10.q.out
@@ -807,8 +807,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -831,17 +831,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: ((UDFToDouble(key) < 200.0D) and (UDFToDouble(key) > 180.0D)) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((UDFToDouble(key) < 200.0D) and (UDFToDouble(key) > 180.0D)) (type: boolean)
-                    Statistics: Num rows: 55 Data size: 4785 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -854,7 +843,7 @@ STAGE PLANS:
                         Statistics: Num rows: 55 Data size: 4785 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: y
@@ -893,7 +882,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1002,8 +991,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1026,17 +1015,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: ((UDFToDouble(key) < 200.0D) and (UDFToDouble(key) > 180.0D)) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((UDFToDouble(key) < 200.0D) and (UDFToDouble(key) > 180.0D)) (type: boolean)
-                    Statistics: Num rows: 55 Data size: 4785 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -1049,7 +1027,7 @@ STAGE PLANS:
                         Statistics: Num rows: 55 Data size: 4785 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: y
@@ -1088,7 +1066,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer3.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer3.q.out
@@ -27,11 +27,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -54,17 +54,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -77,7 +66,7 @@ STAGE PLANS:
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: y
@@ -163,7 +152,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -188,7 +177,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 16 Data size: 1504 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -259,11 +248,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -286,17 +275,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -309,7 +287,7 @@ STAGE PLANS:
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: y
@@ -395,7 +373,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -420,7 +398,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 16 Data size: 1504 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -491,10 +469,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 2 <- Map 4 (BROADCAST_EDGE)
-        Map 5 <- Reducer 3 (BROADCAST_EDGE)
+        Map 2 <- Map 1 (BROADCAST_EDGE)
+        Map 4 <- Reducer 3 (BROADCAST_EDGE)
         Reducer 3 <- Map 1 (BROADCAST_EDGE), Map 2 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -517,6 +495,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 2 
@@ -540,7 +528,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col1
                         input vertices:
-                          1 Map 4
+                          1 Map 1
                         Statistics: Num rows: 39 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -559,27 +547,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: y
@@ -645,7 +612,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 25 Data size: 4575 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: string), _col3 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -718,7 +685,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -769,17 +736,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -950,7 +906,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -1001,17 +957,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string)
                       outputColumnNames: _col0
@@ -1180,7 +1125,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 2 (BROADCAST_EDGE)
-        Map 3 <- Map 6 (BROADCAST_EDGE)
+        Map 3 <- Map 2 (BROADCAST_EDGE)
         Reducer 4 <- Map 1 (BROADCAST_EDGE), Map 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
@@ -1237,6 +1182,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 3 
@@ -1260,7 +1215,7 @@ STAGE PLANS:
                           1 _col0 (type: string)
                         outputColumnNames: _col1
                         input vertices:
-                          1 Map 6
+                          1 Map 2
                         Statistics: Num rows: 39 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -1276,27 +1231,6 @@ STAGE PLANS:
                             Map-reduce partition columns: _col0 (type: string)
                             Statistics: Num rows: 16 Data size: 1504 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 4 

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer6.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer6.q.out
@@ -2940,7 +2940,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2966,6 +2966,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 5 
@@ -2991,28 +3002,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 12 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3193,7 +3182,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3219,6 +3208,17 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 5 
@@ -3244,28 +3244,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 12 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: z
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer7.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer7.q.out
@@ -30,7 +30,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -91,17 +91,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: yy
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
@@ -132,7 +121,7 @@ STAGE PLANS:
                     1 _col0 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
                   input vertices:
-                    1 Map 4
+                    1 Map 3
                   Statistics: Num rows: 3 Data size: 810 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
@@ -215,7 +204,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -276,17 +265,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: yy
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
@@ -317,7 +295,7 @@ STAGE PLANS:
                     1 _col0 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
                   input vertices:
-                    1 Map 4
+                    1 Map 3
                   Statistics: Num rows: 3 Data size: 810 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
@@ -400,7 +378,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -461,17 +439,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: yy
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
@@ -502,7 +469,7 @@ STAGE PLANS:
                     1 _col0 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
                   input vertices:
-                    1 Map 4
+                    1 Map 3
                   Statistics: Num rows: 3 Data size: 810 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
@@ -585,7 +552,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 3 (BROADCAST_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -646,17 +613,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: yy
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: key (type: string), value (type: string)
                       outputColumnNames: _col0, _col1
@@ -687,7 +643,7 @@ STAGE PLANS:
                     1 _col0 (type: string)
                   outputColumnNames: _col0, _col1, _col2, _col3
                   input vertices:
-                    1 Map 4
+                    1 Map 3
                   Statistics: Num rows: 3 Data size: 810 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false

--- a/ql/src/test/results/clientpositive/llap/explainanalyze_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainanalyze_2.q.out
@@ -669,7 +669,7 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -679,15 +679,15 @@ Stage-0
       File Output Operator [FS_16]
         Merge Join Operator [MERGEJOIN_46] (rows=633/1166 width=95)
           Conds:RS_12._col0=RS_13._col0(Inner),Output:["_col0","_col1"]
-        <-Map 5 [SIMPLE_EDGE] llap
+        <-Map 1 [SIMPLE_EDGE] llap
           SHUFFLE [RS_13]
             PartitionCols:_col0
             Select Operator [SEL_8] (rows=242/242 width=4)
               Output:["_col0"]
               Filter Operator [FIL_24] (rows=242/242 width=4)
                 predicate:key is not null
-                TableScan [TS_6] (rows=242/242 width=4)
-                  default@tab_n6,s3,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                TableScan [TS_0] (rows=242/242 width=95)
+                  default@tab_n6,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
         <-Reducer 2 [SIMPLE_EDGE] llap
           SHUFFLE [RS_12]
             PartitionCols:_col0
@@ -700,8 +700,7 @@ Stage-0
                   Output:["_col0","_col1"]
                   Filter Operator [FIL_22] (rows=242/242 width=95)
                     predicate:(key is not null and value is not null)
-                    TableScan [TS_0] (rows=242/242 width=95)
-                      default@tab_n6,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                     Please refer to the previous TableScan [TS_0]
             <-Map 4 [SIMPLE_EDGE] llap
               SHUFFLE [RS_10]
                 PartitionCols:_col0
@@ -800,7 +799,7 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -810,20 +809,28 @@ Stage-0
       File Output Operator [FS_16]
         Merge Join Operator [MERGEJOIN_46] (rows=633/1166 width=95)
           Conds:RS_12._col0=RS_13._col0(Inner),Output:["_col0","_col1"]
-        <-Map 5 [SIMPLE_EDGE] llap
+        <-Map 4 [SIMPLE_EDGE] llap
           SHUFFLE [RS_13]
             PartitionCols:_col0
             Select Operator [SEL_8] (rows=242/242 width=4)
               Output:["_col0"]
               Filter Operator [FIL_24] (rows=242/242 width=4)
                 predicate:key is not null
-                TableScan [TS_6] (rows=242/242 width=4)
-                  default@tab2_n3,s3,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                TableScan [TS_3] (rows=242/242 width=91)
+                  default@tab2_n3,s2,Tbl:COMPLETE,Col:COMPLETE,Output:["value","key"]
         <-Reducer 2 [SIMPLE_EDGE] llap
           SHUFFLE [RS_12]
             PartitionCols:_col0
             Merge Join Operator [MERGEJOIN_45] (rows=382/480 width=95)
               Conds:RS_9._col1=RS_10._col0(Inner),Output:["_col0","_col1"]
+            <-Map 4 [SIMPLE_EDGE] llap
+              SHUFFLE [RS_10]
+                PartitionCols:_col0
+                Select Operator [SEL_5] (rows=242/242 width=91)
+                  Output:["_col0"]
+                  Filter Operator [FIL_23] (rows=242/242 width=91)
+                    predicate:value is not null
+                     Please refer to the previous TableScan [TS_3]
             <-Map 1 [SIMPLE_EDGE] llap
               SHUFFLE [RS_9]
                 PartitionCols:_col1
@@ -833,15 +840,6 @@ Stage-0
                     predicate:(key is not null and value is not null)
                     TableScan [TS_0] (rows=242/242 width=95)
                       default@tab_n6,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-            <-Map 4 [SIMPLE_EDGE] llap
-              SHUFFLE [RS_10]
-                PartitionCols:_col0
-                Select Operator [SEL_5] (rows=242/242 width=91)
-                  Output:["_col0"]
-                  Filter Operator [FIL_23] (rows=242/242 width=91)
-                    predicate:value is not null
-                    TableScan [TS_3] (rows=242/242 width=91)
-                      default@tab2_n3,s2,Tbl:COMPLETE,Col:COMPLETE,Output:["value"]
 
 PREHOOK: query: select count(*) from (select s1.key as key, s1.value as value from tab_n6 s1 join tab_n6 s3 on s1.key=s3.key
 UNION  ALL
@@ -988,10 +986,10 @@ POSTHOOK: Input: default@tab_part_n7@ds=2008-04-08
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 9 <- Union 4 (CONTAINS)
+Map 8 <- Union 4 (CONTAINS)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
-Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
-Reducer 5 <- Map 10 (SIMPLE_EDGE), Union 4 (SIMPLE_EDGE)
+Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE), Union 4 (CONTAINS)
+Reducer 5 <- Map 9 (SIMPLE_EDGE), Union 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -1006,7 +1004,7 @@ Stage-0
           PARTITION_ONLY_SHUFFLE [RS_28]
             Merge Join Operator [MERGEJOIN_81] (rows=1443/3768 width=8)
               Conds:Union 4._col0=RS_25._col0(Inner)
-            <-Map 10 [SIMPLE_EDGE] llap
+            <-Map 9 [SIMPLE_EDGE] llap
               SHUFFLE [RS_25]
                 PartitionCols:_col0
                 Select Operator [SEL_23] (rows=500/500 width=4)
@@ -1016,7 +1014,7 @@ Stage-0
                     TableScan [TS_21] (rows=500/500 width=4)
                       default@tab_part_n7,b_n10,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
             <-Union 4 [SIMPLE_EDGE]
-              <-Map 9 [CONTAINS] llap
+              <-Map 8 [CONTAINS] llap
                 Reduce Output Operator [RS_89]
                   PartitionCols:_col0
                   Select Operator [SEL_87] (rows=242/242 width=4)
@@ -1030,15 +1028,15 @@ Stage-0
                   PartitionCols:_col0
                   Merge Join Operator [MERGEJOIN_82] (rows=633/1166 width=4)
                     Conds:RS_12._col0=RS_13._col0(Inner),Output:["_col0"]
-                  <-Map 8 [SIMPLE_EDGE] llap
+                  <-Map 1 [SIMPLE_EDGE] llap
                     SHUFFLE [RS_13]
                       PartitionCols:_col0
                       Select Operator [SEL_8] (rows=242/242 width=4)
                         Output:["_col0"]
                         Filter Operator [FIL_44] (rows=242/242 width=4)
                           predicate:key is not null
-                          TableScan [TS_6] (rows=242/242 width=4)
-                            default@tab_n6,s3,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                          TableScan [TS_0] (rows=242/242 width=95)
+                            default@tab_n6,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                   <-Reducer 2 [SIMPLE_EDGE] llap
                     SHUFFLE [RS_12]
                       PartitionCols:_col0
@@ -1051,8 +1049,7 @@ Stage-0
                             Output:["_col0","_col1"]
                             Filter Operator [FIL_42] (rows=242/242 width=95)
                               predicate:(key is not null and value is not null)
-                              TableScan [TS_0] (rows=242/242 width=95)
-                                default@tab_n6,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                               Please refer to the previous TableScan [TS_0]
                       <-Map 7 [SIMPLE_EDGE] llap
                         SHUFFLE [RS_10]
                           PartitionCols:_col0

--- a/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/explainuser_1.q.out
@@ -2379,7 +2379,7 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -2391,7 +2391,7 @@ Stage-0
           Output:["_col0","_col1"]
           Merge Join Operator [MERGEJOIN_51] (rows=1 width=8)
             Conds:RS_17._col1, _col4=RS_18._col0, _col1(Left Semi),Output:["_col0","_col3"]
-          <-Map 5 [SIMPLE_EDGE] llap
+          <-Map 1 [SIMPLE_EDGE] llap
             SHUFFLE [RS_18]
               PartitionCols:_col0, _col1
               Group By Operator [GBY_16] (rows=1 width=8)
@@ -2400,8 +2400,8 @@ Stage-0
                   Output:["_col0","_col1"]
                   Filter Operator [FIL_29] (rows=2 width=96)
                     predicate:((l_linenumber = 1) and (l_shipmode = 'AIR') and l_orderkey is not null)
-                    TableScan [TS_12] (rows=100 width=96)
-                      default@lineitem,lineitem,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey","l_linenumber","l_shipmode"]
+                    TableScan [TS_0] (rows=100 width=16)
+                      default@lineitem,li,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey","l_partkey","l_suppkey","l_linenumber","l_shipmode"]
           <-Reducer 2 [SIMPLE_EDGE] llap
             SHUFFLE [RS_17]
               PartitionCols:_col1, _col4
@@ -2416,8 +2416,7 @@ Stage-0
                       Output:["_col0","_col1","_col2","_col3"]
                       Filter Operator [FIL_27] (rows=14 width=16)
                         predicate:((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null)
-                        TableScan [TS_0] (rows=100 width=16)
-                          default@lineitem,li,Tbl:COMPLETE,Col:COMPLETE,Output:["l_orderkey","l_partkey","l_suppkey","l_linenumber"]
+                         Please refer to the previous TableScan [TS_0]
                 <-Map 4 [SIMPLE_EDGE] llap
                   SHUFFLE [RS_9]
                     PartitionCols:_col0
@@ -2450,7 +2449,7 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
 Reducer 6 <- Map 1 (SIMPLE_EDGE)
@@ -2477,15 +2476,15 @@ Stage-0
                     Output:["_col0","_col1","_col2"],aggregations:["count()"],keys:_col1, _col2
                     Merge Join Operator [MERGEJOIN_55] (rows=131 width=178)
                       Conds:RS_10._col0=RS_11._col0(Inner),Output:["_col1","_col2"]
-                    <-Map 7 [SIMPLE_EDGE] llap
+                    <-Map 1 [SIMPLE_EDGE] llap
                       SHUFFLE [RS_11]
                         PartitionCols:_col0
                         Select Operator [SEL_9] (rows=166 width=178)
                           Output:["_col0","_col1"]
                           Filter Operator [FIL_41] (rows=166 width=178)
                             predicate:(key > '8')
-                            TableScan [TS_7] (rows=500 width=178)
-                              default@src_cbo,b,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
+                            TableScan [TS_0] (rows=500 width=87)
+                              default@src_cbo,src_cbo,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
                     <-Reducer 2 [SIMPLE_EDGE] llap
                       SHUFFLE [RS_10]
                         PartitionCols:_col0
@@ -2498,8 +2497,7 @@ Stage-0
                               Output:["_col0"],keys:key
                               Filter Operator [FIL_40] (rows=166 width=87)
                                 predicate:(key > '8')
-                                TableScan [TS_0] (rows=500 width=87)
-                                  default@src_cbo,src_cbo,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
+                                 Please refer to the previous TableScan [TS_0]
         <-Reducer 6 [SIMPLE_EDGE] llap
           SHUFFLE [RS_30]
             PartitionCols:_col0
@@ -2542,8 +2540,8 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 5 <- Map 4 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 4 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -2569,7 +2567,7 @@ Stage-0
                       predicate:p_name is not null
                       TableScan [TS_0] (rows=26 width=223)
                         default@part,part,Tbl:COMPLETE,Col:COMPLETE,Output:["p_name","p_mfgr","p_size"]
-        <-Reducer 5 [SIMPLE_EDGE] llap
+        <-Reducer 4 [SIMPLE_EDGE] llap
           SHUFFLE [RS_18]
             PartitionCols:_col0
             Group By Operator [GBY_16] (rows=13 width=184)
@@ -2582,11 +2580,10 @@ Stage-0
                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col5 ASC NULLS LAST","partition by:":"_col2"}]
                     Select Operator [SEL_9] (rows=26 width=491)
                       Output:["_col1","_col2","_col5"]
-                    <-Map 4 [SIMPLE_EDGE] llap
+                    <-Map 1 [SIMPLE_EDGE] llap
                       SHUFFLE [RS_8]
                         PartitionCols:p_mfgr
-                        TableScan [TS_7] (rows=26 width=223)
-                          default@part,part,Tbl:COMPLETE,Col:COMPLETE,Output:["p_mfgr","p_name","p_size"]
+                         Please refer to the previous TableScan [TS_0]
 
 PREHOOK: query: explain select * 
 from src_cbo 
@@ -2609,11 +2606,11 @@ POSTHOOK: Input: default@src_cbo
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Map 1 (SIMPLE_EDGE)
+Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -2638,39 +2635,38 @@ Stage-0
                       Merge Join Operator [MERGEJOIN_36] (rows=631 width=178)
                         Conds:RS_16._col0=RS_17._col0(Left Outer),Output:["_col0","_col1","_col3"]
                       <-Map 1 [SIMPLE_EDGE] llap
-                        SHUFFLE [RS_16]
+                        PARTITION_ONLY_SHUFFLE [RS_16]
                           PartitionCols:_col0
                           Select Operator [SEL_1] (rows=500 width=178)
                             Output:["_col0","_col1"]
                             TableScan [TS_0] (rows=500 width=178)
                               default@src_cbo,src_cbo,Tbl:COMPLETE,Col:COMPLETE,Output:["key","value"]
-                      <-Reducer 6 [SIMPLE_EDGE] llap
+                      <-Reducer 5 [SIMPLE_EDGE] llap
                         SHUFFLE [RS_17]
                           PartitionCols:_col0
                           Select Operator [SEL_8] (rows=83 width=91)
                             Output:["_col0","_col1"]
                             Group By Operator [GBY_7] (rows=83 width=87)
                               Output:["_col0"],keys:KEY._col0
-                            <-Map 5 [SIMPLE_EDGE] llap
+                            <-Map 1 [SIMPLE_EDGE] llap
                               PARTITION_ONLY_SHUFFLE [RS_6]
                                 PartitionCols:_col0
                                 Group By Operator [GBY_5] (rows=83 width=87)
                                   Output:["_col0"],keys:key
                                   Filter Operator [FIL_29] (rows=166 width=87)
                                     predicate:(key > '2')
-                                    TableScan [TS_2] (rows=500 width=87)
-                                      default@src_cbo,s1,Tbl:COMPLETE,Col:COMPLETE,Output:["key"]
-                  <-Reducer 7 [CUSTOM_SIMPLE_EDGE] llap
+                                     Please refer to the previous TableScan [TS_0]
+                  <-Reducer 6 [CUSTOM_SIMPLE_EDGE] llap
                     PARTITION_ONLY_SHUFFLE [RS_20]
                       Group By Operator [GBY_14] (rows=1 width=16)
                         Output:["_col0","_col1"],aggregations:["count(VALUE._col0)","count(VALUE._col1)"]
-                      <-Map 5 [CUSTOM_SIMPLE_EDGE] llap
+                      <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                         PARTITION_ONLY_SHUFFLE [RS_13]
                           Group By Operator [GBY_12] (rows=1 width=16)
                             Output:["_col0","_col1"],aggregations:["count()","count(key)"]
                             Filter Operator [FIL_30] (rows=166 width=87)
                               predicate:(key > '2')
-                               Please refer to the previous TableScan [TS_2]
+                               Please refer to the previous TableScan [TS_0]
 
 PREHOOK: query: explain select p_mfgr, b.p_name, p_size 
 from part b 
@@ -2780,10 +2776,10 @@ POSTHOOK: Input: default@part
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -2803,7 +2799,7 @@ Stage-0
                   Output:["_col0","_col1","_col2","_col3","_col5"]
                   Merge Join Operator [MERGEJOIN_40] (rows=27 width=141)
                     Conds:(Inner),Output:["_col0","_col1","_col3","_col4","_col5"]
-                  <-Reducer 6 [CUSTOM_SIMPLE_EDGE] llap
+                  <-Reducer 5 [CUSTOM_SIMPLE_EDGE] llap
                     PARTITION_ONLY_SHUFFLE [RS_27]
                       Group By Operator [GBY_21] (rows=1 width=16)
                         Output:["_col0","_col1"],aggregations:["count()","count(_col0)"]
@@ -2811,19 +2807,25 @@ Stage-0
                           Output:["_col0"]
                           Group By Operator [GBY_7] (rows=1 width=16)
                             Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                          <-Map 5 [CUSTOM_SIMPLE_EDGE] llap
+                          <-Map 1 [CUSTOM_SIMPLE_EDGE] llap
                             PARTITION_ONLY_SHUFFLE [RS_6]
                               Group By Operator [GBY_5] (rows=1 width=16)
                                 Output:["_col0","_col1"],aggregations:["sum(p_size)","count(p_size)"]
                                 Filter Operator [FIL_37] (rows=5 width=4)
                                   predicate:(p_size < 10)
-                                  TableScan [TS_2] (rows=26 width=4)
-                                    default@part,part,Tbl:COMPLETE,Col:COMPLETE,Output:["p_size"]
+                                  TableScan [TS_0] (rows=26 width=125)
+                                    default@part,part,Tbl:COMPLETE,Col:COMPLETE,Output:["p_name","p_size"]
                   <-Reducer 2 [CUSTOM_SIMPLE_EDGE] llap
                     PARTITION_ONLY_SHUFFLE [RS_26]
                       Merge Join Operator [MERGEJOIN_39] (rows=27 width=125)
                         Conds:RS_23.UDFToDouble(_col1)=RS_24._col0(Left Outer),Output:["_col0","_col1","_col3"]
-                      <-Reducer 6 [SIMPLE_EDGE] llap
+                      <-Map 1 [SIMPLE_EDGE] llap
+                        PARTITION_ONLY_SHUFFLE [RS_23]
+                          PartitionCols:UDFToDouble(_col1)
+                          Select Operator [SEL_1] (rows=26 width=125)
+                            Output:["_col0","_col1"]
+                             Please refer to the previous TableScan [TS_0]
+                      <-Reducer 5 [SIMPLE_EDGE] llap
                         PARTITION_ONLY_SHUFFLE [RS_24]
                           PartitionCols:_col0
                           Select Operator [SEL_10] (rows=1 width=12)
@@ -2831,13 +2833,6 @@ Stage-0
                             Filter Operator [FIL_9] (rows=1 width=16)
                               predicate:(_col1 is not null and UDFToDouble(_col0) is not null)
                                Please refer to the previous Group By Operator [GBY_7]
-                      <-Map 1 [SIMPLE_EDGE] llap
-                        SHUFFLE [RS_23]
-                          PartitionCols:UDFToDouble(_col1)
-                          Select Operator [SEL_1] (rows=26 width=125)
-                            Output:["_col0","_col1"]
-                            TableScan [TS_0] (rows=26 width=125)
-                              default@part,part,Tbl:COMPLETE,Col:COMPLETE,Output:["p_name","p_size"]
 
 PREHOOK: query: explain select b.p_mfgr, min(p_retailprice) 
 from part b 

--- a/ql/src/test/results/clientpositive/llap/filter_cond_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/filter_cond_pushdown.q.out
@@ -22,32 +22,10 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: m
-                  filterExpr: ((value <> '') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((value <> '') and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string), (value = '2008-04-08') (type: boolean)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: boolean)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: f
@@ -69,11 +47,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: boolean), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: g
-                  filterExpr: (value <> '') (type: boolean)
+                  filterExpr: ((value <> '') or ((value <> '') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value <> '') (type: boolean)
@@ -88,6 +66,20 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((value <> '') and key is not null) (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string), (value = '2008-04-08') (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -162,32 +154,10 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: m
-                  filterExpr: ((value <> '') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((value <> '') and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string), (value = '2008-04-08') (type: boolean)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: boolean)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: f
@@ -209,11 +179,11 @@ STAGE PLANS:
                         value expressions: _col1 (type: boolean), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: g
-                  filterExpr: (value <> '') (type: boolean)
+                  filterExpr: ((value <> '') or ((value <> '') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value <> '') (type: boolean)
@@ -228,6 +198,20 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((value <> '') and key is not null) (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string), (value = '2008-04-08') (type: boolean)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 91000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: boolean)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/filter_join_breaktask.q.out
+++ b/ql/src/test/results/clientpositive/llap/filter_join_breaktask.q.out
@@ -54,78 +54,10 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: f
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        bucketingVersion: 2
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        numBuckets: -1
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                        tag: 0
-                        auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: ds=2008-04-08
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  partition values:
-                    ds 2008-04-08
-                  properties:
-                    column.name.delimiter ,
-                    columns key,value
-                    columns.types int:string
-#### A masked pattern was here ####
-                    name default.filter_join_breaktask
-                    partition_columns ds
-                    partition_columns.types string
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,value
-                      columns.comments 
-                      columns.types int:string
-#### A masked pattern was here ####
-                      name default.filter_join_breaktask
-                      partition_columns ds
-                      partition_columns.types string
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.filter_join_breaktask
-                  name: default.filter_join_breaktask
-            Truncated Path -> Alias:
-              /filter_join_breaktask/ds=2008-04-08 [f]
-        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: m
@@ -194,11 +126,11 @@ STAGE PLANS:
                   name: default.filter_join_breaktask
             Truncated Path -> Alias:
               /filter_join_breaktask/ds=2008-04-08 [m]
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: g
-                  filterExpr: (value <> '') (type: boolean)
+                  filterExpr: ((value <> '') or key is not null) (type: boolean)
                   Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                   GatherStats: false
                   Filter Operator
@@ -218,6 +150,24 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                         tag: 1
+                        auto parallelism: true
+                  Filter Operator
+                    isSamplingPred: false
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        bucketingVersion: 2
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        numBuckets: -1
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 15 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                        tag: 0
                         auto parallelism: true
             Execution mode: vectorized, llap
             LLAP IO: no inputs

--- a/ql/src/test/results/clientpositive/llap/groupby_sort_1_23.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_sort_1_23.q.out
@@ -3185,8 +3185,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3217,61 +3217,6 @@ STAGE PLANS:
                         tag: 0
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: t1_n80
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    SORTBUCKETCOLSPREFIX TRUE
-                    bucket_count 2
-                    bucket_field_name key
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns key,val
-                    columns.types string:string
-#### A masked pattern was here ####
-                    name default.t1_n80
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      SORTBUCKETCOLSPREFIX TRUE
-                      bucket_count 2
-                      bucket_field_name key
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,val
-                      columns.comments 
-                      columns.types string:string
-#### A masked pattern was here ####
-                      name default.t1_n80
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.t1_n80
-                  name: default.t1_n80
-            Truncated Path -> Alias:
-              /t1_n80 [t1_n80]
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: t1_n80
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 2208 Basic stats: COMPLETE Column stats: NONE
-                  GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2208 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string), val (type: string)
@@ -3371,7 +3316,7 @@ STAGE PLANS:
                   TotalFiles: 1
                   GatherStats: false
                   MultiFileSpray: false
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/groupby_sort_skew_1_23.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_sort_skew_1_23.q.out
@@ -3295,9 +3295,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3328,61 +3328,6 @@ STAGE PLANS:
                         tag: 0
                         value expressions: _col1 (type: bigint)
                         auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: t1_n56
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    SORTBUCKETCOLSPREFIX TRUE
-                    bucket_count 2
-                    bucket_field_name key
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns key,val
-                    columns.types string:string
-#### A masked pattern was here ####
-                    name default.t1_n56
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      SORTBUCKETCOLSPREFIX TRUE
-                      bucket_count 2
-                      bucket_field_name key
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns key,val
-                      columns.comments 
-                      columns.types string:string
-#### A masked pattern was here ####
-                      name default.t1_n56
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.t1_n56
-                  name: default.t1_n56
-            Truncated Path -> Alias:
-              /t1_n56 [t1_n56]
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: t1_n56
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 6 Data size: 2208 Basic stats: COMPLETE Column stats: NONE
-                  GatherStats: false
-                  Filter Operator
-                    isSamplingPred: false
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 6 Data size: 2208 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       aggregations: count()
                       keys: key (type: string), val (type: string)
@@ -3482,7 +3427,7 @@ STAGE PLANS:
                   TotalFiles: 1
                   GatherStats: false
                   MultiFileSpray: false
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:
@@ -3503,7 +3448,7 @@ STAGE PLANS:
                   tag: -1
                   value expressions: _col2 (type: bigint)
                   auto parallelism: true
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
@@ -976,17 +976,17 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 2 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
-        Map 8 <- Map 10 (BROADCAST_EDGE), Map 7 (BROADCAST_EDGE)
+        Map 7 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
         Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -997,23 +997,15 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: y
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 2 
@@ -1061,7 +1053,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1072,26 +1064,18 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: z
@@ -1108,7 +1092,7 @@ STAGE PLANS:
                         1 value (type: string)
                       outputColumnNames: _col1
                       input vertices:
-                        0 Map 7
+                        0 Map 1
                       Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -1117,7 +1101,7 @@ STAGE PLANS:
                           0 _col1 (type: string)
                           1 value (type: string)
                         input vertices:
-                          1 Map 10
+                          1 Map 6
                         Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -1167,7 +1151,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1274,17 +1258,17 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 2 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
-        Map 8 <- Map 10 (BROADCAST_EDGE), Map 7 (BROADCAST_EDGE)
+        Map 7 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
         Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1295,23 +1279,15 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: y
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 2 
@@ -1359,7 +1335,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1370,26 +1346,18 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: z
@@ -1406,7 +1374,7 @@ STAGE PLANS:
                         1 value (type: string)
                       outputColumnNames: _col1
                       input vertices:
-                        0 Map 7
+                        0 Map 1
                       Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -1415,7 +1383,7 @@ STAGE PLANS:
                           0 _col1 (type: string)
                           1 value (type: string)
                         input vertices:
-                          1 Map 10
+                          1 Map 6
                         Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -1465,7 +1433,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/infer_join_preds.q.out
+++ b/ql/src/test/results/clientpositive/llap/infer_join_preds.q.out
@@ -1299,7 +1299,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1343,17 +1343,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: bigint)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: d
-                  filterExpr: prid is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 776 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: prid is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 776 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: prid (type: bigint), concat(CASE WHEN (length(pruid) is null) THEN ('') ELSE (pruid) END, ',', CASE WHEN (prid is null) THEN (1L) ELSE (prid) END, ',', CASE WHEN (prtimesheetid is null) THEN (1L) ELSE (prtimesheetid) END, ',', CASE WHEN (prassignmentid is null) THEN (1L) ELSE (prassignmentid) END, ',', CASE WHEN (prchargecodeid is null) THEN (1L) ELSE (prchargecodeid) END, ',', CASE WHEN (prtypecodeid is null) THEN ('') ELSE (CAST( prtypecodeid AS STRING)) END, ',', CASE WHEN (practsum is null) THEN (1) ELSE (practsum) END, ',', CASE WHEN (prsequence is null) THEN (1L) ELSE (prsequence) END, ',', CASE WHEN (length(prmodby) is null) THEN ('') ELSE (prmodby) END, ',', CASE WHEN (prmodtime is null) THEN (TIMESTAMP'2017-12-08 00:00:00') ELSE (prmodtime) END, ',', CASE WHEN (prrmexported is null) THEN (1L) ELSE (prrmexported) END, ',', CASE WHEN (prrmckdel is null) THEN (1L) ELSE (prrmckdel) END, ',', CASE WHEN (slice_status is null) THEN (1) ELSE (slice_status) END, ',', CASE WHEN (role_id is null) THEN (1L) ELSE (role_id) END, ',', CASE WHEN (length(user_lov1) is null) THEN ('') ELSE (user_lov1) END, ',', CASE WHEN (length(user_lov2) is null) THEN ('') ELSE (user_lov2) END, ',', CASE WHEN (incident_id is null) THEN (1L) ELSE (incident_id) END, ',', CASE WHEN (incident_investment_id is null) THEN (1L) ELSE (incident_investment_id) END, ',', CASE WHEN (odf_ss_actuals is null) THEN (1L) ELSE (odf_ss_actuals) END) (type: string)
                       outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/join12.q.out
+++ b/ql/src/test/results/clientpositive/llap/join12.q.out
@@ -34,7 +34,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -63,27 +63,6 @@ STAGE PLANS:
                 TableScan
                   alias: src
                   filterExpr: (UDFToDouble(key) < 80.0D) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) < 80.0D) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: (UDFToDouble(key) < 80.0D) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble(key) < 80.0D) (type: boolean)
@@ -99,6 +78,16 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Select Operator
+                      expressions: key (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/join2.q.out
+++ b/ql/src/test/results/clientpositive/llap/join2.q.out
@@ -30,14 +30,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src1
-                  filterExpr: (key is not null and UDFToDouble(key) is not null) (type: boolean)
+                  filterExpr: ((key is not null and UDFToDouble(key) is not null) or UDFToDouble(key) is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and UDFToDouble(key) is not null) (type: boolean)
@@ -53,6 +53,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: double)
+                  Filter Operator
+                    predicate: UDFToDouble(key) is not null (type: boolean)
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: value (type: string), UDFToDouble(key) (type: double)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 500 Data size: 49500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: double)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: double)
+                        Statistics: Num rows: 500 Data size: 49500 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -75,28 +89,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src3
-                  filterExpr: UDFToDouble(key) is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: UDFToDouble(key) is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: value (type: string), UDFToDouble(key) (type: double)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 500 Data size: 49500 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: double)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col1 (type: double)
-                        Statistics: Num rows: 500 Data size: 49500 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/join3.q.out
+++ b/ql/src/test/results/clientpositive/llap/join3.q.out
@@ -30,7 +30,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -53,6 +53,17 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 5 
@@ -74,28 +85,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: src3
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 

--- a/ql/src/test/results/clientpositive/llap/join_alt_syntax.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_alt_syntax.q.out
@@ -458,7 +458,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -494,7 +494,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: p4
-                  filterExpr: p_partkey is not null (type: boolean)
+                  filterExpr: (p_partkey is not null or p_name is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -510,14 +510,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: p3
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
@@ -623,7 +615,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -659,7 +651,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: p4
-                  filterExpr: p_partkey is not null (type: boolean)
+                  filterExpr: (p_partkey is not null or p_name is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -675,14 +667,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: p3
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/join_merging.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_merging.q.out
@@ -21,8 +21,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -40,14 +40,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p2
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -64,7 +56,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: p1
@@ -108,7 +100,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -160,8 +152,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -179,14 +171,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p2
-                  filterExpr: (p_partkey is not null and p_size is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_partkey is not null and p_size is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -203,7 +187,7 @@ STAGE PLANS:
                         value expressions: _col1 (type: int), _col2 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: p1
@@ -247,7 +231,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator

--- a/ql/src/test/results/clientpositive/llap/join_parse.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_parse.q.out
@@ -32,7 +32,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -61,7 +61,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -76,14 +76,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src1
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -180,7 +172,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -209,7 +201,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -224,14 +216,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src1
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -328,7 +312,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -357,7 +341,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -372,14 +356,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src1
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/keep_uniform.q.out
+++ b/ql/src/test/results/clientpositive/llap/keep_uniform.q.out
@@ -437,25 +437,25 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 12 <- Map 11 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
+        Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
+        Reducer 11 <- Map 1 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
+        Reducer 12 <- Map 1 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
         Reducer 13 <- Reducer 12 (SIMPLE_EDGE)
-        Reducer 14 <- Map 11 (SIMPLE_EDGE), Map 18 (SIMPLE_EDGE)
-        Reducer 15 <- Map 11 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
-        Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-        Reducer 3 <- Map 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 13 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 16 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 19 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 14 (SIMPLE_EDGE)
+        Reducer 3 <- Map 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 13 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 18 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
         Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: ws1
-                  filterExpr: (ws_order_number is not null and ws_ship_date_sk is not null and ws_ship_addr_sk is not null and ws_web_site_sk is not null) (type: boolean)
+                  filterExpr: ((ws_order_number is not null and ws_ship_date_sk is not null and ws_ship_addr_sk is not null and ws_web_site_sk is not null) or ws_order_number is not null) (type: boolean)
                   Statistics: Num rows: 1 Data size: 240 Basic stats: COMPLETE Column stats: NONE
                   TableScan Vectorization:
                       native: true
@@ -488,84 +488,6 @@ STAGE PLANS:
                             valueColumns: 2:int, 13:int, 17:int, 28:decimal(7,2), 33:decimal(7,2)
                         Statistics: Num rows: 1 Data size: 240 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int), _col4 (type: decimal(7,2)), _col5 (type: decimal(7,2))
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 34
-                    includeColumns: [2, 11, 13, 17, 28, 33]
-                    dataColumns: ws_sold_date_sk:int, ws_sold_time_sk:int, ws_ship_date_sk:int, ws_item_sk:int, ws_bill_customer_sk:int, ws_bill_cdemo_sk:int, ws_bill_hdemo_sk:int, ws_bill_addr_sk:int, ws_ship_customer_sk:int, ws_ship_cdemo_sk:int, ws_ship_hdemo_sk:int, ws_ship_addr_sk:int, ws_web_page_sk:int, ws_web_site_sk:int, ws_ship_mode_sk:int, ws_warehouse_sk:int, ws_promo_sk:int, ws_order_number:int, ws_quantity:int, ws_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_list_price:decimal(7,2)/DECIMAL_64, ws_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_discount_amt:decimal(7,2)/DECIMAL_64, ws_ext_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_ext_list_price:decimal(7,2)/DECIMAL_64, ws_ext_tax:decimal(7,2)/DECIMAL_64, ws_coupon_amt:decimal(7,2)/DECIMAL_64, ws_ext_ship_cost:decimal(7,2)/DECIMAL_64, ws_net_paid:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_tax:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship_tax:decimal(7,2)/DECIMAL_64, ws_net_profit:decimal(7,2)/DECIMAL_64
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: web_site
-                  filterExpr: ((web_company_name = 'pri') and web_site_sk is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:web_site_sk:int, 1:web_site_id:string, 2:web_rec_start_date:string, 3:web_rec_end_date:string, 4:web_name:string, 5:web_open_date_sk:int, 6:web_close_date_sk:int, 7:web_class:string, 8:web_manager:string, 9:web_mkt_id:int, 10:web_mkt_class:string, 11:web_mkt_desc:string, 12:web_market_manager:string, 13:web_company_id:int, 14:web_company_name:string, 15:web_street_number:string, 16:web_street_name:string, 17:web_street_type:string, 18:web_suite_number:string, 19:web_city:string, 20:web_county:string, 21:web_state:string, 22:web_zip:string, 23:web_country:string, 24:web_gmt_offset:decimal(5,2)/DECIMAL_64, 25:web_tax_percentage:decimal(5,2)/DECIMAL_64, 26:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
-                  Filter Operator
-                    Filter Vectorization:
-                        className: VectorFilterOperator
-                        native: true
-                        predicateExpression: FilterExprAndExpr(children: FilterStringGroupColEqualStringScalar(col 14:string, val pri), SelectColumnIsNotNull(col 0:int))
-                    predicate: ((web_company_name = 'pri') and web_site_sk is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: web_site_sk (type: int)
-                      outputColumnNames: _col0
-                      Select Vectorization:
-                          className: VectorSelectOperator
-                          native: true
-                          projectedOutputColumnNums: [0]
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Reduce Sink Vectorization:
-                            className: VectorReduceSinkLongOperator
-                            keyColumns: 0:int
-                            native: true
-                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 26
-                    includeColumns: [0, 14]
-                    dataColumns: web_site_sk:int, web_site_id:string, web_rec_start_date:string, web_rec_end_date:string, web_name:string, web_open_date_sk:int, web_close_date_sk:int, web_class:string, web_manager:string, web_mkt_id:int, web_mkt_class:string, web_mkt_desc:string, web_market_manager:string, web_company_id:int, web_company_name:string, web_street_number:string, web_street_name:string, web_street_type:string, web_suite_number:string, web_city:string, web_county:string, web_state:string, web_zip:string, web_country:string, web_gmt_offset:decimal(5,2)/DECIMAL_64, web_tax_percentage:decimal(5,2)/DECIMAL_64
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: ws1
-                  filterExpr: ws_order_number is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:ws_sold_date_sk:int, 1:ws_sold_time_sk:int, 2:ws_ship_date_sk:int, 3:ws_item_sk:int, 4:ws_bill_customer_sk:int, 5:ws_bill_cdemo_sk:int, 6:ws_bill_hdemo_sk:int, 7:ws_bill_addr_sk:int, 8:ws_ship_customer_sk:int, 9:ws_ship_cdemo_sk:int, 10:ws_ship_hdemo_sk:int, 11:ws_ship_addr_sk:int, 12:ws_web_page_sk:int, 13:ws_web_site_sk:int, 14:ws_ship_mode_sk:int, 15:ws_warehouse_sk:int, 16:ws_promo_sk:int, 17:ws_order_number:int, 18:ws_quantity:int, 19:ws_wholesale_cost:decimal(7,2)/DECIMAL_64, 20:ws_list_price:decimal(7,2)/DECIMAL_64, 21:ws_sales_price:decimal(7,2)/DECIMAL_64, 22:ws_ext_discount_amt:decimal(7,2)/DECIMAL_64, 23:ws_ext_sales_price:decimal(7,2)/DECIMAL_64, 24:ws_ext_wholesale_cost:decimal(7,2)/DECIMAL_64, 25:ws_ext_list_price:decimal(7,2)/DECIMAL_64, 26:ws_ext_tax:decimal(7,2)/DECIMAL_64, 27:ws_coupon_amt:decimal(7,2)/DECIMAL_64, 28:ws_ext_ship_cost:decimal(7,2)/DECIMAL_64, 29:ws_net_paid:decimal(7,2)/DECIMAL_64, 30:ws_net_paid_inc_tax:decimal(7,2)/DECIMAL_64, 31:ws_net_paid_inc_ship:decimal(7,2)/DECIMAL_64, 32:ws_net_paid_inc_ship_tax:decimal(7,2)/DECIMAL_64, 33:ws_net_profit:decimal(7,2)/DECIMAL_64, 34:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
                   Filter Operator
                     Filter Vectorization:
                         className: VectorFilterOperator
@@ -633,11 +555,115 @@ STAGE PLANS:
                 vectorized: true
                 rowBatchContext:
                     dataColumnCount: 34
-                    includeColumns: [15, 17]
+                    includeColumns: [2, 11, 13, 15, 17, 28, 33]
                     dataColumns: ws_sold_date_sk:int, ws_sold_time_sk:int, ws_ship_date_sk:int, ws_item_sk:int, ws_bill_customer_sk:int, ws_bill_cdemo_sk:int, ws_bill_hdemo_sk:int, ws_bill_addr_sk:int, ws_ship_customer_sk:int, ws_ship_cdemo_sk:int, ws_ship_hdemo_sk:int, ws_ship_addr_sk:int, ws_web_page_sk:int, ws_web_site_sk:int, ws_ship_mode_sk:int, ws_warehouse_sk:int, ws_promo_sk:int, ws_order_number:int, ws_quantity:int, ws_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_list_price:decimal(7,2)/DECIMAL_64, ws_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_discount_amt:decimal(7,2)/DECIMAL_64, ws_ext_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_ext_list_price:decimal(7,2)/DECIMAL_64, ws_ext_tax:decimal(7,2)/DECIMAL_64, ws_coupon_amt:decimal(7,2)/DECIMAL_64, ws_ext_ship_cost:decimal(7,2)/DECIMAL_64, ws_net_paid:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_tax:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship_tax:decimal(7,2)/DECIMAL_64, ws_net_profit:decimal(7,2)/DECIMAL_64
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 17 
+        Map 14 
+            Map Operator Tree:
+                TableScan
+                  alias: customer_address
+                  filterExpr: ((ca_state = 'TX') and ca_address_sk is not null) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:ca_address_sk:int, 1:ca_address_id:string, 2:ca_street_number:string, 3:ca_street_name:string, 4:ca_street_type:string, 5:ca_suite_number:string, 6:ca_city:string, 7:ca_county:string, 8:ca_state:string, 9:ca_zip:string, 10:ca_country:string, 11:ca_gmt_offset:decimal(5,2)/DECIMAL_64, 12:ca_location_type:string, 13:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: FilterExprAndExpr(children: FilterStringGroupColEqualStringScalar(col 8:string, val TX), SelectColumnIsNotNull(col 0:int))
+                    predicate: ((ca_state = 'TX') and ca_address_sk is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: ca_address_sk (type: int)
+                      outputColumnNames: _col0
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [0]
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Reduce Sink Vectorization:
+                            className: VectorReduceSinkLongOperator
+                            keyColumns: 0:int
+                            native: true
+                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 13
+                    includeColumns: [0, 8]
+                    dataColumns: ca_address_sk:int, ca_address_id:string, ca_street_number:string, ca_street_name:string, ca_street_type:string, ca_suite_number:string, ca_city:string, ca_county:string, ca_state:string, ca_zip:string, ca_country:string, ca_gmt_offset:decimal(5,2)/DECIMAL_64, ca_location_type:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Map 15 
+            Map Operator Tree:
+                TableScan
+                  alias: web_site
+                  filterExpr: ((web_company_name = 'pri') and web_site_sk is not null) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:web_site_sk:int, 1:web_site_id:string, 2:web_rec_start_date:string, 3:web_rec_end_date:string, 4:web_name:string, 5:web_open_date_sk:int, 6:web_close_date_sk:int, 7:web_class:string, 8:web_manager:string, 9:web_mkt_id:int, 10:web_mkt_class:string, 11:web_mkt_desc:string, 12:web_market_manager:string, 13:web_company_id:int, 14:web_company_name:string, 15:web_street_number:string, 16:web_street_name:string, 17:web_street_type:string, 18:web_suite_number:string, 19:web_city:string, 20:web_county:string, 21:web_state:string, 22:web_zip:string, 23:web_country:string, 24:web_gmt_offset:decimal(5,2)/DECIMAL_64, 25:web_tax_percentage:decimal(5,2)/DECIMAL_64, 26:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: FilterExprAndExpr(children: FilterStringGroupColEqualStringScalar(col 14:string, val pri), SelectColumnIsNotNull(col 0:int))
+                    predicate: ((web_company_name = 'pri') and web_site_sk is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: web_site_sk (type: int)
+                      outputColumnNames: _col0
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [0]
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Reduce Sink Vectorization:
+                            className: VectorReduceSinkLongOperator
+                            keyColumns: 0:int
+                            native: true
+                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 26
+                    includeColumns: [0, 14]
+                    dataColumns: web_site_sk:int, web_site_id:string, web_rec_start_date:string, web_rec_end_date:string, web_name:string, web_open_date_sk:int, web_close_date_sk:int, web_class:string, web_manager:string, web_mkt_id:int, web_mkt_class:string, web_mkt_desc:string, web_market_manager:string, web_company_id:int, web_company_name:string, web_street_number:string, web_street_name:string, web_street_type:string, web_suite_number:string, web_city:string, web_county:string, web_state:string, web_zip:string, web_country:string, web_gmt_offset:decimal(5,2)/DECIMAL_64, web_tax_percentage:decimal(5,2)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Map 16 
             Map Operator Tree:
                 TableScan
                   alias: ws2
@@ -691,7 +717,7 @@ STAGE PLANS:
                     dataColumns: ws_sold_date_sk:int, ws_sold_time_sk:int, ws_ship_date_sk:int, ws_item_sk:int, ws_bill_customer_sk:int, ws_bill_cdemo_sk:int, ws_bill_hdemo_sk:int, ws_bill_addr_sk:int, ws_ship_customer_sk:int, ws_ship_cdemo_sk:int, ws_ship_hdemo_sk:int, ws_ship_addr_sk:int, ws_web_page_sk:int, ws_web_site_sk:int, ws_ship_mode_sk:int, ws_warehouse_sk:int, ws_promo_sk:int, ws_order_number:int, ws_quantity:int, ws_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_list_price:decimal(7,2)/DECIMAL_64, ws_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_discount_amt:decimal(7,2)/DECIMAL_64, ws_ext_sales_price:decimal(7,2)/DECIMAL_64, ws_ext_wholesale_cost:decimal(7,2)/DECIMAL_64, ws_ext_list_price:decimal(7,2)/DECIMAL_64, ws_ext_tax:decimal(7,2)/DECIMAL_64, ws_coupon_amt:decimal(7,2)/DECIMAL_64, ws_ext_ship_cost:decimal(7,2)/DECIMAL_64, ws_net_paid:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_tax:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship:decimal(7,2)/DECIMAL_64, ws_net_paid_inc_ship_tax:decimal(7,2)/DECIMAL_64, ws_net_profit:decimal(7,2)/DECIMAL_64
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 18 
+        Map 17 
             Map Operator Tree:
                 TableScan
                   alias: web_returns
@@ -743,7 +769,7 @@ STAGE PLANS:
                     dataColumns: wr_returned_date_sk:int, wr_returned_time_sk:int, wr_item_sk:int, wr_refunded_customer_sk:int, wr_refunded_cdemo_sk:int, wr_refunded_hdemo_sk:int, wr_refunded_addr_sk:int, wr_returning_customer_sk:int, wr_returning_cdemo_sk:int, wr_returning_hdemo_sk:int, wr_returning_addr_sk:int, wr_web_page_sk:int, wr_reason_sk:int, wr_order_number:int, wr_return_quantity:int, wr_return_amt:decimal(7,2)/DECIMAL_64, wr_return_tax:decimal(7,2)/DECIMAL_64, wr_return_amt_inc_tax:decimal(7,2)/DECIMAL_64, wr_fee:decimal(7,2)/DECIMAL_64, wr_return_ship_cost:decimal(7,2)/DECIMAL_64, wr_refunded_cash:decimal(7,2)/DECIMAL_64, wr_reversed_charge:decimal(7,2)/DECIMAL_64, wr_account_credit:decimal(7,2)/DECIMAL_64, wr_net_loss:decimal(7,2)/DECIMAL_64
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 19 
+        Map 18 
             Map Operator Tree:
                 TableScan
                   alias: date_dim
@@ -795,90 +821,7 @@ STAGE PLANS:
                     dataColumns: d_date_sk:int, d_date_id:string, d_date:string, d_month_seq:int, d_week_seq:int, d_quarter_seq:int, d_year:int, d_dow:int, d_moy:int, d_dom:int, d_qoy:int, d_fy_year:int, d_fy_quarter_seq:int, d_fy_week_seq:int, d_day_name:string, d_quarter_name:string, d_holiday:string, d_weekend:string, d_following_holiday:string, d_first_dom:int, d_last_dom:int, d_same_day_ly:int, d_same_day_lq:int, d_current_day:string, d_current_week:string, d_current_month:string, d_current_quarter:string, d_current_year:string
                     partitionColumnCount: 0
                     scratchColumnTypeNames: [timestamp]
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: customer_address
-                  filterExpr: ((ca_state = 'TX') and ca_address_sk is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:ca_address_sk:int, 1:ca_address_id:string, 2:ca_street_number:string, 3:ca_street_name:string, 4:ca_street_type:string, 5:ca_suite_number:string, 6:ca_city:string, 7:ca_county:string, 8:ca_state:string, 9:ca_zip:string, 10:ca_country:string, 11:ca_gmt_offset:decimal(5,2)/DECIMAL_64, 12:ca_location_type:string, 13:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
-                  Filter Operator
-                    Filter Vectorization:
-                        className: VectorFilterOperator
-                        native: true
-                        predicateExpression: FilterExprAndExpr(children: FilterStringGroupColEqualStringScalar(col 8:string, val TX), SelectColumnIsNotNull(col 0:int))
-                    predicate: ((ca_state = 'TX') and ca_address_sk is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: ca_address_sk (type: int)
-                      outputColumnNames: _col0
-                      Select Vectorization:
-                          className: VectorSelectOperator
-                          native: true
-                          projectedOutputColumnNums: [0]
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Reduce Sink Vectorization:
-                            className: VectorReduceSinkLongOperator
-                            keyColumns: 0:int
-                            native: true
-                            nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 13
-                    includeColumns: [0, 8]
-                    dataColumns: ca_address_sk:int, ca_address_id:string, ca_street_number:string, ca_street_name:string, ca_street_type:string, ca_suite_number:string, ca_city:string, ca_county:string, ca_state:string, ca_zip:string, ca_country:string, ca_gmt_offset:decimal(5,2)/DECIMAL_64, ca_location_type:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-        Reducer 12 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col1 (type: int)
-                  1 _col1 (type: int)
-                outputColumnNames: _col0, _col1, _col2
-                residual filter predicates: {(_col0 <> _col2)}
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: _col1 (type: int)
-                  outputColumnNames: _col1
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                  Group By Operator
-                    keys: _col1 (type: int)
-                    minReductionHashAggr: 0.99
-                    mode: hash
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 13 
+        Reducer 10 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -917,7 +860,7 @@ STAGE PLANS:
                       native: true
                       nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
-        Reducer 14 
+        Reducer 11 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -938,7 +881,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 15 
+        Reducer 12 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -969,7 +912,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 16 
+        Reducer 13 
             Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
@@ -1210,6 +1153,37 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 9 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                residual filter predicates: {(_col0 <> _col2)}
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col1 (type: int)
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                  Group By Operator
+                    keys: _col1 (type: int)
+                    minReductionHashAggr: 0.99
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            MergeJoin Vectorization:
+                enabled: false
+                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/leftsemijoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/leftsemijoin.q.out
@@ -108,7 +108,7 @@ POSTHOOK: query: drop table things_n1
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@things_n1
 POSTHOOK: Output: default@things_n1
-Warning: Shuffle Join MERGEJOIN[34][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[34][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select part.p_type from part join (select p1.p_name from part p1, part p2 group by p1.p_name) pp ON pp.p_name = part.p_name
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -126,8 +126,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Map 5 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -150,17 +150,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_name is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: p_name (type: string)
                       outputColumnNames: _col0
@@ -172,7 +161,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: p2
@@ -207,7 +196,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -237,7 +226,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[34][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[34][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select part.p_type from part join (select p1.p_name from part p1, part p2 group by p1.p_name) pp ON pp.p_name = part.p_name
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part

--- a/ql/src/test/results/clientpositive/llap/limit_join_transpose.q.out
+++ b/ql/src/test/results/clientpositive/llap/limit_join_transpose.q.out
@@ -739,7 +739,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Map 1 (SIMPLE_EDGE)
-        Reducer 5 <- Map 7 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -778,14 +778,6 @@ STAGE PLANS:
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src3
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1735,7 +1727,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Map 1 (SIMPLE_EDGE)
-        Reducer 5 <- Map 7 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -1774,14 +1766,6 @@ STAGE PLANS:
                         sort order: +
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: src3
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/mapjoin_hint.q.out
+++ b/ql/src/test/results/clientpositive/llap/mapjoin_hint.q.out
@@ -478,7 +478,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 3 <- Map 6 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
+        Reducer 3 <- Map 4 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -525,17 +525,6 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n1
-                  filterExpr: p_name is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_name is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                       Limit
@@ -626,7 +615,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 4 (BROADCAST_EDGE), Reducer 3 (BROADCAST_EDGE)
+        Map 1 <- Map 2 (BROADCAST_EDGE), Reducer 3 (BROADCAST_EDGE)
         Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -660,7 +649,7 @@ STAGE PLANS:
                             1 
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                           input vertices:
-                            1 Map 4
+                            1 Map 2
                           Statistics: Num rows: 0 Data size: 0 Basic stats: NONE Column stats: NONE
                           File Output Operator
                             compressed: false
@@ -695,17 +684,6 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n1
-                  filterExpr: p_name is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_name is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                       Limit

--- a/ql/src/test/results/clientpositive/llap/masking_12.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_12.q.out
@@ -120,8 +120,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -146,9 +146,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -172,31 +184,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n1
-                  filterExpr: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                  properties:
-                    insideView TRUE
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -218,6 +205,25 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -245,25 +251,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/masking_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_3.q.out
@@ -30,8 +30,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -54,9 +54,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -78,29 +90,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -119,6 +108,25 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -146,25 +154,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -702,8 +691,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -726,9 +715,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -750,29 +751,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -791,6 +769,25 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -818,25 +815,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -2028,8 +2006,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2052,9 +2030,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -2074,29 +2064,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: double)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -2121,6 +2088,25 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -2148,25 +2134,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -2712,8 +2679,8 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 3 (SIMPLE_EDGE)
+        Reducer 6 <- Map 7 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2758,9 +2725,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -2780,29 +2759,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: double)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -2849,6 +2805,25 @@ STAGE PLANS:
                     Map-reduce partition columns: _col2 (type: double)
                     Statistics: Num rows: 325 Data size: 33475 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: int), _col1 (type: string)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
@@ -2876,25 +2851,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -7054,8 +7010,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7078,9 +7034,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -7102,29 +7070,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -7143,6 +7088,25 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -7170,25 +7134,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -7723,8 +7668,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7747,9 +7692,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -7771,29 +7728,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n3
-                  filterExpr: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((key > 0) and UDFToDouble(key) is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -7812,6 +7746,25 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -7839,25 +7792,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/masking_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_4.q.out
@@ -138,8 +138,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Map 5 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -162,9 +162,21 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col0 (type: int)
                         Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
+                    Group By Operator
+                      keys: key (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -186,29 +198,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: masking_test_subq_n2
-                  filterExpr: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (UDFToDouble(key) is not null and key is not null) (type: boolean)
-                    Statistics: Num rows: 500 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: key (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -227,6 +216,25 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int)
         Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
@@ -254,25 +262,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: UDFToDouble(_col0) (type: double), _col1 (type: int)
                       Statistics: Num rows: 197 Data size: 17927 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 250 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 250 Data size: 3000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/nonblock_op_deduplicate.q.out
+++ b/ql/src/test/results/clientpositive/llap/nonblock_op_deduplicate.q.out
@@ -55,8 +55,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -73,13 +73,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: src1
-                  Statistics: Num rows: 25 Data size: 191 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 25 Data size: 191 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -113,7 +106,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/ppd_join5.q.out
+++ b/ql/src/test/results/clientpositive/llap/ppd_join5.q.out
@@ -59,7 +59,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -86,7 +86,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: c
-                  filterExpr: (d <= 1) (type: boolean)
+                  filterExpr: ((d <= 1) or ((d <= 1) and id is not null)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (d <= 1) (type: boolean)
@@ -100,14 +100,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: ((d <= 1) and id is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((d <= 1) and id is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
@@ -202,7 +194,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
+        Reducer 3 <- Map 4 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -230,7 +222,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: ((d <= 1) and id is not null) (type: boolean)
+                  filterExpr: (((d <= 1) and id is not null) or (d <= 1)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((d <= 1) and id is not null) (type: boolean)
@@ -246,14 +238,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 89 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: c
-                  filterExpr: (d <= 1) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (d <= 1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf.q.out
@@ -1111,29 +1111,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: p_mfgr (type: string), p_name (type: string)
-                    null sort order: az
-                    sort order: ++
-                    Map-reduce partition columns: p_mfgr (type: string)
-                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: p_partkey (type: int), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -1144,9 +1129,34 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: p_partkey (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: p_mfgr (type: string), p_name (type: string)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: p_mfgr (type: string)
+                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: p_partkey (type: int), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 p_partkey (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -1177,24 +1187,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 23062 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 p_partkey (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1273,15 +1265,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -1292,13 +1283,6 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: p_partkey (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_name (type: string)
                     null sort order: az
@@ -1330,7 +1314,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -2442,30 +2426,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: p_mfgr (type: string), p_name (type: string)
-                    null sort order: az
-                    sort order: ++
-                    Map-reduce partition columns: p_mfgr (type: string)
-                    Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: p_partkey (type: int), p_size (type: int), p_retailprice (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -2476,40 +2445,16 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: p_partkey (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: p_mfgr (type: string), p_name (type: string)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: p_mfgr (type: string)
+                    Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: p_partkey (type: int), p_size (type: int), p_retailprice (type: double)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
-                outputColumnNames: _col0, _col1, _col2, _col5, _col7
-                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: part
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        type: TABLE
-                      Partition table definition
-                        input alias: abc
-                        name: noop
-                        order by: _col1 ASC NULLS LAST
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        partition by: _col2
-                        raw input shape:
-                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: _col0 is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2527,7 +2472,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col5 (type: int), _col7 (type: double)
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -2592,6 +2537,37 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
+                outputColumnNames: _col0, _col1, _col2, _col5, _col7
+                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: part
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        type: TABLE
+                      Partition table definition
+                        input alias: abc
+                        name: noop
+                        order by: _col1 ASC NULLS LAST
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        partition by: _col2
+                        raw input shape:
+                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/ptf_streaming.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf_streaming.q.out
@@ -414,29 +414,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: p_mfgr (type: string), p_name (type: string)
-                    null sort order: az
-                    sort order: ++
-                    Map-reduce partition columns: p_mfgr (type: string)
-                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: p_partkey (type: int), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -447,9 +432,34 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: p_partkey (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: p_mfgr (type: string), p_name (type: string)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: p_mfgr (type: string)
+                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: p_partkey (type: int), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 p_partkey (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -480,24 +490,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 23062 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 p_partkey (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
 
   Stage: Stage-0
     Fetch Operator
@@ -1699,30 +1691,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: p_mfgr (type: string), p_name (type: string)
-                    null sort order: az
-                    sort order: ++
-                    Map-reduce partition columns: p_mfgr (type: string)
-                    Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: p_partkey (type: int), p_size (type: int), p_retailprice (type: double)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -1733,40 +1710,16 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: p_partkey (type: int)
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: p_mfgr (type: string), p_name (type: string)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: p_mfgr (type: string)
+                    Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: p_partkey (type: int), p_size (type: int), p_retailprice (type: double)
             Execution mode: llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
-                outputColumnNames: _col0, _col1, _col2, _col5, _col7
-                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: part
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        type: TABLE
-                      Partition table definition
-                        input alias: abc
-                        name: noopstreaming
-                        order by: _col1 ASC NULLS LAST
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        partition by: _col2
-                        raw input shape:
-                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: _col0 is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1784,7 +1737,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col5 (type: int), _col7 (type: double)
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -1849,6 +1802,37 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
+                outputColumnNames: _col0, _col1, _col2, _col5, _col7
+                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: part
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        type: TABLE
+                      Partition table definition
+                        input alias: abc
+                        name: noopstreaming
+                        order by: _col1 ASC NULLS LAST
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        partition by: _col2
+                        raw input shape:
+                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/reduce_deduplicate_extended2.q.out
+++ b/ql/src/test/results/clientpositive/llap/reduce_deduplicate_extended2.q.out
@@ -553,9 +553,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -579,13 +579,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 21750 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: value (type: string)
                     outputColumnNames: value
@@ -647,7 +640,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/semijoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin.q.out
@@ -3346,15 +3346,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: outr
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -3374,14 +3374,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3445,7 +3437,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                       Statistics: Num rows: 20833 Data size: 3708274 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/semijoin2.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin2.q.out
@@ -61,19 +61,28 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: t1
-                  filterExpr: (bigint_col_22 is not null and decimal1709_col_26 is not null and tinyint_col_8 is not null and timestamp_col_10 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: NONE
+                  alias: tt1
+                  filterExpr: (decimal1208_col_20 is not null or (bigint_col_22 is not null and decimal1709_col_26 is not null and tinyint_col_8 is not null and timestamp_col_10 is not null)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: decimal1208_col_20 is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: decimal1208_col_20 (type: decimal(38,6))
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: decimal1208_col_20 (type: decimal(38,6))
+                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (bigint_col_22 is not null and decimal1709_col_26 is not null and tinyint_col_8 is not null and timestamp_col_10 is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: NONE
@@ -86,12 +95,22 @@ STAGE PLANS:
                       value expressions: smallint_col_25 (type: smallint), double_col_61 (type: double), timestamp_col_10 (type: timestamp)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 7 
             Map Operator Tree:
                 TableScan
-                  alias: t2
-                  filterExpr: (UDFToLong(tinyint_col_6) is not null and decimal0504_col_37 is not null and tinyint_col_33 is not null and UDFToInteger(smallint_col_38) is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 128 Basic stats: COMPLETE Column stats: NONE
+                  alias: tt2
+                  filterExpr: ((decimal1611_col_22 is not null and timestamp_col_18 is not null) or (UDFToLong(tinyint_col_6) is not null and decimal0504_col_37 is not null and tinyint_col_33 is not null and UDFToInteger(smallint_col_38) is not null)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (decimal1611_col_22 is not null and timestamp_col_18 is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: decimal1611_col_22 (type: decimal(38,6))
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: decimal1611_col_22 (type: decimal(38,6))
+                      Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: timestamp_col_18 (type: timestamp)
                   Filter Operator
                     predicate: (UDFToLong(tinyint_col_6) is not null and decimal0504_col_37 is not null and tinyint_col_33 is not null and UDFToInteger(smallint_col_38) is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 128 Basic stats: COMPLETE Column stats: NONE
@@ -104,41 +123,6 @@ STAGE PLANS:
                       value expressions: int_col_2 (type: int), smallint_col_38 (type: smallint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: tt1
-                  filterExpr: decimal1208_col_20 is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: decimal1208_col_20 is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: decimal1208_col_20 (type: decimal(38,6))
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: decimal1208_col_20 (type: decimal(38,6))
-                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: tt2
-                  filterExpr: (decimal1611_col_22 is not null and timestamp_col_18 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (decimal1611_col_22 is not null and timestamp_col_18 is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: decimal1611_col_22 (type: decimal(38,6))
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: decimal1611_col_22 (type: decimal(38,6))
-                      Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: timestamp_col_18 (type: timestamp)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -146,17 +130,26 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 bigint_col_22 (type: bigint), decimal1709_col_26 (type: decimal(38,23)), tinyint_col_8 (type: tinyint)
-                  1 UDFToLong(tinyint_col_6) (type: bigint), decimal0504_col_37 (type: decimal(38,23)), tinyint_col_33 (type: tinyint)
-                outputColumnNames: _col16, _col21, _col72, _col98, _col105
-                Statistics: Num rows: 1 Data size: 193 Basic stats: COMPLETE Column stats: NONE
-                Reduce Output Operator
-                  key expressions: UDFToInteger(_col105) (type: int), _col72 (type: timestamp)
-                  null sort order: zz
-                  sort order: ++
-                  Map-reduce partition columns: UDFToInteger(_col105) (type: int), _col72 (type: timestamp)
-                  Statistics: Num rows: 1 Data size: 193 Basic stats: COMPLETE Column stats: NONE
-                  value expressions: _col16 (type: smallint), _col21 (type: double), _col98 (type: int)
+                  0 decimal1208_col_20 (type: decimal(38,6))
+                  1 decimal1611_col_22 (type: decimal(38,6))
+                outputColumnNames: _col115
+                Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col115 (type: timestamp)
+                  outputColumnNames: _col1
+                  Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
+                  Group By Operator
+                    keys: -92 (type: int), _col1 (type: timestamp)
+                    minReductionHashAggr: 0.99
+                    mode: hash
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: -92 (type: int), _col1 (type: timestamp)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: -92 (type: int), _col1 (type: timestamp)
+                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
         Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
@@ -252,33 +245,24 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 8 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 decimal1208_col_20 (type: decimal(38,6))
-                  1 decimal1611_col_22 (type: decimal(38,6))
-                outputColumnNames: _col115
-                Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: _col115 (type: timestamp)
-                  outputColumnNames: _col1
-                  Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
-                  Group By Operator
-                    keys: -92 (type: int), _col1 (type: timestamp)
-                    minReductionHashAggr: 0.99
-                    mode: hash
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: -92 (type: int), _col1 (type: timestamp)
-                      null sort order: zz
-                      sort order: ++
-                      Map-reduce partition columns: -92 (type: int), _col1 (type: timestamp)
-                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
+                  0 bigint_col_22 (type: bigint), decimal1709_col_26 (type: decimal(38,23)), tinyint_col_8 (type: tinyint)
+                  1 UDFToLong(tinyint_col_6) (type: bigint), decimal0504_col_37 (type: decimal(38,23)), tinyint_col_33 (type: tinyint)
+                outputColumnNames: _col16, _col21, _col72, _col98, _col105
+                Statistics: Num rows: 1 Data size: 193 Basic stats: COMPLETE Column stats: NONE
+                Reduce Output Operator
+                  key expressions: UDFToInteger(_col105) (type: int), _col72 (type: timestamp)
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: UDFToInteger(_col105) (type: int), _col72 (type: timestamp)
+                  Statistics: Num rows: 1 Data size: 193 Basic stats: COMPLETE Column stats: NONE
+                  value expressions: _col16 (type: smallint), _col21 (type: double), _col98 (type: int)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/semijoin4.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin4.q.out
@@ -70,17 +70,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  filterExpr: ((tinyint_col_46 = -92Y) and bigint_col_13 is not null and decimal1309_col_65 is not null) (type: boolean)
+                  filterExpr: (((tinyint_col_46 = -92Y) and bigint_col_13 is not null and decimal1309_col_65 is not null) or (decimal1309_col_65 is not null and timestamp_col_66 is not null)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: ((tinyint_col_46 = -92Y) and bigint_col_13 is not null and decimal1309_col_65 is not null) (type: boolean)
@@ -95,35 +95,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: bigint), _col1 (type: decimal(27,9))
                         Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: t2
-                  filterExpr: ((tinyint_col_21 = -92Y) and UDFToLong(tinyint_col_18) is not null and decimal2709_col_9 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: ((tinyint_col_21 = -92Y) and UDFToLong(tinyint_col_18) is not null and decimal2709_col_9 is not null) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: decimal2709_col_9 (type: decimal(27,9)), UDFToLong(tinyint_col_18) (type: bigint)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col1 (type: bigint), _col0 (type: decimal(27,9))
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col1 (type: bigint), _col0 (type: decimal(27,9))
-                        Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: tt1
-                  filterExpr: (decimal1309_col_65 is not null and timestamp_col_66 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (decimal1309_col_65 is not null and timestamp_col_66 is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
@@ -139,12 +110,25 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
+        Map 6 
             Map Operator Tree:
                 TableScan
-                  alias: tt2
-                  filterExpr: (decimal1911_col_16 is not null and timestamp_col_19 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
+                  alias: t2
+                  filterExpr: (((tinyint_col_21 = -92Y) and UDFToLong(tinyint_col_18) is not null and decimal2709_col_9 is not null) or (decimal1911_col_16 is not null and timestamp_col_19 is not null)) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: ((tinyint_col_21 = -92Y) and UDFToLong(tinyint_col_18) is not null and decimal2709_col_9 is not null) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: decimal2709_col_9 (type: decimal(27,9)), UDFToLong(tinyint_col_18) (type: bigint)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: bigint), _col0 (type: decimal(27,9))
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col1 (type: bigint), _col0 (type: decimal(27,9))
+                        Statistics: Num rows: 1 Data size: 120 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (decimal1911_col_16 is not null and timestamp_col_19 is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
@@ -195,7 +179,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -217,7 +201,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: boolean)
                     Statistics: Num rows: 1 Data size: 167 Basic stats: COMPLETE Column stats: NONE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/semijoin5.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin5.q.out
@@ -61,17 +61,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  filterExpr: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null) (type: boolean)
+                  filterExpr: ((bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null) or decimal2612_col_77 is not null) (type: boolean)
                   Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null) (type: boolean)
@@ -87,13 +87,26 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: tinyint), _col4 (type: decimal(34,16)), _col1 (type: bigint)
                         Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col2 (type: timestamp), _col3 (type: double), _col5 (type: smallint)
+                  Filter Operator
+                    predicate: decimal2612_col_77 is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: decimal2612_col_77 (type: decimal(26,12))
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: decimal(26,12))
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: decimal(26,12))
+                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: t2
-                  filterExpr: (UDFToLong(tinyint_col_15) is not null and decimal2709_col_9 is not null and tinyint_col_20 is not null and UDFToInteger(smallint_col_19) is not null) (type: boolean)
+                  filterExpr: ((UDFToLong(tinyint_col_15) is not null and decimal2709_col_9 is not null and tinyint_col_20 is not null and UDFToInteger(smallint_col_19) is not null) or (timestamp_col_18 is not null and decimal1911_col_16 is not null)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 128 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (UDFToLong(tinyint_col_15) is not null and decimal2709_col_9 is not null and tinyint_col_20 is not null and UDFToInteger(smallint_col_19) is not null) (type: boolean)
@@ -109,14 +122,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: tinyint), _col0 (type: decimal(34,16)), UDFToLong(_col2) (type: bigint)
                         Statistics: Num rows: 1 Data size: 128 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int), _col3 (type: smallint)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: tt2
-                  filterExpr: (timestamp_col_18 is not null and decimal1911_col_16 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (timestamp_col_18 is not null and decimal1911_col_16 is not null) (type: boolean)
                     Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
@@ -131,27 +136,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: decimal(26,12))
                         Statistics: Num rows: 1 Data size: 152 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: timestamp)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: tt1
-                  filterExpr: decimal2612_col_77 is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: decimal2612_col_77 is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: decimal2612_col_77 (type: decimal(26,12))
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: decimal(26,12))
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: decimal(26,12))
-                        Statistics: Num rows: 1 Data size: 112 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
@@ -228,7 +212,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator

--- a/ql/src/test/results/clientpositive/llap/sharedwork.q.out
+++ b/ql/src/test/results/clientpositive/llap/sharedwork.q.out
@@ -618,12 +618,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 8 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 10 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 9 <- Map 7 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -647,52 +647,6 @@ STAGE PLANS:
                       tag: 0
                       value expressions: _col0 (type: string), _col1 (type: string)
                       auto parallelism: true
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Path -> Alias:
-#### A masked pattern was here ####
-            Path -> Partition:
-#### A masked pattern was here ####
-                Partition
-                  base file name: part
-                  input format: org.apache.hadoop.mapred.TextInputFormat
-                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                  properties:
-                    bucket_count -1
-                    bucketing_version 2
-                    column.name.delimiter ,
-                    columns p_partkey,p_name,p_mfgr,p_brand,p_type,p_size,p_container,p_retailprice,p_comment
-                    columns.types int:string:string:string:string:int:string:double:string
-#### A masked pattern was here ####
-                    name default.part
-                    serialization.format 1
-                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                
-                    input format: org.apache.hadoop.mapred.TextInputFormat
-                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
-                    properties:
-                      bucketing_version 2
-                      column.name.delimiter ,
-                      columns p_partkey,p_name,p_mfgr,p_brand,p_type,p_size,p_container,p_retailprice,p_comment
-                      columns.comments 
-                      columns.types int:string:string:string:string:int:string:double:string
-#### A masked pattern was here ####
-                      name default.part
-                      serialization.format 1
-                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-                    name: default.part
-                  name: default.part
-            Truncated Path -> Alias:
-              /part [part]
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_size is not null or (p_size is not null and p_type is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                  GatherStats: false
                   Filter Operator
                     isSamplingPred: false
                     predicate: p_size is not null (type: boolean)
@@ -782,7 +736,7 @@ STAGE PLANS:
                   name: default.part
             Truncated Path -> Alias:
               /part [part]
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: part
@@ -862,25 +816,6 @@ STAGE PLANS:
                   name: default.part
             Truncated Path -> Alias:
               /part [part]
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Needs Tagging: false
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  bucketingVersion: 2
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  numBuckets: -1
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                  tag: 1
-                  auto parallelism: true
         Reducer 2 
             Execution mode: llap
             Needs Tagging: false
@@ -950,7 +885,7 @@ STAGE PLANS:
                       TotalFiles: 1
                       GatherStats: false
                       MultiFileSpray: false
-        Reducer 5 
+        Reducer 4 
             Needs Tagging: false
             Reduce Operator Tree:
               Group By Operator
@@ -992,7 +927,7 @@ STAGE PLANS:
                       tag: 1
                       value expressions: _col1 (type: bigint), _col2 (type: bigint)
                       auto parallelism: true
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Needs Tagging: false
             Reduce Operator Tree:
@@ -1016,7 +951,7 @@ STAGE PLANS:
                     tag: 0
                     value expressions: _col0 (type: string)
                     auto parallelism: true
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Needs Tagging: false
             Reduce Operator Tree:
@@ -1044,6 +979,25 @@ STAGE PLANS:
                     tag: 1
                     value expressions: _col2 (type: boolean)
                     auto parallelism: true
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Needs Tagging: false
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  bucketingVersion: 2
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  numBuckets: -1
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                  tag: 1
+                  auto parallelism: true
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/sharedworkresidual.q.out
+++ b/ql/src/test/results/clientpositive/llap/sharedworkresidual.q.out
@@ -40,9 +40,9 @@ POSTHOOK: query: CREATE TABLE dimension_date (
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@dimension_date
-Warning: Shuffle Join MERGEJOIN[42][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[42][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 Warning: Shuffle Join MERGEJOIN[44][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 Warning: Shuffle Join MERGEJOIN[45][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain
  with daily as (
@@ -111,12 +111,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE), Map 9 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 4 (CUSTOM_SIMPLE_EDGE), Map 9 (CUSTOM_SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE), Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE), Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -134,17 +134,6 @@ STAGE PLANS:
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: dly
-                  filterExpr: (dateid = 20200228) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: (dateid = 20200228) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: completedate (type: string)
                       outputColumnNames: _col0
@@ -161,7 +150,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 9 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: wk
@@ -220,7 +209,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -248,7 +237,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: boolean)
                       Statistics: Num rows: 1 Data size: 373 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -266,7 +255,7 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 373 Basic stats: COMPLETE Column stats: NONE
                     value expressions: _col0 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -294,7 +283,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: boolean)
                       Statistics: Num rows: 1 Data size: 373 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_cume_dist_partition_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_cume_dist_partition_by.q.out
@@ -81,9 +81,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -102,13 +102,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: char(1))
                       Statistics: Num rows: 26 Data size: 2163 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: float)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: sketch_input
-                  Statistics: Num rows: 26 Data size: 2059 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: category (type: char(1)), UDFToFloat(id) (type: float)
                     outputColumnNames: _col0, _col1
@@ -165,7 +158,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile_partition_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile_partition_by.q.out
@@ -120,9 +120,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -141,13 +141,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: char(1))
                       Statistics: Num rows: 26 Data size: 2163 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: float)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: sketch_input
-                  Statistics: Num rows: 26 Data size: 2059 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: category (type: char(1)), UDFToFloat(id) (type: float)
                     outputColumnNames: _col0, _col1
@@ -204,7 +197,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank_partition_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank_partition_by.q.out
@@ -86,9 +86,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -107,13 +107,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: char(1))
                       Statistics: Num rows: 26 Data size: 2163 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: float)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: sketch_input
-                  Statistics: Num rows: 26 Data size: 2059 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: category (type: char(1)), UDFToFloat(id) (type: float)
                     outputColumnNames: _col0, _col1
@@ -170,7 +163,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_1.q.out
@@ -1452,14 +1452,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or ((value > 'val_9') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1478,14 +1478,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((value > 'val_9') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value > 'val_9') and key is not null) (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1829,18 +1821,28 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: line/item
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: li
+                  filterExpr: ((l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) or l_partkey is not null or ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1))) (type: boolean)
+                  Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
+                    Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: l_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: l_partkey (type: int)
+                      Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: l_orderkey (type: int), l_suppkey (type: int)
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
                     Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1856,32 +1858,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: li
-                  filterExpr: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                    Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: l_partkey (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: l_partkey (type: int)
-                      Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: l_orderkey (type: int), l_suppkey (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: line/item
-                  filterExpr: ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
                     Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1904,20 +1880,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1935,7 +1897,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: int), 1 (type: int)
                   Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col3 (type: int)
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1956,7 +1918,7 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -1970,6 +1932,20 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -2227,16 +2203,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: p/a/r/t
-                  filterExpr: p_name is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -2255,13 +2230,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 13 Data size: 3835 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: struct<count:bigint,sum:double,input:int>)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_size (type: int)
                     null sort order: az
@@ -2318,7 +2286,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -2408,29 +2376,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src/_/cbo
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: key (type: string), value (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
                   alias: s1
-                  filterExpr: ((key > '2') or ((key > '2') and key is null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '2') (type: boolean)
@@ -2461,27 +2416,14 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint)
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: key (type: string), value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: string)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2505,7 +2447,7 @@ STAGE PLANS:
                       sort order: +
                       Statistics: Num rows: 500 Data size: 104051 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -2519,7 +2461,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2542,6 +2484,24 @@ STAGE PLANS:
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
 
   Stage: Stage-0
     Fetch Operator
@@ -2590,10 +2550,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2606,14 +2566,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: ((p_size < 10) or ((p_size < 10) and (p_name is null or p_mfgr is null))) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 1115 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2701,7 +2653,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2772,10 +2724,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2788,14 +2740,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: (p_size < 10) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2872,7 +2816,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2955,12 +2899,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2973,14 +2917,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: ((p_size < 10) or (p_size < 10)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3081,7 +3017,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3100,7 +3036,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
                     Statistics: Num rows: 2 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3125,7 +3061,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3188,18 +3124,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: (l_linenumber = 1) (type: boolean)
+                  filterExpr: ((l_linenumber = 1) or ((l_shipmode = 'AIR') or ((l_shipmode = 'AIR') and l_orderkey is null))) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (l_linenumber = 1) (type: boolean)
@@ -3209,14 +3145,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: l_orderkey (type: int), l_partkey (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: line/item
-                  filterExpr: ((l_shipmode = 'AIR') or ((l_shipmode = 'AIR') and l_orderkey is null)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (l_shipmode = 'AIR') (type: boolean)
                     Statistics: Num rows: 14 Data size: 1288 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3327,7 +3255,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/special_character_in_tabnames_quotes_1.q.out
@@ -1624,14 +1624,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or ((value > 'val_9') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1650,14 +1650,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((value > 'val_9') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value > 'val_9') and key is not null) (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2001,18 +1993,28 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Map 7 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: line/item
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: li
+                  filterExpr: ((l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) or l_partkey is not null or ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1))) (type: boolean)
+                  Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
+                    Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: l_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: l_partkey (type: int)
+                      Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: l_orderkey (type: int), l_suppkey (type: int)
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
                     Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2028,32 +2030,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: li
-                  filterExpr: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (l_partkey is not null and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                    Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: l_partkey (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: l_partkey (type: int)
-                      Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: l_orderkey (type: int), l_suppkey (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: line/item
-                  filterExpr: ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_shipmode = 'AIR') and l_orderkey is not null and (l_linenumber = 1)) (type: boolean)
                     Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2076,20 +2052,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2107,7 +2069,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: int), 1 (type: int)
                   Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col3 (type: int)
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2128,7 +2090,7 @@ STAGE PLANS:
                     sort order: +
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -2142,6 +2104,20 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -2399,16 +2375,15 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: p/a/r/t
-                  filterExpr: p_name is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -2427,13 +2402,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 13 Data size: 3835 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: struct<count:bigint,sum:double,input:int>)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_size (type: int)
                     null sort order: az
@@ -2490,7 +2458,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator
@@ -2580,29 +2548,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: src/_/cbo
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: key (type: string), value (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
                   alias: s1
-                  filterExpr: ((key > '2') or ((key > '2') and key is null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '2') (type: boolean)
@@ -2633,27 +2588,14 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint)
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: key (type: string), value (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Semi Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: string)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: string)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: string)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2677,7 +2619,7 @@ STAGE PLANS:
                       sort order: +
                       Statistics: Num rows: 500 Data size: 104051 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -2691,7 +2633,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2714,6 +2656,24 @@ STAGE PLANS:
                         null sort order: 
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: string)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: string)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: string)
 
   Stage: Stage-0
     Fetch Operator
@@ -2762,10 +2722,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2778,14 +2738,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: ((p_size < 10) or ((p_size < 10) and (p_name is null or p_mfgr is null))) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 1115 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2873,7 +2825,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2944,10 +2896,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2960,14 +2912,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: (p_size < 10) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3044,7 +2988,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3127,12 +3071,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3145,14 +3089,6 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: p_name (type: string), p_mfgr (type: string), p_size (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p/a/r/t
-                  filterExpr: ((p_size < 10) or (p_size < 10)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size < 10) (type: boolean)
                     Statistics: Num rows: 5 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3253,7 +3189,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3272,7 +3208,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
                     Statistics: Num rows: 2 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3297,7 +3233,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3360,18 +3296,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: (l_linenumber = 1) (type: boolean)
+                  filterExpr: ((l_linenumber = 1) or ((l_shipmode = 'AIR') or ((l_shipmode = 'AIR') and l_orderkey is null))) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (l_linenumber = 1) (type: boolean)
@@ -3381,14 +3317,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: l_orderkey (type: int), l_partkey (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: line/item
-                  filterExpr: ((l_shipmode = 'AIR') or ((l_shipmode = 'AIR') and l_orderkey is null)) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (l_shipmode = 'AIR') (type: boolean)
                     Statistics: Num rows: 14 Data size: 1288 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3499,7 +3427,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_ALL.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_ALL.q.out
@@ -469,7 +469,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 26
-Warning: Shuffle Join MERGEJOIN[52][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 9' is a cross product
+Warning: Shuffle Join MERGEJOIN[52][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 8' is a cross product
 Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select count(*) from part where p_partkey >= ALL (select p_partkey from part)
 	AND p_size <> ALL (select p_size from part group by p_size)
@@ -490,14 +490,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Reducer 11 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
+        Reducer 9 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -516,35 +516,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: p_partkey (type: int)
-                    outputColumnNames: p_partkey
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: max(p_partkey), count(), count(p_partkey)
-                      minReductionHashAggr: 0.96153843
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -576,21 +547,23 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: p_partkey (type: int)
+                    outputColumnNames: p_partkey
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: max(p_partkey), count(), count(p_partkey)
+                      minReductionHashAggr: 0.96153843
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 11 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: max(VALUE._col0), count(VALUE._col1), count(VALUE._col2)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -654,7 +627,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -673,7 +646,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -692,7 +665,7 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -705,7 +678,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -721,6 +694,19 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint)
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0), count(VALUE._col1), count(VALUE._col2)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -741,7 +727,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 1
-Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain cbo select count(*) from part where p_partkey 
 	>= ALL (select p_partkey from part where p_size >= ALL(select p_size from part_null_n0 group by p_size))
@@ -771,7 +757,7 @@ HiveAggregate(group=[{}], agg#0=[count()])
                 HiveAggregate(group=[{5}])
                   HiveTableScan(table=[[default, part_null_n0]], table:alias=[part_null_n0])
 
-Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select count(*) from part where p_partkey 
 	>= ALL (select p_partkey from part where p_size >= ALL(select p_size from part_null_n0 group by p_size))

--- a/ql/src/test/results/clientpositive/llap/subquery_ANY.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_ANY.q.out
@@ -376,7 +376,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 26
-Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: explain cbo select count(*) from part where p_partkey >= ANY (select p_partkey from part) 
 	AND p_size = ANY (select p_size from part group by p_size)
 PREHOOK: type: QUERY
@@ -402,7 +402,7 @@ HiveAggregate(group=[{}], agg#0=[count()])
         HiveAggregate(group=[{}], m=[MIN($0)], c=[COUNT()], d=[COUNT($0)])
           HiveTableScan(table=[[default, part]], table:alias=[part])
 
-Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[43][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: select count(*) from part where p_partkey >= ANY (select p_partkey from part) 
 	AND p_size = ANY (select p_size from part group by p_size)
 PREHOOK: type: QUERY
@@ -414,7 +414,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 26
-Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain cbo select count(*) from part where p_partkey 
 	>= ANY (select p_partkey from part where p_size >= ANY(select p_size from part_null_n0 group by p_size))
@@ -444,7 +444,7 @@ HiveAggregate(group=[{}], agg#0=[count()])
                 HiveAggregate(group=[{5}])
                   HiveTableScan(table=[[default, part_null_n0]], table:alias=[part_null_n0])
 
-Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select count(*) from part where p_partkey 
 	>= ANY (select p_partkey from part where p_size >= ANY(select p_size from part_null_n0 group by p_size))
@@ -621,8 +621,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -641,14 +641,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col4 (type: string)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -693,7 +685,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -746,8 +738,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -766,14 +758,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -815,7 +799,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1326,8 +1310,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1346,14 +1330,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1395,7 +1371,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1488,8 +1464,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1518,7 +1494,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_name is not null) or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
@@ -1534,14 +1510,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1609,7 +1577,7 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 3 Data size: 675 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1696,8 +1664,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1726,7 +1694,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_name is not null) or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
@@ -1747,14 +1715,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 13 Data size: 2925 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1817,7 +1777,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_exists.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_exists.q.out
@@ -354,8 +354,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -372,14 +372,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: (value > 'val_9') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value > 'val_9') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -417,7 +409,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_exists_having.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_exists_having.q.out
@@ -32,14 +32,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or ((value > 'val_9') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -58,14 +58,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((value > 'val_9') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value > 'val_9') and key is not null) (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
@@ -190,14 +182,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or ((value > 'val_9') and key is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -216,14 +208,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((value > 'val_9') and key is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value > 'val_9') and key is not null) (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/subquery_in.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_in.q.out
@@ -290,16 +290,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: UDFToDouble(p_size) is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(p_size) is not null (type: boolean)
@@ -315,13 +314,6 @@ STAGE PLANS:
                         Map-reduce partition columns: UDFToDouble(_col1) (type: double)
                         Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Top N Key Operator
                     sort order: ++
                     keys: p_mfgr (type: string), p_size (type: int)
@@ -355,7 +347,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -401,7 +393,7 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -480,16 +472,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: (p_mfgr is not null and p_size is not null) (type: boolean)
+                  filterExpr: ((p_mfgr is not null and p_size is not null) or p_mfgr is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_mfgr is not null and p_size is not null) (type: boolean)
@@ -505,14 +497,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_mfgr is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_mfgr is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
@@ -553,7 +537,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -602,7 +586,7 @@ STAGE PLANS:
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 4 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -826,15 +810,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or (key > '9')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -850,14 +834,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: (key > '9') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '9') (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -898,7 +874,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1120,16 +1096,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: ((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null) (type: boolean)
+                  filterExpr: (((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null) or l_partkey is not null or ((l_shipmode = 'AIR') and l_orderkey is not null)) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null) (type: boolean)
@@ -1145,14 +1121,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
                     Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1168,14 +1136,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: ((l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
                     Statistics: Num rows: 14 Data size: 1288 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1237,7 +1197,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1317,17 +1277,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: lineitem
-                  filterExpr: (l_partkey is not null and l_quantity is not null) (type: boolean)
+                  filterExpr: ((l_partkey is not null and l_quantity is not null) or l_partkey is not null) (type: boolean)
                   Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (l_partkey is not null and l_quantity is not null) (type: boolean)
@@ -1343,9 +1303,26 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: double), _col2 (type: double)
+                  Filter Operator
+                    predicate: l_partkey is not null (type: boolean)
+                    Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(l_quantity), count(l_quantity)
+                      keys: l_partkey (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 50 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 50 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: part
@@ -1364,31 +1341,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: l_partkey is not null (type: boolean)
-                    Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: sum(l_quantity), count(l_quantity)
-                      keys: l_partkey (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 50 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 50 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: double), _col2 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1446,7 +1398,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1509,15 +1461,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: ((p_size <> 340) and (p_brand <> 'Brand#14') and p_type is not null) (type: boolean)
+                  filterExpr: (((p_size <> 340) and (p_brand <> 'Brand#14') and p_type is not null) or ((p_size <> 340) and p_type is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_size <> 340) and (p_brand <> 'Brand#14') and p_type is not null) (type: boolean)
@@ -1533,14 +1485,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: string), _col5 (type: int)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: ((p_size <> 340) and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_size <> 340) and p_type is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1576,7 +1520,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1652,15 +1596,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_size is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
@@ -1676,13 +1619,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col9 (type: int)
                         Statistics: Num rows: 26 Data size: 16198 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -1721,7 +1657,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1795,15 +1731,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_partkey is not null and p_size is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_partkey is not null and p_size is not null) (type: boolean)
@@ -1819,13 +1754,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col9 (type: int)
                         Statistics: Num rows: 26 Data size: 16198 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_partkey (type: int), p_type (type: string)
                     outputColumnNames: p_partkey, p_type
@@ -1864,7 +1792,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2050,15 +1978,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_retailprice is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_retailprice is not null (type: boolean)
@@ -2074,13 +2001,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col9 (type: bigint)
                         Statistics: Num rows: 26 Data size: 16302 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_retailprice (type: double)
                     outputColumnNames: p_type, p_retailprice
@@ -2119,7 +2039,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2568,16 +2488,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_size is not null and p_type is not null) (type: boolean)
+                  filterExpr: ((p_size is not null and p_type is not null) or p_size is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_type is not null) (type: boolean)
@@ -2593,17 +2513,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_size is not null and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (p_size is not null and p_type is not null) (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: p_type (type: string), (p_size + 1) (type: int)
                       outputColumnNames: _col0, _col1
@@ -2615,14 +2524,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_size is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2662,7 +2563,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2689,7 +2590,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
                       Statistics: Num rows: 8 Data size: 864 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2761,17 +2662,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: value is not null (type: boolean)
+                  filterExpr: (value is not null or (key = '90')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
@@ -2787,9 +2688,28 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: (key = '90') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: true (type: boolean)
+                        minReductionHashAggr: 0.5
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: boolean)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: boolean)
+                          Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -2814,33 +2734,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 250 Data size: 22750 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: (key = '90') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (key = '90') (type: boolean)
-                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        aggregations: count()
-                        keys: true (type: boolean)
-                        minReductionHashAggr: 0.5
-                        mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: boolean)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: boolean)
-                          Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -2905,7 +2798,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2994,17 +2887,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: (key is not null and value is not null) (type: boolean)
+                  filterExpr: ((key is not null and value is not null) or (key = '90')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key is not null and value is not null) (type: boolean)
@@ -3019,9 +2912,28 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (key = '90') (type: boolean)
+                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: count()
+                        keys: true (type: boolean)
+                        minReductionHashAggr: 0.5
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: boolean)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: boolean)
+                          Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: sc
@@ -3046,33 +2958,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 44500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: (key = '90') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (key = '90') (type: boolean)
-                    Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        aggregations: count()
-                        keys: true (type: boolean)
-                        minReductionHashAggr: 0.5
-                        mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: boolean)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: boolean)
-                          Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3137,7 +3022,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3226,16 +3111,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_size is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
@@ -3251,13 +3135,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col9 (type: int)
                         Statistics: Num rows: 26 Data size: 16198 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -3309,7 +3186,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3383,16 +3260,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_size is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
@@ -3408,13 +3284,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col9 (type: int)
                         Statistics: Num rows: 26 Data size: 16198 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -3475,7 +3344,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3812,15 +3681,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_size is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_size is not null and p_name is not null) or (p_type is not null and p_name is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_name is not null) (type: boolean)
@@ -3836,14 +3705,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3860,7 +3721,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -3900,7 +3761,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3987,15 +3848,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_size is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_size is not null and p_name is not null) or (p_size is not null and p_type is not null and p_name is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_name is not null) (type: boolean)
@@ -4011,14 +3872,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_size is not null and p_type is not null and p_name is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_type is not null and p_name is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4035,7 +3888,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -4075,7 +3928,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4164,15 +4017,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_size is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_size is not null and p_name is not null) or (p_type is not null and p_name is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 6058 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_size is not null and p_name is not null) (type: boolean)
@@ -4188,14 +4041,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: string), _col3 (type: int)
                         Statistics: Num rows: 26 Data size: 6058 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4212,7 +4057,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -4252,7 +4097,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4305,15 +4150,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_size is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_size is not null and p_name is not null) or (p_type is not null and p_name is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_name is not null) (type: boolean)
@@ -4329,14 +4174,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4353,7 +4190,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 5 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -4393,7 +4230,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4480,17 +4317,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and UDFToLong(p_size) is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and UDFToLong(p_size) is not null) or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and UDFToLong(p_size) is not null) (type: boolean)
@@ -4506,14 +4343,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: string)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4588,7 +4417,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4609,7 +4438,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4668,15 +4497,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_partkey is not null and UDFToDouble(p_size) is not null) (type: boolean)
+                  filterExpr: ((p_partkey is not null and UDFToDouble(p_size) is not null) or p_partkey is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_partkey is not null and UDFToDouble(p_size) is not null) (type: boolean)
@@ -4692,14 +4521,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), UDFToDouble(_col5) (type: double)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4737,7 +4558,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4806,7 +4627,7 @@ POSTHOOK: Input: default@part
 85768	almond antique chartreuse lavender yellow	Manufacturer#1	Brand#12	LARGE BRUSHED STEEL	34	SM BAG	1753.76	refull
 86428	almond aquamarine burnished black steel	Manufacturer#1	Brand#12	STANDARD ANODIZED STEEL	28	WRAP BAG	1414.42	arefully 
 90681	almond antique chartreuse khaki white	Manufacturer#3	Brand#31	MEDIUM BURNISHED TIN	17	SM CASE	1671.68	are slyly after the sl
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select * from part where p_size in (select min(pp.p_size) from part pp where pp.p_partkey > part.p_partkey)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -4824,17 +4645,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_partkey is not null and p_size is not null) (type: boolean)
+                  filterExpr: ((p_partkey is not null and p_size is not null) or p_partkey is not null or p_partkey is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_partkey is not null and p_size is not null) (type: boolean)
@@ -4850,14 +4671,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int), _col5 (type: int)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4870,14 +4683,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4913,7 +4718,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4943,7 +4748,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4967,7 +4772,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                       Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4987,7 +4792,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[53][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select * from part where p_size in (select min(pp.p_size) from part pp where pp.p_partkey > part.p_partkey)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -5016,12 +4821,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5040,14 +4845,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col4 (type: string)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5161,7 +4958,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5182,7 +4979,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5204,7 +5001,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 6 Data size: 720 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5282,11 +5079,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5305,14 +5102,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5328,14 +5117,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5423,7 +5204,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5444,7 +5225,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 6 Data size: 72 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5907,7 +5688,7 @@ POSTHOOK: query: drop table tt_n2
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@tt_n2
 POSTHOOK: Output: default@tt_n2
-Warning: Shuffle Join MERGEJOIN[49][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[49][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select * from part where p_size IN (select max(p_size) from part p where p.p_type <> part.p_name)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -5925,17 +5706,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_name is not null and p_size is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_name is not null and p_size is not null) (type: boolean)
@@ -5951,13 +5731,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col5 (type: int)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: _col0, _col1
@@ -5967,14 +5740,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6010,7 +5775,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6040,7 +5805,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 13 Data size: 1625 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6064,7 +5829,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
                       Statistics: Num rows: 6 Data size: 750 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6084,7 +5849,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[49][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[49][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select * from part where p_size IN (select max(p_size) from part p where p.p_type <> part.p_name)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -6094,7 +5859,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 15103	almond aquamarine dodger light gainsboro	Manufacturer#5	Brand#53	ECONOMY BURNISHED STEEL	46	LG PACK	1018.1	packages hinder carefu
-Warning: Shuffle Join MERGEJOIN[71][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[71][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: explain select * from part where p_size IN (select pp.p_size from part p join part pp on pp.p_type = p.p_type where part.p_type <> p.p_name)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -6112,17 +5877,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_size is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_size is not null) or p_type is not null or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_size is not null) (type: boolean)
@@ -6138,14 +5903,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: string), _col5 (type: int)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6160,6 +5917,21 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
+                  Filter Operator
+                    predicate: p_type is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: p_type (type: string)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 6 
@@ -6184,29 +5956,6 @@ STAGE PLANS:
                         value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_type is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: p_type (type: string)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -6225,7 +5974,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6241,7 +5990,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 28 Data size: 3500 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: string), _col3 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6269,7 +6018,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
                       Statistics: Num rows: 182 Data size: 19656 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6289,7 +6038,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[71][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[71][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: select * from part where p_size IN (select pp.p_size from part p join part pp on pp.p_type = p.p_type where part.p_type <> p.p_name)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part

--- a/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_in_having.q.out
@@ -575,7 +575,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (SIMPLE_EDGE)
@@ -585,7 +585,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((key > '8') or (key > '9')) (type: boolean)
+                  filterExpr: ((key > '8') or (key > '9') or (key > '8')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '8') (type: boolean)
@@ -619,14 +619,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: (key > '8') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '8') (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1009,16 +1001,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Map 1 <- Map 3 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (BROADCAST_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Map 1 <- Map 4 (BROADCAST_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (BROADCAST_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: (value is not null and key is not null) (type: boolean)
+                  filterExpr: ((value is not null and key is not null) or (key > '9')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value is not null and key is not null) (type: boolean)
@@ -1035,7 +1027,7 @@ STAGE PLANS:
                           1 _col0 (type: string), _col1 (type: string)
                         outputColumnNames: _col0, _col1
                         input vertices:
-                          1 Map 3
+                          1 Map 4
                         Statistics: Num rows: 395 Data size: 70310 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -1051,9 +1043,26 @@ STAGE PLANS:
                             Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                             Statistics: Num rows: 197 Data size: 36642 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col2 (type: bigint)
+                  Filter Operator
+                    predicate: (key > '9') (type: boolean)
+                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: key (type: string)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
+        Map 4 
             Map Operator Tree:
                 TableScan
                   alias: src
@@ -1080,31 +1089,6 @@ STAGE PLANS:
                           Statistics: Num rows: 250 Data size: 44500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: (key > '9') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (key > '9') (type: boolean)
-                    Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: count()
-                      keys: key (type: string)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 83 Data size: 7885 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -1125,7 +1109,7 @@ STAGE PLANS:
                       1 _col0 (type: bigint)
                     outputColumnNames: _col0, _col1, _col2
                     input vertices:
-                      1 Reducer 5
+                      1 Reducer 3
                     Statistics: Num rows: 41 Data size: 7626 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
@@ -1134,7 +1118,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1515,15 +1499,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (BROADCAST_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (BROADCAST_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part_subq
-                  filterExpr: p_name is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -1542,13 +1525,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col2 (type: bigint), _col3 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part_subq
-                  Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_size (type: int)
                     null sort order: az
@@ -1579,7 +1555,7 @@ STAGE PLANS:
                       1 _col0 (type: string)
                     outputColumnNames: _col0, _col1, _col2
                     input vertices:
-                      1 Reducer 4
+                      1 Reducer 3
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
@@ -1588,7 +1564,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_multi.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_multi.q.out
@@ -96,16 +96,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part_null
-                  filterExpr: (p_size is not null and p_brand is not null) (type: boolean)
+                  filterExpr: ((p_size is not null and p_brand is not null) or p_size is not null or p_brand is not null) (type: boolean)
                   Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (p_size is not null and p_brand is not null) (type: boolean)
@@ -121,14 +121,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_size is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
@@ -144,14 +136,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_brand is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_brand is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -209,7 +193,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -265,7 +249,7 @@ POSTHOOK: Input: default@part_null
 85768	almond antique chartreuse lavender yellow	Manufacturer#1	Brand#12	LARGE BRUSHED STEEL	34	SM BAG	1753.76	refull
 86428	almond aquamarine burnished black steel	Manufacturer#1	Brand#12	STANDARD ANODIZED STEEL	28	WRAP BAG	1414.42	arefully 
 90681	almond antique chartreuse khaki white	Manufacturer#3	Brand#31	MEDIUM BURNISHED TIN	17	SM CASE	1671.68	are slyly after the sl
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: explain select * from part_null where p_name IN (select p_name from part_null) AND p_brand NOT IN (select p_name from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -283,19 +267,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
-        Reducer 8 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part_null
-                  filterExpr: p_name is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -311,13 +294,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col3 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -412,7 +388,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -431,7 +407,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -444,7 +420,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -462,7 +438,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 1 Data size: 385 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -482,7 +458,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: select * from part_null where p_name IN (select p_name from part_null) AND p_brand NOT IN (select p_name from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -491,7 +467,7 @@ POSTHOOK: query: select * from part_null where p_name IN (select p_name from par
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part_null
 #### A masked pattern was here ####
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: explain select * from part_null where p_name IN (select p_name from part_null) AND p_brand NOT IN (select p_type from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -509,19 +485,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part_null
-                  filterExpr: p_name is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -537,13 +512,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col3 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -574,14 +542,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -646,7 +606,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -665,7 +625,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -678,7 +638,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -696,7 +656,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 1 Data size: 385 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -716,7 +676,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: select * from part_null where p_name IN (select p_name from part_null) AND p_brand NOT IN (select p_type from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -751,7 +711,7 @@ POSTHOOK: Input: default@part_null
 85768	almond antique chartreuse lavender yellow	Manufacturer#1	Brand#12	LARGE BRUSHED STEEL	34	SM BAG	1753.76	refull
 86428	almond aquamarine burnished black steel	Manufacturer#1	Brand#12	STANDARD ANODIZED STEEL	28	WRAP BAG	1414.42	arefully 
 90681	almond antique chartreuse khaki white	Manufacturer#3	Brand#31	MEDIUM BURNISHED TIN	17	SM CASE	1671.68	are slyly after the sl
-Warning: Shuffle Join MERGEJOIN[63][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[63][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: explain select * from part_null where p_brand IN (select p_brand from part_null) AND p_brand NOT IN (select p_name from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -769,19 +729,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part_null
-                  filterExpr: p_brand is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_brand is not null (type: boolean)
@@ -797,13 +756,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col3 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -834,14 +786,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_brand is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_brand is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
@@ -906,7 +850,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -925,7 +869,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -938,7 +882,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -956,7 +900,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string)
                   Statistics: Num rows: 1 Data size: 385 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -976,7 +920,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[63][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[63][tables = [$hdt$_2, $hdt$_3]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: select * from part_null where p_brand IN (select p_brand from part_null) AND p_brand NOT IN (select p_name from part_null)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part_null
@@ -1007,7 +951,7 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 4 <- Map 8 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
         Reducer 6 <- Map 5 (SIMPLE_EDGE)
         Reducer 7 <- Map 5 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
@@ -1032,6 +976,22 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
+                    Select Operator
+                      expressions: p_brand (type: string)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        keys: _col0 (type: string)
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: string)
+                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 5 
@@ -1069,33 +1029,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 102 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: bigint), _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_brand is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_brand is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: p_brand (type: string)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                      Group By Operator
-                        keys: _col0 (type: string)
-                        minReductionHashAggr: 0.99
-                        mode: hash
-                        outputColumnNames: _col0
-                        Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: string)
-                          Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1258,10 +1191,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1284,17 +1217,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_name is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       keys: p_name (type: string)
                       minReductionHashAggr: 0.99
@@ -1309,7 +1231,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: tnull
@@ -1364,7 +1286,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1378,7 +1300,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1456,10 +1378,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1482,17 +1404,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col5 (type: int)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_size is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_size is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       keys: p_size (type: int)
                       minReductionHashAggr: 0.99
@@ -1507,7 +1418,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: tempty
@@ -1562,7 +1473,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1576,7 +1487,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1628,10 +1539,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1654,17 +1565,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_name is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       keys: p_name (type: string)
                       minReductionHashAggr: 0.99
@@ -1679,7 +1579,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: tempty
@@ -1741,7 +1641,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1755,7 +1655,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1875,13 +1775,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 7 <- Map 11 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
-        Reducer 9 <- Map 11 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 6 <- Map 10 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 10 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1906,7 +1806,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 11 
+        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -1943,7 +1843,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_name is not null) or ((p_type is not null and p_brand is not null) or (p_type is not null and p_brand is not null and p_container is not null))) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
@@ -1964,14 +1864,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 13 Data size: 2925 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: ((p_type is not null and p_brand is not null) or (p_type is not null and p_brand is not null and p_container is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 7488 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_brand is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 7488 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2002,25 +1894,6 @@ STAGE PLANS:
                         value expressions: _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string), KEY._col1 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: string), true (type: boolean), _col1 (type: string)
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string), _col2 (type: string)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: string), _col2 (type: string)
-                    Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: boolean)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -2082,7 +1955,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2107,7 +1980,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 7 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2123,7 +1996,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 7 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2146,6 +2019,25 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), true (type: boolean), _col1 (type: string)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col2 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col2 (type: string)
+                    Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: boolean)
 
   Stage: Stage-0
     Fetch Operator
@@ -2213,7 +2105,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -2243,7 +2135,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_name is not null (type: boolean)
+                  filterExpr: (p_name is not null or (p_type is not null and p_brand is not null)) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
@@ -2260,14 +2152,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1573 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_type is not null and p_brand is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_brand is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2401,13 +2285,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 7 <- Map 11 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
-        Reducer 9 <- Map 11 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 6 <- Map 10 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 10 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2432,7 +2316,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col7 (type: double), _col8 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 11 
+        Map 10 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -2469,7 +2353,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_container is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_container is not null and p_name is not null) or ((p_type is not null and p_brand is not null) or (p_type is not null and p_brand is not null and p_container is not null))) (type: boolean)
                   Statistics: Num rows: 26 Data size: 8242 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_container is not null and p_name is not null) (type: boolean)
@@ -2490,14 +2374,6 @@ STAGE PLANS:
                           sort order: +++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string), _col2 (type: string)
                           Statistics: Num rows: 13 Data size: 4121 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: ((p_type is not null and p_brand is not null) or (p_type is not null and p_brand is not null and p_container is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 7488 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_brand is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 7488 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2528,25 +2404,6 @@ STAGE PLANS:
                         value expressions: _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string), KEY._col1 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: string), true (type: boolean), _col1 (type: string)
-                  outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string), _col2 (type: string)
-                    null sort order: zz
-                    sort order: ++
-                    Map-reduce partition columns: _col0 (type: string), _col2 (type: string)
-                    Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: boolean)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -2608,7 +2465,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2633,7 +2490,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 7 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2649,7 +2506,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 7 Data size: 840 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2672,6 +2529,25 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string), KEY._col1 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 7 Data size: 1372 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), true (type: boolean), _col1 (type: string)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string), _col2 (type: string)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: string), _col2 (type: string)
+                    Statistics: Num rows: 7 Data size: 1400 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: boolean)
 
   Stage: Stage-0
     Fetch Operator
@@ -2735,10 +2611,10 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2767,7 +2643,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_name is not null) or (p_size is not null or (p_size is not null and p_type is not null))) (type: boolean)
                   Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
@@ -2788,14 +2664,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 13 Data size: 2925 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_size is not null or (p_size is not null and p_type is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2891,7 +2759,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2907,7 +2775,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 13 Data size: 260 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3151,7 +3019,7 @@ POSTHOOK: Input: default@part_null
 85768	almond antique chartreuse lavender yellow	Manufacturer#1	Brand#12	LARGE BRUSHED STEEL	34	SM BAG	1753.76	refull
 86428	almond aquamarine burnished black steel	Manufacturer#1	Brand#12	STANDARD ANODIZED STEEL	28	WRAP BAG	1414.42	arefully 
 90681	almond antique chartreuse khaki white	Manufacturer#3	Brand#31	MEDIUM BURNISHED TIN	17	SM CASE	1671.68	are slyly after the sl
-Warning: Shuffle Join MERGEJOIN[85][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[85][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: explain select p.p_partkey, li.l_suppkey
 from (select distinct l_partkey as p_partkey from lineitem) p join lineitem li on p.p_partkey = li.l_partkey
 where li.l_linenumber = 1 and
@@ -3175,18 +3043,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: ((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and l_partkey is not null and l_orderkey is not null) (type: boolean)
@@ -3202,9 +3069,38 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 14 Data size: 224 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: int), _col3 (type: int)
+                  Filter Operator
+                    predicate: ((l_linenumber = 1) and (l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: l_orderkey (type: int), l_quantity (type: double)
+                      outputColumnNames: _col0, _col2
+                      Statistics: Num rows: 2 Data size: 206 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col2 (type: double)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col2 (type: double)
+                        Statistics: Num rows: 2 Data size: 206 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int)
+                  Select Operator
+                    expressions: l_quantity (type: double)
+                    outputColumnNames: l_quantity
+                    Statistics: Num rows: 100 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(l_quantity), count(l_quantity)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: double), _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 4 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: lineitem
@@ -3229,50 +3125,6 @@ STAGE PLANS:
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: ((l_linenumber = 1) and (l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 10400 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((l_linenumber = 1) and (l_shipmode = 'AIR') and l_orderkey is not null) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: l_orderkey (type: int), l_quantity (type: double)
-                      outputColumnNames: _col0, _col2
-                      Statistics: Num rows: 2 Data size: 206 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col2 (type: double)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col2 (type: double)
-                        Statistics: Num rows: 2 Data size: 206 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  Statistics: Num rows: 100 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: l_quantity (type: double)
-                    outputColumnNames: l_quantity
-                    Statistics: Num rows: 100 Data size: 800 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: sum(l_quantity), count(l_quantity)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: double), _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -3319,7 +3171,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3335,7 +3187,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int), _col2 (type: double), _col5 (type: boolean)
-        Reducer 7 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3369,7 +3221,7 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3412,7 +3264,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[85][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 7' is a cross product
+Warning: Shuffle Join MERGEJOIN[85][tables = [$hdt$_1, $hdt$_2, $hdt$_3]] in Stage 'Reducer 5' is a cross product
 PREHOOK: query: select p.p_partkey, li.l_suppkey
 from (select distinct l_partkey as p_partkey from lineitem) p join lineitem li on p.p_partkey = li.l_partkey
 where li.l_linenumber = 1 and
@@ -3459,7 +3311,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -3502,7 +3354,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: (value is not null and key is not null) (type: boolean)
+                  filterExpr: ((value is not null and key is not null) or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value is not null and key is not null) (type: boolean)
@@ -3523,14 +3375,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 44500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: s2
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3993,7 +3837,7 @@ POSTHOOK: Input: default@src
 96	val_96	1
 97	val_97	2
 98	val_98	2
-Warning: Shuffle Join MERGEJOIN[50][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[50][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select * from part where p_name IN (select p_name from part p where part.p_type <> '1')
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -4011,16 +3855,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: ((p_type <> '1') and p_name is not null) (type: boolean)
+                  filterExpr: (((p_type <> '1') and p_name is not null) or p_name is not null or (p_type <> '1')) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_type <> '1') and p_name is not null) (type: boolean)
@@ -4036,14 +3880,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: string), _col4 (type: string)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4056,14 +3892,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_type <> '1') (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type <> '1') (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4099,7 +3927,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4122,7 +3950,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 169 Data size: 38025 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4142,7 +3970,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[50][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[50][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select * from part where p_name IN (select p_name from part p where part.p_type <> '1')
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -4388,13 +4216,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4411,14 +4239,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: ((key > '9') or (key > '9')) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '9') (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4450,13 +4270,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 83 Data size: 7221 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -4473,19 +4286,6 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: boolean)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: boolean)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -4562,7 +4362,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4575,7 +4375,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4594,6 +4394,19 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 83 Data size: 7553 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: boolean)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: boolean)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_multiinsert.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_multiinsert.q.out
@@ -76,12 +76,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -103,41 +103,6 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: key (type: string), value (type: string)
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: a
-                  filterExpr: ((key > '9') and value is not null) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((key > '9') and value is not null) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: key (type: string), value (type: string)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-                      Group By Operator
-                        keys: _col0 (type: string), _col1 (type: string)
-                        minReductionHashAggr: 0.0
-                        mode: hash
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 83 Data size: 14774 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: string), _col1 (type: string)
-                          null sort order: zz
-                          sort order: ++
-                          Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                          Statistics: Num rows: 83 Data size: 14774 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: ((key > '2') or ((key > '2') and key is null)) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '2') (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -167,6 +132,33 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Map 8 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  filterExpr: ((key > '9') and value is not null) (type: boolean)
+                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((key > '9') and value is not null) (type: boolean)
+                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: key (type: string), value (type: string)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: _col0 (type: string), _col1 (type: string)
+                        minReductionHashAggr: 0.0
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 83 Data size: 14774 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: string), _col1 (type: string)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
+                          Statistics: Num rows: 83 Data size: 14774 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -299,7 +291,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_notexists.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_notexists.q.out
@@ -663,7 +663,7 @@ POSTHOOK: Input: default@src
 98	val_98
 98	val_98
 Warning: Shuffle Join MERGEJOIN[60][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: explain SELECT p1.p_name FROM part p1 LEFT JOIN (select p_type as p_col from part ) p2 WHERE NOT EXISTS
                 (select pp1.p_type as p_col from part pp1 where pp1.p_partkey = p2.p_col)
 PREHOOK: type: QUERY
@@ -683,12 +683,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Map 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 5 <- Map 10 (XPROD_EDGE), Map 4 (XPROD_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 9 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (XPROD_EDGE), Map 8 (XPROD_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -705,13 +705,19 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: UDFToDouble(p_partkey) is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: UDFToDouble(p_partkey) (type: double)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: double)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: double)
+                        Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -720,7 +726,7 @@ STAGE PLANS:
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 4 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: part
@@ -746,27 +752,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: pp1
-                  filterExpr: UDFToDouble(p_partkey) is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: UDFToDouble(p_partkey) is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: UDFToDouble(p_partkey) (type: double)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: double)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: double)
-                        Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -812,49 +797,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col1
-                Statistics: Num rows: 676 Data size: 70304 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  keys: _col1 (type: string)
-                  minReductionHashAggr: 0.964497
-                  mode: hash
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: string)
-                    Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: string), UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 24 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: double)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: double)
-                    Statistics: Num rows: 24 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: string)
-        Reducer 7 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -877,7 +820,7 @@ STAGE PLANS:
                     sort order: +
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 12 Data size: 1248 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -896,6 +839,48 @@ STAGE PLANS:
                     Map-reduce partition columns: _col1 (type: string)
                     Statistics: Num rows: 12 Data size: 1296 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: boolean)
+        Reducer 6 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col1
+                Statistics: Num rows: 676 Data size: 70304 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  keys: _col1 (type: string)
+                  minReductionHashAggr: 0.964497
+                  mode: hash
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: string)
+                    Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 24 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), UDFToDouble(_col0) (type: double)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 24 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: double)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: double)
+                    Statistics: Num rows: 24 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: string)
 
   Stage: Stage-0
     Fetch Operator
@@ -904,7 +889,7 @@ STAGE PLANS:
         ListSink
 
 Warning: Shuffle Join MERGEJOIN[60][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
-Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[61][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: SELECT p1.p_name FROM part p1 LEFT JOIN (select p_type as p_col from part ) p2 WHERE NOT EXISTS
                 (select pp1.p_type as p_col from part pp1 where pp1.p_partkey = p2.p_col)
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/subquery_notin.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_notin.q.out
@@ -28,10 +28,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -50,14 +50,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: ((key > '2') or (key > '2')) (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '2') (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -134,7 +126,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -153,7 +145,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 83 Data size: 7553 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -649,11 +641,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -672,13 +664,6 @@ STAGE PLANS:
                       Map-reduce partition columns: UDFToDouble(_col1) (type: double)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Top N Key Operator
                     sort order: ++
                     keys: p_mfgr (type: string), p_size (type: int)
@@ -739,7 +724,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -824,7 +809,7 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -846,7 +831,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: double)
                       Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: boolean)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -951,13 +936,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -976,14 +961,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_mfgr is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_mfgr is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1070,7 +1047,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -1201,7 +1178,7 @@ STAGE PLANS:
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 4 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col1 (type: int)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1222,7 +1199,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 2 Data size: 212 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1244,7 +1221,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 2 Data size: 228 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1715,17 +1692,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: ((p_size <> 340) and (p_brand <> 'Brand#14')) (type: boolean)
+                  filterExpr: (((p_size <> 340) and (p_brand <> 'Brand#14')) or (p_type is not null or (((p_size * p_size) <> 340) and p_type is not null and p_size is not null))) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_size <> 340) and (p_brand <> 'Brand#14')) (type: boolean)
@@ -1741,14 +1718,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: string)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_type is not null or (((p_size * p_size) <> 340) and p_type is not null and p_size is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1834,7 +1803,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1850,7 +1819,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 13 Data size: 1560 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1925,12 +1894,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1949,13 +1918,6 @@ STAGE PLANS:
                       Map-reduce partition columns: (_col5 - 1) (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -2034,7 +1996,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2073,7 +2035,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2092,7 +2054,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2155,11 +2117,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2178,13 +2140,6 @@ STAGE PLANS:
                       Map-reduce partition columns: (_col0 * _col5) (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_partkey (type: int), p_type (type: string)
                     outputColumnNames: p_partkey, p_type
@@ -2250,7 +2205,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2289,7 +2244,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2308,7 +2263,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2379,13 +2334,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 10 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2404,14 +2359,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_name is not null or (p_name is not null and p_partkey is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2444,14 +2391,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: string)
                         Statistics: Num rows: 13 Data size: 1625 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: e
-                  filterExpr: p_size is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2469,21 +2408,6 @@ STAGE PLANS:
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: (_col0 + 100) (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: (_col0 + 100) (type: int)
-                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -2544,7 +2468,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2560,7 +2484,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 13 Data size: 1781 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2579,7 +2503,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 13 Data size: 1677 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean), _col2 (type: string)
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -2597,6 +2521,21 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string), _col3 (type: int)
                   Statistics: Num rows: 13 Data size: 1677 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: boolean)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: (_col0 + 100) (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: (_col0 + 100) (type: int)
+                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -2631,11 +2570,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2654,13 +2593,6 @@ STAGE PLANS:
                       Map-reduce partition columns: floor(_col7) (type: bigint)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_retailprice (type: double)
                     outputColumnNames: p_type, p_retailprice
@@ -2726,7 +2658,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2773,7 +2705,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2792,7 +2724,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 6 Data size: 72 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2839,10 +2771,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2861,14 +2793,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col5 (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: ((((p_size + 121150) = p_partkey) and p_size is not null) or (((p_size + 121150) = p_partkey) and p_size is not null and p_name is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (((p_size + 121150) = p_partkey) and p_size is not null) (type: boolean)
                     Statistics: Num rows: 13 Data size: 1677 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2954,7 +2878,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2970,7 +2894,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 6 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3045,10 +2969,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3067,14 +2991,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int), _col5 (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: ((p_size is not null and p_partkey is not null) or (p_size is not null and p_partkey is not null and p_name is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_partkey is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3152,7 +3068,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3168,7 +3084,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                   Statistics: Num rows: 13 Data size: 312 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3219,10 +3135,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3241,14 +3157,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col2 (type: string)
                       Statistics: Num rows: 26 Data size: 8242 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_brand is not null or (p_brand is not null and UDFToDouble(p_type) is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_brand is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3334,7 +3242,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3350,7 +3258,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3401,14 +3309,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE)
-        Reducer 11 <- Map 9 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 4 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3427,14 +3335,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col2 (type: int)
                       Statistics: Num rows: 26 Data size: 5954 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_size is not null or (p_size is not null and p_type is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3463,14 +3363,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_size is not null or p_size is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3511,34 +3403,6 @@ STAGE PLANS:
                           Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 11 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -3582,7 +3446,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3607,7 +3471,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3623,7 +3487,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3646,7 +3510,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
                     Statistics: Num rows: 8 Data size: 864 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3665,6 +3529,34 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string), _col2 (type: int)
                     Statistics: Num rows: 8 Data size: 896 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -3724,13 +3616,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 6 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3749,13 +3641,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3896,7 +3781,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3915,7 +3800,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 250 Data size: 22750 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3928,7 +3813,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4021,10 +3906,10 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (SIMPLE_EDGE)
         Reducer 7 <- Map 1 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4083,14 +3968,6 @@ STAGE PLANS:
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                           Statistics: Num rows: 250 Data size: 67750 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: (key = '90') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key = '90') (type: boolean)
                     Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4234,7 +4111,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col2 (type: string), _col0 (type: string)
                     Statistics: Num rows: 250 Data size: 68750 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4324,12 +4201,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4348,13 +4225,6 @@ STAGE PLANS:
                       Map-reduce partition columns: (_col5 - 1) (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -4433,7 +4303,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4472,7 +4342,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4491,7 +4361,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4554,12 +4424,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4578,13 +4448,6 @@ STAGE PLANS:
                       Map-reduce partition columns: (_col5 - 1) (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -4672,7 +4535,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4711,7 +4574,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4730,7 +4593,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 6 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5525,13 +5388,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Map 5 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 10 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5550,14 +5413,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 2496 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: (p_brand is not null or (p_brand is not null and UDFToDouble(p_type) is not null)) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_brand is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5590,14 +5445,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 13 Data size: 2548 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: e
-                  filterExpr: (UDFToDouble((p_size + 100)) is not null and p_size is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (UDFToDouble((p_size + 100)) is not null and p_size is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5615,21 +5462,6 @@ STAGE PLANS:
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: UDFToDouble((_col0 + 100)) (type: double)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: UDFToDouble((_col0 + 100)) (type: double)
-                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -5690,7 +5522,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5706,7 +5538,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string)
                   Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5725,7 +5557,7 @@ STAGE PLANS:
                     Map-reduce partition columns: UDFToDouble(_col0) (type: double)
                     Statistics: Num rows: 13 Data size: 2600 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean), _col2 (type: string)
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5743,6 +5575,21 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: string), _col3 (type: int)
                   Statistics: Num rows: 13 Data size: 1300 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: boolean)
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: UDFToDouble((_col0 + 100)) (type: double)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: UDFToDouble((_col0 + 100)) (type: double)
+                  Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: int)
 
   Stage: Stage-0
     Fetch Operator
@@ -5988,13 +5835,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 10 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 10 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 9 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 9 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6013,9 +5860,24 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: char(100))
                       Statistics: Num rows: 4 Data size: 368 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: (c2 is not null and UDFToDouble(c2) is not null) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: c2 (type: char(100))
+                      minReductionHashAggr: 0.0
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: char(100))
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: char(100))
+                        Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 10 
+        Map 9 
             Map Operator Tree:
                 TableScan
                   alias: t2_n0
@@ -6049,29 +5911,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: double)
                         Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: t1_n0
-                  filterExpr: (c2 is not null and UDFToDouble(c2) is not null) (type: boolean)
-                  Statistics: Num rows: 4 Data size: 352 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (c2 is not null and UDFToDouble(c2) is not null) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: c2 (type: char(100))
-                      minReductionHashAggr: 0.0
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: char(100))
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: char(100))
-                        Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -6117,7 +5956,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6143,7 +5982,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col1 (type: double)
                     Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: char(100))
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6168,7 +6007,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: char(100))
                     Statistics: Num rows: 1 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6184,7 +6023,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: char(100))
                   Statistics: Num rows: 1 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6207,7 +6046,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: char(100))
                     Statistics: Num rows: 1 Data size: 92 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6548,12 +6387,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6572,9 +6411,24 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
+                  Filter Operator
+                    predicate: j is not null (type: boolean)
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: j (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 4 
+        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: t7
@@ -6612,29 +6466,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: fixob
-                  filterExpr: j is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: j is not null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: j (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -6680,7 +6511,39 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 5 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col2 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col2 (type: int)
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col1 (type: boolean)
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6696,7 +6559,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 1 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: bigint), _col2 (type: bigint)
-        Reducer 6 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6715,38 +6578,6 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 7 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col1, _col2
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col2 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col2 (type: int)
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col1 (type: boolean)
-        Reducer 9 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -6820,8 +6651,8 @@ STAGE PLANS:
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Map 1 (SIMPLE_EDGE)
         Reducer 5 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6872,14 +6703,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: t_n0
-                  filterExpr: j is not null (type: boolean)
-                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: j is not null (type: boolean)
                     Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6993,7 +6816,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col2 (type: int)
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -7210,10 +7033,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7232,13 +7055,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: t1_n0
-                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: i is not null (type: boolean)
                     Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -7316,7 +7132,7 @@ STAGE PLANS:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                             serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -7335,7 +7151,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -7566,10 +7382,10 @@ STAGE PLANS:
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 4 <- Map 1 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
         Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7615,14 +7431,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 83 Data size: 14774 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
                     Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -7749,7 +7557,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: string)
                     Statistics: Num rows: 83 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: boolean), _col2 (type: string)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_scalar.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_scalar.q.out
@@ -251,8 +251,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
-        Reducer 4 <- Map 6 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
+        Reducer 4 <- Map 5 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -273,14 +273,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: tempty_n0
-                  filterExpr: UDFToDouble(c) is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: UDFToDouble(c) is not null (type: boolean)
                     Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: NONE
@@ -295,7 +287,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: part
@@ -400,7 +392,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 3 <- Map 6 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
+        Reducer 3 <- Map 4 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
         Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -447,17 +439,6 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 196 Basic stats: COMPLETE Column stats: NONE
                           value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n0
-                  filterExpr: p_name is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_name is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                       Limit
@@ -843,17 +824,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: UDFToDouble(p_size) is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToDouble(p_size) is not null (type: boolean)
@@ -867,13 +847,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 16302 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string), _col9 (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_size (type: int)
                     outputColumnNames: p_size
@@ -942,7 +915,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -962,7 +935,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: double)
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1036,16 +1009,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_size is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
@@ -1059,13 +1031,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string), _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2652 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_size (type: int)
                     null sort order: az
@@ -1097,7 +1062,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -1139,7 +1104,7 @@ STAGE PLANS:
                         null sort order: z
                         sort order: +
                         Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -1220,8 +1185,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1238,13 +1203,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 16198 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string), _col9 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_partkey (type: int)
                     outputColumnNames: p_partkey
@@ -1285,7 +1243,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1357,16 +1315,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: e
-                  filterExpr: (p_name is not null and p_size is not null) (type: boolean)
+                  filterExpr: ((p_name is not null and p_size is not null) or p_name is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_name is not null and p_size is not null) (type: boolean)
@@ -1382,14 +1340,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_name is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1449,7 +1399,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1505,9 +1455,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1529,17 +1479,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_name is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_name is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(p_partkey)
                       keys: p_name (type: string)
@@ -1592,7 +1531,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1785,9 +1724,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1816,7 +1755,6 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part_null_n0
-                  filterExpr: p_type is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
@@ -1835,13 +1773,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n0
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: p_size (type: int)
                     outputColumnNames: p_size
@@ -1922,7 +1853,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col0 (type: int)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2003,9 +1934,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2034,7 +1965,6 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part_null_n0
-                  filterExpr: p_type is not null (type: boolean)
                   Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
@@ -2053,13 +1983,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n0
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: p_retailprice (type: double)
                     outputColumnNames: p_retailprice
@@ -2140,7 +2063,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col0 (type: int)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2218,16 +2141,15 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: ((p_size <> 340) and p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_size <> 340) and p_type is not null) (type: boolean)
@@ -2241,13 +2163,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2392 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_brand (type: string)
                     outputColumnNames: p_brand
@@ -2263,14 +2178,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: ((p_size <> 340) and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((p_size <> 340) and p_type is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2329,7 +2236,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2398,8 +2305,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2418,14 +2325,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int), _col5 (type: int)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_size is not null and p_partkey is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_partkey is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2470,7 +2369,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2547,11 +2446,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2568,13 +2467,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: value (type: string)
                     outputColumnNames: value
@@ -2590,14 +2482,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  filterExpr: (key = '90') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key = '90') (type: boolean)
                     Statistics: Num rows: 2 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2689,7 +2573,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2702,7 +2586,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: string)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2773,8 +2657,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2800,13 +2684,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_retailprice (type: double)
                     outputColumnNames: p_retailprice
@@ -2868,7 +2745,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -2920,19 +2797,18 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Reducer 9 (SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 4 <- Map 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Union 6 (CONTAINS)
-        Reducer 7 <- Union 6 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
+        Reducer 6 <- Union 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Union 5 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: UDFToLong(p_size) is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: UDFToLong(p_size) is not null (type: boolean)
@@ -2946,13 +2822,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 16302 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string), _col9 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_name (type: string)
                     outputColumnNames: p_name
@@ -2968,13 +2837,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2392 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_brand (type: string)
                     outputColumnNames: p_brand
@@ -2992,29 +2854,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: bigint)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count(_col1)
-                  keys: _col0 (type: bigint)
-                  minReductionHashAggr: 0.5
-                  mode: hash
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: bigint)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: bigint)
-                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: bigint)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -3038,7 +2877,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3063,7 +2902,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: bigint)
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3086,7 +2925,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: bigint)
                     Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3107,7 +2946,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3132,8 +2971,31 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: bigint)
                       Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint)
-        Union 6 
-            Vertex: Union 6
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: bigint)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count(_col1)
+                  keys: _col0 (type: bigint)
+                  minReductionHashAggr: 0.5
+                  mode: hash
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: bigint)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: bigint)
+                    Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: bigint)
+        Union 5 
+            Vertex: Union 5
 
   Stage: Stage-0
     Fetch Operator
@@ -3176,16 +3038,16 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: p_size is not null (type: boolean)
+                  filterExpr: (p_size is not null or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size is not null (type: boolean)
@@ -3201,14 +3063,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col2 (type: int)
                         Statistics: Num rows: 26 Data size: 3354 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3225,7 +3079,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -3270,7 +3124,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3295,7 +3149,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col1 (type: string)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3375,8 +3229,8 @@ STAGE PLANS:
         Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
         Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3432,13 +3286,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col3 (type: string)
                       Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part_null_n0
-                  Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: p_name (type: string)
                     outputColumnNames: p_name
@@ -3550,7 +3397,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 385 Basic stats: COMPLETE Column stats: NONE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: string)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3630,9 +3477,9 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
         Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 8 <- Map 7 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3692,17 +3539,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col3 (type: string)
                         Statistics: Num rows: 1 Data size: 1120 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: p_type is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                     Group By Operator
                       aggregations: min(p_name)
                       keys: p_type (type: string)
@@ -3819,7 +3655,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3882,17 +3718,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: ((l_linenumber = 1) and l_partkey is not null) (type: boolean)
+                  filterExpr: (((l_linenumber = 1) and l_partkey is not null) or l_partkey is not null or ((l_linenumber = 1) and (l_shipmode = 'AIR'))) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and l_partkey is not null) (type: boolean)
@@ -3908,14 +3744,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
                     Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3931,14 +3759,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: ((l_linenumber = 1) and (l_shipmode = 'AIR')) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and (l_shipmode = 'AIR')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4001,7 +3821,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4015,7 +3835,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4104,17 +3924,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: li
-                  filterExpr: ((l_linenumber = 1) and l_partkey is not null) (type: boolean)
+                  filterExpr: (((l_linenumber = 1) and l_partkey is not null) or l_partkey is not null or ((l_linenumber = 1) and (l_shipmode = 'AIR'))) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and l_partkey is not null) (type: boolean)
@@ -4130,14 +3950,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 14 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: l_partkey is not null (type: boolean)
-                  Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
                     Statistics: Num rows: 100 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4153,14 +3965,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: ((l_linenumber = 1) and (l_shipmode = 'AIR')) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 9600 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((l_linenumber = 1) and (l_shipmode = 'AIR')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4223,7 +4027,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4237,7 +4041,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 50 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4322,34 +4126,12 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: lineitem
-                  filterExpr: (l_partkey is not null and l_quantity is not null) (type: boolean)
-                  Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (l_partkey is not null and l_quantity is not null) (type: boolean)
-                    Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: l_partkey (type: int), l_quantity (type: double), l_extendedprice (type: double)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: double), _col2 (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: part
@@ -4370,11 +4152,11 @@ STAGE PLANS:
                         Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: lineitem
-                  filterExpr: l_partkey is not null (type: boolean)
+                  filterExpr: (l_partkey is not null or (l_partkey is not null and l_quantity is not null)) (type: boolean)
                   Statistics: Num rows: 100 Data size: 1200 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: l_partkey is not null (type: boolean)
@@ -4393,6 +4175,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 50 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: double), _col2 (type: bigint)
+                  Filter Operator
+                    predicate: (l_partkey is not null and l_quantity is not null) (type: boolean)
+                    Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: l_partkey (type: int), l_quantity (type: double), l_extendedprice (type: double)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 100 Data size: 2000 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: double), _col2 (type: double)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -4455,7 +4251,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4516,8 +4312,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 3 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4546,7 +4342,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_name is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_name is not null) or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 8242 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_name is not null) (type: boolean)
@@ -4562,14 +4358,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col2 (type: string)
                         Statistics: Num rows: 26 Data size: 8242 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string), _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5096 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4635,7 +4423,7 @@ STAGE PLANS:
                       sort order: ++
                       Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                       Statistics: Num rows: 3 Data size: 675 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5318,9 +5106,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
         Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 4 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5349,7 +5137,6 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: depts_n3
-                  filterExpr: name is not null (type: boolean)
                   Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: name is not null (type: boolean)
@@ -5368,13 +5155,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: depts_n3
-                  Statistics: Num rows: 3 Data size: 279 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: name (type: string)
                     outputColumnNames: name
@@ -5452,7 +5232,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col1 (type: string)
                     Statistics: Num rows: 1 Data size: 101 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5696,7 +5476,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 7 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
         Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
@@ -5706,7 +5486,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: src
-                  filterExpr: ((key > '8') or (key > '9')) (type: boolean)
+                  filterExpr: ((key > '8') or (key > '9') or (key > '8')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '8') (type: boolean)
@@ -5739,14 +5519,6 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: (key > '8') (type: boolean)
-                  Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key > '8') (type: boolean)
                     Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5882,8 +5654,8 @@ having count(*) > (select count(*) from src s1 where s1.key > '9' )
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
-Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
-Warning: Shuffle Join MERGEJOIN[39][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[38][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[39][tables = [$hdt$_1, $hdt$_2, $hdt$_0]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain  select * from part where p_size > (select max(p_size) from part group by p_type)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@part
@@ -5901,18 +5673,30 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 4 <- Map 8 (XPROD_EDGE), Reducer 3 (XPROD_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: p_size is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_partkey (type: int), p_name (type: string), p_mfgr (type: string), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                      Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: p_type, p_size
@@ -5931,13 +5715,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string)
                     outputColumnNames: p_type
@@ -5956,27 +5733,30 @@ STAGE PLANS:
                         Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_size is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_size is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: p_partkey (type: int), p_name (type: string), p_mfgr (type: string), p_brand (type: string), p_type (type: string), p_size (type: int), p_container (type: string), p_retailprice (type: double), p_comment (type: string)
-                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                      Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
         Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
+                residual filter predicates: {(_col7 > _col0)}
+                Statistics: Num rows: 112 Data size: 69776 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col2 (type: int), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: string), _col9 (type: double), _col10 (type: string)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                  Statistics: Num rows: 112 Data size: 69328 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 112 Data size: 69328 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6001,7 +5781,7 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-        Reducer 3 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6017,30 +5797,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int)
-        Reducer 4 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
-                residual filter predicates: {(_col7 > _col0)}
-                Statistics: Num rows: 112 Data size: 69776 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col2 (type: int), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: int), _col8 (type: string), _col9 (type: double), _col10 (type: string)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                  Statistics: Num rows: 112 Data size: 69328 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 112 Data size: 69328 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6061,7 +5818,7 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6102,17 +5859,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: part
-                  filterExpr: (p_type is not null and p_size is not null) (type: boolean)
+                  filterExpr: ((p_type is not null and p_size is not null) or p_type is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_type is not null and p_size is not null) (type: boolean)
@@ -6128,14 +5885,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col4 (type: string)
                         Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6151,14 +5900,6 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6219,7 +5960,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6246,7 +5987,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6280,7 +6021,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select * from part where p_size <>
     (select count(p_size) from part pp where part.p_type <> pp.p_type)
 PREHOOK: type: QUERY
@@ -6300,10 +6041,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6322,13 +6063,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col4 (type: string)
                       Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col3 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_type (type: string), p_size (type: int)
                     outputColumnNames: _col0, _col1
@@ -6338,14 +6072,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6388,7 +6114,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6418,7 +6144,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6438,7 +6164,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col2 (type: string)
                     Statistics: Num rows: 13 Data size: 1508 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint), _col1 (type: boolean)
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6458,7 +6184,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select * from part where p_size <>
     (select count(p_size) from part pp where part.p_type <> pp.p_type)
 PREHOOK: type: QUERY
@@ -6512,7 +6238,7 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t_n11
 POSTHOOK: Lineage: t_n11.i SCRIPT []
 POSTHOOK: Lineage: t_n11.j SCRIPT []
-Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain select * from t_n11 where 0 = (select count(*) from t_n11 tt_n11 where tt_n11.j <> t_n11.i)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t_n11
@@ -6530,10 +6256,10 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6552,13 +6278,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: tt_n11
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: j (type: int)
                     outputColumnNames: _col0
@@ -6568,14 +6287,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: t_n11
-                  filterExpr: i is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: i is not null (type: boolean)
                     Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6618,7 +6329,7 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -6648,7 +6359,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6668,7 +6379,7 @@ STAGE PLANS:
                     Map-reduce partition columns: _col2 (type: int)
                     Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint), _col1 (type: boolean)
-        Reducer 7 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -6688,7 +6399,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
+Warning: Shuffle Join MERGEJOIN[33][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: select * from t_n11 where 0 = (select count(*) from t_n11 tt_n11 where tt_n11.j <> t_n11.i)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t_n11
@@ -6717,9 +6428,9 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 6 (XPROD_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -6750,14 +6461,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: t_n11
-                  filterExpr: i is not null (type: boolean)
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: i is not null (type: boolean)
                     Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -6845,7 +6548,7 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -7176,8 +6879,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -7203,13 +6906,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 250 Data size: 23750 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: s1
-                  Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -7268,7 +6964,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_select.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_select.q.out
@@ -641,37 +641,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_type is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: p_type (type: string)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: string)
-                        Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
             Map Operator Tree:
                 TableScan
                   alias: p
@@ -721,30 +698,69 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
+                  Filter Operator
+                    predicate: p_type is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: p_type (type: string)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: string)
+                        Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
+                aggregations: max(VALUE._col0)
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
-                Group By Operator
-                  aggregations: count()
-                  keys: _col0 (type: string)
-                  mode: complete
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: string)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col0 (type: string)
-                    Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: bigint)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col1 is not null (type: boolean)
+                  Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: int), true (type: boolean), _col0 (type: string)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col2 (type: string)
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col2 (type: string)
+                      Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: boolean)
         Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col1 (type: int), _col0 (type: string)
+                  1 _col0 (type: int), _col2 (type: string)
+                outputColumnNames: _col1, _col2, _col4, _col5, _col6, _col8
+                Statistics: Num rows: 13 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: int), ((_col5 or _col4 is null) is true or ((_col2 or _col6) is true and null and (_col5 or _col4 is null) is not true and _col8 is null) or ((_col5 or _col4 is null) is not true and _col8 is null and (_col2 or _col6) is not true)) (type: boolean)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -769,7 +785,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 10 Data size: 1120 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int), _col2 (type: boolean)
-        Reducer 4 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -787,52 +803,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: int), _col0 (type: string)
                   Statistics: Num rows: 10 Data size: 1280 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: boolean), _col4 (type: bigint), _col5 (type: boolean), _col6 (type: boolean)
-        Reducer 5 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col1 (type: int), _col0 (type: string)
-                  1 _col0 (type: int), _col2 (type: string)
-                outputColumnNames: _col1, _col2, _col4, _col5, _col6, _col8
-                Statistics: Num rows: 13 Data size: 356 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: int), ((_col5 or _col4 is null) is true or ((_col2 or _col6) is true and null and (_col5 or _col4 is null) is not true and _col8 is null) or ((_col5 or _col4 is null) is not true and _col8 is null and (_col2 or _col6) is not true)) (type: boolean)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  File Output Operator
-                    compressed: false
-                    Statistics: Num rows: 13 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    table:
-                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: max(VALUE._col0)
-                keys: KEY._col0 (type: string)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: _col1 is not null (type: boolean)
-                  Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col1 (type: int), true (type: boolean), _col0 (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int), _col2 (type: string)
-                      null sort order: zz
-                      sort order: ++
-                      Map-reduce partition columns: _col0 (type: int), _col2 (type: string)
-                      Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: boolean)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -858,6 +829,27 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 6 Data size: 720 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: bigint), _col2 (type: boolean), _col3 (type: boolean)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 13 Data size: 1352 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: count()
+                  keys: _col0 (type: string)
+                  mode: complete
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: string)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col0 (type: string)
+                    Statistics: Num rows: 6 Data size: 672 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col1 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -923,8 +915,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -941,13 +933,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -986,7 +971,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1066,8 +1051,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1086,14 +1071,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1133,7 +1110,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1215,8 +1192,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1233,13 +1210,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -1278,7 +1248,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1358,8 +1328,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1378,14 +1348,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1425,7 +1387,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1504,8 +1466,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1524,14 +1486,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1573,7 +1527,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1651,8 +1605,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -1671,14 +1625,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 3250 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 5850 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1720,7 +1666,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -1940,15 +1886,14 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (XPROD_EDGE), Reducer 4 (XPROD_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: ((value is not null and key is not null) or ((key > '9') and value is not null)) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (value is not null and key is not null) (type: boolean)
@@ -1975,13 +1920,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: src
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: string)
                     outputColumnNames: key
@@ -2040,7 +1978,7 @@ STAGE PLANS:
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                     Statistics: Num rows: 83 Data size: 22825 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3089,9 +3027,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3108,13 +3046,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Top N Key Operator
                     sort order: +
                     keys: p_size (type: int)
@@ -3163,7 +3094,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -3248,12 +3179,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (XPROD_EDGE), Reducer 9 (XPROD_EDGE)
-        Reducer 7 <- Map 6 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (XPROD_EDGE), Reducer 7 (XPROD_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3272,14 +3203,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 26 Data size: 6162 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: string), _col2 (type: int), _col3 (type: boolean), _col4 (type: boolean)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3297,13 +3220,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string)
                         Statistics: Num rows: 13 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3146 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_name (type: string)
                     outputColumnNames: p_name
@@ -3395,7 +3311,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3435,7 +3351,7 @@ STAGE PLANS:
                       Map-reduce partition columns: _col2 (type: string), _col0 (type: int)
                       Statistics: Num rows: 13 Data size: 1456 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: boolean)
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3538,8 +3454,8 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -3558,14 +3474,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: p_type is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_type is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2704 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3605,7 +3513,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -3693,7 +3601,7 @@ STAGE PLANS:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (XPROD_EDGE), Reducer 8 (XPROD_EDGE)
         Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 9 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 5 (SIMPLE_EDGE)
         Reducer 8 <- Reducer 7 (CUSTOM_SIMPLE_EDGE)
@@ -3730,13 +3638,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -3984,12 +3885,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 9 (CUSTOM_SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Map 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4003,14 +3904,6 @@ STAGE PLANS:
                       null sort order: 
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_size BETWEEN 1 AND 20 (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_size BETWEEN 1 AND 20 (type: boolean)
                     Statistics: Num rows: 25 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4027,14 +3920,6 @@ STAGE PLANS:
                           sort order: 
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_partkey BETWEEN 1 AND 20 (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey BETWEEN 1 AND 20 (type: boolean)
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4049,14 +3934,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint), _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 9 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  filterExpr: p_partkey BETWEEN 10000 AND 20000 (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey BETWEEN 10000 AND 20000 (type: boolean)
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4077,23 +3954,6 @@ STAGE PLANS:
                           value expressions: _col0 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: max(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: UDFToDouble(_col0) (type: double)
-                  outputColumnNames: _col0
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    null sort order: 
-                    sort order: 
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: double)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -4148,7 +4008,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 6 
+        Reducer 5 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4165,7 +4025,7 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: boolean)
-        Reducer 8 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4175,6 +4035,23 @@ STAGE PLANS:
                 Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: (UDFToDouble(_col0) / _col1) (type: double)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    null sort order: 
+                    sort order: 
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: double)
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: max(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: UDFToDouble(_col0) (type: double)
                   outputColumnNames: _col0
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
@@ -4263,8 +4140,8 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Map 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4287,13 +4164,6 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     Statistics: Num rows: 26 Data size: 3147 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
@@ -4348,7 +4218,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4382,7 +4252,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@part
 #### A masked pattern was here ####
 true
-Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: explain select o.p_size, (select count(distinct p_type) from part p where p.p_partkey = o.p_partkey) tmp
     FROM part o right join (select * from part where p_size > (select avg(p_size) from part)) t on t.p_partkey = o.p_partkey
 PREHOOK: type: QUERY
@@ -4402,40 +4272,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Map 6 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
-        Reducer 4 <- Map 6 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
-        Reducer 8 <- Map 7 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (XPROD_EDGE), Reducer 5 (XPROD_EDGE)
+        Reducer 5 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: p_size (type: int)
-                    outputColumnNames: p_size
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      aggregations: sum(p_size), count(p_size)
-                      minReductionHashAggr: 0.96153843
-                      mode: hash
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        null sort order: 
-                        sort order: 
-                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col0 (type: bigint), _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
                   alias: o
-                  filterExpr: (p_partkey is not null or UDFToDouble(p_size) is not null) (type: boolean)
                   Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
@@ -4463,14 +4310,21 @@ STAGE PLANS:
                         sort order: 
                         Statistics: Num rows: 26 Data size: 312 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: int), _col1 (type: double)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: p_size (type: int)
+                    outputColumnNames: p_size
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: sum(p_size), count(p_size)
+                      minReductionHashAggr: 0.96153843
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        null sort order: 
+                        sort order: 
+                        Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint), _col1 (type: bigint)
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4489,44 +4343,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: sum(VALUE._col0), count(VALUE._col1)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: (_col1 is not null and UDFToDouble(_col0) is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: (UDFToDouble(_col0) / _col1) (type: double)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      null sort order: 
-                      sort order: 
-                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: double)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 
-                  1 
-                outputColumnNames: _col0, _col1, _col2
-                residual filter predicates: {(_col1 > _col2)}
-                Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col0 (type: int)
-                  Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4544,7 +4360,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col3 (type: int)
                   Statistics: Num rows: 16 Data size: 72 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col4 (type: int)
-        Reducer 5 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -4566,7 +4382,45 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 8 
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 
+                  1 
+                outputColumnNames: _col0, _col1, _col2
+                residual filter predicates: {(_col1 > _col2)}
+                Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col0 (type: int)
+                  Statistics: Num rows: 8 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), count(VALUE._col1)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (_col1 is not null and UDFToDouble(_col0) is not null) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: (UDFToDouble(_col0) / _col1) (type: double)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      null sort order: 
+                      sort order: 
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: double)
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4598,7 +4452,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[55][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 4' is a cross product
 PREHOOK: query: select o.p_size, (select count(distinct p_type) from part p where p.p_partkey = o.p_partkey) tmp
     FROM part o right join (select * from part where p_size > (select avg(p_size) from part)) t on t.p_partkey = o.p_partkey
 PREHOOK: type: QUERY
@@ -4645,14 +4499,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
-        Reducer 5 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 8 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4666,13 +4520,6 @@ STAGE PLANS:
                       null sort order: 
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 6 
-            Map Operator Tree:
-                TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: p_size (type: int)
                     outputColumnNames: p_size
@@ -4723,19 +4570,6 @@ STAGE PLANS:
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: sum(VALUE._col0)
-                mode: mergepartial
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint)
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -4806,7 +4640,7 @@ STAGE PLANS:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4819,7 +4653,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int)
-        Reducer 8 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4832,7 +4666,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -4849,6 +4683,19 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: double)
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator
@@ -4920,9 +4767,9 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4939,14 +4786,6 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_size is not null and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_type is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4962,7 +4801,7 @@ STAGE PLANS:
                         Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 6 
+        Map 5 
             Map Operator Tree:
                 TableScan
                   alias: pp
@@ -5001,7 +4840,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5022,7 +4861,7 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint)
-        Reducer 5 
+        Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5107,13 +4946,13 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 12 <- Map 11 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 5 <- Map 10 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 12 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5130,14 +4969,35 @@ STAGE PLANS:
                       sort order: 
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: (p_size is not null and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_partkey (type: int), p_type (type: string), p_size (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: int)
+                  Filter Operator
+                    predicate: p_partkey is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: p_partkey (type: int)
+                      minReductionHashAggr: 0.5
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (p_size is not null and p_type is not null) (type: boolean)
                     Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5151,14 +5011,6 @@ STAGE PLANS:
                         sort order: ++
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
                         Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: a1
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5178,77 +5030,6 @@ STAGE PLANS:
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: p_partkey (type: int), p_type (type: string), p_size (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: a1
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: p_partkey is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: p_partkey (type: int)
-                      minReductionHashAggr: 0.5
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Reducer 12 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: sum(VALUE._col0)
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col0 (type: int), _col1 (type: bigint)
-                  outputColumnNames: _col1, _col2
-                  Statistics: Num rows: 13 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (_col2 > 0L) (type: boolean)
-                    Statistics: Num rows: 13 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: _col1 (type: int)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 2 
             Execution mode: llap
             Reduce Operator Tree:
@@ -5267,7 +5048,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5285,7 +5066,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                   Statistics: Num rows: 28 Data size: 3136 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int)
-        Reducer 5 
+        Reducer 4 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5302,7 +5083,7 @@ STAGE PLANS:
                   sort order: +
                   Map-reduce partition columns: _col0 (type: int)
                   Statistics: Num rows: 30 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 6 
+        Reducer 5 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5323,7 +5104,7 @@ STAGE PLANS:
                     sort order: 
                     Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: bigint)
-        Reducer 7 
+        Reducer 6 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5336,7 +5117,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint)
-        Reducer 9 
+        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5363,6 +5144,32 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col1 (type: bigint)
+                  outputColumnNames: _col1, _col2
+                  Statistics: Num rows: 13 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (_col2 > 0L) (type: boolean)
+                    Statistics: Num rows: 13 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: _col1 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -5441,17 +5248,17 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 10 <- Map 8 (SIMPLE_EDGE)
-        Reducer 11 <- Map 8 (SIMPLE_EDGE)
-        Reducer 12 <- Map 14 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-        Reducer 13 <- Map 15 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 10 <- Map 1 (SIMPLE_EDGE)
+        Reducer 11 <- Map 1 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+        Reducer 12 <- Map 1 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Map 1 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 13 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 12 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (SIMPLE_EDGE)
+        Reducer 8 <- Map 1 (SIMPLE_EDGE)
+        Reducer 9 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5487,57 +5294,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 14 
-            Map Operator Tree:
-                TableScan
-                  alias: p
-                  filterExpr: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: p_partkey (type: int), p_type (type: string), p_size (type: int)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: string), _col2 (type: int)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 15 
-            Map Operator Tree:
-                TableScan
-                  alias: pp
-                  filterExpr: (p_size is not null and p_type is not null) (type: boolean)
-                  Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (p_size is not null and p_type is not null) (type: boolean)
-                    Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: p_type (type: string), p_size (type: int)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: string), _col1 (type: int)
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
-                        Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: t2
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: p_partkey is not null (type: boolean)
                     Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
@@ -5579,29 +5335,36 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 13 Data size: 52 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (p_size is not null and p_type is not null and p_partkey is not null) (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_partkey (type: int), p_type (type: string), p_size (type: int)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 26 Data size: 2912 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: string), _col2 (type: int)
+                  Filter Operator
+                    predicate: (p_size is not null and p_type is not null) (type: boolean)
+                    Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: p_type (type: string), p_size (type: int)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: string), _col1 (type: int)
+                        null sort order: zz
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: string), _col1 (type: int)
+                        Statistics: Num rows: 26 Data size: 2808 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 10 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Group By Operator
-                aggregations: count(VALUE._col0)
-                keys: KEY._col0 (type: int)
-                mode: mergepartial
-                outputColumnNames: _col0, _col1
-                Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
-                Select Operator
-                  expressions: _col1 (type: bigint), _col0 (type: int)
-                  outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col1 (type: int)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: _col1 (type: int)
-                    Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: bigint)
-        Reducer 11 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5628,7 +5391,7 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
-        Reducer 12 
+        Reducer 11 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5646,7 +5409,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: string), _col2 (type: int)
                   Statistics: Num rows: 28 Data size: 3136 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: int)
-        Reducer 13 
+        Reducer 12 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -5779,7 +5542,7 @@ STAGE PLANS:
                   sort order: 
                   Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint)
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator
@@ -5806,6 +5569,26 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 9 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col1 (type: bigint), _col0 (type: int)
+                  outputColumnNames: _col0, _col1
+                  Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col1 (type: int)
+                    null sort order: z
+                    sort order: +
+                    Map-reduce partition columns: _col1 (type: int)
+                    Statistics: Num rows: 13 Data size: 156 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: bigint)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/subquery_views.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_views.q.out
@@ -109,13 +109,13 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 10 <- Map 1 (SIMPLE_EDGE)
-        Reducer 12 <- Map 11 (SIMPLE_EDGE)
+        Reducer 11 <- Map 1 (SIMPLE_EDGE)
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
         Reducer 5 <- Map 1 (SIMPLE_EDGE)
         Reducer 6 <- Map 1 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 11 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
         Reducer 8 <- Reducer 7 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
         Reducer 9 <- Map 1 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
 #### A masked pattern was here ####
@@ -124,7 +124,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: b
-                  filterExpr: ((key < '11') or ((key < '11') and (value > 'val_11')) or ((key < '11') and (value > 'val_11'))) (type: boolean)
+                  filterExpr: ((key < '11') or ((key < '11') and (value > 'val_11')) or ((key < '11') and (value > 'val_11')) or (key < '11')) (type: boolean)
                   properties:
                     insideView TRUE
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -203,16 +203,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                         Statistics: Num rows: 27 Data size: 5238 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col2 (type: bigint), _col3 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 11 
-            Map Operator Tree:
-                TableScan
-                  alias: b
-                  filterExpr: (key < '11') (type: boolean)
-                  properties:
-                    insideView TRUE
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (key < '11') (type: boolean)
                     Statistics: Num rows: 166 Data size: 14442 Basic stats: COMPLETE Column stats: COMPLETE
@@ -246,7 +236,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
                   Statistics: Num rows: 27 Data size: 5238 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: bigint), _col3 (type: bigint)
-        Reducer 12 
+        Reducer 11 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/tez_self_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_self_join.q.out
@@ -81,7 +81,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
+        Reducer 3 <- Map 4 (XPROD_EDGE), Reducer 2 (XPROD_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -109,7 +109,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: self1
-                  filterExpr: ((id2 = 'ab') and id1 is not null) (type: boolean)
+                  filterExpr: (((id2 = 'ab') and id1 is not null) or (id3 = 'ab')) (type: boolean)
                   Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((id2 = 'ab') and id1 is not null) (type: boolean)
@@ -125,14 +125,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 90 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: self2
-                  filterExpr: (id3 = 'ab') (type: boolean)
-                  Statistics: Num rows: 3 Data size: 258 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (id3 = 'ab') (type: boolean)
                     Statistics: Num rows: 1 Data size: 86 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/unionall_lateralview.q.out
+++ b/ql/src/test/results/clientpositive/llap/unionall_lateralview.q.out
@@ -31,7 +31,7 @@ POSTHOOK: query: CREATE TABLE unionall_lateralview2(col1 INT)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@unionall_lateralview2
-Warning: Shuffle Join MERGEJOIN[38][tables = [x1, expdobj]] in Stage 'Reducer 5' is a cross product
+Warning: Shuffle Join MERGEJOIN[38][tables = [x1, expdobj]] in Stage 'Reducer 6' is a cross product
 PREHOOK: query: INSERT INTO unionall_lateralview2
 SELECT 1 AS `col1`
 FROM unionall_lateralview1

--- a/ql/src/test/results/clientpositive/llap/vector_join30.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_join30.q.out
@@ -3201,7 +3201,7 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 1 <- Map 4 (BROADCAST_EDGE)
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 4 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
@@ -3276,7 +3276,6 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: orcsrc_n0
-                  filterExpr: key is not null (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -3309,31 +3308,6 @@ STAGE PLANS:
                             valueColumns: 1:string
                         Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 2
-                    includeColumns: [0, 1]
-                    dataColumns: key:string, value:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: orcsrc_n0
-                  Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:key:string, 1:value:string, 2:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
                   Select Operator
                     expressions: key (type: string)
                     outputColumnNames: _col0
@@ -3366,7 +3340,7 @@ STAGE PLANS:
                 vectorized: true
                 rowBatchContext:
                     dataColumnCount: 2
-                    includeColumns: [0]
+                    includeColumns: [0, 1]
                     dataColumns: key:string, value:string
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []

--- a/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
@@ -1369,19 +1369,38 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part
-                  Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: p1
+                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: SelectColumnIsNotNull(col 0:int)
+                    predicate: p_partkey is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: p_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: p_partkey (type: int)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          partitionColumns: 0:int
+                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_name (type: string)
                     null sort order: az
@@ -1413,88 +1432,7 @@ STAGE PLANS:
                     dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
-                  Filter Operator
-                    Filter Vectorization:
-                        className: VectorFilterOperator
-                        native: true
-                        predicateExpression: SelectColumnIsNotNull(col 0:int)
-                    predicate: p_partkey is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: p_partkey (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: p_partkey (type: int)
-                      Reduce Sink Vectorization:
-                          className: VectorReduceSinkObjectHashOperator
-                          keyColumns: 0:int
-                          native: true
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                          partitionColumns: 0:int
-                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: no inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 9
-                    includeColumns: [0]
-                    dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: NOOP not supported
-                vectorized: false
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
-                outputColumnNames: _col0, _col1, _col2, _col5, _col7
-                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: part
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        type: TABLE
-                      Partition table definition
-                        input alias: abc
-                        name: noop
-                        order by: _col1 ASC NULLS LAST
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        partition by: _col2
-                        raw input shape:
-                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: _col0 is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -1515,7 +1453,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Vectorization:
                 enabled: true
@@ -1579,6 +1517,42 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: PTF operator: NOOP not supported
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
+                outputColumnNames: _col0, _col1, _col2, _col5, _col7
+                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: part
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        type: TABLE
+                      Partition table definition
+                        input alias: abc
+                        name: noop
+                        order by: _col1 ASC NULLS LAST
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        partition by: _col2
+                        raw input shape:
+                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/vectorized_ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_ptf.q.out
@@ -1549,18 +1549,36 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 4 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part_orc
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: p1
+                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: SelectColumnIsNotNull(col 0:int)
+                    predicate: p_partkey is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: p_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: p_partkey (type: int)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkLongOperator
+                          keyColumns: 0:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_name (type: string)
                     null sort order: az
@@ -1592,51 +1610,28 @@ STAGE PLANS:
                     dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 4 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
-                  Filter Operator
-                    Filter Vectorization:
-                        className: VectorFilterOperator
-                        native: true
-                        predicateExpression: SelectColumnIsNotNull(col 0:int)
-                    predicate: p_partkey is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: p_partkey (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: p_partkey (type: int)
-                      Reduce Sink Vectorization:
-                          className: VectorReduceSinkLongOperator
-                          keyColumns: 0:int
-                          native: true
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 9
-                    includeColumns: [0]
-                    dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
         Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 p_partkey (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            MergeJoin Vectorization:
+                enabled: false
+                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
+        Reducer 3 
             Execution mode: llap
             Reduce Vectorization:
                 enabled: true
@@ -1672,27 +1667,6 @@ STAGE PLANS:
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 26 Data size: 23062 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: int), _col6 (type: string), _col7 (type: double), _col8 (type: string)
-        Reducer 3 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 p_partkey (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
-                Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 27 Data size: 16713 Basic stats: COMPLETE Column stats: COMPLETE
-                  table:
-                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
-                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-            MergeJoin Vectorization:
-                enabled: false
-                enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
 
   Stage: Stage-0
     Fetch Operator
@@ -1775,15 +1749,14 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-        Reducer 4 <- Map 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+        Reducer 3 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
                   Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
@@ -1806,31 +1779,6 @@ STAGE PLANS:
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
                       Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 9
-                    includeColumns: [0]
-                    dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
-        Map 3 
-            Map Operator Tree:
-                TableScan
-                  alias: part_orc
-                  Statistics: Num rows: 26 Data size: 16094 Basic stats: COMPLETE Column stats: COMPLETE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_name (type: string)
                     null sort order: az
@@ -1887,7 +1835,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Vectorization:
                 enabled: true
@@ -3301,19 +3249,37 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE)
-        Reducer 3 <- Map 5 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Map 1 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
-                  alias: part_orc
-                  Statistics: Num rows: 26 Data size: 6110 Basic stats: COMPLETE Column stats: COMPLETE
+                  alias: p1
+                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   TableScan Vectorization:
                       native: true
                       vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: SelectColumnIsNotNull(col 0:int)
+                    predicate: p_partkey is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: p_partkey (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: p_partkey (type: int)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkLongOperator
+                          keyColumns: 0:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: p_mfgr (type: string), p_name (type: string)
                     null sort order: az
@@ -3345,87 +3311,7 @@ STAGE PLANS:
                     dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: p1
-                  filterExpr: p_partkey is not null (type: boolean)
-                  Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                  TableScan Vectorization:
-                      native: true
-                      vectorizationSchemaColumns: [0:p_partkey:int, 1:p_name:string, 2:p_mfgr:string, 3:p_brand:string, 4:p_type:string, 5:p_size:int, 6:p_container:string, 7:p_retailprice:double, 8:p_comment:string, 9:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
-                  Filter Operator
-                    Filter Vectorization:
-                        className: VectorFilterOperator
-                        native: true
-                        predicateExpression: SelectColumnIsNotNull(col 0:int)
-                    predicate: p_partkey is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: p_partkey (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: p_partkey (type: int)
-                      Reduce Sink Vectorization:
-                          className: VectorReduceSinkLongOperator
-                          keyColumns: 0:int
-                          native: true
-                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                      Statistics: Num rows: 26 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-            Map Vectorization:
-                enabled: true
-                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
-                inputFormatFeatureSupport: [DECIMAL_64]
-                featureSupportInUse: [DECIMAL_64]
-                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                allNative: true
-                usesVectorUDFAdaptor: false
-                vectorized: true
-                rowBatchContext:
-                    dataColumnCount: 9
-                    includeColumns: [0]
-                    dataColumns: p_partkey:int, p_name:string, p_mfgr:string, p_brand:string, p_type:string, p_size:int, p_container:string, p_retailprice:double, p_comment:string
-                    partitionColumnCount: 0
-                    scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
-            Reduce Vectorization:
-                enabled: true
-                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: NOOP not supported
-                vectorized: false
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
-                outputColumnNames: _col0, _col1, _col2, _col5, _col7
-                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                PTF Operator
-                  Function definitions:
-                      Input definition
-                        input alias: part_orc
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        type: TABLE
-                      Partition table definition
-                        input alias: abc
-                        name: noop
-                        order by: _col1 ASC NULLS LAST
-                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
-                        partition by: _col2
-                        raw input shape:
-                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: _col0 is not null (type: boolean)
-                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
-        Reducer 3 
             Execution mode: llap
             Reduce Operator Tree:
               Merge Join Operator
@@ -3446,7 +3332,7 @@ STAGE PLANS:
             MergeJoin Vectorization:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
-        Reducer 4 
+        Reducer 3 
             Execution mode: llap
             Reduce Vectorization:
                 enabled: true
@@ -3516,6 +3402,42 @@ STAGE PLANS:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: PTF operator: NOOP not supported
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
+                outputColumnNames: _col0, _col1, _col2, _col5, _col7
+                Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: part_orc
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        type: TABLE
+                      Partition table definition
+                        input alias: abc
+                        name: noop
+                        order by: _col1 ASC NULLS LAST
+                        output shape: _col0: int, _col1: string, _col2: string, _col5: int, _col7: double
+                        partition by: _col2
+                        raw input shape:
+                  Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: _col0 is not null (type: boolean)
+                    Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 26 Data size: 13078 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: string), _col5 (type: int), _col7 (type: double)
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/perf/tez/cbo_query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/cbo_query23.q.out
@@ -1,5 +1,5 @@
-Warning: Shuffle Join MERGEJOIN[454][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 26' is a cross product
-Warning: Shuffle Join MERGEJOIN[456][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 31' is a cross product
+Warning: Shuffle Join MERGEJOIN[454][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 25' is a cross product
+Warning: Shuffle Join MERGEJOIN[456][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 26' is a cross product
 PREHOOK: query: explain cbo
 with frequent_ss_items as 
  (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/cbo_query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/cbo_query23.q.out
@@ -1,5 +1,5 @@
-Warning: Shuffle Join MERGEJOIN[358][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 17' is a cross product
-Warning: Shuffle Join MERGEJOIN[360][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 23' is a cross product
+Warning: Shuffle Join MERGEJOIN[358][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 10' is a cross product
+Warning: Shuffle Join MERGEJOIN[360][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 16' is a cross product
 PREHOOK: query: explain cbo
 with frequent_ss_items as 
  (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
@@ -98,13 +98,13 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 11 <- Map 10 (SIMPLE_EDGE)
+Reducer 10 <- Map 1 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 2 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 2 (CUSTOM_SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-Reducer 6 <- Map 12 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 6 <- Map 11 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 7 <- Map 11 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 3 (SIMPLE_EDGE)
 
@@ -124,7 +124,7 @@ Stage-0
                 Output:["_col0","_col1","_col2"]
                 Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
                   Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
-                <-Map 12 [SIMPLE_EDGE] vectorized
+                <-Map 11 [SIMPLE_EDGE] vectorized
                   SHUFFLE [RS_148]
                     PartitionCols:_col0
                     Select Operator [SEL_146] (rows=462000 width=111)
@@ -136,7 +136,7 @@ Stage-0
                     PartitionCols:_col2
                     Merge Join Operator [MERGEJOIN_117] (rows=6951 width=115)
                       Conds:RS_63._col0=RS_147._col0(Inner),Output:["_col1","_col2","_col5"]
-                    <-Map 12 [SIMPLE_EDGE] vectorized
+                    <-Map 11 [SIMPLE_EDGE] vectorized
                       SHUFFLE [RS_147]
                         PartitionCols:_col0
                          Please refer to the previous Select Operator [SEL_146]
@@ -167,7 +167,7 @@ Stage-0
                                             predicate:(_col1 > (0.9 * _col2))
                                             Merge Join Operator [MERGEJOIN_114] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                            <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_135]
                                                 Select Operator [SEL_134] (rows=1 width=112)
                                                   Output:["_col0"]
@@ -177,36 +177,35 @@ Stage-0
                                                       Output:["_col1","_col2"]
                                                       Group By Operator [GBY_131] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                                      <-Map 10 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_130]
+                                                      <-Map 1 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_126]
                                                           PartitionCols:_col0
-                                                          Group By Operator [GBY_129] (rows=258 width=124)
+                                                          Group By Operator [GBY_124] (rows=258 width=124)
                                                             Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_128] (rows=287946 width=114)
+                                                            Select Operator [SEL_122] (rows=287946 width=114)
                                                               Output:["_col1"]
-                                                              Filter Operator [FIL_127] (rows=287946 width=114)
+                                                              Filter Operator [FIL_120] (rows=287946 width=114)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
-                                                                TableScan [TS_8] (rows=575995635 width=114)
-                                                                  default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_hdemo_sk","ss_store_sk","ss_net_profit"]
+                                                                TableScan [TS_0] (rows=575995635 width=114)
+                                                                  default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_126]
-                                                Select Operator [SEL_125] (rows=62562 width=116)
+                                              PARTITION_ONLY_SHUFFLE [RS_130]
+                                                Select Operator [SEL_129] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_124] (rows=62562 width=124)
+                                                  Filter Operator [FIL_128] (rows=62562 width=124)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_123] (rows=62562 width=124)
+                                                    Group By Operator [GBY_127] (rows=62562 width=124)
                                                       Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
                                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_122]
+                                                      SHUFFLE [RS_125]
                                                         PartitionCols:_col0
-                                                        Group By Operator [GBY_121] (rows=3199976 width=124)
+                                                        Group By Operator [GBY_123] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_120] (rows=6399952 width=114)
+                                                          Select Operator [SEL_121] (rows=6399952 width=114)
                                                             Output:["ss_item_sk","ss_net_profit"]
                                                             Filter Operator [FIL_119] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)
-                                                              TableScan [TS_0] (rows=575995635 width=114)
-                                                                default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit"]
+                                                               Please refer to the previous TableScan [TS_0]
                           <-Reducer 9 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_145]
                               PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query11.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query11.q.out
@@ -173,20 +173,20 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Map 1 <- Reducer 11 (BROADCAST_EDGE)
 Map 25 <- Reducer 15 (BROADCAST_EDGE)
-Map 27 <- Reducer 19 (BROADCAST_EDGE)
-Map 28 <- Reducer 23 (BROADCAST_EDGE)
+Map 26 <- Reducer 19 (BROADCAST_EDGE)
+Map 27 <- Reducer 23 (BROADCAST_EDGE)
 Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE)
 Reducer 12 <- Map 10 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
-Reducer 13 <- Map 26 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 13 <- Map 24 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
 Reducer 15 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Map 10 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 17 <- Map 26 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
+Reducer 16 <- Map 10 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 17 <- Map 24 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
 Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
 Reducer 19 <- Map 10 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
-Reducer 20 <- Map 10 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
-Reducer 21 <- Map 26 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 20 <- Map 10 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
+Reducer 21 <- Map 24 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
 Reducer 22 <- Reducer 21 (SIMPLE_EDGE)
 Reducer 23 <- Map 10 (CUSTOM_SIMPLE_EDGE)
 Reducer 3 <- Map 24 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
@@ -194,7 +194,7 @@ Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 14 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 18 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 22 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 29 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 8 <- Map 24 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -214,14 +214,14 @@ Stage-0
                 Top N Key Operator [TNK_180] (rows=15944136 width=372)
                   keys:_col0, _col2, _col3, _col4,top n:100
                   Merge Join Operator [MERGEJOIN_330] (rows=15944136 width=372)
-                    Conds:RS_99._col0=RS_403._col0(Inner),Output:["_col0","_col2","_col3","_col4"]
-                  <-Map 29 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_403]
+                    Conds:RS_99._col0=RS_370._col0(Inner),Output:["_col0","_col2","_col3","_col4"]
+                  <-Map 24 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_370]
                       PartitionCols:_col0
-                      Select Operator [SEL_402] (rows=80000000 width=372)
+                      Select Operator [SEL_365] (rows=80000000 width=372)
                         Output:["_col0","_col1","_col2","_col3"]
-                        TableScan [TS_97] (rows=80000000 width=372)
-                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_id","c_first_name","c_last_name","c_birth_country"]
+                        TableScan [TS_8] (rows=80000000 width=196)
+                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_birth_country","c_first_name","c_last_name"]
                   <-Reducer 7 [SIMPLE_EDGE]
                     SHUFFLE [RS_99]
                       PartitionCols:_col0
@@ -230,15 +230,15 @@ Stage-0
                         Filter Operator [FIL_95] (rows=13333333 width=552)
                           predicate:CASE WHEN (_col4 is not null) THEN (CASE WHEN (_col9) THEN (((_col6 / _col8) > (_col2 / _col4))) ELSE ((0 > (_col2 / _col4))) END) ELSE (CASE WHEN (_col9) THEN (((_col6 / _col8) > 0)) ELSE (false) END) END
                           Merge Join Operator [MERGEJOIN_329] (rows=26666666 width=552)
-                            Conds:RS_92._col0=RS_401._col0(Inner),Output:["_col0","_col2","_col4","_col6","_col8","_col9"]
+                            Conds:RS_92._col0=RS_403._col0(Inner),Output:["_col0","_col2","_col4","_col6","_col8","_col9"]
                           <-Reducer 22 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_401]
+                            SHUFFLE [RS_403]
                               PartitionCols:_col0
-                              Select Operator [SEL_400] (rows=14325562 width=216)
+                              Select Operator [SEL_402] (rows=14325562 width=216)
                                 Output:["_col0","_col1","_col2"]
-                                Filter Operator [FIL_399] (rows=14325562 width=212)
+                                Filter Operator [FIL_401] (rows=14325562 width=212)
                                   predicate:(_col1 > 0)
-                                  Group By Operator [GBY_398] (rows=42976686 width=212)
+                                  Group By Operator [GBY_400] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                   <-Reducer 21 [SIMPLE_EDGE]
                                     SHUFFLE [RS_82]
@@ -246,19 +246,18 @@ Stage-0
                                       Group By Operator [GBY_81] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_326] (rows=51391963 width=212)
-                                          Conds:RS_77._col1=RS_378._col0(Inner),Output:["_col2","_col5"]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_378]
+                                          Conds:RS_77._col1=RS_369._col0(Inner),Output:["_col2","_col5"]
+                                        <-Map 24 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_369]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_375] (rows=80000000 width=104)
+                                            Select Operator [SEL_364] (rows=80000000 width=104)
                                               Output:["_col0","_col1"]
-                                              TableScan [TS_29] (rows=80000000 width=104)
-                                                default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id"]
+                                               Please refer to the previous TableScan [TS_8]
                                         <-Reducer 20 [SIMPLE_EDGE]
                                           SHUFFLE [RS_77]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_325] (rows=51391963 width=115)
-                                              Conds:RS_397._col0=RS_346._col0(Inner),Output:["_col1","_col2"]
+                                              Conds:RS_399._col0=RS_346._col0(Inner),Output:["_col1","_col2"]
                                             <-Map 10 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_346]
                                                 PartitionCols:_col0
@@ -270,22 +269,22 @@ Stage-0
                                                       Output:["_col0","_col1"]
                                                       TableScan [TS_4] (rows=73049 width=8)
                                                         default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                            <-Map 28 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_397]
+                                            <-Map 27 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_399]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_396] (rows=143930993 width=119)
+                                                Select Operator [SEL_398] (rows=143930993 width=119)
                                                   Output:["_col0","_col1","_col2"]
-                                                  Filter Operator [FIL_395] (rows=143930993 width=231)
+                                                  Filter Operator [FIL_397] (rows=143930993 width=231)
                                                     predicate:(_col0 is not null and _col1 is not null)
-                                                    Select Operator [SEL_394] (rows=144002668 width=231)
+                                                    Select Operator [SEL_396] (rows=144002668 width=231)
                                                       Output:["_col0","_col1","_col2","_col3"]
-                                                      Filter Operator [FIL_393] (rows=144002668 width=231)
+                                                      Filter Operator [FIL_395] (rows=144002668 width=231)
                                                         predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_75_date_dim_d_date_sk_min) AND DynamicValue(RS_75_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_75_date_dim_d_date_sk_bloom_filter)))
                                                         TableScan [TS_64] (rows=144002668 width=231)
                                                           default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_ext_discount_amt","ws_ext_list_price"]
                                                         <-Reducer 23 [BROADCAST_EDGE] vectorized
-                                                          BROADCAST [RS_392]
-                                                            Group By Operator [GBY_391] (rows=1 width=12)
+                                                          BROADCAST [RS_394]
+                                                            Group By Operator [GBY_393] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                             <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_355]
@@ -298,11 +297,11 @@ Stage-0
                             SHUFFLE [RS_92]
                               PartitionCols:_col0
                               Merge Join Operator [MERGEJOIN_328] (rows=26666666 width=436)
-                                Conds:RS_89._col0=RS_390._col0(Inner),Output:["_col0","_col2","_col4","_col6"]
+                                Conds:RS_89._col0=RS_392._col0(Inner),Output:["_col0","_col2","_col4","_col6"]
                               <-Reducer 18 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_390]
+                                SHUFFLE [RS_392]
                                   PartitionCols:_col0
-                                  Group By Operator [GBY_389] (rows=42976686 width=212)
+                                  Group By Operator [GBY_391] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                   <-Reducer 17 [SIMPLE_EDGE]
                                     SHUFFLE [RS_61]
@@ -310,16 +309,16 @@ Stage-0
                                       Group By Operator [GBY_60] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_324] (rows=51391963 width=212)
-                                          Conds:RS_56._col1=RS_377._col0(Inner),Output:["_col2","_col5"]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_377]
+                                          Conds:RS_56._col1=RS_368._col0(Inner),Output:["_col2","_col5"]
+                                        <-Map 24 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_368]
                                             PartitionCols:_col0
-                                             Please refer to the previous Select Operator [SEL_375]
+                                             Please refer to the previous Select Operator [SEL_364]
                                         <-Reducer 16 [SIMPLE_EDGE]
                                           SHUFFLE [RS_56]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_323] (rows=51391963 width=115)
-                                              Conds:RS_388._col0=RS_344._col0(Inner),Output:["_col1","_col2"]
+                                              Conds:RS_390._col0=RS_344._col0(Inner),Output:["_col1","_col2"]
                                             <-Map 10 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_344]
                                                 PartitionCols:_col0
@@ -328,22 +327,22 @@ Stage-0
                                                   Filter Operator [FIL_334] (rows=652 width=8)
                                                     predicate:(_col1 = 2000)
                                                      Please refer to the previous Select Operator [SEL_331]
-                                            <-Map 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_388]
+                                            <-Map 26 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_390]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_387] (rows=143930993 width=119)
+                                                Select Operator [SEL_389] (rows=143930993 width=119)
                                                   Output:["_col0","_col1","_col2"]
-                                                  Filter Operator [FIL_386] (rows=143930993 width=231)
+                                                  Filter Operator [FIL_388] (rows=143930993 width=231)
                                                     predicate:(_col0 is not null and _col1 is not null)
-                                                    Select Operator [SEL_385] (rows=144002668 width=231)
+                                                    Select Operator [SEL_387] (rows=144002668 width=231)
                                                       Output:["_col0","_col1","_col2","_col3"]
-                                                      Filter Operator [FIL_384] (rows=144002668 width=231)
+                                                      Filter Operator [FIL_386] (rows=144002668 width=231)
                                                         predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_54_date_dim_d_date_sk_min) AND DynamicValue(RS_54_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_54_date_dim_d_date_sk_bloom_filter)))
                                                         TableScan [TS_43] (rows=144002668 width=231)
                                                           default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_ext_discount_amt","ws_ext_list_price"]
                                                         <-Reducer 19 [BROADCAST_EDGE] vectorized
-                                                          BROADCAST [RS_383]
-                                                            Group By Operator [GBY_382] (rows=1 width=12)
+                                                          BROADCAST [RS_385]
+                                                            Group By Operator [GBY_384] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                             <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_354]
@@ -356,13 +355,13 @@ Stage-0
                                 SHUFFLE [RS_89]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_327] (rows=26666666 width=324)
-                                    Conds:RS_367._col0=RS_381._col0(Inner),Output:["_col0","_col2","_col4"]
+                                    Conds:RS_373._col0=RS_383._col0(Inner),Output:["_col0","_col2","_col4"]
                                   <-Reducer 14 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_381]
+                                    SHUFFLE [RS_383]
                                       PartitionCols:_col0
-                                      Filter Operator [FIL_380] (rows=22300081 width=212)
+                                      Filter Operator [FIL_382] (rows=22300081 width=212)
                                         predicate:(_col1 > 0)
-                                        Group By Operator [GBY_379] (rows=66900244 width=212)
+                                        Group By Operator [GBY_381] (rows=66900244 width=212)
                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                         <-Reducer 13 [SIMPLE_EDGE]
                                           SHUFFLE [RS_39]
@@ -370,16 +369,16 @@ Stage-0
                                             Group By Operator [GBY_38] (rows=80000000 width=212)
                                               Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                               Merge Join Operator [MERGEJOIN_322] (rows=187573258 width=212)
-                                                Conds:RS_34._col1=RS_376._col0(Inner),Output:["_col2","_col5"]
-                                              <-Map 26 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_376]
+                                                Conds:RS_34._col1=RS_367._col0(Inner),Output:["_col2","_col5"]
+                                              <-Map 24 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_367]
                                                   PartitionCols:_col0
-                                                   Please refer to the previous Select Operator [SEL_375]
+                                                   Please refer to the previous Select Operator [SEL_364]
                                               <-Reducer 12 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_34]
                                                   PartitionCols:_col1
                                                   Merge Join Operator [MERGEJOIN_321] (rows=187573258 width=115)
-                                                    Conds:RS_374._col0=RS_342._col0(Inner),Output:["_col1","_col2"]
+                                                    Conds:RS_380._col0=RS_342._col0(Inner),Output:["_col1","_col2"]
                                                   <-Map 10 [SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_342]
                                                       PartitionCols:_col0
@@ -389,21 +388,21 @@ Stage-0
                                                           predicate:(_col1 = 1999)
                                                            Please refer to the previous Select Operator [SEL_331]
                                                   <-Map 25 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_374]
+                                                    SHUFFLE [RS_380]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_373] (rows=525327388 width=119)
+                                                      Select Operator [SEL_379] (rows=525327388 width=119)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_372] (rows=525327388 width=221)
+                                                        Filter Operator [FIL_378] (rows=525327388 width=221)
                                                           predicate:(_col0 is not null and _col1 is not null)
-                                                          Select Operator [SEL_371] (rows=575995635 width=221)
+                                                          Select Operator [SEL_377] (rows=575995635 width=221)
                                                             Output:["_col0","_col1","_col2","_col3"]
-                                                            Filter Operator [FIL_370] (rows=575995635 width=221)
+                                                            Filter Operator [FIL_376] (rows=575995635 width=221)
                                                               predicate:(ss_sold_date_sk BETWEEN DynamicValue(RS_32_date_dim_d_date_sk_min) AND DynamicValue(RS_32_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_32_date_dim_d_date_sk_bloom_filter)))
                                                               TableScan [TS_21] (rows=575995635 width=221)
                                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_ext_discount_amt","ss_ext_list_price"]
                                                               <-Reducer 15 [BROADCAST_EDGE] vectorized
-                                                                BROADCAST [RS_369]
-                                                                  Group By Operator [GBY_368] (rows=1 width=12)
+                                                                BROADCAST [RS_375]
+                                                                  Group By Operator [GBY_374] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                   <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                     PARTITION_ONLY_SHUFFLE [RS_353]
@@ -413,11 +412,11 @@ Stage-0
                                                                           Output:["_col0"]
                                                                            Please refer to the previous Select Operator [SEL_337]
                                   <-Reducer 4 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_367]
+                                    SHUFFLE [RS_373]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_366] (rows=80000000 width=304)
+                                      Select Operator [SEL_372] (rows=80000000 width=304)
                                         Output:["_col0","_col2"]
-                                        Group By Operator [GBY_365] (rows=80000000 width=304)
+                                        Group By Operator [GBY_371] (rows=80000000 width=304)
                                           Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
                                         <-Reducer 3 [SIMPLE_EDGE]
                                           SHUFFLE [RS_18]
@@ -425,14 +424,13 @@ Stage-0
                                             Group By Operator [GBY_17] (rows=80000000 width=304)
                                               Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)"],keys:_col5, _col8
                                               Merge Join Operator [MERGEJOIN_320] (rows=187573258 width=304)
-                                                Conds:RS_13._col1=RS_364._col0(Inner),Output:["_col2","_col5","_col8"]
+                                                Conds:RS_13._col1=RS_366._col0(Inner),Output:["_col2","_col5","_col8"]
                                               <-Map 24 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_364]
+                                                SHUFFLE [RS_366]
                                                   PartitionCols:_col0
                                                   Select Operator [SEL_363] (rows=80000000 width=196)
                                                     Output:["_col0","_col1","_col4"]
-                                                    TableScan [TS_8] (rows=80000000 width=196)
-                                                      default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_birth_country"]
+                                                     Please refer to the previous TableScan [TS_8]
                                               <-Reducer 2 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_13]
                                                   PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query14.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query14.q.out
@@ -223,75 +223,71 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 12 (BROADCAST_EDGE)
-Map 49 <- Reducer 52 (BROADCAST_EDGE)
-Map 67 <- Reducer 54 (BROADCAST_EDGE)
-Map 68 <- Reducer 56 (BROADCAST_EDGE)
-Map 69 <- Reducer 60 (BROADCAST_EDGE)
-Map 70 <- Reducer 75 (BROADCAST_EDGE)
-Map 76 <- Reducer 81 (BROADCAST_EDGE)
-Map 82 <- Reducer 19 (BROADCAST_EDGE)
-Map 83 <- Reducer 26 (BROADCAST_EDGE)
+Map 64 <- Reducer 45 (BROADCAST_EDGE)
+Map 65 <- Reducer 52 (BROADCAST_EDGE)
+Map 66 <- Reducer 71 (BROADCAST_EDGE)
+Map 72 <- Reducer 77 (BROADCAST_EDGE)
+Map 78 <- Reducer 19 (BROADCAST_EDGE)
+Map 79 <- Reducer 26 (BROADCAST_EDGE)
 Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
 Reducer 12 <- Map 11 (CUSTOM_SIMPLE_EDGE)
-Reducer 13 <- Map 11 (SIMPLE_EDGE), Map 82 (SIMPLE_EDGE)
-Reducer 14 <- Map 27 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (SIMPLE_EDGE), Reducer 39 (SIMPLE_EDGE)
-Reducer 16 <- Map 27 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
+Reducer 13 <- Map 11 (SIMPLE_EDGE), Map 78 (SIMPLE_EDGE)
+Reducer 14 <- Map 62 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (SIMPLE_EDGE), Reducer 35 (SIMPLE_EDGE)
+Reducer 16 <- Map 62 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
 Reducer 17 <- Reducer 16 (SIMPLE_EDGE)
-Reducer 18 <- Reducer 17 (CUSTOM_SIMPLE_EDGE), Reducer 63 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+Reducer 18 <- Reducer 17 (CUSTOM_SIMPLE_EDGE), Reducer 58 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
 Reducer 19 <- Map 11 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-Reducer 20 <- Map 11 (SIMPLE_EDGE), Map 83 (SIMPLE_EDGE)
-Reducer 21 <- Map 27 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
-Reducer 22 <- Reducer 21 (SIMPLE_EDGE), Reducer 42 (SIMPLE_EDGE)
-Reducer 23 <- Map 27 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
+Reducer 20 <- Map 11 (SIMPLE_EDGE), Map 79 (SIMPLE_EDGE)
+Reducer 21 <- Map 62 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 22 <- Reducer 21 (SIMPLE_EDGE), Reducer 38 (SIMPLE_EDGE)
+Reducer 23 <- Map 62 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 24 <- Reducer 23 (SIMPLE_EDGE)
-Reducer 25 <- Reducer 24 (CUSTOM_SIMPLE_EDGE), Reducer 66 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+Reducer 25 <- Reducer 24 (CUSTOM_SIMPLE_EDGE), Reducer 61 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
 Reducer 26 <- Map 11 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 27 (SIMPLE_EDGE), Reducer 50 (SIMPLE_EDGE)
+Reducer 27 <- Map 11 (SIMPLE_EDGE), Map 63 (SIMPLE_EDGE)
+Reducer 28 <- Map 62 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
 Reducer 29 <- Reducer 28 (SIMPLE_EDGE), Union 30 (CONTAINS)
-Reducer 3 <- Map 27 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Map 62 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 31 <- Union 30 (SIMPLE_EDGE)
-Reducer 32 <- Map 27 (SIMPLE_EDGE), Reducer 53 (SIMPLE_EDGE)
-Reducer 33 <- Reducer 32 (SIMPLE_EDGE), Union 30 (CONTAINS)
-Reducer 34 <- Map 27 (SIMPLE_EDGE), Reducer 55 (SIMPLE_EDGE)
-Reducer 35 <- Reducer 34 (SIMPLE_EDGE), Union 30 (CONTAINS)
-Reducer 36 <- Map 27 (SIMPLE_EDGE), Reducer 50 (SIMPLE_EDGE)
-Reducer 37 <- Reducer 36 (SIMPLE_EDGE), Union 38 (CONTAINS)
-Reducer 39 <- Union 38 (SIMPLE_EDGE)
+Reducer 32 <- Map 62 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
+Reducer 33 <- Reducer 32 (SIMPLE_EDGE), Union 34 (CONTAINS)
+Reducer 35 <- Union 34 (SIMPLE_EDGE)
+Reducer 36 <- Reducer 32 (SIMPLE_EDGE), Union 37 (CONTAINS)
+Reducer 38 <- Union 37 (SIMPLE_EDGE)
+Reducer 39 <- Map 11 (SIMPLE_EDGE), Map 64 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE)
-Reducer 40 <- Reducer 36 (SIMPLE_EDGE), Union 41 (CONTAINS)
-Reducer 42 <- Union 41 (SIMPLE_EDGE)
-Reducer 43 <- Map 27 (SIMPLE_EDGE), Reducer 53 (SIMPLE_EDGE)
-Reducer 44 <- Reducer 43 (SIMPLE_EDGE), Union 38 (CONTAINS)
-Reducer 45 <- Reducer 43 (SIMPLE_EDGE), Union 41 (CONTAINS)
-Reducer 46 <- Map 27 (SIMPLE_EDGE), Reducer 55 (SIMPLE_EDGE)
-Reducer 47 <- Reducer 46 (SIMPLE_EDGE), Union 38 (CONTAINS)
-Reducer 48 <- Reducer 46 (SIMPLE_EDGE), Union 41 (CONTAINS)
-Reducer 5 <- Map 27 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-Reducer 50 <- Map 49 (SIMPLE_EDGE), Map 51 (SIMPLE_EDGE)
-Reducer 52 <- Map 51 (CUSTOM_SIMPLE_EDGE)
-Reducer 53 <- Map 51 (SIMPLE_EDGE), Map 67 (SIMPLE_EDGE)
-Reducer 54 <- Map 51 (CUSTOM_SIMPLE_EDGE)
-Reducer 55 <- Map 51 (SIMPLE_EDGE), Map 68 (SIMPLE_EDGE)
-Reducer 56 <- Map 51 (CUSTOM_SIMPLE_EDGE)
-Reducer 57 <- Map 51 (SIMPLE_EDGE), Map 69 (SIMPLE_EDGE), Union 58 (CONTAINS)
-Reducer 59 <- Union 58 (CUSTOM_SIMPLE_EDGE)
+Reducer 40 <- Map 62 (SIMPLE_EDGE), Reducer 39 (SIMPLE_EDGE)
+Reducer 41 <- Reducer 40 (SIMPLE_EDGE), Union 30 (CONTAINS)
+Reducer 42 <- Map 62 (SIMPLE_EDGE), Reducer 39 (SIMPLE_EDGE)
+Reducer 43 <- Reducer 42 (SIMPLE_EDGE), Union 34 (CONTAINS)
+Reducer 44 <- Reducer 42 (SIMPLE_EDGE), Union 37 (CONTAINS)
+Reducer 45 <- Map 11 (CUSTOM_SIMPLE_EDGE)
+Reducer 46 <- Map 11 (SIMPLE_EDGE), Map 65 (SIMPLE_EDGE)
+Reducer 47 <- Map 62 (SIMPLE_EDGE), Reducer 46 (SIMPLE_EDGE)
+Reducer 48 <- Reducer 47 (SIMPLE_EDGE), Union 30 (CONTAINS)
+Reducer 49 <- Map 62 (SIMPLE_EDGE), Reducer 46 (SIMPLE_EDGE)
+Reducer 5 <- Map 62 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 50 <- Reducer 49 (SIMPLE_EDGE), Union 34 (CONTAINS)
+Reducer 51 <- Reducer 49 (SIMPLE_EDGE), Union 37 (CONTAINS)
+Reducer 52 <- Map 11 (CUSTOM_SIMPLE_EDGE)
+Reducer 53 <- Map 11 (SIMPLE_EDGE), Map 63 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 55 <- Union 54 (CUSTOM_SIMPLE_EDGE)
+Reducer 56 <- Map 11 (SIMPLE_EDGE), Map 63 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 58 <- Union 57 (CUSTOM_SIMPLE_EDGE)
+Reducer 59 <- Map 11 (SIMPLE_EDGE), Map 63 (SIMPLE_EDGE), Union 60 (CONTAINS)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-Reducer 60 <- Map 51 (CUSTOM_SIMPLE_EDGE)
-Reducer 61 <- Map 51 (SIMPLE_EDGE), Map 69 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 63 <- Union 62 (CUSTOM_SIMPLE_EDGE)
-Reducer 64 <- Map 51 (SIMPLE_EDGE), Map 69 (SIMPLE_EDGE), Union 65 (CONTAINS)
-Reducer 66 <- Union 65 (CUSTOM_SIMPLE_EDGE)
-Reducer 7 <- Reducer 59 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
-Reducer 71 <- Map 70 (SIMPLE_EDGE), Map 74 (SIMPLE_EDGE), Union 58 (CONTAINS)
-Reducer 72 <- Map 70 (SIMPLE_EDGE), Map 74 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 73 <- Map 70 (SIMPLE_EDGE), Map 74 (SIMPLE_EDGE), Union 65 (CONTAINS)
-Reducer 75 <- Map 74 (CUSTOM_SIMPLE_EDGE)
-Reducer 77 <- Map 76 (SIMPLE_EDGE), Map 80 (SIMPLE_EDGE), Union 58 (CONTAINS)
-Reducer 78 <- Map 76 (SIMPLE_EDGE), Map 80 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 79 <- Map 76 (SIMPLE_EDGE), Map 80 (SIMPLE_EDGE), Union 65 (CONTAINS)
-Reducer 81 <- Map 80 (CUSTOM_SIMPLE_EDGE)
+Reducer 61 <- Union 60 (CUSTOM_SIMPLE_EDGE)
+Reducer 67 <- Map 66 (SIMPLE_EDGE), Map 70 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 68 <- Map 66 (SIMPLE_EDGE), Map 70 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 69 <- Map 66 (SIMPLE_EDGE), Map 70 (SIMPLE_EDGE), Union 60 (CONTAINS)
+Reducer 7 <- Reducer 55 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE), Union 8 (CONTAINS)
+Reducer 71 <- Map 70 (CUSTOM_SIMPLE_EDGE)
+Reducer 73 <- Map 72 (SIMPLE_EDGE), Map 76 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 74 <- Map 72 (SIMPLE_EDGE), Map 76 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 75 <- Map 72 (SIMPLE_EDGE), Map 76 (SIMPLE_EDGE), Union 60 (CONTAINS)
+Reducer 77 <- Map 76 (CUSTOM_SIMPLE_EDGE)
 Reducer 9 <- Union 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -299,16 +295,16 @@ Stage-0
     limit:100
     Stage-1
       Reducer 10 vectorized
-      File Output Operator [FS_1345]
-        Limit [LIM_1344] (rows=100 width=220)
+      File Output Operator [FS_1359]
+        Limit [LIM_1358] (rows=100 width=220)
           Number of rows:100
-          Select Operator [SEL_1343] (rows=205 width=220)
+          Select Operator [SEL_1357] (rows=205 width=220)
             Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
           <-Reducer 9 [SIMPLE_EDGE] vectorized
-            SHUFFLE [RS_1342]
-              Select Operator [SEL_1341] (rows=205 width=220)
+            SHUFFLE [RS_1356]
+              Select Operator [SEL_1355] (rows=205 width=220)
                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                Group By Operator [GBY_1340] (rows=205 width=228)
+                Group By Operator [GBY_1354] (rows=205 width=228)
                   Output:["_col0","_col1","_col2","_col3","_col5","_col6"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4
                 <-Union 8 [SIMPLE_EDGE]
                   <-Reducer 18 [CONTAINS]
@@ -325,10 +321,10 @@ Stage-0
                               Merge Join Operator [MERGEJOIN_1179] (rows=72 width=243)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                               <-Reducer 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1357]
-                                  Filter Operator [FIL_1356] (rows=72 width=131)
+                                PARTITION_ONLY_SHUFFLE [RS_1371]
+                                  Filter Operator [FIL_1370] (rows=72 width=131)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1355] (rows=72 width=131)
+                                    Group By Operator [GBY_1369] (rows=72 width=131)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 16 [SIMPLE_EDGE]
                                       SHUFFLE [RS_236]
@@ -338,11 +334,11 @@ Stage-0
                                           Select Operator [SEL_233] (rows=12217 width=10)
                                             Output:["_col0","_col1","_col2","_col3"]
                                             Merge Join Operator [MERGEJOIN_1152] (rows=12217 width=10)
-                                              Conds:RS_230._col1=RS_1317._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
-                                            <-Map 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_1317]
+                                              Conds:RS_230._col1=RS_1331._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
+                                            <-Map 62 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_1331]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_1308] (rows=462000 width=15)
+                                                Select Operator [SEL_1322] (rows=462000 width=15)
                                                   Output:["_col0","_col1","_col2","_col3"]
                                                   TableScan [TS_6] (rows=462000 width=15)
                                                     default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_brand_id","i_class_id","i_category_id"]
@@ -350,232 +346,220 @@ Stage-0
                                               SHUFFLE [RS_230]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1151] (rows=12217 width=4)
-                                                  Conds:RS_227._col6, _col7, _col8=RS_1354._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
+                                                  Conds:RS_227._col6, _col7, _col8=RS_1368._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
                                                 <-Reducer 14 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_227]
                                                     PartitionCols:_col6, _col7, _col8
                                                     Merge Join Operator [MERGEJOIN_1144] (rows=7733674 width=110)
-                                                      Conds:RS_224._col1=RS_1324._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                    <-Map 27 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1324]
+                                                      Conds:RS_224._col1=RS_1338._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                    <-Map 62 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_1338]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1313] (rows=458612 width=15)
+                                                        Select Operator [SEL_1327] (rows=458612 width=15)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1304] (rows=458612 width=15)
+                                                          Filter Operator [FIL_1318] (rows=458612 width=15)
                                                             predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                              Please refer to the previous TableScan [TS_6]
                                                     <-Reducer 13 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_224]
                                                         PartitionCols:_col1
                                                         Merge Join Operator [MERGEJOIN_1143] (rows=7790806 width=98)
-                                                          Conds:RS_1350._col0=RS_1287._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                          Conds:RS_1364._col0=RS_1289._col0(Inner),Output:["_col1","_col2","_col3"]
                                                         <-Map 11 [SIMPLE_EDGE] vectorized
-                                                          PARTITION_ONLY_SHUFFLE [RS_1287]
+                                                          SHUFFLE [RS_1289]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_1284] (rows=50 width=4)
+                                                            Select Operator [SEL_1285] (rows=50 width=4)
                                                               Output:["_col0"]
                                                               Filter Operator [FIL_1283] (rows=50 width=12)
                                                                 predicate:((d_year = 2000) and (d_moy = 11))
                                                                 TableScan [TS_3] (rows=73049 width=12)
                                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                                        <-Map 82 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_1350]
+                                                        <-Map 78 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_1364]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_1349] (rows=286549727 width=123)
+                                                            Select Operator [SEL_1363] (rows=286549727 width=123)
                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                              Filter Operator [FIL_1348] (rows=286549727 width=123)
+                                                              Filter Operator [FIL_1362] (rows=286549727 width=123)
                                                                 predicate:(cs_sold_date_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_222_date_dim_d_date_sk_min) AND DynamicValue(RS_222_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_222_date_dim_d_date_sk_bloom_filter)))
                                                                 TableScan [TS_142] (rows=287989836 width=123)
                                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_item_sk","cs_quantity","cs_list_price"]
                                                                 <-Reducer 19 [BROADCAST_EDGE] vectorized
-                                                                  BROADCAST [RS_1347]
-                                                                    Group By Operator [GBY_1346] (rows=1 width=12)
+                                                                  BROADCAST [RS_1361]
+                                                                    Group By Operator [GBY_1360] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                     <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_1295]
-                                                                        Group By Operator [GBY_1292] (rows=1 width=12)
+                                                                      SHUFFLE [RS_1307]
+                                                                        Group By Operator [GBY_1302] (rows=1 width=12)
                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                          Select Operator [SEL_1288] (rows=50 width=4)
+                                                                          Select Operator [SEL_1290] (rows=50 width=4)
                                                                             Output:["_col0"]
-                                                                             Please refer to the previous Select Operator [SEL_1284]
-                                                <-Reducer 39 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1354]
+                                                                             Please refer to the previous Select Operator [SEL_1285]
+                                                <-Reducer 35 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1368]
                                                     PartitionCols:_col0, _col1, _col2
-                                                    Select Operator [SEL_1353] (rows=1 width=12)
+                                                    Select Operator [SEL_1367] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"]
-                                                      Filter Operator [FIL_1352] (rows=1 width=20)
+                                                      Filter Operator [FIL_1366] (rows=1 width=20)
                                                         predicate:(_col3 = 3L)
-                                                        Group By Operator [GBY_1351] (rows=121728 width=19)
+                                                        Group By Operator [GBY_1365] (rows=121728 width=19)
                                                           Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                        <-Union 38 [SIMPLE_EDGE]
-                                                          <-Reducer 37 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1424]
+                                                        <-Union 34 [SIMPLE_EDGE]
+                                                          <-Reducer 33 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1405]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1423] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1404] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1422] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1403] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 36 [SIMPLE_EDGE]
+                                                                <-Reducer 32 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_168]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                     Group By Operator [GBY_167] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1146] (rows=14628613 width=11)
-                                                                        Conds:RS_163._col1=RS_1325._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1325]
+                                                                        Conds:RS_163._col1=RS_1339._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1339]
                                                                           PartitionCols:_col0
-                                                                          Select Operator [SEL_1314] (rows=458612 width=15)
+                                                                          Select Operator [SEL_1328] (rows=458612 width=15)
                                                                             Output:["_col0","_col1","_col2","_col3"]
-                                                                            Filter Operator [FIL_1305] (rows=458612 width=15)
+                                                                            Filter Operator [FIL_1319] (rows=458612 width=15)
                                                                               predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                                                Please refer to the previous TableScan [TS_6]
-                                                                      <-Reducer 50 [SIMPLE_EDGE]
+                                                                      <-Reducer 27 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_163]
                                                                           PartitionCols:_col1
                                                                           Merge Join Operator [MERGEJOIN_1132] (rows=14736682 width=4)
-                                                                            Conds:RS_1402._col0=RS_1380._col0(Inner),Output:["_col1"]
-                                                                          <-Map 51 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1380]
+                                                                            Conds:RS_1396._col0=RS_1293._col0(Inner),Output:["_col1"]
+                                                                          <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1293]
                                                                               PartitionCols:_col0
-                                                                              Select Operator [SEL_1379] (rows=1957 width=4)
+                                                                              Select Operator [SEL_1286] (rows=1957 width=4)
                                                                                 Output:["_col0"]
-                                                                                Filter Operator [FIL_1378] (rows=1957 width=8)
+                                                                                Filter Operator [FIL_1284] (rows=1957 width=8)
                                                                                   predicate:d_year BETWEEN 1999 AND 2001
-                                                                                  TableScan [TS_12] (rows=73049 width=8)
-                                                                                    default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                                          <-Map 49 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1402]
+                                                                                   Please refer to the previous TableScan [TS_3]
+                                                                          <-Map 63 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1396]
                                                                               PartitionCols:_col0
-                                                                              Select Operator [SEL_1401] (rows=550076554 width=7)
+                                                                              Select Operator [SEL_1394] (rows=550076554 width=7)
                                                                                 Output:["_col0","_col1"]
-                                                                                Filter Operator [FIL_1400] (rows=550076554 width=7)
-                                                                                  predicate:(ss_sold_date_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_19_d1_d_date_sk_min) AND DynamicValue(RS_19_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_19_d1_d_date_sk_bloom_filter)))
+                                                                                Filter Operator [FIL_1392] (rows=550076554 width=7)
+                                                                                  predicate:ss_sold_date_sk is not null
                                                                                   TableScan [TS_9] (rows=575995635 width=7)
-                                                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk"]
-                                                                                  <-Reducer 52 [BROADCAST_EDGE] vectorized
-                                                                                    BROADCAST [RS_1399]
-                                                                                      Group By Operator [GBY_1398] (rows=1 width=12)
-                                                                                        Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                      <-Map 51 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                        SHUFFLE [RS_1394]
-                                                                                          Group By Operator [GBY_1390] (rows=1 width=12)
-                                                                                            Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                            Select Operator [SEL_1381] (rows=1957 width=4)
-                                                                                              Output:["_col0"]
-                                                                                               Please refer to the previous Select Operator [SEL_1379]
-                                                          <-Reducer 44 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1430]
+                                                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_quantity","ss_list_price"]
+                                                          <-Reducer 43 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1419]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1429] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1418] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1428] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1417] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 43 [SIMPLE_EDGE]
+                                                                <-Reducer 42 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_188]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                     Group By Operator [GBY_187] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1148] (rows=7620440 width=11)
-                                                                        Conds:RS_183._col1=RS_1326._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1326]
+                                                                        Conds:RS_183._col1=RS_1340._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1340]
                                                                           PartitionCols:_col0
-                                                                          Select Operator [SEL_1315] (rows=458612 width=15)
+                                                                          Select Operator [SEL_1329] (rows=458612 width=15)
                                                                             Output:["_col0","_col1","_col2","_col3"]
-                                                                            Filter Operator [FIL_1306] (rows=458612 width=15)
+                                                                            Filter Operator [FIL_1320] (rows=458612 width=15)
                                                                               predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                                                Please refer to the previous TableScan [TS_6]
-                                                                      <-Reducer 53 [SIMPLE_EDGE]
+                                                                      <-Reducer 39 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_183]
                                                                           PartitionCols:_col1
                                                                           Merge Join Operator [MERGEJOIN_1134] (rows=7676736 width=4)
-                                                                            Conds:RS_1410._col0=RS_1382._col0(Inner),Output:["_col1"]
-                                                                          <-Map 51 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1382]
+                                                                            Conds:RS_1413._col0=RS_1294._col0(Inner),Output:["_col1"]
+                                                                          <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1294]
                                                                               PartitionCols:_col0
-                                                                               Please refer to the previous Select Operator [SEL_1379]
-                                                                          <-Map 67 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1410]
+                                                                               Please refer to the previous Select Operator [SEL_1286]
+                                                                          <-Map 64 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1413]
                                                                               PartitionCols:_col0
-                                                                              Select Operator [SEL_1409] (rows=286549727 width=7)
+                                                                              Select Operator [SEL_1412] (rows=286549727 width=7)
                                                                                 Output:["_col0","_col1"]
-                                                                                Filter Operator [FIL_1408] (rows=286549727 width=7)
+                                                                                Filter Operator [FIL_1411] (rows=286549727 width=7)
                                                                                   predicate:(cs_sold_date_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_39_d2_d_date_sk_min) AND DynamicValue(RS_39_d2_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_39_d2_d_date_sk_bloom_filter)))
                                                                                   TableScan [TS_29] (rows=287989836 width=7)
                                                                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_item_sk"]
-                                                                                  <-Reducer 54 [BROADCAST_EDGE] vectorized
-                                                                                    BROADCAST [RS_1407]
-                                                                                      Group By Operator [GBY_1406] (rows=1 width=12)
+                                                                                  <-Reducer 45 [BROADCAST_EDGE] vectorized
+                                                                                    BROADCAST [RS_1410]
+                                                                                      Group By Operator [GBY_1409] (rows=1 width=12)
                                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                      <-Map 51 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                        SHUFFLE [RS_1395]
-                                                                                          Group By Operator [GBY_1391] (rows=1 width=12)
+                                                                                      <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                        SHUFFLE [RS_1309]
+                                                                                          Group By Operator [GBY_1304] (rows=1 width=12)
                                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                            Select Operator [SEL_1383] (rows=1957 width=4)
+                                                                                            Select Operator [SEL_1295] (rows=1957 width=4)
                                                                                               Output:["_col0"]
-                                                                                               Please refer to the previous Select Operator [SEL_1379]
-                                                          <-Reducer 47 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1436]
+                                                                                               Please refer to the previous Select Operator [SEL_1286]
+                                                          <-Reducer 50 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1433]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1435] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1432] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1434] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1431] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 46 [SIMPLE_EDGE]
+                                                                <-Reducer 49 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_209]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                     Group By Operator [GBY_208] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1150] (rows=3828623 width=11)
-                                                                        Conds:RS_204._col1=RS_1327._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1327]
+                                                                        Conds:RS_204._col1=RS_1341._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1341]
                                                                           PartitionCols:_col0
-                                                                          Select Operator [SEL_1316] (rows=458612 width=15)
+                                                                          Select Operator [SEL_1330] (rows=458612 width=15)
                                                                             Output:["_col0","_col1","_col2","_col3"]
-                                                                            Filter Operator [FIL_1307] (rows=458612 width=15)
+                                                                            Filter Operator [FIL_1321] (rows=458612 width=15)
                                                                               predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                                                Please refer to the previous TableScan [TS_6]
-                                                                      <-Reducer 55 [SIMPLE_EDGE]
+                                                                      <-Reducer 46 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_204]
                                                                           PartitionCols:_col1
                                                                           Merge Join Operator [MERGEJOIN_1136] (rows=3856907 width=4)
-                                                                            Conds:RS_1418._col0=RS_1384._col0(Inner),Output:["_col1"]
-                                                                          <-Map 51 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1384]
+                                                                            Conds:RS_1427._col0=RS_1296._col0(Inner),Output:["_col1"]
+                                                                          <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1296]
                                                                               PartitionCols:_col0
-                                                                               Please refer to the previous Select Operator [SEL_1379]
-                                                                          <-Map 68 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1418]
+                                                                               Please refer to the previous Select Operator [SEL_1286]
+                                                                          <-Map 65 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1427]
                                                                               PartitionCols:_col0
-                                                                              Select Operator [SEL_1417] (rows=143966864 width=7)
+                                                                              Select Operator [SEL_1426] (rows=143966864 width=7)
                                                                                 Output:["_col0","_col1"]
-                                                                                Filter Operator [FIL_1416] (rows=143966864 width=7)
+                                                                                Filter Operator [FIL_1425] (rows=143966864 width=7)
                                                                                   predicate:(ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_60_d3_d_date_sk_min) AND DynamicValue(RS_60_d3_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_60_d3_d_date_sk_bloom_filter)))
                                                                                   TableScan [TS_50] (rows=144002668 width=7)
                                                                                     default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk"]
-                                                                                  <-Reducer 56 [BROADCAST_EDGE] vectorized
-                                                                                    BROADCAST [RS_1415]
-                                                                                      Group By Operator [GBY_1414] (rows=1 width=12)
+                                                                                  <-Reducer 52 [BROADCAST_EDGE] vectorized
+                                                                                    BROADCAST [RS_1424]
+                                                                                      Group By Operator [GBY_1423] (rows=1 width=12)
                                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                      <-Map 51 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                        SHUFFLE [RS_1396]
-                                                                                          Group By Operator [GBY_1392] (rows=1 width=12)
+                                                                                      <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                        SHUFFLE [RS_1310]
+                                                                                          Group By Operator [GBY_1305] (rows=1 width=12)
                                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                            Select Operator [SEL_1385] (rows=1957 width=4)
+                                                                                            Select Operator [SEL_1297] (rows=1957 width=4)
                                                                                               Output:["_col0"]
-                                                                                               Please refer to the previous Select Operator [SEL_1379]
-                              <-Reducer 63 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1361]
-                                  Select Operator [SEL_1360] (rows=1 width=112)
+                                                                                               Please refer to the previous Select Operator [SEL_1286]
+                              <-Reducer 58 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1375]
+                                  Select Operator [SEL_1374] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1359] (rows=1 width=120)
+                                    Filter Operator [FIL_1373] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1358] (rows=1 width=120)
+                                      Group By Operator [GBY_1372] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 62 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 61 [CONTAINS]
+                                      <-Union 57 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 56 [CONTAINS]
                                           Reduce Output Operator [RS_1240]
                                             Group By Operator [GBY_1239] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -584,32 +568,20 @@ Stage-0
                                                 Select Operator [SEL_1236] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1235] (rows=14736682 width=0)
-                                                    Conds:RS_1445._col0=RS_1388._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 51 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1388]
+                                                    Conds:RS_1398._col0=RS_1299._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 11 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1299]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1379]
-                                                  <-Map 69 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1445]
+                                                       Please refer to the previous Select Operator [SEL_1286]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1398]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1443] (rows=550076554 width=114)
+                                                      Select Operator [SEL_1395] (rows=550076554 width=114)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1442] (rows=550076554 width=114)
-                                                          predicate:(ss_sold_date_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_105_date_dim_d_date_sk_min) AND DynamicValue(RS_105_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_105_date_dim_d_date_sk_bloom_filter)))
-                                                          TableScan [TS_98] (rows=575995635 width=114)
-                                                            default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_quantity","ss_list_price"]
-                                                          <-Reducer 60 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1441]
-                                                              Group By Operator [GBY_1440] (rows=1 width=12)
-                                                                Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 51 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_1397]
-                                                                  Group By Operator [GBY_1393] (rows=1 width=12)
-                                                                    Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1387] (rows=1957 width=4)
-                                                                      Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1379]
-                                        <-Reducer 72 [CONTAINS]
+                                                        Filter Operator [FIL_1393] (rows=550076554 width=114)
+                                                          predicate:(ss_sold_date_sk is not null and ss_sold_date_sk is not null)
+                                                           Please refer to the previous TableScan [TS_9]
+                                        <-Reducer 68 [CONTAINS]
                                           Reduce Output Operator [RS_1258]
                                             Group By Operator [GBY_1257] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -618,37 +590,37 @@ Stage-0
                                                 Select Operator [SEL_1254] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1253] (rows=7676736 width=94)
-                                                    Conds:RS_1460._col0=RS_1451._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 74 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1451]
+                                                    Conds:RS_1450._col0=RS_1441._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 70 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1441]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1448] (rows=1957 width=4)
+                                                      Select Operator [SEL_1438] (rows=1957 width=4)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_1447] (rows=1957 width=8)
+                                                        Filter Operator [FIL_1437] (rows=1957 width=8)
                                                           predicate:d_year BETWEEN 1998 AND 2000
                                                           TableScan [TS_111] (rows=73049 width=8)
                                                             default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                  <-Map 70 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1460]
+                                                  <-Map 66 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1450]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1458] (rows=286549727 width=119)
+                                                      Select Operator [SEL_1448] (rows=286549727 width=119)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1457] (rows=286549727 width=119)
+                                                        Filter Operator [FIL_1447] (rows=286549727 width=119)
                                                           predicate:(cs_sold_date_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_115_date_dim_d_date_sk_min) AND DynamicValue(RS_115_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_115_date_dim_d_date_sk_bloom_filter)))
                                                           TableScan [TS_108] (rows=287989836 width=119)
                                                             default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_quantity","cs_list_price"]
-                                                          <-Reducer 75 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1456]
-                                                              Group By Operator [GBY_1455] (rows=1 width=12)
+                                                          <-Reducer 71 [BROADCAST_EDGE] vectorized
+                                                            BROADCAST [RS_1446]
+                                                              Group By Operator [GBY_1445] (rows=1 width=12)
                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 74 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_1454]
-                                                                  Group By Operator [GBY_1453] (rows=1 width=12)
+                                                              <-Map 70 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_1444]
+                                                                  Group By Operator [GBY_1443] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1450] (rows=1957 width=4)
+                                                                    Select Operator [SEL_1440] (rows=1957 width=4)
                                                                       Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1448]
-                                        <-Reducer 78 [CONTAINS]
+                                                                       Please refer to the previous Select Operator [SEL_1438]
+                                        <-Reducer 74 [CONTAINS]
                                           Reduce Output Operator [RS_1276]
                                             Group By Operator [GBY_1275] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -657,36 +629,36 @@ Stage-0
                                                 Select Operator [SEL_1272] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1271] (rows=3856907 width=114)
-                                                    Conds:RS_1475._col0=RS_1466._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 80 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1466]
+                                                    Conds:RS_1465._col0=RS_1456._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 76 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1456]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1463] (rows=1957 width=4)
+                                                      Select Operator [SEL_1453] (rows=1957 width=4)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_1462] (rows=1957 width=8)
+                                                        Filter Operator [FIL_1452] (rows=1957 width=8)
                                                           predicate:d_year BETWEEN 1998 AND 2000
                                                           TableScan [TS_122] (rows=73049 width=8)
                                                             default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                  <-Map 76 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1475]
+                                                  <-Map 72 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1465]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1473] (rows=143966864 width=119)
+                                                      Select Operator [SEL_1463] (rows=143966864 width=119)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1472] (rows=143966864 width=119)
+                                                        Filter Operator [FIL_1462] (rows=143966864 width=119)
                                                           predicate:(ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_126_date_dim_d_date_sk_min) AND DynamicValue(RS_126_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_126_date_dim_d_date_sk_bloom_filter)))
                                                           TableScan [TS_119] (rows=144002668 width=119)
                                                             default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_quantity","ws_list_price"]
-                                                          <-Reducer 81 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1471]
-                                                              Group By Operator [GBY_1470] (rows=1 width=12)
+                                                          <-Reducer 77 [BROADCAST_EDGE] vectorized
+                                                            BROADCAST [RS_1461]
+                                                              Group By Operator [GBY_1460] (rows=1 width=12)
                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 80 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_1469]
-                                                                  Group By Operator [GBY_1468] (rows=1 width=12)
+                                                              <-Map 76 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_1459]
+                                                                  Group By Operator [GBY_1458] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1465] (rows=1957 width=4)
+                                                                    Select Operator [SEL_1455] (rows=1957 width=4)
                                                                       Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1463]
+                                                                       Please refer to the previous Select Operator [SEL_1453]
                   <-Reducer 25 [CONTAINS]
                     Reduce Output Operator [RS_1192]
                       PartitionCols:_col0, _col1, _col2, _col3, _col4
@@ -701,10 +673,10 @@ Stage-0
                               Merge Join Operator [MERGEJOIN_1186] (rows=40 width=242)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                               <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1373]
-                                  Filter Operator [FIL_1372] (rows=40 width=130)
+                                PARTITION_ONLY_SHUFFLE [RS_1387]
+                                  Filter Operator [FIL_1386] (rows=40 width=130)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1371] (rows=40 width=130)
+                                    Group By Operator [GBY_1385] (rows=40 width=130)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 23 [SIMPLE_EDGE]
                                       SHUFFLE [RS_379]
@@ -714,113 +686,113 @@ Stage-0
                                           Select Operator [SEL_376] (rows=6181 width=9)
                                             Output:["_col0","_col1","_col2","_col3"]
                                             Merge Join Operator [MERGEJOIN_1165] (rows=6181 width=9)
-                                              Conds:RS_373._col1=RS_1319._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
-                                            <-Map 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_1319]
+                                              Conds:RS_373._col1=RS_1333._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
+                                            <-Map 62 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_1333]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_1310] (rows=462000 width=15)
+                                                Select Operator [SEL_1324] (rows=462000 width=15)
                                                   Output:["_col0","_col1","_col2","_col3"]
                                                    Please refer to the previous TableScan [TS_6]
                                             <-Reducer 22 [SIMPLE_EDGE]
                                               SHUFFLE [RS_373]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1164] (rows=6181 width=4)
-                                                  Conds:RS_370._col6, _col7, _col8=RS_1370._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
+                                                  Conds:RS_370._col6, _col7, _col8=RS_1384._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
                                                 <-Reducer 21 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_370]
                                                     PartitionCols:_col6, _col7, _col8
                                                     Merge Join Operator [MERGEJOIN_1157] (rows=3913176 width=130)
-                                                      Conds:RS_367._col1=RS_1328._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                    <-Map 27 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1328]
+                                                      Conds:RS_367._col1=RS_1342._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                    <-Map 62 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_1342]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1318] (rows=458612 width=15)
+                                                        Select Operator [SEL_1332] (rows=458612 width=15)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1309] (rows=458612 width=15)
+                                                          Filter Operator [FIL_1323] (rows=458612 width=15)
                                                             predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                              Please refer to the previous TableScan [TS_6]
                                                     <-Reducer 20 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_367]
                                                         PartitionCols:_col1
                                                         Merge Join Operator [MERGEJOIN_1156] (rows=3942084 width=118)
-                                                          Conds:RS_1366._col0=RS_1289._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                          Conds:RS_1380._col0=RS_1291._col0(Inner),Output:["_col1","_col2","_col3"]
                                                         <-Map 11 [SIMPLE_EDGE] vectorized
-                                                          PARTITION_ONLY_SHUFFLE [RS_1289]
+                                                          SHUFFLE [RS_1291]
                                                             PartitionCols:_col0
-                                                             Please refer to the previous Select Operator [SEL_1284]
-                                                        <-Map 83 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_1366]
+                                                             Please refer to the previous Select Operator [SEL_1285]
+                                                        <-Map 79 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_1380]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_1365] (rows=143966864 width=123)
+                                                            Select Operator [SEL_1379] (rows=143966864 width=123)
                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                              Filter Operator [FIL_1364] (rows=143966864 width=123)
+                                                              Filter Operator [FIL_1378] (rows=143966864 width=123)
                                                                 predicate:(ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_365_date_dim_d_date_sk_min) AND DynamicValue(RS_365_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_365_date_dim_d_date_sk_bloom_filter)))
                                                                 TableScan [TS_285] (rows=144002668 width=123)
                                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_quantity","ws_list_price"]
                                                                 <-Reducer 26 [BROADCAST_EDGE] vectorized
-                                                                  BROADCAST [RS_1363]
-                                                                    Group By Operator [GBY_1362] (rows=1 width=12)
+                                                                  BROADCAST [RS_1377]
+                                                                    Group By Operator [GBY_1376] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                     <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_1296]
-                                                                        Group By Operator [GBY_1293] (rows=1 width=12)
+                                                                      SHUFFLE [RS_1308]
+                                                                        Group By Operator [GBY_1303] (rows=1 width=12)
                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                          Select Operator [SEL_1290] (rows=50 width=4)
+                                                                          Select Operator [SEL_1292] (rows=50 width=4)
                                                                             Output:["_col0"]
-                                                                             Please refer to the previous Select Operator [SEL_1284]
-                                                <-Reducer 42 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1370]
+                                                                             Please refer to the previous Select Operator [SEL_1285]
+                                                <-Reducer 38 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1384]
                                                     PartitionCols:_col0, _col1, _col2
-                                                    Select Operator [SEL_1369] (rows=1 width=12)
+                                                    Select Operator [SEL_1383] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"]
-                                                      Filter Operator [FIL_1368] (rows=1 width=20)
+                                                      Filter Operator [FIL_1382] (rows=1 width=20)
                                                         predicate:(_col3 = 3L)
-                                                        Group By Operator [GBY_1367] (rows=121728 width=19)
+                                                        Group By Operator [GBY_1381] (rows=121728 width=19)
                                                           Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                        <-Union 41 [SIMPLE_EDGE]
-                                                          <-Reducer 40 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1427]
+                                                        <-Union 37 [SIMPLE_EDGE]
+                                                          <-Reducer 36 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1408]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1426] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1407] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1425] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1406] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 36 [SIMPLE_EDGE]
+                                                                <-Reducer 32 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_311]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                      Please refer to the previous Group By Operator [GBY_167]
-                                                          <-Reducer 45 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1433]
+                                                          <-Reducer 44 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1422]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1432] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1421] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1431] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1420] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 43 [SIMPLE_EDGE]
+                                                                <-Reducer 42 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_331]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                      Please refer to the previous Group By Operator [GBY_187]
-                                                          <-Reducer 48 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1439]
+                                                          <-Reducer 51 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1436]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1438] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1435] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1437] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1434] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 46 [SIMPLE_EDGE]
+                                                                <-Reducer 49 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_352]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                      Please refer to the previous Group By Operator [GBY_208]
-                              <-Reducer 66 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1377]
-                                  Select Operator [SEL_1376] (rows=1 width=112)
+                              <-Reducer 61 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1391]
+                                  Select Operator [SEL_1390] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1375] (rows=1 width=120)
+                                    Filter Operator [FIL_1389] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1374] (rows=1 width=120)
+                                      Group By Operator [GBY_1388] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 65 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 64 [CONTAINS]
+                                      <-Union 60 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 59 [CONTAINS]
                                           Reduce Output Operator [RS_1246]
                                             Group By Operator [GBY_1245] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -829,16 +801,16 @@ Stage-0
                                                 Select Operator [SEL_1242] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1241] (rows=14736682 width=0)
-                                                    Conds:RS_1446._col0=RS_1389._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 51 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1389]
+                                                    Conds:RS_1399._col0=RS_1300._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 11 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1300]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1379]
-                                                  <-Map 69 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1446]
+                                                       Please refer to the previous Select Operator [SEL_1286]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1399]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1443]
-                                        <-Reducer 73 [CONTAINS]
+                                                       Please refer to the previous Select Operator [SEL_1395]
+                                        <-Reducer 69 [CONTAINS]
                                           Reduce Output Operator [RS_1264]
                                             Group By Operator [GBY_1263] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -847,16 +819,16 @@ Stage-0
                                                 Select Operator [SEL_1260] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1259] (rows=7676736 width=94)
-                                                    Conds:RS_1461._col0=RS_1452._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 74 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1452]
+                                                    Conds:RS_1451._col0=RS_1442._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 70 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1442]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1438]
+                                                  <-Map 66 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1451]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1448]
-                                                  <-Map 70 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1461]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1458]
-                                        <-Reducer 79 [CONTAINS]
+                                        <-Reducer 75 [CONTAINS]
                                           Reduce Output Operator [RS_1282]
                                             Group By Operator [GBY_1281] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -865,15 +837,15 @@ Stage-0
                                                 Select Operator [SEL_1278] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1277] (rows=3856907 width=114)
-                                                    Conds:RS_1476._col0=RS_1467._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 80 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1467]
+                                                    Conds:RS_1466._col0=RS_1457._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 76 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1457]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1453]
+                                                  <-Map 72 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1466]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1463]
-                                                  <-Map 76 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1476]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1473]
                   <-Reducer 7 [CONTAINS]
                     Reduce Output Operator [RS_1178]
                       PartitionCols:_col0, _col1, _col2, _col3, _col4
@@ -887,16 +859,16 @@ Stage-0
                               predicate:(_col3 > _col5)
                               Merge Join Operator [MERGEJOIN_1172] (rows=136 width=243)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                              <-Reducer 59 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1339]
-                                  Select Operator [SEL_1338] (rows=1 width=112)
+                              <-Reducer 55 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1353]
+                                  Select Operator [SEL_1352] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1337] (rows=1 width=120)
+                                    Filter Operator [FIL_1351] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1336] (rows=1 width=120)
+                                      Group By Operator [GBY_1350] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 58 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 57 [CONTAINS]
+                                      <-Union 54 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 53 [CONTAINS]
                                           Reduce Output Operator [RS_1234]
                                             Group By Operator [GBY_1233] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -905,16 +877,16 @@ Stage-0
                                                 Select Operator [SEL_1230] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1229] (rows=14736682 width=0)
-                                                    Conds:RS_1444._col0=RS_1386._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 51 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1386]
+                                                    Conds:RS_1397._col0=RS_1298._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 11 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1298]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1379]
-                                                  <-Map 69 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1444]
+                                                       Please refer to the previous Select Operator [SEL_1286]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1397]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1443]
-                                        <-Reducer 71 [CONTAINS]
+                                                       Please refer to the previous Select Operator [SEL_1395]
+                                        <-Reducer 67 [CONTAINS]
                                           Reduce Output Operator [RS_1252]
                                             Group By Operator [GBY_1251] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -923,16 +895,16 @@ Stage-0
                                                 Select Operator [SEL_1248] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1247] (rows=7676736 width=94)
-                                                    Conds:RS_1459._col0=RS_1449._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 74 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1449]
+                                                    Conds:RS_1449._col0=RS_1439._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 70 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1439]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1438]
+                                                  <-Map 66 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1449]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1448]
-                                                  <-Map 70 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1459]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1458]
-                                        <-Reducer 77 [CONTAINS]
+                                        <-Reducer 73 [CONTAINS]
                                           Reduce Output Operator [RS_1270]
                                             Group By Operator [GBY_1269] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -941,20 +913,20 @@ Stage-0
                                                 Select Operator [SEL_1266] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1265] (rows=3856907 width=114)
-                                                    Conds:RS_1474._col0=RS_1464._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 80 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1464]
+                                                    Conds:RS_1464._col0=RS_1454._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 76 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1454]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1453]
+                                                  <-Map 72 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1464]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1463]
-                                                  <-Map 76 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1474]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1473]
                               <-Reducer 6 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1335]
-                                  Filter Operator [FIL_1334] (rows=136 width=131)
+                                PARTITION_ONLY_SHUFFLE [RS_1349]
+                                  Filter Operator [FIL_1348] (rows=136 width=131)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1333] (rows=136 width=131)
+                                    Group By Operator [GBY_1347] (rows=136 width=131)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 5 [SIMPLE_EDGE]
                                       SHUFFLE [RS_94]
@@ -964,76 +936,76 @@ Stage-0
                                           Select Operator [SEL_91] (rows=23620 width=11)
                                             Output:["_col0","_col1","_col2","_col3"]
                                             Merge Join Operator [MERGEJOIN_1139] (rows=23620 width=11)
-                                              Conds:RS_88._col1=RS_1312._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
-                                            <-Map 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_1312]
+                                              Conds:RS_88._col1=RS_1326._col0(Inner),Output:["_col2","_col3","_col13","_col14","_col15"]
+                                            <-Map 62 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_1326]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_1303] (rows=462000 width=15)
+                                                Select Operator [SEL_1317] (rows=462000 width=15)
                                                   Output:["_col0","_col1","_col2","_col3"]
                                                    Please refer to the previous TableScan [TS_6]
                                             <-Reducer 4 [SIMPLE_EDGE]
                                               SHUFFLE [RS_88]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1138] (rows=23620 width=4)
-                                                  Conds:RS_85._col6, _col7, _col8=RS_1332._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
+                                                  Conds:RS_85._col6, _col7, _col8=RS_1346._col0, _col1, _col2(Inner),Output:["_col1","_col2","_col3"]
                                                 <-Reducer 3 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_85]
                                                     PartitionCols:_col6, _col7, _col8
                                                     Merge Join Operator [MERGEJOIN_1131] (rows=14951676 width=15)
-                                                      Conds:RS_82._col1=RS_1320._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                    <-Map 27 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1320]
+                                                      Conds:RS_82._col1=RS_1334._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                    <-Map 62 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_1334]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1311] (rows=458612 width=15)
+                                                        Select Operator [SEL_1325] (rows=458612 width=15)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1302] (rows=458612 width=15)
+                                                          Filter Operator [FIL_1316] (rows=458612 width=15)
                                                             predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null)
                                                              Please refer to the previous TableScan [TS_6]
                                                     <-Reducer 2 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_82]
                                                         PartitionCols:_col1
                                                         Merge Join Operator [MERGEJOIN_1130] (rows=15062131 width=4)
-                                                          Conds:RS_1301._col0=RS_1285._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                          Conds:RS_1315._col0=RS_1287._col0(Inner),Output:["_col1","_col2","_col3"]
                                                         <-Map 11 [SIMPLE_EDGE] vectorized
-                                                          PARTITION_ONLY_SHUFFLE [RS_1285]
+                                                          SHUFFLE [RS_1287]
                                                             PartitionCols:_col0
-                                                             Please refer to the previous Select Operator [SEL_1284]
+                                                             Please refer to the previous Select Operator [SEL_1285]
                                                         <-Map 1 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_1301]
+                                                          SHUFFLE [RS_1315]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_1300] (rows=550076554 width=118)
+                                                            Select Operator [SEL_1314] (rows=550076554 width=118)
                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                              Filter Operator [FIL_1299] (rows=550076554 width=118)
+                                                              Filter Operator [FIL_1313] (rows=550076554 width=118)
                                                                 predicate:(ss_sold_date_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_80_date_dim_d_date_sk_min) AND DynamicValue(RS_80_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_80_date_dim_d_date_sk_bloom_filter)))
                                                                 TableScan [TS_0] (rows=575995635 width=118)
                                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_quantity","ss_list_price"]
                                                                 <-Reducer 12 [BROADCAST_EDGE] vectorized
-                                                                  BROADCAST [RS_1298]
-                                                                    Group By Operator [GBY_1297] (rows=1 width=12)
+                                                                  BROADCAST [RS_1312]
+                                                                    Group By Operator [GBY_1311] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                     <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_1294]
-                                                                        Group By Operator [GBY_1291] (rows=1 width=12)
+                                                                      SHUFFLE [RS_1306]
+                                                                        Group By Operator [GBY_1301] (rows=1 width=12)
                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                          Select Operator [SEL_1286] (rows=50 width=4)
+                                                                          Select Operator [SEL_1288] (rows=50 width=4)
                                                                             Output:["_col0"]
-                                                                             Please refer to the previous Select Operator [SEL_1284]
+                                                                             Please refer to the previous Select Operator [SEL_1285]
                                                 <-Reducer 31 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1332]
+                                                  SHUFFLE [RS_1346]
                                                     PartitionCols:_col0, _col1, _col2
-                                                    Select Operator [SEL_1331] (rows=1 width=12)
+                                                    Select Operator [SEL_1345] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"]
-                                                      Filter Operator [FIL_1330] (rows=1 width=20)
+                                                      Filter Operator [FIL_1344] (rows=1 width=20)
                                                         predicate:(_col3 = 3L)
-                                                        Group By Operator [GBY_1329] (rows=121728 width=19)
+                                                        Group By Operator [GBY_1343] (rows=121728 width=19)
                                                           Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                                                         <-Union 30 [SIMPLE_EDGE]
                                                           <-Reducer 29 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1405]
+                                                            Reduce Output Operator [RS_1402]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1404] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1401] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1403] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1400] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                                                                 <-Reducer 28 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_26]
@@ -1041,56 +1013,56 @@ Stage-0
                                                                     Group By Operator [GBY_25] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1133] (rows=14628613 width=11)
-                                                                        Conds:RS_21._col1=RS_1321._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1321]
+                                                                        Conds:RS_21._col1=RS_1335._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1335]
                                                                           PartitionCols:_col0
-                                                                           Please refer to the previous Select Operator [SEL_1311]
-                                                                      <-Reducer 50 [SIMPLE_EDGE]
+                                                                           Please refer to the previous Select Operator [SEL_1325]
+                                                                      <-Reducer 27 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_21]
                                                                           PartitionCols:_col1
                                                                            Please refer to the previous Merge Join Operator [MERGEJOIN_1132]
-                                                          <-Reducer 33 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1413]
+                                                          <-Reducer 41 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1416]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1412] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1415] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1411] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1414] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 32 [SIMPLE_EDGE]
+                                                                <-Reducer 40 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_46]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                     Group By Operator [GBY_45] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1135] (rows=7620440 width=11)
-                                                                        Conds:RS_41._col1=RS_1322._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1322]
+                                                                        Conds:RS_41._col1=RS_1336._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1336]
                                                                           PartitionCols:_col0
-                                                                           Please refer to the previous Select Operator [SEL_1311]
-                                                                      <-Reducer 53 [SIMPLE_EDGE]
+                                                                           Please refer to the previous Select Operator [SEL_1325]
+                                                                      <-Reducer 39 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_41]
                                                                           PartitionCols:_col1
                                                                            Please refer to the previous Merge Join Operator [MERGEJOIN_1134]
-                                                          <-Reducer 35 [CONTAINS] vectorized
-                                                            Reduce Output Operator [RS_1421]
+                                                          <-Reducer 48 [CONTAINS] vectorized
+                                                            Reduce Output Operator [RS_1430]
                                                               PartitionCols:_col0, _col1, _col2
-                                                              Group By Operator [GBY_1420] (rows=121728 width=19)
+                                                              Group By Operator [GBY_1429] (rows=121728 width=19)
                                                                 Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1419] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1428] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                <-Reducer 34 [SIMPLE_EDGE]
+                                                                <-Reducer 47 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_67]
                                                                     PartitionCols:_col0, _col1, _col2
                                                                     Group By Operator [GBY_66] (rows=121728 width=19)
                                                                       Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                       Merge Join Operator [MERGEJOIN_1137] (rows=3828623 width=11)
-                                                                        Conds:RS_62._col1=RS_1323._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                      <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1323]
+                                                                        Conds:RS_62._col1=RS_1337._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                      <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1337]
                                                                           PartitionCols:_col0
-                                                                           Please refer to the previous Select Operator [SEL_1311]
-                                                                      <-Reducer 55 [SIMPLE_EDGE]
+                                                                           Please refer to the previous Select Operator [SEL_1325]
+                                                                      <-Reducer 46 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_62]
                                                                           PartitionCols:_col1
                                                                            Please refer to the previous Merge Join Operator [MERGEJOIN_1136]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query18.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query18.q.out
@@ -88,7 +88,7 @@ Reducer 13 <- Map 12 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 11 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Map 15 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 16 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 5 <- Map 14 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 
@@ -116,23 +116,23 @@ Stage-0
                       Group By Operator [GBY_39] (rows=11124280 width=1229)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18"],aggregations:["sum(_col12)","count(_col12)","sum(_col13)","count(_col13)","sum(_col14)","count(_col14)","sum(_col15)","count(_col15)","sum(_col16)","count(_col16)","sum(_col3)","count(_col3)","sum(_col19)","count(_col19)"],keys:_col21, _col5, _col6, _col7, 0L
                         Merge Join Operator [MERGEJOIN_145] (rows=2224856 width=816)
-                          Conds:RS_35._col1=RS_169._col0(Inner),Output:["_col3","_col5","_col6","_col7","_col12","_col13","_col14","_col15","_col16","_col19","_col21"]
-                        <-Map 16 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_169]
+                          Conds:RS_35._col1=RS_166._col0(Inner),Output:["_col3","_col5","_col6","_col7","_col12","_col13","_col14","_col15","_col16","_col19","_col21"]
+                        <-Map 14 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_166]
                             PartitionCols:_col0
-                            Select Operator [SEL_168] (rows=1861800 width=4)
+                            Select Operator [SEL_164] (rows=1861800 width=4)
                               Output:["_col0"]
-                              TableScan [TS_24] (rows=1861800 width=4)
-                                default@customer_demographics,cd2,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk"]
+                              TableScan [TS_12] (rows=1861800 width=187)
+                                default@customer_demographics,cd1,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_gender","cd_education_status","cd_dep_count"]
                         <-Reducer 4 [SIMPLE_EDGE]
                           SHUFFLE [RS_35]
                             PartitionCols:_col1
                             Merge Join Operator [MERGEJOIN_144] (rows=2193833 width=813)
-                              Conds:RS_32._col11=RS_167._col0(Inner),Output:["_col1","_col3","_col5","_col6","_col7","_col12","_col13","_col14","_col15","_col16","_col19","_col21"]
+                              Conds:RS_32._col11=RS_169._col0(Inner),Output:["_col1","_col3","_col5","_col6","_col7","_col12","_col13","_col14","_col15","_col16","_col19","_col21"]
                             <-Map 15 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_167]
+                              SHUFFLE [RS_169]
                                 PartitionCols:_col0
-                                Select Operator [SEL_166] (rows=462000 width=104)
+                                Select Operator [SEL_168] (rows=462000 width=104)
                                   Output:["_col0","_col1"]
                                   TableScan [TS_22] (rows=462000 width=104)
                                     default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
@@ -145,16 +145,15 @@ Stage-0
                                   SHUFFLE [RS_30]
                                     PartitionCols:_col1
                                     Merge Join Operator [MERGEJOIN_142] (rows=15983636 width=639)
-                                      Conds:RS_18._col2=RS_165._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
+                                      Conds:RS_18._col2=RS_167._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
                                     <-Map 14 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_165]
+                                      SHUFFLE [RS_167]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_164] (rows=103434 width=116)
+                                        Select Operator [SEL_165] (rows=103434 width=116)
                                           Output:["_col0","_col1"]
                                           Filter Operator [FIL_163] (rows=103434 width=187)
                                             predicate:((cd_education_status = 'College') and (cd_gender = 'M'))
-                                            TableScan [TS_12] (rows=1861800 width=187)
-                                              default@customer_demographics,cd1,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_gender","cd_education_status","cd_dep_count"]
+                                             Please refer to the previous TableScan [TS_12]
                                     <-Reducer 10 [SIMPLE_EDGE]
                                       SHUFFLE [RS_18]
                                         PartitionCols:_col2

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query2.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query2.q.out
@@ -131,10 +131,10 @@ Map 1 <- Union 2 (CONTAINS)
 Map 9 <- Union 2 (CONTAINS)
 Reducer 3 <- Map 10 (SIMPLE_EDGE), Union 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 5 <- Map 10 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 8 <- Map 10 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -154,20 +154,20 @@ Stage-0
                 SHUFFLE [RS_53]
                   PartitionCols:(_col0 - 53)
                   Merge Join Operator [MERGEJOIN_143] (rows=652 width=788)
-                    Conds:RS_164._col0=RS_170._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                  <-Map 11 [SIMPLE_EDGE] vectorized
+                    Conds:RS_170._col0=RS_167._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                  <-Map 10 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_167]
+                      PartitionCols:_col0
+                      Select Operator [SEL_164] (rows=652 width=4)
+                        Output:["_col0"]
+                        Filter Operator [FIL_161] (rows=652 width=8)
+                          predicate:((d_year = 2002) and d_week_seq is not null)
+                          TableScan [TS_8] (rows=73049 width=99)
+                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name","d_year"]
+                  <-Reducer 4 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_170]
                       PartitionCols:_col0
-                      Select Operator [SEL_168] (rows=652 width=4)
-                        Output:["_col0"]
-                        Filter Operator [FIL_166] (rows=652 width=8)
-                          predicate:((d_year = 2002) and d_week_seq is not null)
-                          TableScan [TS_20] (rows=73049 width=8)
-                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_week_seq","d_year"]
-                  <-Reducer 4 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_164]
-                      PartitionCols:_col0
-                      Group By Operator [GBY_163] (rows=13152 width=788)
+                      Group By Operator [GBY_169] (rows=13152 width=788)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)","sum(VALUE._col5)","sum(VALUE._col6)"],keys:KEY._col0
                       <-Reducer 3 [SIMPLE_EDGE]
                         SHUFFLE [RS_17]
@@ -177,16 +177,15 @@ Stage-0
                             Select Operator [SEL_14] (rows=430516591 width=143)
                               Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
                               Merge Join Operator [MERGEJOIN_142] (rows=430516591 width=143)
-                                Conds:Union 2._col0=RS_162._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
+                                Conds:Union 2._col0=RS_166._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
                               <-Map 10 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_162]
+                                SHUFFLE [RS_166]
                                   PartitionCols:_col0
-                                  Select Operator [SEL_161] (rows=73049 width=36)
+                                  Select Operator [SEL_163] (rows=73049 width=36)
                                     Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                     Filter Operator [FIL_160] (rows=73049 width=99)
                                       predicate:d_week_seq is not null
-                                      TableScan [TS_8] (rows=73049 width=99)
-                                        default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name"]
+                                       Please refer to the previous TableScan [TS_8]
                               <-Union 2 [SIMPLE_EDGE]
                                 <-Map 1 [CONTAINS] vectorized
                                   Reduce Output Operator [RS_159]
@@ -210,17 +209,17 @@ Stage-0
                 SHUFFLE [RS_54]
                   PartitionCols:_col0
                   Merge Join Operator [MERGEJOIN_145] (rows=652 width=788)
-                    Conds:RS_165._col0=RS_171._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                  <-Map 11 [SIMPLE_EDGE] vectorized
+                    Conds:RS_171._col0=RS_168._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                  <-Map 10 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_168]
+                      PartitionCols:_col0
+                      Select Operator [SEL_165] (rows=652 width=4)
+                        Output:["_col0"]
+                        Filter Operator [FIL_162] (rows=652 width=8)
+                          predicate:((d_year = 2001) and d_week_seq is not null)
+                           Please refer to the previous TableScan [TS_8]
+                  <-Reducer 4 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_171]
                       PartitionCols:_col0
-                      Select Operator [SEL_169] (rows=652 width=4)
-                        Output:["_col0"]
-                        Filter Operator [FIL_167] (rows=652 width=8)
-                          predicate:((d_year = 2001) and d_week_seq is not null)
-                           Please refer to the previous TableScan [TS_20]
-                  <-Reducer 4 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_165]
-                      PartitionCols:_col0
-                       Please refer to the previous Group By Operator [GBY_163]
+                       Please refer to the previous Group By Operator [GBY_169]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query23.q.out
@@ -1,5 +1,5 @@
-Warning: Shuffle Join MERGEJOIN[358][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 17' is a cross product
-Warning: Shuffle Join MERGEJOIN[360][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 23' is a cross product
+Warning: Shuffle Join MERGEJOIN[358][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 10' is a cross product
+Warning: Shuffle Join MERGEJOIN[360][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 16' is a cross product
 PREHOOK: query: explain
 with frequent_ss_items as 
  (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt
@@ -119,38 +119,38 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Reducer 9 (BROADCAST_EDGE)
-Map 15 <- Reducer 7 (BROADCAST_EDGE)
-Map 19 <- Reducer 26 (BROADCAST_EDGE)
-Map 27 <- Reducer 33 (BROADCAST_EDGE)
-Map 35 <- Reducer 14 (BROADCAST_EDGE)
-Map 36 <- Reducer 13 (BROADCAST_EDGE)
-Reducer 10 <- Map 35 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Reducer 10 (CUSTOM_SIMPLE_EDGE)
-Reducer 14 <- Map 8 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Map 15 (SIMPLE_EDGE)
-Reducer 17 <- Reducer 16 (CUSTOM_SIMPLE_EDGE), Reducer 22 (CUSTOM_SIMPLE_EDGE)
-Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 20 <- Map 19 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
-Reducer 21 <- Reducer 20 (SIMPLE_EDGE)
-Reducer 22 <- Reducer 21 (CUSTOM_SIMPLE_EDGE)
-Reducer 23 <- Reducer 22 (CUSTOM_SIMPLE_EDGE), Reducer 37 (CUSTOM_SIMPLE_EDGE)
-Reducer 24 <- Reducer 23 (SIMPLE_EDGE)
-Reducer 26 <- Map 25 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 27 (SIMPLE_EDGE), Map 32 (SIMPLE_EDGE)
-Reducer 29 <- Map 34 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 18 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Reducer 29 (SIMPLE_EDGE)
-Reducer 31 <- Reducer 29 (SIMPLE_EDGE)
-Reducer 33 <- Map 32 (CUSTOM_SIMPLE_EDGE)
-Reducer 37 <- Map 36 (SIMPLE_EDGE)
-Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 30 (SIMPLE_EDGE), Union 5 (CONTAINS)
+Map 1 <- Reducer 22 (BROADCAST_EDGE)
+Map 12 <- Reducer 21 (BROADCAST_EDGE)
+Map 31 <- Reducer 30 (BROADCAST_EDGE)
+Map 33 <- Reducer 25 (BROADCAST_EDGE)
+Map 34 <- Reducer 24 (BROADCAST_EDGE)
+Map 8 <- Reducer 7 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
+Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 20 (SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 35 (CUSTOM_SIMPLE_EDGE)
+Reducer 17 <- Reducer 16 (SIMPLE_EDGE)
+Reducer 18 <- Reducer 17 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Reducer 19 <- Reducer 18 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE), Union 5 (CONTAINS)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 20 (SIMPLE_EDGE)
+Reducer 21 <- Map 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 22 <- Map 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 23 <- Map 20 (SIMPLE_EDGE), Map 33 (SIMPLE_EDGE)
+Reducer 24 <- Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 25 <- Map 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 26 <- Map 20 (SIMPLE_EDGE), Map 31 (SIMPLE_EDGE)
+Reducer 27 <- Map 32 (SIMPLE_EDGE), Reducer 26 (SIMPLE_EDGE)
+Reducer 28 <- Reducer 27 (SIMPLE_EDGE)
+Reducer 29 <- Reducer 27 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 11 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 30 <- Map 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 35 <- Map 34 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 28 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (CUSTOM_SIMPLE_EDGE)
 Reducer 7 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 9 <- Map 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -161,7 +161,7 @@ Stage-0
         Group By Operator [GBY_439] (rows=1 width=112)
           Output:["_col0"],aggregations:["sum(VALUE._col0)"]
         <-Union 5 [CUSTOM_SIMPLE_EDGE]
-          <-Reducer 12 [CONTAINS]
+          <-Reducer 19 [CONTAINS]
             Reduce Output Operator [RS_373]
               Group By Operator [GBY_372] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(_col0)"]
@@ -169,26 +169,26 @@ Stage-0
                   Output:["_col0"]
                   Merge Join Operator [MERGEJOIN_369] (rows=3941102 width=114)
                     Conds:RS_152._col1=RS_462._col0(Left Semi),Output:["_col3","_col4"]
-                  <-Reducer 11 [SIMPLE_EDGE]
+                  <-Reducer 18 [SIMPLE_EDGE]
                     SHUFFLE [RS_152]
                       PartitionCols:_col1
                       Merge Join Operator [MERGEJOIN_361] (rows=3941102 width=118)
                         Conds:RS_147._col2=RS_456._col0(Inner),Output:["_col1","_col3","_col4"]
-                      <-Reducer 10 [SIMPLE_EDGE]
+                      <-Reducer 23 [SIMPLE_EDGE]
                         PARTITION_ONLY_SHUFFLE [RS_147]
                           PartitionCols:_col2
                           Merge Join Operator [MERGEJOIN_354] (rows=3941102 width=122)
-                            Conds:RS_445._col0=RS_378._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                          <-Map 8 [SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_378]
+                            Conds:RS_445._col0=RS_384._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                          <-Map 20 [SIMPLE_EDGE] vectorized
+                            PARTITION_ONLY_SHUFFLE [RS_384]
                               PartitionCols:_col0
-                              Select Operator [SEL_375] (rows=50 width=4)
+                              Select Operator [SEL_378] (rows=50 width=4)
                                 Output:["_col0"]
-                                Filter Operator [FIL_374] (rows=50 width=12)
+                                Filter Operator [FIL_375] (rows=50 width=12)
                                   predicate:((d_year = 1999) and (d_moy = 1))
-                                  TableScan [TS_3] (rows=73049 width=12)
-                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                          <-Map 35 [SIMPLE_EDGE] vectorized
+                                  TableScan [TS_18] (rows=73049 width=8)
+                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy","d_date"]
+                          <-Map 33 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_445]
                               PartitionCols:_col0
                               Select Operator [SEL_444] (rows=143930993 width=127)
@@ -197,23 +197,23 @@ Stage-0
                                   predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_145_date_dim_d_date_sk_min) AND DynamicValue(RS_145_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_145_date_dim_d_date_sk_bloom_filter)))
                                   TableScan [TS_78] (rows=144002668 width=127)
                                     default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk","ws_quantity","ws_list_price"]
-                                  <-Reducer 14 [BROADCAST_EDGE] vectorized
+                                  <-Reducer 25 [BROADCAST_EDGE] vectorized
                                     BROADCAST [RS_442]
                                       Group By Operator [GBY_441] (rows=1 width=12)
                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                      <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_383]
-                                          Group By Operator [GBY_381] (rows=1 width=12)
+                                      <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_394]
+                                          Group By Operator [GBY_390] (rows=1 width=12)
                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                            Select Operator [SEL_379] (rows=50 width=4)
+                                            Select Operator [SEL_385] (rows=50 width=4)
                                               Output:["_col0"]
-                                               Please refer to the previous Select Operator [SEL_375]
-                      <-Reducer 24 [SIMPLE_EDGE] vectorized
+                                               Please refer to the previous Select Operator [SEL_378]
+                      <-Reducer 17 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_456]
                           PartitionCols:_col0
                           Group By Operator [GBY_455] (rows=235937 width=3)
                             Output:["_col0"],keys:KEY._col0
-                          <-Reducer 23 [SIMPLE_EDGE]
+                          <-Reducer 16 [SIMPLE_EDGE]
                             SHUFFLE [RS_120]
                               PartitionCols:_col0
                               Group By Operator [GBY_119] (rows=235937 width=3)
@@ -224,65 +224,64 @@ Stage-0
                                     predicate:(_col1 > _col2)
                                     Merge Join Operator [MERGEJOIN_360] (rows=1415626 width=227)
                                       Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                    <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_417]
-                                        Select Operator [SEL_415] (rows=1 width=112)
+                                    <-Reducer 15 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      PARTITION_ONLY_SHUFFLE [RS_423]
+                                        Select Operator [SEL_421] (rows=1 width=112)
                                           Output:["_col0"]
-                                          Filter Operator [FIL_414] (rows=1 width=112)
+                                          Filter Operator [FIL_420] (rows=1 width=112)
                                             predicate:_col0 is not null
-                                            Group By Operator [GBY_413] (rows=1 width=112)
+                                            Group By Operator [GBY_419] (rows=1 width=112)
                                               Output:["_col0"],aggregations:["max(VALUE._col0)"]
-                                            <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_412]
-                                                Group By Operator [GBY_411] (rows=1 width=112)
+                                            <-Reducer 14 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              PARTITION_ONLY_SHUFFLE [RS_418]
+                                                Group By Operator [GBY_417] (rows=1 width=112)
                                                   Output:["_col0"],aggregations:["max(_col1)"]
-                                                  Select Operator [SEL_410] (rows=50562 width=112)
+                                                  Select Operator [SEL_416] (rows=50562 width=112)
                                                     Output:["_col1"]
-                                                    Group By Operator [GBY_409] (rows=50562 width=112)
+                                                    Group By Operator [GBY_415] (rows=50562 width=112)
                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                                    <-Reducer 20 [SIMPLE_EDGE]
+                                                    <-Reducer 13 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_26]
                                                         PartitionCols:_col0
                                                         Group By Operator [GBY_25] (rows=455058 width=112)
                                                           Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col1
                                                           Merge Join Operator [MERGEJOIN_351] (rows=18762463 width=112)
-                                                            Conds:RS_408._col0=RS_400._col0(Inner),Output:["_col1","_col2"]
-                                                          <-Map 25 [SIMPLE_EDGE] vectorized
-                                                            PARTITION_ONLY_SHUFFLE [RS_400]
+                                                            Conds:RS_414._col0=RS_380._col0(Inner),Output:["_col1","_col2"]
+                                                          <-Map 20 [SIMPLE_EDGE] vectorized
+                                                            PARTITION_ONLY_SHUFFLE [RS_380]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_399] (rows=2609 width=4)
+                                                              Select Operator [SEL_377] (rows=2609 width=4)
                                                                 Output:["_col0"]
-                                                                Filter Operator [FIL_398] (rows=2609 width=8)
+                                                                Filter Operator [FIL_374] (rows=2609 width=8)
                                                                   predicate:(d_year) IN (1999, 2000, 2001, 2002)
-                                                                  TableScan [TS_18] (rows=73049 width=8)
-                                                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                          <-Map 19 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_408]
+                                                                   Please refer to the previous TableScan [TS_18]
+                                                          <-Map 12 [SIMPLE_EDGE] vectorized
+                                                            SHUFFLE [RS_414]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_407] (rows=525327388 width=119)
+                                                              Select Operator [SEL_413] (rows=525327388 width=119)
                                                                 Output:["_col0","_col1","_col2"]
-                                                                Filter Operator [FIL_406] (rows=525327388 width=118)
+                                                                Filter Operator [FIL_412] (rows=525327388 width=118)
                                                                   predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_22_date_dim_d_date_sk_min) AND DynamicValue(RS_22_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_22_date_dim_d_date_sk_bloom_filter)))
                                                                   TableScan [TS_15] (rows=575995635 width=118)
                                                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_quantity","ss_sales_price"]
-                                                                  <-Reducer 26 [BROADCAST_EDGE] vectorized
-                                                                    BROADCAST [RS_405]
-                                                                      Group By Operator [GBY_404] (rows=1 width=12)
+                                                                  <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                                    BROADCAST [RS_411]
+                                                                      Group By Operator [GBY_410] (rows=1 width=12)
                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                      <-Map 25 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                        PARTITION_ONLY_SHUFFLE [RS_403]
-                                                                          Group By Operator [GBY_402] (rows=1 width=12)
+                                                                      <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                        PARTITION_ONLY_SHUFFLE [RS_392]
+                                                                          Group By Operator [GBY_388] (rows=1 width=12)
                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                            Select Operator [SEL_401] (rows=2609 width=4)
+                                                                            Select Operator [SEL_381] (rows=2609 width=4)
                                                                               Output:["_col0"]
-                                                                               Please refer to the previous Select Operator [SEL_399]
-                                    <-Reducer 37 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                               Please refer to the previous Select Operator [SEL_377]
+                                    <-Reducer 35 [CUSTOM_SIMPLE_EDGE] vectorized
                                       PARTITION_ONLY_SHUFFLE [RS_454]
                                         Filter Operator [FIL_453] (rows=1415626 width=115)
                                           predicate:_col1 is not null
                                           Group By Operator [GBY_452] (rows=1415626 width=115)
                                             Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                          <-Map 36 [SIMPLE_EDGE] vectorized
+                                          <-Map 34 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_451]
                                               PartitionCols:_col0
                                               Group By Operator [GBY_450] (rows=550080312 width=115)
@@ -293,18 +292,18 @@ Stage-0
                                                     predicate:(ss_customer_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS_147_web_sales_ws_bill_customer_sk_min) AND DynamicValue(RS_147_web_sales_ws_bill_customer_sk_max) and in_bloom_filter(ss_customer_sk, DynamicValue(RS_147_web_sales_ws_bill_customer_sk_bloom_filter)))
                                                     TableScan [TS_84] (rows=575995635 width=114)
                                                       default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_customer_sk","ss_quantity","ss_sales_price"]
-                                                    <-Reducer 13 [BROADCAST_EDGE] vectorized
+                                                    <-Reducer 24 [BROADCAST_EDGE] vectorized
                                                       BROADCAST [RS_447]
                                                         Group By Operator [GBY_446] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                        <-Reducer 10 [CUSTOM_SIMPLE_EDGE]
+                                                        <-Reducer 23 [CUSTOM_SIMPLE_EDGE]
                                                           PARTITION_ONLY_SHUFFLE [RS_319]
                                                             Group By Operator [GBY_318] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
                                                               Select Operator [SEL_317] (rows=3941102 width=7)
                                                                 Output:["_col0"]
                                                                  Please refer to the previous Merge Join Operator [MERGEJOIN_354]
-                  <-Reducer 31 [SIMPLE_EDGE] vectorized
+                  <-Reducer 29 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_462]
                       PartitionCols:_col0
                       Group By Operator [GBY_461] (rows=2235 width=4)
@@ -317,35 +316,34 @@ Stage-0
                               Output:["_col0","_col2"]
                               Group By Operator [GBY_457] (rows=5831115 width=106)
                                 Output:["_col0","_col1","_col2"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                              <-Reducer 29 [SIMPLE_EDGE]
+                              <-Reducer 27 [SIMPLE_EDGE]
                                 SHUFFLE [RS_139]
                                   PartitionCols:_col0, _col1
                                   Group By Operator [GBY_60] (rows=19646398 width=106)
                                     Output:["_col0","_col1","_col2"],aggregations:["count()"],keys:_col4, _col3
                                     Merge Join Operator [MERGEJOIN_353] (rows=19646398 width=98)
                                       Conds:RS_56._col1=RS_432._col0(Inner),Output:["_col3","_col4"]
-                                    <-Map 34 [SIMPLE_EDGE] vectorized
+                                    <-Map 32 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_432]
                                         PartitionCols:_col0
                                         Select Operator [SEL_431] (rows=462000 width=188)
                                           Output:["_col0"]
                                           TableScan [TS_51] (rows=462000 width=4)
                                             default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk"]
-                                    <-Reducer 28 [SIMPLE_EDGE]
+                                    <-Reducer 26 [SIMPLE_EDGE]
                                       SHUFFLE [RS_56]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_352] (rows=19646398 width=98)
-                                          Conds:RS_430._col0=RS_422._col0(Inner),Output:["_col1","_col3"]
-                                        <-Map 32 [SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_422]
+                                          Conds:RS_430._col0=RS_386._col0(Inner),Output:["_col1","_col3"]
+                                        <-Map 20 [SIMPLE_EDGE] vectorized
+                                          PARTITION_ONLY_SHUFFLE [RS_386]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_421] (rows=2609 width=98)
+                                            Select Operator [SEL_379] (rows=2609 width=98)
                                               Output:["_col0","_col1"]
-                                              Filter Operator [FIL_420] (rows=2609 width=102)
+                                              Filter Operator [FIL_376] (rows=2609 width=102)
                                                 predicate:(d_year) IN (1999, 2000, 2001, 2002)
-                                                TableScan [TS_48] (rows=73049 width=102)
-                                                  default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_year"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
+                                                 Please refer to the previous TableScan [TS_18]
+                                        <-Map 31 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_430]
                                             PartitionCols:_col0
                                             Select Operator [SEL_429] (rows=550076554 width=7)
@@ -354,17 +352,17 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_54_date_dim_d_date_sk_min) AND DynamicValue(RS_54_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_54_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_45] (rows=575995635 width=7)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk"]
-                                                <-Reducer 33 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 30 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_427]
                                                     Group By Operator [GBY_426] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 32 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_425]
-                                                        Group By Operator [GBY_424] (rows=1 width=12)
+                                                    <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      PARTITION_ONLY_SHUFFLE [RS_395]
+                                                        Group By Operator [GBY_391] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                          Select Operator [SEL_423] (rows=2609 width=4)
+                                                          Select Operator [SEL_387] (rows=2609 width=4)
                                                             Output:["_col0"]
-                                                             Please refer to the previous Select Operator [SEL_421]
+                                                             Please refer to the previous Select Operator [SEL_379]
           <-Reducer 4 [CONTAINS]
             Reduce Output Operator [RS_368]
               Group By Operator [GBY_367] (rows=1 width=112)
@@ -373,88 +371,7 @@ Stage-0
                   Output:["_col0"]
                   Merge Join Operator [MERGEJOIN_364] (rows=7751875 width=94)
                     Conds:RS_74._col2=RS_438._col0(Left Semi),Output:["_col3","_col4"]
-                  <-Reducer 3 [SIMPLE_EDGE]
-                    SHUFFLE [RS_74]
-                      PartitionCols:_col2
-                      Merge Join Operator [MERGEJOIN_359] (rows=7751875 width=98)
-                        Conds:RS_69._col1=RS_419._col0(Inner),Output:["_col2","_col3","_col4"]
-                      <-Reducer 2 [SIMPLE_EDGE]
-                        PARTITION_ONLY_SHUFFLE [RS_69]
-                          PartitionCols:_col1
-                          Merge Join Operator [MERGEJOIN_350] (rows=7751875 width=101)
-                            Conds:RS_388._col0=RS_376._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                          <-Map 8 [SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_376]
-                              PartitionCols:_col0
-                               Please refer to the previous Select Operator [SEL_375]
-                          <-Map 1 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_388]
-                              PartitionCols:_col0
-                              Select Operator [SEL_387] (rows=285117831 width=127)
-                                Output:["_col0","_col1","_col2","_col3","_col4"]
-                                Filter Operator [FIL_386] (rows=285117831 width=127)
-                                  predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_67_date_dim_d_date_sk_min) AND DynamicValue(RS_67_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_67_date_dim_d_date_sk_bloom_filter)))
-                                  TableScan [TS_0] (rows=287989836 width=127)
-                                    default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk","cs_quantity","cs_list_price"]
-                                  <-Reducer 9 [BROADCAST_EDGE] vectorized
-                                    BROADCAST [RS_385]
-                                      Group By Operator [GBY_384] (rows=1 width=12)
-                                        Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                      <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_382]
-                                          Group By Operator [GBY_380] (rows=1 width=12)
-                                            Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                            Select Operator [SEL_377] (rows=50 width=4)
-                                              Output:["_col0"]
-                                               Please refer to the previous Select Operator [SEL_375]
-                      <-Reducer 18 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_419]
-                          PartitionCols:_col0
-                          Group By Operator [GBY_418] (rows=235937 width=3)
-                            Output:["_col0"],keys:KEY._col0
-                          <-Reducer 17 [SIMPLE_EDGE]
-                            SHUFFLE [RS_42]
-                              PartitionCols:_col0
-                              Group By Operator [GBY_41] (rows=235937 width=3)
-                                Output:["_col0"],keys:_col0
-                                Select Operator [SEL_40] (rows=471875 width=227)
-                                  Output:["_col0"]
-                                  Filter Operator [FIL_39] (rows=471875 width=227)
-                                    predicate:(_col1 > _col2)
-                                    Merge Join Operator [MERGEJOIN_358] (rows=1415626 width=227)
-                                      Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                    <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_416]
-                                         Please refer to the previous Select Operator [SEL_415]
-                                    <-Reducer 16 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_397]
-                                        Filter Operator [FIL_396] (rows=1415626 width=115)
-                                          predicate:_col1 is not null
-                                          Group By Operator [GBY_395] (rows=1415626 width=115)
-                                            Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                          <-Map 15 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_394]
-                                              PartitionCols:_col0
-                                              Group By Operator [GBY_393] (rows=550080312 width=115)
-                                                Output:["_col0","_col1"],aggregations:["sum(_col1)"],keys:_col0
-                                                Select Operator [SEL_392] (rows=550080312 width=114)
-                                                  Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_391] (rows=550080312 width=114)
-                                                    predicate:(ss_customer_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_min) AND DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_max) and in_bloom_filter(ss_customer_sk, DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_bloom_filter)))
-                                                    TableScan [TS_6] (rows=575995635 width=114)
-                                                      default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_customer_sk","ss_quantity","ss_sales_price"]
-                                                    <-Reducer 7 [BROADCAST_EDGE] vectorized
-                                                      BROADCAST [RS_390]
-                                                        Group By Operator [GBY_389] (rows=1 width=12)
-                                                          Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                        <-Reducer 2 [CUSTOM_SIMPLE_EDGE]
-                                                          PARTITION_ONLY_SHUFFLE [RS_256]
-                                                            Group By Operator [GBY_255] (rows=1 width=12)
-                                                              Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                              Select Operator [SEL_254] (rows=7751875 width=6)
-                                                                Output:["_col0"]
-                                                                 Please refer to the previous Merge Join Operator [MERGEJOIN_350]
-                  <-Reducer 30 [SIMPLE_EDGE] vectorized
+                  <-Reducer 28 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_438]
                       PartitionCols:_col0
                       Group By Operator [GBY_437] (rows=2235 width=4)
@@ -467,8 +384,89 @@ Stage-0
                               Output:["_col0","_col2"]
                               Group By Operator [GBY_433] (rows=5831115 width=106)
                                 Output:["_col0","_col1","_col2"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                              <-Reducer 29 [SIMPLE_EDGE]
+                              <-Reducer 27 [SIMPLE_EDGE]
                                 SHUFFLE [RS_61]
                                   PartitionCols:_col0, _col1
                                    Please refer to the previous Group By Operator [GBY_60]
+                  <-Reducer 3 [SIMPLE_EDGE]
+                    SHUFFLE [RS_74]
+                      PartitionCols:_col2
+                      Merge Join Operator [MERGEJOIN_359] (rows=7751875 width=98)
+                        Conds:RS_69._col1=RS_425._col0(Inner),Output:["_col2","_col3","_col4"]
+                      <-Reducer 2 [SIMPLE_EDGE]
+                        PARTITION_ONLY_SHUFFLE [RS_69]
+                          PartitionCols:_col1
+                          Merge Join Operator [MERGEJOIN_350] (rows=7751875 width=101)
+                            Conds:RS_400._col0=RS_382._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                          <-Map 20 [SIMPLE_EDGE] vectorized
+                            PARTITION_ONLY_SHUFFLE [RS_382]
+                              PartitionCols:_col0
+                               Please refer to the previous Select Operator [SEL_378]
+                          <-Map 1 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_400]
+                              PartitionCols:_col0
+                              Select Operator [SEL_399] (rows=285117831 width=127)
+                                Output:["_col0","_col1","_col2","_col3","_col4"]
+                                Filter Operator [FIL_398] (rows=285117831 width=127)
+                                  predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_67_date_dim_d_date_sk_min) AND DynamicValue(RS_67_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_67_date_dim_d_date_sk_bloom_filter)))
+                                  TableScan [TS_0] (rows=287989836 width=127)
+                                    default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk","cs_quantity","cs_list_price"]
+                                  <-Reducer 22 [BROADCAST_EDGE] vectorized
+                                    BROADCAST [RS_397]
+                                      Group By Operator [GBY_396] (rows=1 width=12)
+                                        Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
+                                      <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_393]
+                                          Group By Operator [GBY_389] (rows=1 width=12)
+                                            Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
+                                            Select Operator [SEL_383] (rows=50 width=4)
+                                              Output:["_col0"]
+                                               Please refer to the previous Select Operator [SEL_378]
+                      <-Reducer 11 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_425]
+                          PartitionCols:_col0
+                          Group By Operator [GBY_424] (rows=235937 width=3)
+                            Output:["_col0"],keys:KEY._col0
+                          <-Reducer 10 [SIMPLE_EDGE]
+                            SHUFFLE [RS_42]
+                              PartitionCols:_col0
+                              Group By Operator [GBY_41] (rows=235937 width=3)
+                                Output:["_col0"],keys:_col0
+                                Select Operator [SEL_40] (rows=471875 width=227)
+                                  Output:["_col0"]
+                                  Filter Operator [FIL_39] (rows=471875 width=227)
+                                    predicate:(_col1 > _col2)
+                                    Merge Join Operator [MERGEJOIN_358] (rows=1415626 width=227)
+                                      Conds:(Inner),Output:["_col0","_col1","_col2"]
+                                    <-Reducer 15 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      PARTITION_ONLY_SHUFFLE [RS_422]
+                                         Please refer to the previous Select Operator [SEL_421]
+                                    <-Reducer 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      PARTITION_ONLY_SHUFFLE [RS_409]
+                                        Filter Operator [FIL_408] (rows=1415626 width=115)
+                                          predicate:_col1 is not null
+                                          Group By Operator [GBY_407] (rows=1415626 width=115)
+                                            Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
+                                          <-Map 8 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_406]
+                                              PartitionCols:_col0
+                                              Group By Operator [GBY_405] (rows=550080312 width=115)
+                                                Output:["_col0","_col1"],aggregations:["sum(_col1)"],keys:_col0
+                                                Select Operator [SEL_404] (rows=550080312 width=114)
+                                                  Output:["_col0","_col1"]
+                                                  Filter Operator [FIL_403] (rows=550080312 width=114)
+                                                    predicate:(ss_customer_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_min) AND DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_max) and in_bloom_filter(ss_customer_sk, DynamicValue(RS_69_catalog_sales_cs_bill_customer_sk_bloom_filter)))
+                                                    TableScan [TS_6] (rows=575995635 width=114)
+                                                      default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_customer_sk","ss_quantity","ss_sales_price"]
+                                                    <-Reducer 7 [BROADCAST_EDGE] vectorized
+                                                      BROADCAST [RS_402]
+                                                        Group By Operator [GBY_401] (rows=1 width=12)
+                                                          Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
+                                                        <-Reducer 2 [CUSTOM_SIMPLE_EDGE]
+                                                          PARTITION_ONLY_SHUFFLE [RS_256]
+                                                            Group By Operator [GBY_255] (rows=1 width=12)
+                                                              Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
+                                                              Select Operator [SEL_254] (rows=7751875 width=6)
+                                                                Output:["_col0"]
+                                                                 Please refer to the previous Merge Join Operator [MERGEJOIN_350]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query29.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query29.q.out
@@ -108,15 +108,15 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 9 (BROADCAST_EDGE)
-Map 10 <- Reducer 14 (BROADCAST_EDGE)
-Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 14 <- Map 13 (CUSTOM_SIMPLE_EDGE)
-Reducer 15 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Map 14 <- Reducer 12 (BROADCAST_EDGE)
+Reducer 10 <- Map 14 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 12 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Map 15 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 17 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 18 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 11 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 4 <- Map 16 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 5 <- Map 17 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
@@ -144,7 +144,7 @@ Stage-0
                       keys:_col22, _col23, _col19, _col20,top n:100
                       Merge Join Operator [MERGEJOIN_214] (rows=4156223234 width=483)
                         Conds:RS_42._col6=RS_246._col0(Inner),Output:["_col3","_col10","_col16","_col19","_col20","_col22","_col23"]
-                      <-Map 18 [SIMPLE_EDGE] vectorized
+                      <-Map 17 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_246]
                           PartitionCols:_col0
                           Select Operator [SEL_245] (rows=462000 width=288)
@@ -156,7 +156,7 @@ Stage-0
                           PartitionCols:_col6
                           Merge Join Operator [MERGEJOIN_213] (rows=4156223234 width=203)
                             Conds:RS_39._col8=RS_244._col0(Inner),Output:["_col3","_col6","_col10","_col16","_col19","_col20"]
-                          <-Map 17 [SIMPLE_EDGE] vectorized
+                          <-Map 16 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_244]
                               PartitionCols:_col0
                               Select Operator [SEL_243] (rows=1704 width=192)
@@ -168,26 +168,26 @@ Stage-0
                               PartitionCols:_col8
                               Merge Join Operator [MERGEJOIN_212] (rows=4156223234 width=19)
                                 Conds:RS_36._col1, _col2=RS_37._col9, _col8(Inner),Output:["_col3","_col6","_col8","_col10","_col16"]
-                              <-Reducer 12 [SIMPLE_EDGE]
+                              <-Reducer 11 [SIMPLE_EDGE]
                                 SHUFFLE [RS_37]
                                   PartitionCols:_col9, _col8
                                   Merge Join Operator [MERGEJOIN_211] (rows=21091879 width=18)
                                     Conds:RS_25._col2, _col1, _col4=RS_26._col2, _col1, _col3(Inner),Output:["_col1","_col3","_col5","_col8","_col9","_col11"]
-                                  <-Reducer 11 [SIMPLE_EDGE]
+                                  <-Reducer 10 [SIMPLE_EDGE]
                                     SHUFFLE [RS_25]
                                       PartitionCols:_col2, _col1, _col4
                                       Merge Join Operator [MERGEJOIN_209] (rows=13737330 width=8)
-                                        Conds:RS_239._col0=RS_230._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                      <-Map 13 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_230]
+                                        Conds:RS_239._col0=RS_223._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
+                                      <-Map 8 [SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_223]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_228] (rows=50 width=4)
+                                          Select Operator [SEL_219] (rows=50 width=4)
                                             Output:["_col0"]
-                                            Filter Operator [FIL_226] (rows=50 width=12)
+                                            Filter Operator [FIL_216] (rows=50 width=12)
                                               predicate:((d_year = 1999) and (d_moy = 4))
-                                              TableScan [TS_9] (rows=73049 width=12)
-                                                default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                      <-Map 10 [SIMPLE_EDGE] vectorized
+                                              TableScan [TS_3] (rows=73049 width=8)
+                                                default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
+                                      <-Map 14 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_239]
                                           PartitionCols:_col0
                                           Select Operator [SEL_238] (rows=501694138 width=23)
@@ -196,31 +196,31 @@ Stage-0
                                               predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_23_d1_d_date_sk_min) AND DynamicValue(RS_23_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_23_d1_d_date_sk_bloom_filter)))
                                               TableScan [TS_6] (rows=575995635 width=23)
                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_ticket_number","ss_quantity"]
-                                              <-Reducer 14 [BROADCAST_EDGE] vectorized
+                                              <-Reducer 12 [BROADCAST_EDGE] vectorized
                                                 BROADCAST [RS_236]
                                                   Group By Operator [GBY_235] (rows=1 width=12)
                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                  <-Map 13 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_234]
-                                                      Group By Operator [GBY_233] (rows=1 width=12)
+                                                  <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_229]
+                                                      Group By Operator [GBY_227] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                        Select Operator [SEL_231] (rows=50 width=4)
+                                                        Select Operator [SEL_224] (rows=50 width=4)
                                                           Output:["_col0"]
-                                                           Please refer to the previous Select Operator [SEL_228]
-                                  <-Reducer 15 [SIMPLE_EDGE]
+                                                           Please refer to the previous Select Operator [SEL_219]
+                                  <-Reducer 13 [SIMPLE_EDGE]
                                     SHUFFLE [RS_26]
                                       PartitionCols:_col2, _col1, _col3
                                       Merge Join Operator [MERGEJOIN_210] (rows=5384572 width=13)
-                                        Conds:RS_242._col0=RS_232._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                                      <-Map 13 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_232]
+                                        Conds:RS_242._col0=RS_225._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                                      <-Map 8 [SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_225]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_229] (rows=201 width=4)
+                                          Select Operator [SEL_220] (rows=201 width=4)
                                             Output:["_col0"]
-                                            Filter Operator [FIL_227] (rows=201 width=12)
+                                            Filter Operator [FIL_217] (rows=201 width=12)
                                               predicate:((d_year = 1999) and d_moy BETWEEN 4 AND 7)
-                                               Please refer to the previous TableScan [TS_9]
-                                      <-Map 16 [SIMPLE_EDGE] vectorized
+                                               Please refer to the previous TableScan [TS_3]
+                                      <-Map 15 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_242]
                                           PartitionCols:_col0
                                           Select Operator [SEL_241] (rows=53632139 width=19)
@@ -233,34 +233,33 @@ Stage-0
                                 SHUFFLE [RS_36]
                                   PartitionCols:_col1, _col2
                                   Merge Join Operator [MERGEJOIN_208] (rows=7638375 width=10)
-                                    Conds:RS_225._col0=RS_217._col0(Inner),Output:["_col1","_col2","_col3"]
+                                    Conds:RS_234._col0=RS_221._col0(Inner),Output:["_col1","_col2","_col3"]
                                   <-Map 8 [SIMPLE_EDGE] vectorized
-                                    PARTITION_ONLY_SHUFFLE [RS_217]
+                                    PARTITION_ONLY_SHUFFLE [RS_221]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_216] (rows=1957 width=4)
+                                      Select Operator [SEL_218] (rows=1957 width=4)
                                         Output:["_col0"]
                                         Filter Operator [FIL_215] (rows=1957 width=8)
                                           predicate:(d_year) IN (1999, 2000, 2001)
-                                          TableScan [TS_3] (rows=73049 width=8)
-                                            default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
+                                           Please refer to the previous TableScan [TS_3]
                                   <-Map 1 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_225]
+                                    SHUFFLE [RS_234]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_224] (rows=285117831 width=15)
+                                      Select Operator [SEL_233] (rows=285117831 width=15)
                                         Output:["_col0","_col1","_col2","_col3"]
-                                        Filter Operator [FIL_223] (rows=285117831 width=15)
+                                        Filter Operator [FIL_232] (rows=285117831 width=15)
                                           predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_34_d3_d_date_sk_min) AND DynamicValue(RS_34_d3_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_34_d3_d_date_sk_bloom_filter)))
                                           TableScan [TS_0] (rows=287989836 width=15)
                                             default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk","cs_quantity"]
                                           <-Reducer 9 [BROADCAST_EDGE] vectorized
-                                            BROADCAST [RS_222]
-                                              Group By Operator [GBY_221] (rows=1 width=12)
+                                            BROADCAST [RS_231]
+                                              Group By Operator [GBY_230] (rows=1 width=12)
                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                               <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                PARTITION_ONLY_SHUFFLE [RS_220]
-                                                  Group By Operator [GBY_219] (rows=1 width=12)
+                                                PARTITION_ONLY_SHUFFLE [RS_228]
+                                                  Group By Operator [GBY_226] (rows=1 width=12)
                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                    Select Operator [SEL_218] (rows=1957 width=4)
+                                                    Select Operator [SEL_222] (rows=1957 width=4)
                                                       Output:["_col0"]
-                                                       Please refer to the previous Select Operator [SEL_216]
+                                                       Please refer to the previous Select Operator [SEL_218]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query33.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query33.q.out
@@ -163,27 +163,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -221,40 +221,39 @@ Stage-0
                                 SHUFFLE [RS_104]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_294] (rows=461514 width=7)
-                                    Conds:RS_320._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
+                                    Conds:RS_322._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
                                   <-Map 1 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_320]
+                                    SHUFFLE [RS_322]
                                       PartitionCols:_col1
-                                      Select Operator [SEL_319] (rows=460848 width=7)
+                                      Select Operator [SEL_320] (rows=460848 width=7)
                                         Output:["_col0","_col1"]
                                         Filter Operator [FIL_318] (rows=460848 width=7)
                                           predicate:i_manufact_id is not null
                                           TableScan [TS_0] (rows=462000 width=7)
-                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_manufact_id"]
-                                  <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_manufact_id","i_category"]
+                                  <-Reducer 12 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_326]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_325] (rows=692 width=3)
                                         Output:["_col0"],keys:KEY._col0
-                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                      <-Map 1 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_324]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_323] (rows=692 width=3)
                                             Output:["_col0"],keys:i_manufact_id
-                                            Select Operator [SEL_322] (rows=46085 width=93)
+                                            Select Operator [SEL_321] (rows=46085 width=93)
                                               Output:["i_manufact_id"]
-                                              Filter Operator [FIL_321] (rows=46085 width=93)
+                                              Filter Operator [FIL_319] (rows=46085 width=93)
                                                 predicate:((i_category = 'Books') and i_manufact_id is not null)
-                                                TableScan [TS_3] (rows=462000 width=93)
-                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_category","i_manufact_id"]
-                              <-Reducer 23 [SIMPLE_EDGE]
+                                                 Please refer to the previous TableScan [TS_0]
+                              <-Reducer 22 [SIMPLE_EDGE]
                                 SHUFFLE [RS_105]
                                   PartitionCols:_col2
                                   Select Operator [SEL_100] (rows=788222 width=110)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_302] (rows=788222 width=110)
                                       Conds:RS_97._col2=RS_350._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_350]
                                         PartitionCols:_col0
                                         Select Operator [SEL_347] (rows=8000000 width=4)
@@ -263,12 +262,12 @@ Stage-0
                                             predicate:(ca_gmt_offset = -6)
                                             TableScan [TS_16] (rows=40000000 width=112)
                                               default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                    <-Reducer 22 [SIMPLE_EDGE]
+                                    <-Reducer 21 [SIMPLE_EDGE]
                                       SHUFFLE [RS_97]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_301] (rows=3941109 width=118)
                                           Conds:RS_372._col0=RS_333._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_333]
                                             PartitionCols:_col0
                                             Select Operator [SEL_328] (rows=50 width=4)
@@ -277,7 +276,7 @@ Stage-0
                                                 predicate:((d_year = 1999) and (d_moy = 3))
                                                 TableScan [TS_13] (rows=73049 width=12)
                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
+                                        <-Map 26 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_372]
                                             PartitionCols:_col0
                                             Select Operator [SEL_371] (rows=143931246 width=123)
@@ -286,11 +285,11 @@ Stage-0
                                                 predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_95_date_dim_d_date_sk_min) AND DynamicValue(RS_95_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_95_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_85] (rows=144002668 width=123)
                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_369]
                                                     Group By Operator [GBY_368] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_340]
                                                         Group By Operator [GBY_337] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -315,27 +314,27 @@ Stage-0
                                 SHUFFLE [RS_29]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 16 [SIMPLE_EDGE]
+                              <-Reducer 15 [SIMPLE_EDGE]
                                 SHUFFLE [RS_30]
                                   PartitionCols:_col2
                                   Select Operator [SEL_25] (rows=2876890 width=4)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_296] (rows=2876890 width=4)
                                       Conds:RS_22._col2=RS_348._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_348]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 15 [SIMPLE_EDGE]
+                                    <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_22]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_295] (rows=14384447 width=4)
                                           Conds:RS_345._col0=RS_329._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_329]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 14 [SIMPLE_EDGE] vectorized
+                                        <-Map 13 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_345]
                                             PartitionCols:_col0
                                             Select Operator [SEL_344] (rows=525327191 width=118)
@@ -344,11 +343,11 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_20_date_dim_d_date_sk_min) AND DynamicValue(RS_20_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_20_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_10] (rows=575995635 width=118)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_342]
                                                     Group By Operator [GBY_341] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_338]
                                                         Group By Operator [GBY_335] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -373,27 +372,27 @@ Stage-0
                                 SHUFFLE [RS_66]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 20 [SIMPLE_EDGE]
+                              <-Reducer 19 [SIMPLE_EDGE]
                                 SHUFFLE [RS_67]
                                   PartitionCols:_col3
                                   Select Operator [SEL_62] (rows=1550375 width=13)
                                     Output:["_col3","_col4"]
                                     Merge Join Operator [MERGEJOIN_299] (rows=1550375 width=13)
                                       Conds:RS_59._col1=RS_349._col0(Inner),Output:["_col2","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_349]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 19 [SIMPLE_EDGE]
+                                    <-Reducer 18 [SIMPLE_EDGE]
                                       SHUFFLE [RS_59]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_298] (rows=7751872 width=98)
                                           Conds:RS_364._col0=RS_331._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_331]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
+                                        <-Map 25 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_364]
                                             PartitionCols:_col0
                                             Select Operator [SEL_363] (rows=285117733 width=123)
@@ -402,11 +401,11 @@ Stage-0
                                                 predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_47] (rows=287989836 width=123)
                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_361]
                                                     Group By Operator [GBY_360] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_339]
                                                         Group By Operator [GBY_336] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query4.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query4.q.out
@@ -243,43 +243,43 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Reducer 31 (BROADCAST_EDGE)
-Map 13 <- Reducer 32 (BROADCAST_EDGE)
-Map 17 <- Reducer 33 (BROADCAST_EDGE)
-Map 21 <- Reducer 34 (BROADCAST_EDGE)
-Map 25 <- Reducer 30 (BROADCAST_EDGE)
-Map 40 <- Reducer 38 (BROADCAST_EDGE)
-Reducer 10 <- Map 41 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Map 1 <- Reducer 30 (BROADCAST_EDGE)
+Map 12 <- Reducer 31 (BROADCAST_EDGE)
+Map 16 <- Reducer 32 (BROADCAST_EDGE)
+Map 20 <- Reducer 33 (BROADCAST_EDGE)
+Map 24 <- Reducer 29 (BROADCAST_EDGE)
+Map 39 <- Reducer 37 (BROADCAST_EDGE)
+Reducer 10 <- Map 38 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
-Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 29 (SIMPLE_EDGE)
-Reducer 15 <- Map 39 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (SIMPLE_EDGE), Map 29 (SIMPLE_EDGE)
-Reducer 19 <- Map 39 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 29 (SIMPLE_EDGE)
-Reducer 20 <- Reducer 19 (SIMPLE_EDGE)
-Reducer 22 <- Map 21 (SIMPLE_EDGE), Map 29 (SIMPLE_EDGE)
-Reducer 23 <- Map 39 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Reducer 23 (SIMPLE_EDGE)
-Reducer 26 <- Map 25 (SIMPLE_EDGE), Map 29 (SIMPLE_EDGE)
-Reducer 27 <- Map 39 (SIMPLE_EDGE), Reducer 26 (SIMPLE_EDGE)
-Reducer 28 <- Reducer 27 (SIMPLE_EDGE)
-Reducer 3 <- Map 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 31 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 32 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 33 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 34 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 35 <- Map 29 (SIMPLE_EDGE), Map 40 (SIMPLE_EDGE)
-Reducer 36 <- Map 39 (SIMPLE_EDGE), Reducer 35 (SIMPLE_EDGE)
-Reducer 37 <- Reducer 36 (SIMPLE_EDGE)
-Reducer 38 <- Map 29 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
+Reducer 14 <- Map 38 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
+Reducer 18 <- Map 38 (SIMPLE_EDGE), Reducer 17 (SIMPLE_EDGE)
+Reducer 19 <- Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
+Reducer 21 <- Map 20 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
+Reducer 22 <- Map 38 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Reducer 22 (SIMPLE_EDGE)
+Reducer 25 <- Map 24 (SIMPLE_EDGE), Map 28 (SIMPLE_EDGE)
+Reducer 26 <- Map 38 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
+Reducer 27 <- Reducer 26 (SIMPLE_EDGE)
+Reducer 29 <- Map 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Map 38 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 30 <- Map 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 31 <- Map 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 32 <- Map 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 33 <- Map 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 34 <- Map 28 (SIMPLE_EDGE), Map 39 (SIMPLE_EDGE)
+Reducer 35 <- Map 38 (SIMPLE_EDGE), Reducer 34 (SIMPLE_EDGE)
+Reducer 36 <- Reducer 35 (SIMPLE_EDGE)
+Reducer 37 <- Map 28 (CUSTOM_SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Reducer 16 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-Reducer 6 <- Reducer 20 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Reducer 24 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 28 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Reducer 37 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+Reducer 5 <- Reducer 15 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 6 <- Reducer 19 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 7 <- Reducer 23 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 27 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 9 <- Reducer 36 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -298,14 +298,14 @@ Stage-0
                 Top N Key Operator [TNK_285] (rows=7972067 width=372)
                   keys:_col0, _col2, _col3, _col4,top n:100
                   Merge Join Operator [MERGEJOIN_528] (rows=7972067 width=372)
-                    Conds:RS_149._col0=RS_633._col0(Inner),Output:["_col0","_col2","_col3","_col4"]
-                  <-Map 41 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_633]
+                    Conds:RS_149._col0=RS_580._col0(Inner),Output:["_col0","_col2","_col3","_col4"]
+                  <-Map 38 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_580]
                       PartitionCols:_col0
-                      Select Operator [SEL_632] (rows=80000000 width=372)
+                      Select Operator [SEL_573] (rows=80000000 width=372)
                         Output:["_col0","_col1","_col2","_col3"]
-                        TableScan [TS_147] (rows=80000000 width=372)
-                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_id","c_first_name","c_last_name","c_birth_country"]
+                        TableScan [TS_94] (rows=80000000 width=104)
+                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_birth_country","c_first_name","c_last_name"]
                   <-Reducer 9 [SIMPLE_EDGE]
                     SHUFFLE [RS_149]
                       PartitionCols:_col0
@@ -314,36 +314,35 @@ Stage-0
                         Filter Operator [FIL_145] (rows=6666666 width=556)
                           predicate:CASE WHEN (_col14) THEN (CASE WHEN (_col9) THEN (((_col6 / _col8) > (_col11 / _col13))) ELSE (false) END) ELSE (false) END
                           Merge Join Operator [MERGEJOIN_527] (rows=13333333 width=556)
-                            Conds:RS_142._col0=RS_631._col0(Inner),Output:["_col0","_col6","_col8","_col9","_col11","_col13","_col14"]
-                          <-Reducer 37 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_631]
+                            Conds:RS_142._col0=RS_633._col0(Inner),Output:["_col0","_col6","_col8","_col9","_col11","_col13","_col14"]
+                          <-Reducer 36 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_633]
                               PartitionCols:_col0
-                              Select Operator [SEL_630] (rows=14325562 width=216)
+                              Select Operator [SEL_632] (rows=14325562 width=216)
                                 Output:["_col0","_col1","_col2"]
-                                Filter Operator [FIL_629] (rows=14325562 width=212)
+                                Filter Operator [FIL_631] (rows=14325562 width=212)
                                   predicate:(_col1 > 0)
-                                  Group By Operator [GBY_628] (rows=42976686 width=212)
+                                  Group By Operator [GBY_630] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                  <-Reducer 36 [SIMPLE_EDGE]
+                                  <-Reducer 35 [SIMPLE_EDGE]
                                     SHUFFLE [RS_125]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_124] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_522] (rows=51391963 width=212)
-                                          Conds:RS_120._col1=RS_588._col0(Inner),Output:["_col2","_col5"]
-                                        <-Map 39 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_588]
+                                          Conds:RS_120._col1=RS_578._col0(Inner),Output:["_col2","_col5"]
+                                        <-Map 38 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_578]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_583] (rows=80000000 width=104)
+                                            Select Operator [SEL_571] (rows=80000000 width=104)
                                               Output:["_col0","_col1"]
-                                              TableScan [TS_94] (rows=80000000 width=104)
-                                                default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id"]
-                                        <-Reducer 35 [SIMPLE_EDGE]
+                                               Please refer to the previous TableScan [TS_94]
+                                        <-Reducer 34 [SIMPLE_EDGE]
                                           SHUFFLE [RS_120]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_521] (rows=51391963 width=115)
-                                              Conds:RS_627._col0=RS_550._col0(Inner),Output:["_col1","_col2"]
-                                            <-Map 29 [SIMPLE_EDGE] vectorized
+                                              Conds:RS_629._col0=RS_550._col0(Inner),Output:["_col1","_col2"]
+                                            <-Map 28 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_550]
                                                 PartitionCols:_col0
                                                 Select Operator [SEL_539] (rows=652 width=4)
@@ -354,24 +353,24 @@ Stage-0
                                                       Output:["_col0","_col1"]
                                                       TableScan [TS_90] (rows=73049 width=8)
                                                         default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                            <-Map 40 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_627]
+                                            <-Map 39 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_629]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_626] (rows=143930993 width=119)
+                                                Select Operator [SEL_628] (rows=143930993 width=119)
                                                   Output:["_col0","_col1","_col2"]
-                                                  Filter Operator [FIL_625] (rows=143930993 width=455)
+                                                  Filter Operator [FIL_627] (rows=143930993 width=455)
                                                     predicate:(_col0 is not null and _col1 is not null)
-                                                    Select Operator [SEL_624] (rows=144002668 width=455)
+                                                    Select Operator [SEL_626] (rows=144002668 width=455)
                                                       Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                      Filter Operator [FIL_623] (rows=144002668 width=455)
+                                                      Filter Operator [FIL_625] (rows=144002668 width=455)
                                                         predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_118_date_dim_d_date_sk_min) AND DynamicValue(RS_118_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_118_date_dim_d_date_sk_bloom_filter)))
                                                         TableScan [TS_107] (rows=144002668 width=455)
                                                           default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_ext_discount_amt","ws_ext_sales_price","ws_ext_wholesale_cost","ws_ext_list_price"]
-                                                        <-Reducer 38 [BROADCAST_EDGE] vectorized
-                                                          BROADCAST [RS_622]
-                                                            Group By Operator [GBY_621] (rows=1 width=12)
+                                                        <-Reducer 37 [BROADCAST_EDGE] vectorized
+                                                          BROADCAST [RS_624]
+                                                            Group By Operator [GBY_623] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_563]
                                                                 Group By Operator [GBY_557] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -382,29 +381,29 @@ Stage-0
                             SHUFFLE [RS_142]
                               PartitionCols:_col0
                               Merge Join Operator [MERGEJOIN_526] (rows=13333333 width=440)
-                                Conds:RS_139._col0=RS_620._col0(Inner),Output:["_col0","_col6","_col8","_col9","_col11"]
-                              <-Reducer 28 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_620]
+                                Conds:RS_139._col0=RS_622._col0(Inner),Output:["_col0","_col6","_col8","_col9","_col11"]
+                              <-Reducer 27 [SIMPLE_EDGE] vectorized
+                                SHUFFLE [RS_622]
                                   PartitionCols:_col0
-                                  Group By Operator [GBY_619] (rows=42976686 width=212)
+                                  Group By Operator [GBY_621] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                  <-Reducer 27 [SIMPLE_EDGE]
+                                  <-Reducer 26 [SIMPLE_EDGE]
                                     SHUFFLE [RS_104]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_103] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_520] (rows=51391963 width=212)
-                                          Conds:RS_99._col1=RS_584._col0(Inner),Output:["_col2","_col5"]
-                                        <-Map 39 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_584]
+                                          Conds:RS_99._col1=RS_574._col0(Inner),Output:["_col2","_col5"]
+                                        <-Map 38 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_574]
                                             PartitionCols:_col0
-                                             Please refer to the previous Select Operator [SEL_583]
-                                        <-Reducer 26 [SIMPLE_EDGE]
+                                             Please refer to the previous Select Operator [SEL_571]
+                                        <-Reducer 25 [SIMPLE_EDGE]
                                           SHUFFLE [RS_99]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_519] (rows=51391963 width=115)
-                                              Conds:RS_618._col0=RS_540._col0(Inner),Output:["_col1","_col2"]
-                                            <-Map 29 [SIMPLE_EDGE] vectorized
+                                              Conds:RS_620._col0=RS_540._col0(Inner),Output:["_col1","_col2"]
+                                            <-Map 28 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_540]
                                                 PartitionCols:_col0
                                                 Select Operator [SEL_535] (rows=652 width=4)
@@ -412,24 +411,24 @@ Stage-0
                                                   Filter Operator [FIL_530] (rows=652 width=8)
                                                     predicate:(_col1 = 2000)
                                                      Please refer to the previous Select Operator [SEL_529]
-                                            <-Map 25 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_618]
+                                            <-Map 24 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_620]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_617] (rows=143930993 width=119)
+                                                Select Operator [SEL_619] (rows=143930993 width=119)
                                                   Output:["_col0","_col1","_col2"]
-                                                  Filter Operator [FIL_616] (rows=143930993 width=455)
+                                                  Filter Operator [FIL_618] (rows=143930993 width=455)
                                                     predicate:(_col0 is not null and _col1 is not null)
-                                                    Select Operator [SEL_615] (rows=144002668 width=455)
+                                                    Select Operator [SEL_617] (rows=144002668 width=455)
                                                       Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                      Filter Operator [FIL_614] (rows=144002668 width=455)
+                                                      Filter Operator [FIL_616] (rows=144002668 width=455)
                                                         predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_97_date_dim_d_date_sk_min) AND DynamicValue(RS_97_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_97_date_dim_d_date_sk_bloom_filter)))
                                                         TableScan [TS_86] (rows=144002668 width=455)
                                                           default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_ext_discount_amt","ws_ext_sales_price","ws_ext_wholesale_cost","ws_ext_list_price"]
-                                                        <-Reducer 30 [BROADCAST_EDGE] vectorized
-                                                          BROADCAST [RS_613]
-                                                            Group By Operator [GBY_612] (rows=1 width=12)
+                                                        <-Reducer 29 [BROADCAST_EDGE] vectorized
+                                                          BROADCAST [RS_615]
+                                                            Group By Operator [GBY_614] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_558]
                                                                 Group By Operator [GBY_552] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -442,33 +441,33 @@ Stage-0
                                   Filter Operator [FIL_138] (rows=13333333 width=552)
                                     predicate:CASE WHEN (_col4 is not null) THEN (CASE WHEN (_col9) THEN (((_col6 / _col8) > (_col2 / _col4))) ELSE (false) END) ELSE (false) END
                                     Merge Join Operator [MERGEJOIN_525] (rows=26666666 width=552)
-                                      Conds:RS_135._col0=RS_611._col0(Inner),Output:["_col0","_col2","_col4","_col6","_col8","_col9"]
-                                    <-Reducer 24 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_611]
+                                      Conds:RS_135._col0=RS_613._col0(Inner),Output:["_col0","_col2","_col4","_col6","_col8","_col9"]
+                                    <-Reducer 23 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_613]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_610] (rows=22300081 width=216)
+                                        Select Operator [SEL_612] (rows=22300081 width=216)
                                           Output:["_col0","_col1","_col2"]
-                                          Filter Operator [FIL_609] (rows=22300081 width=212)
+                                          Filter Operator [FIL_611] (rows=22300081 width=212)
                                             predicate:(_col1 > 0)
-                                            Group By Operator [GBY_608] (rows=66900244 width=212)
+                                            Group By Operator [GBY_610] (rows=66900244 width=212)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                            <-Reducer 23 [SIMPLE_EDGE]
+                                            <-Reducer 22 [SIMPLE_EDGE]
                                               SHUFFLE [RS_82]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_81] (rows=80000000 width=212)
                                                   Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                                   Merge Join Operator [MERGEJOIN_518] (rows=101084444 width=212)
-                                                    Conds:RS_77._col1=RS_587._col0(Inner),Output:["_col2","_col5"]
-                                                  <-Map 39 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_587]
+                                                    Conds:RS_77._col1=RS_577._col0(Inner),Output:["_col2","_col5"]
+                                                  <-Map 38 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_577]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_583]
-                                                  <-Reducer 22 [SIMPLE_EDGE]
+                                                       Please refer to the previous Select Operator [SEL_571]
+                                                  <-Reducer 21 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_77]
                                                       PartitionCols:_col1
                                                       Merge Join Operator [MERGEJOIN_517] (rows=101084444 width=115)
-                                                        Conds:RS_607._col0=RS_548._col0(Inner),Output:["_col1","_col2"]
-                                                      <-Map 29 [SIMPLE_EDGE] vectorized
+                                                        Conds:RS_609._col0=RS_548._col0(Inner),Output:["_col1","_col2"]
+                                                      <-Map 28 [SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_548]
                                                           PartitionCols:_col0
                                                           Select Operator [SEL_538] (rows=652 width=4)
@@ -476,24 +475,24 @@ Stage-0
                                                             Filter Operator [FIL_533] (rows=652 width=8)
                                                               predicate:(_col1 = 1999)
                                                                Please refer to the previous Select Operator [SEL_529]
-                                                      <-Map 21 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_607]
+                                                      <-Map 20 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_609]
                                                           PartitionCols:_col0
-                                                          Select Operator [SEL_606] (rows=285117831 width=119)
+                                                          Select Operator [SEL_608] (rows=285117831 width=119)
                                                             Output:["_col0","_col1","_col2"]
-                                                            Filter Operator [FIL_605] (rows=285117831 width=453)
+                                                            Filter Operator [FIL_607] (rows=285117831 width=453)
                                                               predicate:(_col0 is not null and _col1 is not null)
-                                                              Select Operator [SEL_604] (rows=287989836 width=453)
+                                                              Select Operator [SEL_606] (rows=287989836 width=453)
                                                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                                Filter Operator [FIL_603] (rows=287989836 width=453)
+                                                                Filter Operator [FIL_605] (rows=287989836 width=453)
                                                                   predicate:(cs_sold_date_sk BETWEEN DynamicValue(RS_75_date_dim_d_date_sk_min) AND DynamicValue(RS_75_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_75_date_dim_d_date_sk_bloom_filter)))
                                                                   TableScan [TS_64] (rows=287989836 width=453)
                                                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_ext_discount_amt","cs_ext_sales_price","cs_ext_wholesale_cost","cs_ext_list_price"]
-                                                                  <-Reducer 34 [BROADCAST_EDGE] vectorized
-                                                                    BROADCAST [RS_602]
-                                                                      Group By Operator [GBY_601] (rows=1 width=12)
+                                                                  <-Reducer 33 [BROADCAST_EDGE] vectorized
+                                                                    BROADCAST [RS_604]
+                                                                      Group By Operator [GBY_603] (rows=1 width=12)
                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                      <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                      <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                         PARTITION_ONLY_SHUFFLE [RS_562]
                                                                           Group By Operator [GBY_556] (rows=1 width=12)
                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -504,29 +503,29 @@ Stage-0
                                       SHUFFLE [RS_135]
                                         PartitionCols:_col0
                                         Merge Join Operator [MERGEJOIN_524] (rows=26666666 width=436)
-                                          Conds:RS_132._col0=RS_600._col0(Inner),Output:["_col0","_col2","_col4","_col6"]
-                                        <-Reducer 20 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_600]
+                                          Conds:RS_132._col0=RS_602._col0(Inner),Output:["_col0","_col2","_col4","_col6"]
+                                        <-Reducer 19 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_602]
                                             PartitionCols:_col0
-                                            Group By Operator [GBY_599] (rows=66900244 width=212)
+                                            Group By Operator [GBY_601] (rows=66900244 width=212)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                            <-Reducer 19 [SIMPLE_EDGE]
+                                            <-Reducer 18 [SIMPLE_EDGE]
                                               SHUFFLE [RS_61]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_60] (rows=80000000 width=212)
                                                   Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                                   Merge Join Operator [MERGEJOIN_516] (rows=101084444 width=212)
-                                                    Conds:RS_56._col1=RS_586._col0(Inner),Output:["_col2","_col5"]
-                                                  <-Map 39 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_586]
+                                                    Conds:RS_56._col1=RS_576._col0(Inner),Output:["_col2","_col5"]
+                                                  <-Map 38 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_576]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_583]
-                                                  <-Reducer 18 [SIMPLE_EDGE]
+                                                       Please refer to the previous Select Operator [SEL_571]
+                                                  <-Reducer 17 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_56]
                                                       PartitionCols:_col1
                                                       Merge Join Operator [MERGEJOIN_515] (rows=101084444 width=115)
-                                                        Conds:RS_598._col0=RS_546._col0(Inner),Output:["_col1","_col2"]
-                                                      <-Map 29 [SIMPLE_EDGE] vectorized
+                                                        Conds:RS_600._col0=RS_546._col0(Inner),Output:["_col1","_col2"]
+                                                      <-Map 28 [SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_546]
                                                           PartitionCols:_col0
                                                           Select Operator [SEL_537] (rows=652 width=4)
@@ -534,24 +533,24 @@ Stage-0
                                                             Filter Operator [FIL_532] (rows=652 width=8)
                                                               predicate:(_col1 = 2000)
                                                                Please refer to the previous Select Operator [SEL_529]
-                                                      <-Map 17 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_598]
+                                                      <-Map 16 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_600]
                                                           PartitionCols:_col0
-                                                          Select Operator [SEL_597] (rows=285117831 width=119)
+                                                          Select Operator [SEL_599] (rows=285117831 width=119)
                                                             Output:["_col0","_col1","_col2"]
-                                                            Filter Operator [FIL_596] (rows=285117831 width=453)
+                                                            Filter Operator [FIL_598] (rows=285117831 width=453)
                                                               predicate:(_col0 is not null and _col1 is not null)
-                                                              Select Operator [SEL_595] (rows=287989836 width=453)
+                                                              Select Operator [SEL_597] (rows=287989836 width=453)
                                                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                                Filter Operator [FIL_594] (rows=287989836 width=453)
+                                                                Filter Operator [FIL_596] (rows=287989836 width=453)
                                                                   predicate:(cs_sold_date_sk BETWEEN DynamicValue(RS_54_date_dim_d_date_sk_min) AND DynamicValue(RS_54_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_54_date_dim_d_date_sk_bloom_filter)))
                                                                   TableScan [TS_43] (rows=287989836 width=453)
                                                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_ext_discount_amt","cs_ext_sales_price","cs_ext_wholesale_cost","cs_ext_list_price"]
-                                                                  <-Reducer 33 [BROADCAST_EDGE] vectorized
-                                                                    BROADCAST [RS_593]
-                                                                      Group By Operator [GBY_592] (rows=1 width=12)
+                                                                  <-Reducer 32 [BROADCAST_EDGE] vectorized
+                                                                    BROADCAST [RS_595]
+                                                                      Group By Operator [GBY_594] (rows=1 width=12)
                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                      <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                      <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                         PARTITION_ONLY_SHUFFLE [RS_561]
                                                                           Group By Operator [GBY_555] (rows=1 width=12)
                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -562,31 +561,31 @@ Stage-0
                                           SHUFFLE [RS_132]
                                             PartitionCols:_col0
                                             Merge Join Operator [MERGEJOIN_523] (rows=26666666 width=324)
-                                              Conds:RS_575._col0=RS_591._col0(Inner),Output:["_col0","_col2","_col4"]
-                                            <-Reducer 16 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_591]
+                                              Conds:RS_583._col0=RS_593._col0(Inner),Output:["_col0","_col2","_col4"]
+                                            <-Reducer 15 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_593]
                                                 PartitionCols:_col0
-                                                Filter Operator [FIL_590] (rows=22300081 width=212)
+                                                Filter Operator [FIL_592] (rows=22300081 width=212)
                                                   predicate:(_col1 > 0)
-                                                  Group By Operator [GBY_589] (rows=66900244 width=212)
+                                                  Group By Operator [GBY_591] (rows=66900244 width=212)
                                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                                  <-Reducer 15 [SIMPLE_EDGE]
+                                                  <-Reducer 14 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_39]
                                                       PartitionCols:_col0
                                                       Group By Operator [GBY_38] (rows=80000000 width=212)
                                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                                         Merge Join Operator [MERGEJOIN_514] (rows=187573258 width=212)
-                                                          Conds:RS_34._col1=RS_585._col0(Inner),Output:["_col2","_col5"]
-                                                        <-Map 39 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_585]
+                                                          Conds:RS_34._col1=RS_575._col0(Inner),Output:["_col2","_col5"]
+                                                        <-Map 38 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_575]
                                                             PartitionCols:_col0
-                                                             Please refer to the previous Select Operator [SEL_583]
-                                                        <-Reducer 14 [SIMPLE_EDGE]
+                                                             Please refer to the previous Select Operator [SEL_571]
+                                                        <-Reducer 13 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_34]
                                                             PartitionCols:_col1
                                                             Merge Join Operator [MERGEJOIN_513] (rows=187573258 width=115)
-                                                              Conds:RS_582._col0=RS_544._col0(Inner),Output:["_col1","_col2"]
-                                                            <-Map 29 [SIMPLE_EDGE] vectorized
+                                                              Conds:RS_590._col0=RS_544._col0(Inner),Output:["_col1","_col2"]
+                                                            <-Map 28 [SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_544]
                                                                 PartitionCols:_col0
                                                                 Select Operator [SEL_536] (rows=652 width=4)
@@ -594,24 +593,24 @@ Stage-0
                                                                   Filter Operator [FIL_531] (rows=652 width=8)
                                                                     predicate:(_col1 = 1999)
                                                                      Please refer to the previous Select Operator [SEL_529]
-                                                            <-Map 13 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_582]
+                                                            <-Map 12 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_590]
                                                                 PartitionCols:_col0
-                                                                Select Operator [SEL_581] (rows=525327388 width=119)
+                                                                Select Operator [SEL_589] (rows=525327388 width=119)
                                                                   Output:["_col0","_col1","_col2"]
-                                                                  Filter Operator [FIL_580] (rows=525327388 width=435)
+                                                                  Filter Operator [FIL_588] (rows=525327388 width=435)
                                                                     predicate:(_col0 is not null and _col1 is not null)
-                                                                    Select Operator [SEL_579] (rows=575995635 width=435)
+                                                                    Select Operator [SEL_587] (rows=575995635 width=435)
                                                                       Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                                      Filter Operator [FIL_578] (rows=575995635 width=435)
+                                                                      Filter Operator [FIL_586] (rows=575995635 width=435)
                                                                         predicate:(ss_sold_date_sk BETWEEN DynamicValue(RS_32_date_dim_d_date_sk_min) AND DynamicValue(RS_32_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_32_date_dim_d_date_sk_bloom_filter)))
                                                                         TableScan [TS_21] (rows=575995635 width=435)
                                                                           default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price"]
-                                                                        <-Reducer 32 [BROADCAST_EDGE] vectorized
-                                                                          BROADCAST [RS_577]
-                                                                            Group By Operator [GBY_576] (rows=1 width=12)
+                                                                        <-Reducer 31 [BROADCAST_EDGE] vectorized
+                                                                          BROADCAST [RS_585]
+                                                                            Group By Operator [GBY_584] (rows=1 width=12)
                                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                            <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                               PARTITION_ONLY_SHUFFLE [RS_560]
                                                                                 Group By Operator [GBY_554] (rows=1 width=12)
                                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -619,11 +618,11 @@ Stage-0
                                                                                     Output:["_col0"]
                                                                                      Please refer to the previous Select Operator [SEL_536]
                                             <-Reducer 4 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_575]
+                                              SHUFFLE [RS_583]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_574] (rows=80000000 width=304)
+                                                Select Operator [SEL_582] (rows=80000000 width=304)
                                                   Output:["_col0","_col2"]
-                                                  Group By Operator [GBY_573] (rows=80000000 width=304)
+                                                  Group By Operator [GBY_581] (rows=80000000 width=304)
                                                     Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
                                                   <-Reducer 3 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_18]
@@ -631,20 +630,19 @@ Stage-0
                                                       Group By Operator [GBY_17] (rows=80000000 width=304)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)"],keys:_col5, _col8
                                                         Merge Join Operator [MERGEJOIN_512] (rows=187573258 width=304)
-                                                          Conds:RS_13._col1=RS_572._col0(Inner),Output:["_col2","_col5","_col8"]
-                                                        <-Map 12 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_572]
+                                                          Conds:RS_13._col1=RS_579._col0(Inner),Output:["_col2","_col5","_col8"]
+                                                        <-Map 38 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_579]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_571] (rows=80000000 width=196)
+                                                            Select Operator [SEL_572] (rows=80000000 width=196)
                                                               Output:["_col0","_col1","_col4"]
-                                                              TableScan [TS_8] (rows=80000000 width=196)
-                                                                default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_birth_country"]
+                                                               Please refer to the previous TableScan [TS_94]
                                                         <-Reducer 2 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_13]
                                                             PartitionCols:_col1
                                                             Merge Join Operator [MERGEJOIN_511] (rows=187573258 width=115)
                                                               Conds:RS_570._col0=RS_542._col0(Inner),Output:["_col1","_col2"]
-                                                            <-Map 29 [SIMPLE_EDGE] vectorized
+                                                            <-Map 28 [SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_542]
                                                                 PartitionCols:_col0
                                                                  Please refer to the previous Select Operator [SEL_535]
@@ -661,11 +659,11 @@ Stage-0
                                                                         predicate:(ss_sold_date_sk BETWEEN DynamicValue(RS_11_date_dim_d_date_sk_min) AND DynamicValue(RS_11_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_11_date_dim_d_date_sk_bloom_filter)))
                                                                         TableScan [TS_0] (rows=575995635 width=435)
                                                                           default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_ext_discount_amt","ss_ext_sales_price","ss_ext_wholesale_cost","ss_ext_list_price"]
-                                                                        <-Reducer 31 [BROADCAST_EDGE] vectorized
+                                                                        <-Reducer 30 [BROADCAST_EDGE] vectorized
                                                                           BROADCAST [RS_565]
                                                                             Group By Operator [GBY_564] (rows=1 width=12)
                                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                            <-Map 28 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                               PARTITION_ONLY_SHUFFLE [RS_559]
                                                                                 Group By Operator [GBY_553] (rows=1 width=12)
                                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query41.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query41.q.out
@@ -107,10 +107,10 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (SIMPLE_EDGE)
+Reducer 5 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -134,17 +134,17 @@ Stage-0
                     Top N Key Operator [TNK_30] (rows=752 width=107)
                       keys:_col1,top n:100
                       Merge Join Operator [MERGEJOIN_43] (rows=752 width=107)
-                        Conds:RS_46._col0=RS_54._col0(Inner),Output:["_col1"]
+                        Conds:RS_48._col0=RS_54._col0(Inner),Output:["_col1"]
                       <-Map 1 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_46]
+                        SHUFFLE [RS_48]
                           PartitionCols:_col0
-                          Select Operator [SEL_45] (rows=20726 width=202)
+                          Select Operator [SEL_46] (rows=20726 width=202)
                             Output:["_col0","_col1"]
                             Filter Operator [FIL_44] (rows=20726 width=205)
                               predicate:(i_manufact_id BETWEEN 970 AND 1010 and i_manufact is not null)
                               TableScan [TS_0] (rows=462000 width=205)
-                                default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_manufact_id","i_manufact","i_product_name"]
-                      <-Reducer 6 [SIMPLE_EDGE] vectorized
+                                default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_manufact_id","i_manufact","i_product_name","i_category","i_size","i_color","i_units"]
+                      <-Reducer 5 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_54]
                           PartitionCols:_col0
                           Select Operator [SEL_53] (rows=46 width=95)
@@ -153,15 +153,14 @@ Stage-0
                               predicate:(_col1 > 0L)
                               Group By Operator [GBY_51] (rows=140 width=103)
                                 Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                              <-Map 5 [SIMPLE_EDGE] vectorized
+                              <-Map 1 [SIMPLE_EDGE] vectorized
                                 SHUFFLE [RS_50]
                                   PartitionCols:_col0
                                   Group By Operator [GBY_49] (rows=140 width=103)
                                     Output:["_col0","_col1"],aggregations:["count()"],keys:i_manufact
-                                    Select Operator [SEL_48] (rows=280 width=450)
+                                    Select Operator [SEL_47] (rows=280 width=450)
                                       Output:["i_manufact"]
-                                      Filter Operator [FIL_47] (rows=280 width=450)
+                                      Filter Operator [FIL_45] (rows=280 width=450)
                                         predicate:((((i_category = 'Women') and (i_color) IN ('frosted', 'rose') and (i_units) IN ('Lb', 'Gross') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('chocolate', 'black') and (i_units) IN ('Box', 'Dram') and (i_size) IN ('economy', 'petite')) or ((i_category = 'Men') and (i_color) IN ('slate', 'magenta') and (i_units) IN ('Carton', 'Bundle') and (i_size) IN ('N/A', 'small')) or ((i_category = 'Men') and (i_color) IN ('cornflower', 'firebrick') and (i_units) IN ('Pound', 'Oz') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('almond', 'steel') and (i_units) IN ('Tsp', 'Case') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('purple', 'aquamarine') and (i_units) IN ('Bunch', 'Gram') and (i_size) IN ('economy', 'petite')) or ((i_category = 'Men') and (i_color) IN ('lavender', 'papaya') and (i_units) IN ('Pallet', 'Cup') and (i_size) IN ('N/A', 'small')) or ((i_category = 'Men') and (i_color) IN ('maroon', 'cyan') and (i_units) IN ('Each', 'N/A') and (i_size) IN ('medium', 'large'))) and i_manufact is not null)
-                                        TableScan [TS_3] (rows=462000 width=450)
-                                          default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_category","i_manufact","i_size","i_color","i_units"]
+                                         Please refer to the previous TableScan [TS_0]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
@@ -76,13 +76,13 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 11 <- Map 10 (SIMPLE_EDGE)
+Reducer 10 <- Map 1 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 2 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 2 (CUSTOM_SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-Reducer 6 <- Map 12 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 12 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 6 <- Map 11 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 7 <- Map 11 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 3 (SIMPLE_EDGE)
 
@@ -102,7 +102,7 @@ Stage-0
                 Output:["_col0","_col1","_col2"]
                 Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
                   Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
-                <-Map 12 [SIMPLE_EDGE] vectorized
+                <-Map 11 [SIMPLE_EDGE] vectorized
                   SHUFFLE [RS_148]
                     PartitionCols:_col0
                     Select Operator [SEL_146] (rows=462000 width=111)
@@ -114,7 +114,7 @@ Stage-0
                     PartitionCols:_col2
                     Merge Join Operator [MERGEJOIN_117] (rows=6951 width=115)
                       Conds:RS_63._col0=RS_147._col0(Inner),Output:["_col1","_col2","_col5"]
-                    <-Map 12 [SIMPLE_EDGE] vectorized
+                    <-Map 11 [SIMPLE_EDGE] vectorized
                       SHUFFLE [RS_147]
                         PartitionCols:_col0
                          Please refer to the previous Select Operator [SEL_146]
@@ -145,7 +145,7 @@ Stage-0
                                             predicate:(_col1 > (0.9 * _col2))
                                             Merge Join Operator [MERGEJOIN_114] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                            <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_135]
                                                 Select Operator [SEL_134] (rows=1 width=112)
                                                   Output:["_col0"]
@@ -155,36 +155,35 @@ Stage-0
                                                       Output:["_col1","_col2"]
                                                       Group By Operator [GBY_131] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                                      <-Map 10 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_130]
+                                                      <-Map 1 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_126]
                                                           PartitionCols:_col0
-                                                          Group By Operator [GBY_129] (rows=258 width=124)
+                                                          Group By Operator [GBY_124] (rows=258 width=124)
                                                             Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_128] (rows=287946 width=114)
+                                                            Select Operator [SEL_122] (rows=287946 width=114)
                                                               Output:["_col1"]
-                                                              Filter Operator [FIL_127] (rows=287946 width=114)
+                                                              Filter Operator [FIL_120] (rows=287946 width=114)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
-                                                                TableScan [TS_8] (rows=575995635 width=114)
-                                                                  default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_hdemo_sk","ss_store_sk","ss_net_profit"]
+                                                                TableScan [TS_0] (rows=575995635 width=114)
+                                                                  default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_126]
-                                                Select Operator [SEL_125] (rows=62562 width=116)
+                                              PARTITION_ONLY_SHUFFLE [RS_130]
+                                                Select Operator [SEL_129] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_124] (rows=62562 width=124)
+                                                  Filter Operator [FIL_128] (rows=62562 width=124)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_123] (rows=62562 width=124)
+                                                    Group By Operator [GBY_127] (rows=62562 width=124)
                                                       Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
                                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_122]
+                                                      SHUFFLE [RS_125]
                                                         PartitionCols:_col0
-                                                        Group By Operator [GBY_121] (rows=3199976 width=124)
+                                                        Group By Operator [GBY_123] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_120] (rows=6399952 width=114)
+                                                          Select Operator [SEL_121] (rows=6399952 width=114)
                                                             Output:["ss_item_sk","ss_net_profit"]
                                                             Filter Operator [FIL_119] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)
-                                                              TableScan [TS_0] (rows=575995635 width=114)
-                                                                default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit"]
+                                                               Please refer to the previous TableScan [TS_0]
                           <-Reducer 9 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_145]
                               PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query45.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query45.q.out
@@ -52,18 +52,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 17 (BROADCAST_EDGE)
-Reducer 11 <- Map 10 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
-Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
-Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
+Map 13 <- Reducer 16 (BROADCAST_EDGE)
+Reducer 10 <- Map 12 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 16 <- Map 15 (CUSTOM_SIMPLE_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
 Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 4 <- Reducer 12 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 11 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Map 1 (SIMPLE_EDGE)
-Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -94,17 +94,24 @@ Stage-0
                             Output:["_col3","_col7","_col8","_col14","_col16"]
                             Merge Join Operator [MERGEJOIN_137] (rows=10246864 width=310)
                               Conds:RS_44._col0=RS_45._col6(Inner),Output:["_col2","_col4","_col8","_col9","_col13"]
-                            <-Reducer 12 [SIMPLE_EDGE]
+                            <-Reducer 11 [SIMPLE_EDGE]
                               SHUFFLE [RS_45]
                                 PartitionCols:_col6
                                 Merge Join Operator [MERGEJOIN_136] (rows=10246864 width=302)
                                   Conds:RS_34._col0=RS_35._col2(Inner),Output:["_col3","_col4","_col6","_col8"]
-                                <-Reducer 11 [SIMPLE_EDGE]
+                                <-Reducer 10 [SIMPLE_EDGE]
                                   SHUFFLE [RS_34]
                                     PartitionCols:_col0
                                     Merge Join Operator [MERGEJOIN_133] (rows=80000000 width=191)
                                       Conds:RS_155._col1=RS_157._col0(Inner),Output:["_col0","_col3","_col4"]
-                                    <-Map 10 [SIMPLE_EDGE] vectorized
+                                    <-Map 12 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_157]
+                                        PartitionCols:_col0
+                                        Select Operator [SEL_156] (rows=40000000 width=191)
+                                          Output:["_col0","_col1","_col2"]
+                                          TableScan [TS_19] (rows=40000000 width=191)
+                                            default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_zip"]
+                                    <-Map 9 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_155]
                                         PartitionCols:_col1
                                         Select Operator [SEL_154] (rows=80000000 width=8)
@@ -113,19 +120,12 @@ Stage-0
                                             predicate:c_current_addr_sk is not null
                                             TableScan [TS_16] (rows=80000000 width=8)
                                               default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_current_addr_sk"]
-                                    <-Map 13 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_157]
-                                        PartitionCols:_col0
-                                        Select Operator [SEL_156] (rows=40000000 width=191)
-                                          Output:["_col0","_col1","_col2"]
-                                          TableScan [TS_19] (rows=40000000 width=191)
-                                            default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_zip"]
-                                <-Reducer 15 [SIMPLE_EDGE]
+                                <-Reducer 14 [SIMPLE_EDGE]
                                   SHUFFLE [RS_35]
                                     PartitionCols:_col2
                                     Merge Join Operator [MERGEJOIN_134] (rows=10246864 width=119)
                                       Conds:RS_168._col0=RS_160._col0(Inner),Output:["_col1","_col2","_col3"]
-                                    <-Map 16 [SIMPLE_EDGE] vectorized
+                                    <-Map 15 [SIMPLE_EDGE] vectorized
                                       PARTITION_ONLY_SHUFFLE [RS_160]
                                         PartitionCols:_col0
                                         Select Operator [SEL_159] (rows=130 width=12)
@@ -134,7 +134,7 @@ Stage-0
                                             predicate:((d_year = 2000) and (d_qoy = 2))
                                             TableScan [TS_24] (rows=73049 width=12)
                                               default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_qoy"]
-                                    <-Map 14 [SIMPLE_EDGE] vectorized
+                                    <-Map 13 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_168]
                                         PartitionCols:_col0
                                         Select Operator [SEL_167] (rows=143930993 width=123)
@@ -143,11 +143,11 @@ Stage-0
                                             predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_28_date_dim_d_date_sk_min) AND DynamicValue(RS_28_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_28_date_dim_d_date_sk_bloom_filter)))
                                             TableScan [TS_21] (rows=144002668 width=123)
                                               default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk","ws_sales_price"]
-                                            <-Reducer 17 [BROADCAST_EDGE] vectorized
+                                            <-Reducer 16 [BROADCAST_EDGE] vectorized
                                               BROADCAST [RS_165]
                                                 Group By Operator [GBY_164] (rows=1 width=12)
                                                   Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                <-Map 15 [CUSTOM_SIMPLE_EDGE] vectorized
                                                   PARTITION_ONLY_SHUFFLE [RS_163]
                                                     Group By Operator [GBY_162] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -165,24 +165,23 @@ Stage-0
                                     Merge Join Operator [MERGEJOIN_132] (rows=462000 width=112)
                                       Conds:(Inner),Output:["_col0","_col1","_col2"]
                                     <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_140]
+                                      PARTITION_ONLY_SHUFFLE [RS_141]
                                         Select Operator [SEL_138] (rows=462000 width=104)
                                           Output:["_col0","_col1"]
                                           TableScan [TS_0] (rows=462000 width=104)
                                             default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                    <-Reducer 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                    <-Reducer 8 [CUSTOM_SIMPLE_EDGE] vectorized
                                       PARTITION_ONLY_SHUFFLE [RS_149]
                                         Group By Operator [GBY_148] (rows=1 width=8)
                                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                        <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_147]
-                                            Group By Operator [GBY_146] (rows=1 width=8)
+                                            Group By Operator [GBY_145] (rows=1 width=8)
                                               Output:["_col0"],aggregations:["count()"]
-                                              Select Operator [SEL_145] (rows=11 width=4)
-                                                Filter Operator [FIL_144] (rows=11 width=4)
+                                              Select Operator [SEL_143] (rows=11 width=4)
+                                                Filter Operator [FIL_140] (rows=11 width=4)
                                                   predicate:(i_item_sk) IN (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
-                                                  TableScan [TS_2] (rows=462000 width=4)
-                                                    default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk"]
+                                                   Please refer to the previous TableScan [TS_0]
                                 <-Reducer 7 [SIMPLE_EDGE] vectorized
                                   SHUFFLE [RS_152]
                                     PartitionCols:_col0
@@ -191,11 +190,11 @@ Stage-0
                                       Group By Operator [GBY_150] (rows=5 width=100)
                                         Output:["_col0"],keys:KEY._col0
                                       <-Map 1 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_143]
+                                        PARTITION_ONLY_SHUFFLE [RS_146]
                                           PartitionCols:_col0
-                                          Group By Operator [GBY_142] (rows=5 width=100)
+                                          Group By Operator [GBY_144] (rows=5 width=100)
                                             Output:["_col0"],keys:i_item_id
-                                            Select Operator [SEL_141] (rows=11 width=104)
+                                            Select Operator [SEL_142] (rows=11 width=104)
                                               Output:["i_item_id"]
                                               Filter Operator [FIL_139] (rows=11 width=104)
                                                 predicate:(i_item_sk) IN (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query54.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query54.q.out
@@ -133,26 +133,26 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 22 <- Reducer 30 (BROADCAST_EDGE), Union 23 (CONTAINS)
-Map 28 <- Reducer 30 (BROADCAST_EDGE), Union 23 (CONTAINS)
+Map 27 <- Reducer 23 (BROADCAST_EDGE), Union 28 (CONTAINS)
+Map 29 <- Reducer 23 (BROADCAST_EDGE), Union 28 (CONTAINS)
 Reducer 10 <- Map 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE)
 Reducer 12 <- Map 9 (SIMPLE_EDGE)
 Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE)
 Reducer 14 <- Map 9 (SIMPLE_EDGE)
-Reducer 15 <- Map 33 (CUSTOM_SIMPLE_EDGE), Reducer 14 (CUSTOM_SIMPLE_EDGE)
+Reducer 15 <- Map 9 (CUSTOM_SIMPLE_EDGE), Reducer 14 (CUSTOM_SIMPLE_EDGE)
 Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 17 <- Map 9 (SIMPLE_EDGE)
-Reducer 19 <- Map 18 (SIMPLE_EDGE), Map 21 (SIMPLE_EDGE)
+Reducer 18 <- Map 9 (SIMPLE_EDGE), Union 28 (SIMPLE_EDGE)
+Reducer 19 <- Map 30 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 11 (CUSTOM_SIMPLE_EDGE)
-Reducer 20 <- Reducer 19 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
-Reducer 24 <- Map 29 (SIMPLE_EDGE), Union 23 (SIMPLE_EDGE)
-Reducer 25 <- Map 31 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
-Reducer 26 <- Map 32 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
-Reducer 27 <- Reducer 26 (SIMPLE_EDGE)
+Reducer 20 <- Map 31 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
+Reducer 21 <- Reducer 20 (SIMPLE_EDGE)
+Reducer 22 <- Reducer 21 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
+Reducer 23 <- Map 9 (CUSTOM_SIMPLE_EDGE)
+Reducer 25 <- Map 24 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 2 (CUSTOM_SIMPLE_EDGE)
-Reducer 30 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 4 <- Reducer 20 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 22 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 16 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
@@ -209,39 +209,38 @@ Stage-0
                                                 predicate:(_col2 <= _col1)
                                                 Merge Join Operator [MERGEJOIN_284] (rows=1826225 width=12)
                                                   Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                                <-Map 33 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_359]
-                                                    Select Operator [SEL_358] (rows=73049 width=8)
+                                                <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                  PARTITION_ONLY_SHUFFLE [RS_320]
+                                                    Select Operator [SEL_313] (rows=73049 width=8)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_357] (rows=73049 width=8)
+                                                      Filter Operator [FIL_307] (rows=73049 width=8)
                                                         predicate:d_month_seq is not null
-                                                        TableScan [TS_77] (rows=73049 width=8)
-                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
+                                                        TableScan [TS_3] (rows=73049 width=12)
+                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_month_seq","d_year","d_moy","d_date_sk"]
                                                 <-Reducer 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_356]
-                                                    Group By Operator [GBY_355] (rows=25 width=4)
+                                                  PARTITION_ONLY_SHUFFLE [RS_359]
+                                                    Group By Operator [GBY_358] (rows=25 width=4)
                                                       Output:["_col0"],keys:KEY._col0
                                                     <-Map 9 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_316]
+                                                      PARTITION_ONLY_SHUFFLE [RS_323]
                                                         PartitionCols:_col0
-                                                        Group By Operator [GBY_312] (rows=25 width=4)
+                                                        Group By Operator [GBY_316] (rows=25 width=4)
                                                           Output:["_col0"],keys:_col0
-                                                          Select Operator [SEL_308] (rows=50 width=12)
+                                                          Select Operator [SEL_310] (rows=50 width=12)
                                                             Output:["_col0"]
                                                             Filter Operator [FIL_304] (rows=50 width=12)
                                                               predicate:((d_year = 1999) and (d_moy = 3) and d_month_seq is not null)
-                                                              TableScan [TS_3] (rows=73049 width=12)
-                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_month_seq","d_year","d_moy"]
+                                                               Please refer to the previous TableScan [TS_3]
                                           <-Reducer 17 [CUSTOM_SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_361]
                                               Group By Operator [GBY_360] (rows=25 width=4)
                                                 Output:["_col0"],keys:KEY._col0
                                               <-Map 9 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_317]
+                                                PARTITION_ONLY_SHUFFLE [RS_324]
                                                   PartitionCols:_col0
-                                                  Group By Operator [GBY_313] (rows=25 width=4)
+                                                  Group By Operator [GBY_317] (rows=25 width=4)
                                                     Output:["_col0"],keys:_col0
-                                                    Select Operator [SEL_309] (rows=50 width=12)
+                                                    Select Operator [SEL_311] (rows=50 width=12)
                                                       Output:["_col0"]
                                                       Filter Operator [FIL_305] (rows=50 width=12)
                                                         predicate:((d_year = 1999) and (d_moy = 3) and d_month_seq is not null)
@@ -251,89 +250,65 @@ Stage-0
                                       PartitionCols:_col0
                                       Merge Join Operator [MERGEJOIN_288] (rows=525327388 width=114)
                                         Conds:RS_111._col1=RS_112._col0(Inner),Output:["_col0","_col2","_col5"]
-                                      <-Reducer 20 [SIMPLE_EDGE]
+                                      <-Reducer 22 [SIMPLE_EDGE]
                                         SHUFFLE [RS_112]
                                           PartitionCols:_col0
                                           Select Operator [SEL_76] (rows=55046 width=4)
                                             Output:["_col0"]
                                             Merge Join Operator [MERGEJOIN_286] (rows=55046 width=4)
-                                              Conds:RS_73._col0=RS_354._col1(Inner),Output:["_col5"]
-                                            <-Reducer 19 [SIMPLE_EDGE]
-                                              SHUFFLE [RS_73]
-                                                PartitionCols:_col0
-                                                Merge Join Operator [MERGEJOIN_280] (rows=39720279 width=4)
-                                                  Conds:RS_336._col1, _col2=RS_339._col0, _col1(Inner),Output:["_col0"]
-                                                <-Map 18 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_336]
-                                                    PartitionCols:_col1, _col2
-                                                    Select Operator [SEL_335] (rows=40000000 width=188)
-                                                      Output:["_col0","_col1","_col2"]
-                                                      Filter Operator [FIL_334] (rows=40000000 width=188)
-                                                        predicate:(ca_county is not null and ca_state is not null)
-                                                        TableScan [TS_33] (rows=40000000 width=188)
-                                                          default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_state"]
-                                                <-Map 21 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_339]
-                                                    PartitionCols:_col0, _col1
-                                                    Select Operator [SEL_338] (rows=1704 width=184)
-                                                      Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_337] (rows=1704 width=184)
-                                                        predicate:(s_county is not null and s_state is not null)
-                                                        TableScan [TS_36] (rows=1704 width=184)
-                                                          default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_county","s_state"]
-                                            <-Reducer 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_354]
+                                              Conds:RS_73._col0=RS_351._col1(Inner),Output:["_col5"]
+                                            <-Reducer 21 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_351]
                                                 PartitionCols:_col1
-                                                Select Operator [SEL_353] (rows=55046 width=8)
+                                                Select Operator [SEL_350] (rows=55046 width=8)
                                                   Output:["_col0","_col1"]
-                                                  Group By Operator [GBY_352] (rows=55046 width=8)
+                                                  Group By Operator [GBY_349] (rows=55046 width=8)
                                                     Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                                  <-Reducer 26 [SIMPLE_EDGE]
+                                                  <-Reducer 20 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_67]
                                                       PartitionCols:_col0, _col1
                                                       Group By Operator [GBY_66] (rows=55046 width=8)
                                                         Output:["_col0","_col1"],keys:_col6, _col5
                                                         Merge Join Operator [MERGEJOIN_283] (rows=110092 width=8)
-                                                          Conds:RS_62._col1=RS_351._col0(Inner),Output:["_col5","_col6"]
-                                                        <-Map 32 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_351]
+                                                          Conds:RS_62._col1=RS_348._col0(Inner),Output:["_col5","_col6"]
+                                                        <-Map 31 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_348]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_350] (rows=80000000 width=8)
+                                                            Select Operator [SEL_347] (rows=80000000 width=8)
                                                               Output:["_col0","_col1"]
-                                                              Filter Operator [FIL_349] (rows=80000000 width=8)
+                                                              Filter Operator [FIL_346] (rows=80000000 width=8)
                                                                 predicate:c_current_addr_sk is not null
                                                                 TableScan [TS_53] (rows=80000000 width=8)
                                                                   default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_current_addr_sk"]
-                                                        <-Reducer 25 [SIMPLE_EDGE]
+                                                        <-Reducer 19 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_62]
                                                             PartitionCols:_col1
                                                             Merge Join Operator [MERGEJOIN_282] (rows=110092 width=0)
-                                                              Conds:RS_59._col2=RS_348._col0(Inner),Output:["_col1"]
-                                                            <-Map 31 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_348]
+                                                              Conds:RS_59._col2=RS_345._col0(Inner),Output:["_col1"]
+                                                            <-Map 30 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_345]
                                                                 PartitionCols:_col0
-                                                                Select Operator [SEL_347] (rows=453 width=4)
+                                                                Select Operator [SEL_344] (rows=453 width=4)
                                                                   Output:["_col0"]
-                                                                  Filter Operator [FIL_346] (rows=453 width=186)
+                                                                  Filter Operator [FIL_343] (rows=453 width=186)
                                                                     predicate:((i_class = 'consignment') and (i_category = 'Jewelry'))
                                                                     TableScan [TS_50] (rows=462000 width=186)
                                                                       default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_class","i_category"]
-                                                            <-Reducer 24 [SIMPLE_EDGE]
+                                                            <-Reducer 18 [SIMPLE_EDGE]
                                                               SHUFFLE [RS_59]
                                                                 PartitionCols:_col2
                                                                 Merge Join Operator [MERGEJOIN_281] (rows=11665117 width=7)
-                                                                  Conds:Union 23._col0=RS_342._col0(Inner),Output:["_col1","_col2"]
-                                                                <-Map 29 [SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_342]
+                                                                  Conds:Union 28._col0=RS_318._col0(Inner),Output:["_col1","_col2"]
+                                                                <-Map 9 [SIMPLE_EDGE] vectorized
+                                                                  PARTITION_ONLY_SHUFFLE [RS_318]
                                                                     PartitionCols:_col0
-                                                                    Select Operator [SEL_341] (rows=50 width=4)
+                                                                    Select Operator [SEL_312] (rows=50 width=4)
                                                                       Output:["_col0"]
-                                                                      Filter Operator [FIL_340] (rows=50 width=12)
+                                                                      Filter Operator [FIL_306] (rows=50 width=12)
                                                                         predicate:((d_year = 1999) and (d_moy = 3))
-                                                                        TableScan [TS_47] (rows=73049 width=12)
-                                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                                                <-Union 23 [SIMPLE_EDGE]
-                                                                  <-Map 22 [CONTAINS] vectorized
+                                                                         Please refer to the previous TableScan [TS_3]
+                                                                <-Union 28 [SIMPLE_EDGE]
+                                                                  <-Map 27 [CONTAINS] vectorized
                                                                     Reduce Output Operator [RS_379]
                                                                       PartitionCols:_col0
                                                                       Select Operator [SEL_378] (rows=285117831 width=11)
@@ -342,18 +317,18 @@ Stage-0
                                                                           predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                                           TableScan [TS_290] (rows=287989836 width=11)
                                                                             Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk"]
-                                                                          <-Reducer 30 [BROADCAST_EDGE] vectorized
+                                                                          <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                                             BROADCAST [RS_375]
                                                                               Group By Operator [GBY_374] (rows=1 width=12)
                                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                              <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                PARTITION_ONLY_SHUFFLE [RS_345]
-                                                                                  Group By Operator [GBY_344] (rows=1 width=12)
+                                                                              <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                PARTITION_ONLY_SHUFFLE [RS_326]
+                                                                                  Group By Operator [GBY_325] (rows=1 width=12)
                                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                    Select Operator [SEL_343] (rows=50 width=4)
+                                                                                    Select Operator [SEL_319] (rows=50 width=4)
                                                                                       Output:["_col0"]
-                                                                                       Please refer to the previous Select Operator [SEL_341]
-                                                                  <-Map 28 [CONTAINS] vectorized
+                                                                                       Please refer to the previous Select Operator [SEL_312]
+                                                                  <-Map 29 [CONTAINS] vectorized
                                                                     Reduce Output Operator [RS_382]
                                                                       PartitionCols:_col0
                                                                       Select Operator [SEL_381] (rows=143930993 width=11)
@@ -362,34 +337,57 @@ Stage-0
                                                                           predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                                           TableScan [TS_295] (rows=144002668 width=11)
                                                                             Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk"]
-                                                                          <-Reducer 30 [BROADCAST_EDGE] vectorized
+                                                                          <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                                             BROADCAST [RS_376]
                                                                                Please refer to the previous Group By Operator [GBY_374]
+                                            <-Reducer 25 [SIMPLE_EDGE]
+                                              SHUFFLE [RS_73]
+                                                PartitionCols:_col0
+                                                Merge Join Operator [MERGEJOIN_280] (rows=39720279 width=4)
+                                                  Conds:RS_354._col1, _col2=RS_357._col0, _col1(Inner),Output:["_col0"]
+                                                <-Map 24 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_354]
+                                                    PartitionCols:_col1, _col2
+                                                    Select Operator [SEL_353] (rows=40000000 width=188)
+                                                      Output:["_col0","_col1","_col2"]
+                                                      Filter Operator [FIL_352] (rows=40000000 width=188)
+                                                        predicate:(ca_county is not null and ca_state is not null)
+                                                        TableScan [TS_33] (rows=40000000 width=188)
+                                                          default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_state"]
+                                                <-Map 26 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_357]
+                                                    PartitionCols:_col0, _col1
+                                                    Select Operator [SEL_356] (rows=1704 width=184)
+                                                      Output:["_col0","_col1"]
+                                                      Filter Operator [FIL_355] (rows=1704 width=184)
+                                                        predicate:(s_county is not null and s_state is not null)
+                                                        TableScan [TS_36] (rows=1704 width=184)
+                                                          default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_county","s_state"]
                                       <-Reducer 3 [SIMPLE_EDGE]
                                         SHUFFLE [RS_111]
                                           PartitionCols:_col1
                                           Merge Join Operator [MERGEJOIN_285] (rows=525327388 width=114)
                                             Conds:(Inner),Output:["_col0","_col1","_col2"]
                                           <-Reducer 13 [CUSTOM_SIMPLE_EDGE] vectorized
-                                            PARTITION_ONLY_SHUFFLE [RS_333]
-                                              Select Operator [SEL_332] (rows=1 width=8)
-                                                Filter Operator [FIL_331] (rows=1 width=8)
+                                            PARTITION_ONLY_SHUFFLE [RS_342]
+                                              Select Operator [SEL_341] (rows=1 width=8)
+                                                Filter Operator [FIL_340] (rows=1 width=8)
                                                   predicate:(sq_count_check(_col0) <= 1)
-                                                  Group By Operator [GBY_330] (rows=1 width=8)
+                                                  Group By Operator [GBY_339] (rows=1 width=8)
                                                     Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                   <-Reducer 12 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_329]
-                                                      Group By Operator [GBY_328] (rows=1 width=8)
+                                                    PARTITION_ONLY_SHUFFLE [RS_338]
+                                                      Group By Operator [GBY_337] (rows=1 width=8)
                                                         Output:["_col0"],aggregations:["count()"]
-                                                        Select Operator [SEL_327] (rows=25 width=4)
-                                                          Group By Operator [GBY_326] (rows=25 width=4)
+                                                        Select Operator [SEL_336] (rows=25 width=4)
+                                                          Group By Operator [GBY_335] (rows=25 width=4)
                                                             Output:["_col0"],keys:KEY._col0
                                                           <-Map 9 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_315]
+                                                            PARTITION_ONLY_SHUFFLE [RS_322]
                                                               PartitionCols:_col0
-                                                              Group By Operator [GBY_311] (rows=25 width=4)
+                                                              Group By Operator [GBY_315] (rows=25 width=4)
                                                                 Output:["_col0"],keys:_col0
-                                                                Select Operator [SEL_307] (rows=50 width=12)
+                                                                Select Operator [SEL_309] (rows=50 width=12)
                                                                   Output:["_col0"]
                                                                   Filter Operator [FIL_303] (rows=50 width=12)
                                                                     predicate:((d_year = 1999) and (d_moy = 3))
@@ -407,25 +405,25 @@ Stage-0
                                                       TableScan [TS_0] (rows=575995635 width=114)
                                                         default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_ext_sales_price"]
                                               <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                PARTITION_ONLY_SHUFFLE [RS_325]
-                                                  Select Operator [SEL_324] (rows=1 width=8)
-                                                    Filter Operator [FIL_323] (rows=1 width=8)
+                                                PARTITION_ONLY_SHUFFLE [RS_334]
+                                                  Select Operator [SEL_333] (rows=1 width=8)
+                                                    Filter Operator [FIL_332] (rows=1 width=8)
                                                       predicate:(sq_count_check(_col0) <= 1)
-                                                      Group By Operator [GBY_322] (rows=1 width=8)
+                                                      Group By Operator [GBY_331] (rows=1 width=8)
                                                         Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                       <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                        PARTITION_ONLY_SHUFFLE [RS_321]
-                                                          Group By Operator [GBY_320] (rows=1 width=8)
+                                                        PARTITION_ONLY_SHUFFLE [RS_330]
+                                                          Group By Operator [GBY_329] (rows=1 width=8)
                                                             Output:["_col0"],aggregations:["count()"]
-                                                            Select Operator [SEL_319] (rows=25 width=4)
-                                                              Group By Operator [GBY_318] (rows=25 width=4)
+                                                            Select Operator [SEL_328] (rows=25 width=4)
+                                                              Group By Operator [GBY_327] (rows=25 width=4)
                                                                 Output:["_col0"],keys:KEY._col0
                                                               <-Map 9 [SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_314]
+                                                                PARTITION_ONLY_SHUFFLE [RS_321]
                                                                   PartitionCols:_col0
-                                                                  Group By Operator [GBY_310] (rows=25 width=4)
+                                                                  Group By Operator [GBY_314] (rows=25 width=4)
                                                                     Output:["_col0"],keys:_col0
-                                                                    Select Operator [SEL_306] (rows=50 width=12)
+                                                                    Select Operator [SEL_308] (rows=50 width=12)
                                                                       Output:["_col0"]
                                                                        Please refer to the previous Filter Operator [FIL_303]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query56.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query56.q.out
@@ -149,27 +149,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -207,38 +207,37 @@ Stage-0
                                 SHUFFLE [RS_101]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_291] (rows=15609 width=104)
-                                    Conds:RS_316._col1=RS_322._col0(Inner),Output:["_col0","_col1"]
+                                    Conds:RS_317._col1=RS_322._col0(Inner),Output:["_col0","_col1"]
                                   <-Map 1 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_316]
+                                    SHUFFLE [RS_317]
                                       PartitionCols:_col1
                                       Select Operator [SEL_315] (rows=462000 width=104)
                                         Output:["_col0","_col1"]
                                         TableScan [TS_0] (rows=462000 width=104)
-                                          default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                  <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                          default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id","i_color"]
+                                  <-Reducer 12 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_322]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_321] (rows=10500 width=100)
                                         Output:["_col0"],keys:KEY._col0
-                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                      <-Map 1 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_320]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_319] (rows=10500 width=100)
                                             Output:["_col0"],keys:i_item_id
                                             Select Operator [SEL_318] (rows=21000 width=189)
                                               Output:["i_item_id"]
-                                              Filter Operator [FIL_317] (rows=21000 width=189)
+                                              Filter Operator [FIL_316] (rows=21000 width=189)
                                                 predicate:(i_color) IN ('orchid', 'chiffon', 'lace')
-                                                TableScan [TS_2] (rows=462000 width=189)
-                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_id","i_color"]
-                              <-Reducer 23 [SIMPLE_EDGE]
+                                                 Please refer to the previous TableScan [TS_0]
+                              <-Reducer 22 [SIMPLE_EDGE]
                                 SHUFFLE [RS_102]
                                   PartitionCols:_col2
                                   Select Operator [SEL_97] (rows=788222 width=110)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_299] (rows=788222 width=110)
                                       Conds:RS_94._col2=RS_346._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_346]
                                         PartitionCols:_col0
                                         Select Operator [SEL_343] (rows=8000000 width=4)
@@ -247,12 +246,12 @@ Stage-0
                                             predicate:(ca_gmt_offset = -8)
                                             TableScan [TS_15] (rows=40000000 width=112)
                                               default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                    <-Reducer 22 [SIMPLE_EDGE]
+                                    <-Reducer 21 [SIMPLE_EDGE]
                                       SHUFFLE [RS_94]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_298] (rows=3941109 width=118)
                                           Conds:RS_368._col0=RS_329._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_329]
                                             PartitionCols:_col0
                                             Select Operator [SEL_324] (rows=50 width=4)
@@ -261,7 +260,7 @@ Stage-0
                                                 predicate:((d_year = 2000) and (d_moy = 1))
                                                 TableScan [TS_12] (rows=73049 width=12)
                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
+                                        <-Map 26 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_368]
                                             PartitionCols:_col0
                                             Select Operator [SEL_367] (rows=143931246 width=123)
@@ -270,11 +269,11 @@ Stage-0
                                                 predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_92_date_dim_d_date_sk_min) AND DynamicValue(RS_92_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_92_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_82] (rows=144002668 width=123)
                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_365]
                                                     Group By Operator [GBY_364] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_336]
                                                         Group By Operator [GBY_333] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -299,27 +298,27 @@ Stage-0
                                 SHUFFLE [RS_28]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_291]
-                              <-Reducer 16 [SIMPLE_EDGE]
+                              <-Reducer 15 [SIMPLE_EDGE]
                                 SHUFFLE [RS_29]
                                   PartitionCols:_col2
                                   Select Operator [SEL_24] (rows=2876890 width=4)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_293] (rows=2876890 width=4)
                                       Conds:RS_21._col2=RS_344._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_344]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_343]
-                                    <-Reducer 15 [SIMPLE_EDGE]
+                                    <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_21]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_292] (rows=14384447 width=4)
                                           Conds:RS_341._col0=RS_325._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_325]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_324]
-                                        <-Map 14 [SIMPLE_EDGE] vectorized
+                                        <-Map 13 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_341]
                                             PartitionCols:_col0
                                             Select Operator [SEL_340] (rows=525327191 width=118)
@@ -328,11 +327,11 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_19_date_dim_d_date_sk_min) AND DynamicValue(RS_19_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_19_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_9] (rows=575995635 width=118)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_338]
                                                     Group By Operator [GBY_337] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_334]
                                                         Group By Operator [GBY_331] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -357,27 +356,27 @@ Stage-0
                                 SHUFFLE [RS_64]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_291]
-                              <-Reducer 20 [SIMPLE_EDGE]
+                              <-Reducer 19 [SIMPLE_EDGE]
                                 SHUFFLE [RS_65]
                                   PartitionCols:_col3
                                   Select Operator [SEL_60] (rows=1550375 width=13)
                                     Output:["_col3","_col4"]
                                     Merge Join Operator [MERGEJOIN_296] (rows=1550375 width=13)
                                       Conds:RS_57._col1=RS_345._col0(Inner),Output:["_col2","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_345]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_343]
-                                    <-Reducer 19 [SIMPLE_EDGE]
+                                    <-Reducer 18 [SIMPLE_EDGE]
                                       SHUFFLE [RS_57]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_295] (rows=7751872 width=98)
                                           Conds:RS_360._col0=RS_327._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_327]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_324]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
+                                        <-Map 25 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_360]
                                             PartitionCols:_col0
                                             Select Operator [SEL_359] (rows=285117733 width=123)
@@ -386,11 +385,11 @@ Stage-0
                                                 predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_55_date_dim_d_date_sk_min) AND DynamicValue(RS_55_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_55_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_45] (rows=287989836 width=123)
                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_357]
                                                     Group By Operator [GBY_356] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_335]
                                                         Group By Operator [GBY_332] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query58.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query58.q.out
@@ -142,24 +142,24 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 24 <- Reducer 9 (BROADCAST_EDGE)
-Map 26 <- Reducer 13 (BROADCAST_EDGE)
-Map 27 <- Reducer 17 (BROADCAST_EDGE)
-Reducer 10 <- Map 26 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 11 <- Map 25 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Map 22 <- Reducer 9 (BROADCAST_EDGE)
+Map 24 <- Reducer 13 (BROADCAST_EDGE)
+Map 25 <- Reducer 17 (BROADCAST_EDGE)
+Reducer 10 <- Map 24 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 11 <- Map 23 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
 Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
 Reducer 13 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-Reducer 14 <- Map 27 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 15 <- Map 25 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 14 <- Map 25 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 15 <- Map 23 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
 Reducer 17 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 18 (CUSTOM_SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 20 <- Map 23 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
-Reducer 21 <- Map 23 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
-Reducer 22 <- Reducer 21 (SIMPLE_EDGE)
-Reducer 3 <- Map 24 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 25 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 18 <- Map 1 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 19 <- Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
+Reducer 20 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 21 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Map 22 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 4 <- Map 23 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 12 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 16 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
@@ -200,7 +200,7 @@ Stage-0
                                 Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                                 Merge Join Operator [MERGEJOIN_421] (rows=31537 width=100)
                                   Conds:RS_136._col4=RS_451._col0(Inner),Output:["_col5","_col7"]
-                                <-Map 25 [SIMPLE_EDGE] vectorized
+                                <-Map 23 [SIMPLE_EDGE] vectorized
                                   SHUFFLE [RS_451]
                                     PartitionCols:_col0
                                     Select Operator [SEL_448] (rows=462000 width=104)
@@ -216,66 +216,64 @@ Stage-0
                                       PARTITION_ONLY_SHUFFLE [RS_133]
                                         PartitionCols:_col0
                                         Merge Join Operator [MERGEJOIN_409] (rows=2 width=4)
-                                          Conds:RS_426._col1=RS_442._col0(Inner),Output:["_col0"]
+                                          Conds:RS_432._col1=RS_442._col0(Inner),Output:["_col0"]
                                         <-Map 1 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_426]
+                                          PARTITION_ONLY_SHUFFLE [RS_432]
                                             PartitionCols:_col1
-                                            Select Operator [SEL_425] (rows=73049 width=98)
+                                            Select Operator [SEL_428] (rows=73049 width=98)
                                               Output:["_col0","_col1"]
                                               Filter Operator [FIL_424] (rows=73049 width=98)
                                                 predicate:d_date is not null
                                                 TableScan [TS_0] (rows=73049 width=98)
-                                                  default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
-                                        <-Reducer 22 [SIMPLE_EDGE] vectorized
+                                                  default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq"]
+                                        <-Reducer 19 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_442]
                                             PartitionCols:_col0
                                             Group By Operator [GBY_441] (rows=2 width=94)
                                               Output:["_col0"],keys:KEY._col0
-                                            <-Reducer 21 [SIMPLE_EDGE]
+                                            <-Reducer 18 [SIMPLE_EDGE]
                                               SHUFFLE [RS_26]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_25] (rows=2 width=94)
                                                   Output:["_col0"],keys:_col2
                                                   Merge Join Operator [MERGEJOIN_408] (rows=5 width=94)
-                                                    Conds:RS_21._col1=RS_439._col1(Inner),Output:["_col2"]
-                                                  <-Map 23 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_439]
+                                                    Conds:RS_21._col1=RS_433._col1(Inner),Output:["_col2"]
+                                                  <-Map 1 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_433]
                                                       PartitionCols:_col1
-                                                      Select Operator [SEL_437] (rows=73049 width=98)
+                                                      Select Operator [SEL_429] (rows=73049 width=98)
                                                         Output:["_col0","_col1"]
-                                                        Filter Operator [FIL_435] (rows=73049 width=98)
+                                                        Filter Operator [FIL_425] (rows=73049 width=98)
                                                           predicate:(d_week_seq is not null and d_date is not null)
-                                                          TableScan [TS_15] (rows=73049 width=98)
-                                                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date","d_week_seq"]
+                                                           Please refer to the previous TableScan [TS_0]
                                                   <-Reducer 20 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_21]
                                                       PartitionCols:_col1
                                                       Merge Join Operator [MERGEJOIN_407] (rows=1 width=4)
                                                         Conds:(Inner),Output:["_col1"]
-                                                      <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_440]
-                                                          Select Operator [SEL_438] (rows=1 width=4)
-                                                            Output:["_col0"]
-                                                            Filter Operator [FIL_436] (rows=1 width=98)
-                                                              predicate:((d_date = '1998-02-19') and d_week_seq is not null)
-                                                               Please refer to the previous TableScan [TS_15]
-                                                      <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_434]
-                                                          Select Operator [SEL_433] (rows=1 width=8)
-                                                            Filter Operator [FIL_432] (rows=1 width=8)
+                                                          Select Operator [SEL_430] (rows=1 width=4)
+                                                            Output:["_col0"]
+                                                            Filter Operator [FIL_426] (rows=1 width=98)
+                                                              predicate:((d_date = '1998-02-19') and d_week_seq is not null)
+                                                               Please refer to the previous TableScan [TS_0]
+                                                      <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                        PARTITION_ONLY_SHUFFLE [RS_440]
+                                                          Select Operator [SEL_439] (rows=1 width=8)
+                                                            Filter Operator [FIL_438] (rows=1 width=8)
                                                               predicate:(sq_count_check(_col0) <= 1)
-                                                              Group By Operator [GBY_431] (rows=1 width=8)
+                                                              Group By Operator [GBY_437] (rows=1 width=8)
                                                                 Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                                              <-Map 18 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_430]
-                                                                  Group By Operator [GBY_429] (rows=1 width=8)
+                                                              <-Map 1 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_436]
+                                                                  Group By Operator [GBY_435] (rows=1 width=8)
                                                                     Output:["_col0"],aggregations:["count()"]
-                                                                    Select Operator [SEL_428] (rows=1 width=94)
+                                                                    Select Operator [SEL_431] (rows=1 width=94)
                                                                       Filter Operator [FIL_427] (rows=1 width=94)
                                                                         predicate:(d_date = '1998-02-19')
-                                                                        TableScan [TS_3] (rows=73049 width=94)
-                                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date"]
-                                    <-Map 27 [SIMPLE_EDGE] vectorized
+                                                                         Please refer to the previous TableScan [TS_0]
+                                    <-Map 25 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_465]
                                         PartitionCols:_col0
                                         Select Operator [SEL_464] (rows=143966864 width=119)
@@ -314,7 +312,7 @@ Stage-0
                                     Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                                     Merge Join Operator [MERGEJOIN_416] (rows=120498 width=100)
                                       Conds:RS_88._col4=RS_450._col0(Inner),Output:["_col5","_col7"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 23 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_450]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_448]
@@ -327,7 +325,7 @@ Stage-0
                                           PARTITION_ONLY_SHUFFLE [RS_85]
                                             PartitionCols:_col0
                                              Please refer to the previous Merge Join Operator [MERGEJOIN_409]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
+                                        <-Map 24 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_458]
                                             PartitionCols:_col0
                                             Select Operator [SEL_457] (rows=550076554 width=114)
@@ -359,7 +357,7 @@ Stage-0
                                     Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                                     Merge Join Operator [MERGEJOIN_411] (rows=62327 width=100)
                                       Conds:RS_40._col4=RS_449._col0(Inner),Output:["_col5","_col7"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 23 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_449]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_448]
@@ -372,7 +370,7 @@ Stage-0
                                           PARTITION_ONLY_SHUFFLE [RS_37]
                                             PartitionCols:_col0
                                              Please refer to the previous Merge Join Operator [MERGEJOIN_409]
-                                        <-Map 24 [SIMPLE_EDGE] vectorized
+                                        <-Map 22 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_447]
                                             PartitionCols:_col0
                                             Select Operator [SEL_446] (rows=286549727 width=119)

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query59.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query59.q.out
@@ -95,10 +95,10 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Map 15 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 10 <- Map 14 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Map 14 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Map 15 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 13 <- Map 14 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 13 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
@@ -128,16 +128,16 @@ Stage-0
                     SHUFFLE [RS_55]
                       PartitionCols:_col1, (_col0 - 52)
                       Merge Join Operator [MERGEJOIN_180] (rows=28847 width=676)
-                        Conds:RS_205._col0=RS_203._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                      <-Map 15 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_203]
+                        Conds:RS_205._col0=RS_201._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                      <-Map 14 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_201]
                           PartitionCols:_col0
-                          Select Operator [SEL_201] (rows=317 width=4)
+                          Select Operator [SEL_197] (rows=317 width=4)
                             Output:["_col0"]
-                            Filter Operator [FIL_199] (rows=317 width=8)
+                            Filter Operator [FIL_193] (rows=317 width=8)
                               predicate:(d_month_seq BETWEEN 1197 AND 1208 and d_week_seq is not null)
-                              TableScan [TS_19] (rows=73049 width=8)
-                                default@date_dim,d,Tbl:COMPLETE,Col:COMPLETE,Output:["d_month_seq","d_week_seq"]
+                              TableScan [TS_7] (rows=73049 width=99)
+                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name","d_month_seq"]
                       <-Reducer 12 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_205]
                           PartitionCols:_col0
@@ -151,16 +151,15 @@ Stage-0
                                 Select Operator [SEL_35] (rows=525329897 width=138)
                                   Output:["_col0","_col1","_col2","_col3","_col5","_col6","_col7","_col8"]
                                   Merge Join Operator [MERGEJOIN_179] (rows=525329897 width=138)
-                                    Conds:RS_190._col0=RS_195._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col8","_col9","_col10","_col11"]
+                                    Conds:RS_190._col0=RS_199._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col8","_col9","_col10","_col11"]
                                   <-Map 14 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_195]
+                                    SHUFFLE [RS_199]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_193] (rows=73049 width=36)
+                                      Select Operator [SEL_195] (rows=73049 width=36)
                                         Output:["_col0","_col1","_col2","_col3","_col5","_col6","_col7","_col8"]
                                         Filter Operator [FIL_191] (rows=73049 width=99)
                                           predicate:d_week_seq is not null
-                                          TableScan [TS_7] (rows=73049 width=99)
-                                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name"]
+                                           Please refer to the previous TableScan [TS_7]
                                   <-Map 7 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_190]
                                       PartitionCols:_col0
@@ -179,19 +178,19 @@ Stage-0
                         SHUFFLE [RS_52]
                           PartitionCols:_col1
                           Merge Join Operator [MERGEJOIN_178] (rows=28847 width=788)
-                            Conds:RS_197._col0=RS_202._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                          <-Map 15 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_202]
+                            Conds:RS_203._col0=RS_200._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                          <-Map 14 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_200]
                               PartitionCols:_col0
-                              Select Operator [SEL_200] (rows=317 width=4)
+                              Select Operator [SEL_196] (rows=317 width=4)
                                 Output:["_col0"]
-                                Filter Operator [FIL_198] (rows=317 width=8)
+                                Filter Operator [FIL_192] (rows=317 width=8)
                                   predicate:(d_month_seq BETWEEN 1185 AND 1196 and d_week_seq is not null)
-                                   Please refer to the previous TableScan [TS_19]
+                                   Please refer to the previous TableScan [TS_7]
                           <-Reducer 9 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_197]
+                            SHUFFLE [RS_203]
                               PartitionCols:_col0
-                              Group By Operator [GBY_196] (rows=1196832 width=791)
+                              Group By Operator [GBY_202] (rows=1196832 width=791)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)","sum(VALUE._col5)","sum(VALUE._col6)"],keys:KEY._col0, KEY._col1
                               <-Reducer 8 [SIMPLE_EDGE]
                                 SHUFFLE [RS_16]
@@ -201,11 +200,11 @@ Stage-0
                                     Select Operator [SEL_13] (rows=525329897 width=142)
                                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                       Merge Join Operator [MERGEJOIN_177] (rows=525329897 width=142)
-                                        Conds:RS_189._col0=RS_194._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
+                                        Conds:RS_189._col0=RS_198._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
                                       <-Map 14 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_194]
+                                        SHUFFLE [RS_198]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_192] (rows=73049 width=36)
+                                          Select Operator [SEL_194] (rows=73049 width=36)
                                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                              Please refer to the previous Filter Operator [FIL_191]
                                       <-Map 7 [SIMPLE_EDGE] vectorized

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query60.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query60.q.out
@@ -169,27 +169,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -229,38 +229,37 @@ Stage-0
                                   SHUFFLE [RS_101]
                                     PartitionCols:_col0
                                     Merge Join Operator [MERGEJOIN_296] (rows=34340 width=104)
-                                      Conds:RS_324._col1=RS_330._col0(Inner),Output:["_col0","_col1"]
+                                      Conds:RS_325._col1=RS_330._col0(Inner),Output:["_col0","_col1"]
                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_324]
+                                      SHUFFLE [RS_325]
                                         PartitionCols:_col1
                                         Select Operator [SEL_323] (rows=462000 width=104)
                                           Output:["_col0","_col1"]
                                           TableScan [TS_0] (rows=462000 width=104)
-                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                    <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id","i_category"]
+                                    <-Reducer 12 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_330]
                                         PartitionCols:_col0
                                         Group By Operator [GBY_329] (rows=23100 width=100)
                                           Output:["_col0"],keys:KEY._col0
-                                        <-Map 12 [SIMPLE_EDGE] vectorized
+                                        <-Map 1 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_328]
                                             PartitionCols:_col0
                                             Group By Operator [GBY_327] (rows=23100 width=100)
                                               Output:["_col0"],keys:i_item_id
                                               Select Operator [SEL_326] (rows=46200 width=190)
                                                 Output:["i_item_id"]
-                                                Filter Operator [FIL_325] (rows=46200 width=190)
+                                                Filter Operator [FIL_324] (rows=46200 width=190)
                                                   predicate:(i_category = 'Children')
-                                                  TableScan [TS_2] (rows=462000 width=190)
-                                                    default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_id","i_category"]
-                                <-Reducer 23 [SIMPLE_EDGE]
+                                                   Please refer to the previous TableScan [TS_0]
+                                <-Reducer 22 [SIMPLE_EDGE]
                                   SHUFFLE [RS_102]
                                     PartitionCols:_col2
                                     Select Operator [SEL_97] (rows=788222 width=110)
                                       Output:["_col2","_col4"]
                                       Merge Join Operator [MERGEJOIN_304] (rows=788222 width=110)
                                         Conds:RS_94._col2=RS_354._col0(Inner),Output:["_col1","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_354]
                                           PartitionCols:_col0
                                           Select Operator [SEL_351] (rows=8000000 width=4)
@@ -269,12 +268,12 @@ Stage-0
                                               predicate:(ca_gmt_offset = -6)
                                               TableScan [TS_15] (rows=40000000 width=112)
                                                 default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                      <-Reducer 22 [SIMPLE_EDGE]
+                                      <-Reducer 21 [SIMPLE_EDGE]
                                         SHUFFLE [RS_94]
                                           PartitionCols:_col2
                                           Merge Join Operator [MERGEJOIN_303] (rows=3941109 width=118)
                                             Conds:RS_378._col0=RS_337._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_337]
                                               PartitionCols:_col0
                                               Select Operator [SEL_332] (rows=50 width=4)
@@ -283,7 +282,7 @@ Stage-0
                                                   predicate:((d_year = 1999) and (d_moy = 9))
                                                   TableScan [TS_12] (rows=73049 width=12)
                                                     default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                          <-Map 27 [SIMPLE_EDGE] vectorized
+                                          <-Map 26 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_378]
                                               PartitionCols:_col0
                                               Select Operator [SEL_377] (rows=143931246 width=123)
@@ -292,11 +291,11 @@ Stage-0
                                                   predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_92_date_dim_d_date_sk_min) AND DynamicValue(RS_92_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_92_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_82] (rows=144002668 width=123)
                                                     default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                  <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_375]
                                                       Group By Operator [GBY_374] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_344]
                                                           Group By Operator [GBY_341] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -323,27 +322,27 @@ Stage-0
                                   SHUFFLE [RS_28]
                                     PartitionCols:_col0
                                      Please refer to the previous Merge Join Operator [MERGEJOIN_296]
-                                <-Reducer 16 [SIMPLE_EDGE]
+                                <-Reducer 15 [SIMPLE_EDGE]
                                   SHUFFLE [RS_29]
                                     PartitionCols:_col2
                                     Select Operator [SEL_24] (rows=2876890 width=4)
                                       Output:["_col2","_col4"]
                                       Merge Join Operator [MERGEJOIN_298] (rows=2876890 width=4)
                                         Conds:RS_21._col2=RS_352._col0(Inner),Output:["_col1","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_352]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_351]
-                                      <-Reducer 15 [SIMPLE_EDGE]
+                                      <-Reducer 14 [SIMPLE_EDGE]
                                         SHUFFLE [RS_21]
                                           PartitionCols:_col2
                                           Merge Join Operator [MERGEJOIN_297] (rows=14384447 width=4)
                                             Conds:RS_349._col0=RS_333._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_333]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_332]
-                                          <-Map 14 [SIMPLE_EDGE] vectorized
+                                          <-Map 13 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_349]
                                               PartitionCols:_col0
                                               Select Operator [SEL_348] (rows=525327191 width=118)
@@ -352,11 +351,11 @@ Stage-0
                                                   predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_19_date_dim_d_date_sk_min) AND DynamicValue(RS_19_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_19_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_9] (rows=575995635 width=118)
                                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                  <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_346]
                                                       Group By Operator [GBY_345] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_342]
                                                           Group By Operator [GBY_339] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -383,27 +382,27 @@ Stage-0
                                   SHUFFLE [RS_64]
                                     PartitionCols:_col0
                                      Please refer to the previous Merge Join Operator [MERGEJOIN_296]
-                                <-Reducer 20 [SIMPLE_EDGE]
+                                <-Reducer 19 [SIMPLE_EDGE]
                                   SHUFFLE [RS_65]
                                     PartitionCols:_col3
                                     Select Operator [SEL_60] (rows=1550375 width=13)
                                       Output:["_col3","_col4"]
                                       Merge Join Operator [MERGEJOIN_301] (rows=1550375 width=13)
                                         Conds:RS_57._col1=RS_353._col0(Inner),Output:["_col2","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_353]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_351]
-                                      <-Reducer 19 [SIMPLE_EDGE]
+                                      <-Reducer 18 [SIMPLE_EDGE]
                                         SHUFFLE [RS_57]
                                           PartitionCols:_col1
                                           Merge Join Operator [MERGEJOIN_300] (rows=7751872 width=98)
                                             Conds:RS_369._col0=RS_335._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_335]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_332]
-                                          <-Map 26 [SIMPLE_EDGE] vectorized
+                                          <-Map 25 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_369]
                                               PartitionCols:_col0
                                               Select Operator [SEL_368] (rows=285117733 width=123)
@@ -412,11 +411,11 @@ Stage-0
                                                   predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_55_date_dim_d_date_sk_min) AND DynamicValue(RS_55_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_55_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_45] (rows=287989836 width=123)
                                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                  <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_366]
                                                       Group By Operator [GBY_365] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_343]
                                                           Group By Operator [GBY_340] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query61.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query61.q.out
@@ -104,22 +104,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 23 <- Reducer 19 (BROADCAST_EDGE)
-Map 9 <- Reducer 15 (BROADCAST_EDGE)
-Reducer 10 <- Map 14 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 20 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 21 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Map 22 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Map 14 (SIMPLE_EDGE), Map 23 (SIMPLE_EDGE)
-Reducer 17 <- Map 20 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
-Reducer 18 <- Map 21 (SIMPLE_EDGE), Reducer 17 (SIMPLE_EDGE)
-Reducer 19 <- Map 14 (CUSTOM_SIMPLE_EDGE)
+Reducer 10 <- Map 17 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 11 <- Map 18 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Reducer 12 <- Map 19 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 20 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 14 <- Map 17 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 15 <- Map 18 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 16 <- Map 19 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 18 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 6 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -133,8 +129,8 @@ Stage-0
           Merge Join Operator [MERGEJOIN_263] (rows=1 width=224)
             Conds:(Inner),Output:["_col0","_col1"]
           <-Reducer 4 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_297]
-              Group By Operator [GBY_296] (rows=1 width=112)
+            PARTITION_ONLY_SHUFFLE [RS_292]
+              Group By Operator [GBY_291] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(VALUE._col0)"]
               <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                 PARTITION_ONLY_SHUFFLE [RS_42]
@@ -169,13 +165,13 @@ Stage-0
                       SHUFFLE [RS_38]
                         PartitionCols:_col2
                         Merge Join Operator [MERGEJOIN_256] (rows=2526982 width=0)
-                          Conds:RS_30._col4=RS_295._col0(Inner),Output:["_col2","_col5"]
-                        <-Map 22 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_295]
+                          Conds:RS_30._col4=RS_290._col0(Inner),Output:["_col2","_col5"]
+                        <-Map 20 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_290]
                             PartitionCols:_col0
-                            Select Operator [SEL_294] (rows=2300 width=4)
+                            Select Operator [SEL_289] (rows=2300 width=4)
                               Output:["_col0"]
-                              Filter Operator [FIL_293] (rows=2300 width=259)
+                              Filter Operator [FIL_288] (rows=2300 width=259)
                                 predicate:((p_channel_email = 'Y') or (p_channel_tv = 'Y') or (p_channel_dmail = 'Y'))
                                 TableScan [TS_18] (rows=2300 width=259)
                                   default@promotion,promotion,Tbl:COMPLETE,Col:COMPLETE,Output:["p_promo_sk","p_channel_dmail","p_channel_email","p_channel_tv"]
@@ -183,13 +179,13 @@ Stage-0
                           SHUFFLE [RS_30]
                             PartitionCols:_col4
                             Merge Join Operator [MERGEJOIN_255] (rows=2526982 width=0)
-                              Conds:RS_27._col3=RS_291._col0(Inner),Output:["_col2","_col4","_col5"]
-                            <-Map 21 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_291]
+                              Conds:RS_27._col3=RS_286._col0(Inner),Output:["_col2","_col4","_col5"]
+                            <-Map 19 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_286]
                                 PartitionCols:_col0
-                                Select Operator [SEL_290] (rows=341 width=4)
+                                Select Operator [SEL_285] (rows=341 width=4)
                                   Output:["_col0"]
-                                  Filter Operator [FIL_289] (rows=341 width=115)
+                                  Filter Operator [FIL_284] (rows=341 width=115)
                                     predicate:(s_gmt_offset = -7)
                                     TableScan [TS_15] (rows=1704 width=115)
                                       default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_gmt_offset"]
@@ -197,13 +193,13 @@ Stage-0
                               SHUFFLE [RS_27]
                                 PartitionCols:_col3
                                 Merge Join Operator [MERGEJOIN_254] (rows=12627499 width=0)
-                                  Conds:RS_24._col1=RS_287._col0(Inner),Output:["_col2","_col3","_col4","_col5"]
-                                <-Map 20 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_287]
+                                  Conds:RS_24._col1=RS_282._col0(Inner),Output:["_col2","_col3","_col4","_col5"]
+                                <-Map 18 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_282]
                                     PartitionCols:_col0
-                                    Select Operator [SEL_286] (rows=46200 width=4)
+                                    Select Operator [SEL_281] (rows=46200 width=4)
                                       Output:["_col0"]
-                                      Filter Operator [FIL_285] (rows=46200 width=94)
+                                      Filter Operator [FIL_280] (rows=46200 width=94)
                                         predicate:(i_category = 'Electronics')
                                         TableScan [TS_12] (rows=462000 width=94)
                                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_category"]
@@ -211,39 +207,28 @@ Stage-0
                                   SHUFFLE [RS_24]
                                     PartitionCols:_col1
                                     Merge Join Operator [MERGEJOIN_253] (rows=13119234 width=4)
-                                      Conds:RS_284._col0=RS_272._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                    <-Map 14 [SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_272]
+                                      Conds:RS_274._col0=RS_278._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
+                                    <-Map 17 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_278]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_271] (rows=50 width=4)
+                                        Select Operator [SEL_277] (rows=50 width=4)
                                           Output:["_col0"]
-                                          Filter Operator [FIL_270] (rows=50 width=12)
+                                          Filter Operator [FIL_276] (rows=50 width=12)
                                             predicate:((d_year = 1999) and (d_moy = 11))
                                             TableScan [TS_9] (rows=73049 width=12)
                                               default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
                                     <-Map 9 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_284]
+                                      SHUFFLE [RS_274]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_283] (rows=479120969 width=126)
+                                        Select Operator [SEL_272] (rows=479120969 width=126)
                                           Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                          Filter Operator [FIL_282] (rows=479120969 width=126)
-                                            predicate:(ss_sold_date_sk is not null and ss_promo_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_22_date_dim_d_date_sk_min) AND DynamicValue(RS_22_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_22_date_dim_d_date_sk_bloom_filter)))
+                                          Filter Operator [FIL_270] (rows=479120969 width=126)
+                                            predicate:(ss_sold_date_sk is not null and ss_promo_sk is not null and ss_customer_sk is not null and ss_store_sk is not null)
                                             TableScan [TS_6] (rows=575995635 width=126)
                                               default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_promo_sk","ss_ext_sales_price"]
-                                            <-Reducer 15 [BROADCAST_EDGE] vectorized
-                                              BROADCAST [RS_281]
-                                                Group By Operator [GBY_280] (rows=1 width=12)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                <-Map 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_278]
-                                                    Group By Operator [GBY_276] (rows=1 width=12)
-                                                      Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                      Select Operator [SEL_273] (rows=50 width=4)
-                                                        Output:["_col0"]
-                                                         Please refer to the previous Select Operator [SEL_271]
           <-Reducer 7 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_304]
-              Group By Operator [GBY_303] (rows=1 width=112)
+            PARTITION_ONLY_SHUFFLE [RS_294]
+              Group By Operator [GBY_293] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(VALUE._col0)"]
               <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                 PARTITION_ONLY_SHUFFLE [RS_81]
@@ -255,51 +240,39 @@ Stage-0
                       SHUFFLE [RS_76]
                         PartitionCols:_col0
                          Please refer to the previous Merge Join Operator [MERGEJOIN_252]
-                    <-Reducer 18 [SIMPLE_EDGE]
+                    <-Reducer 16 [SIMPLE_EDGE]
                       SHUFFLE [RS_77]
                         PartitionCols:_col2
                         Merge Join Operator [MERGEJOIN_260] (rows=2646038 width=0)
-                          Conds:RS_69._col3=RS_292._col0(Inner),Output:["_col2","_col4"]
-                        <-Map 21 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_292]
+                          Conds:RS_69._col3=RS_287._col0(Inner),Output:["_col2","_col4"]
+                        <-Map 19 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_287]
                             PartitionCols:_col0
-                             Please refer to the previous Select Operator [SEL_290]
-                        <-Reducer 17 [SIMPLE_EDGE]
+                             Please refer to the previous Select Operator [SEL_285]
+                        <-Reducer 15 [SIMPLE_EDGE]
                           SHUFFLE [RS_69]
                             PartitionCols:_col3
                             Merge Join Operator [MERGEJOIN_259] (rows=13222427 width=0)
-                              Conds:RS_66._col1=RS_288._col0(Inner),Output:["_col2","_col3","_col4"]
-                            <-Map 20 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_288]
+                              Conds:RS_66._col1=RS_283._col0(Inner),Output:["_col2","_col3","_col4"]
+                            <-Map 18 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_283]
                                 PartitionCols:_col0
-                                 Please refer to the previous Select Operator [SEL_286]
-                            <-Reducer 16 [SIMPLE_EDGE]
+                                 Please refer to the previous Select Operator [SEL_281]
+                            <-Reducer 14 [SIMPLE_EDGE]
                               SHUFFLE [RS_66]
                                 PartitionCols:_col1
                                 Merge Join Operator [MERGEJOIN_258] (rows=13737330 width=4)
-                                  Conds:RS_302._col0=RS_274._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                                <-Map 14 [SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_274]
+                                  Conds:RS_275._col0=RS_279._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                                <-Map 17 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_279]
                                     PartitionCols:_col0
-                                     Please refer to the previous Select Operator [SEL_271]
-                                <-Map 23 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_302]
+                                     Please refer to the previous Select Operator [SEL_277]
+                                <-Map 9 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_275]
                                     PartitionCols:_col0
-                                    Select Operator [SEL_301] (rows=501694138 width=122)
+                                    Select Operator [SEL_273] (rows=501694138 width=122)
                                       Output:["_col0","_col1","_col2","_col3","_col4"]
-                                      Filter Operator [FIL_300] (rows=501694138 width=122)
-                                        predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_64_date_dim_d_date_sk_min) AND DynamicValue(RS_64_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_64_date_dim_d_date_sk_bloom_filter)))
-                                        TableScan [TS_51] (rows=575995635 width=122)
-                                          default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_ext_sales_price"]
-                                        <-Reducer 19 [BROADCAST_EDGE] vectorized
-                                          BROADCAST [RS_299]
-                                            Group By Operator [GBY_298] (rows=1 width=12)
-                                              Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                            <-Map 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_279]
-                                                Group By Operator [GBY_277] (rows=1 width=12)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                  Select Operator [SEL_275] (rows=50 width=4)
-                                                    Output:["_col0"]
-                                                     Please refer to the previous Select Operator [SEL_271]
+                                      Filter Operator [FIL_271] (rows=501694138 width=122)
+                                        predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null)
+                                         Please refer to the previous TableScan [TS_6]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query64.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query64.q.out
@@ -265,58 +265,58 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Reducer 45 (BROADCAST_EDGE)
-Map 35 <- Reducer 20 (BROADCAST_EDGE)
-Map 50 <- Reducer 47 (BROADCAST_EDGE)
-Map 54 <- Reducer 53 (BROADCAST_EDGE)
-Reducer 10 <- Map 44 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 44 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 48 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Map 48 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
-Reducer 14 <- Map 49 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 15 <- Map 49 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Map 1 <- Reducer 48 (BROADCAST_EDGE)
+Map 38 <- Reducer 20 (BROADCAST_EDGE)
+Map 52 <- Reducer 49 (BROADCAST_EDGE)
+Map 53 <- Reducer 36 (BROADCAST_EDGE)
+Reducer 10 <- Map 47 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 11 <- Map 47 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Reducer 12 <- Map 50 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 50 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 14 <- Map 51 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Map 51 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
-Reducer 17 <- Reducer 16 (SIMPLE_EDGE), Reducer 34 (SIMPLE_EDGE)
+Reducer 17 <- Reducer 16 (SIMPLE_EDGE), Reducer 35 (SIMPLE_EDGE)
 Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 19 (SIMPLE_EDGE)
 Reducer 20 <- Map 19 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 21 (SIMPLE_EDGE), Reducer 46 (SIMPLE_EDGE)
-Reducer 23 <- Reducer 22 (SIMPLE_EDGE), Reducer 40 (SIMPLE_EDGE)
-Reducer 24 <- Map 41 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
-Reducer 25 <- Map 42 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
-Reducer 26 <- Map 43 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
-Reducer 27 <- Map 43 (SIMPLE_EDGE), Reducer 26 (SIMPLE_EDGE)
-Reducer 28 <- Map 44 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
-Reducer 29 <- Map 44 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE)
-Reducer 3 <- Map 44 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Map 48 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE)
-Reducer 31 <- Map 48 (SIMPLE_EDGE), Reducer 30 (SIMPLE_EDGE)
-Reducer 32 <- Map 49 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE)
-Reducer 33 <- Map 49 (SIMPLE_EDGE), Reducer 32 (SIMPLE_EDGE)
-Reducer 34 <- Reducer 33 (SIMPLE_EDGE)
-Reducer 36 <- Map 35 (SIMPLE_EDGE), Map 38 (SIMPLE_EDGE)
-Reducer 37 <- Reducer 36 (SIMPLE_EDGE)
-Reducer 39 <- Map 38 (SIMPLE_EDGE), Map 54 (SIMPLE_EDGE)
-Reducer 4 <- Map 21 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 21 <- Map 19 (SIMPLE_EDGE), Map 52 (SIMPLE_EDGE)
+Reducer 22 <- Map 47 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 37 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
+Reducer 24 <- Reducer 23 (SIMPLE_EDGE), Reducer 43 (SIMPLE_EDGE)
+Reducer 25 <- Map 44 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
+Reducer 26 <- Map 45 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
+Reducer 27 <- Map 46 (SIMPLE_EDGE), Reducer 26 (SIMPLE_EDGE)
+Reducer 28 <- Map 46 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
+Reducer 29 <- Map 47 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE)
+Reducer 3 <- Map 47 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 30 <- Map 47 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE)
+Reducer 31 <- Map 50 (SIMPLE_EDGE), Reducer 30 (SIMPLE_EDGE)
+Reducer 32 <- Map 50 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE)
+Reducer 33 <- Map 51 (SIMPLE_EDGE), Reducer 32 (SIMPLE_EDGE)
+Reducer 34 <- Map 51 (SIMPLE_EDGE), Reducer 33 (SIMPLE_EDGE)
+Reducer 35 <- Reducer 34 (SIMPLE_EDGE)
+Reducer 36 <- Map 19 (CUSTOM_SIMPLE_EDGE)
+Reducer 39 <- Map 38 (SIMPLE_EDGE), Map 41 (SIMPLE_EDGE)
+Reducer 4 <- Map 37 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 40 <- Reducer 39 (SIMPLE_EDGE)
-Reducer 45 <- Map 44 (CUSTOM_SIMPLE_EDGE)
-Reducer 46 <- Map 44 (SIMPLE_EDGE), Reducer 51 (SIMPLE_EDGE)
-Reducer 47 <- Map 44 (CUSTOM_SIMPLE_EDGE)
-Reducer 5 <- Reducer 37 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-Reducer 51 <- Map 50 (SIMPLE_EDGE), Map 52 (SIMPLE_EDGE)
-Reducer 53 <- Map 52 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Map 41 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 42 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 43 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Map 43 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+Reducer 42 <- Map 41 (SIMPLE_EDGE), Map 53 (SIMPLE_EDGE)
+Reducer 43 <- Reducer 42 (SIMPLE_EDGE)
+Reducer 48 <- Map 47 (CUSTOM_SIMPLE_EDGE)
+Reducer 49 <- Map 47 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Reducer 4 (SIMPLE_EDGE), Reducer 40 (SIMPLE_EDGE)
+Reducer 6 <- Map 44 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 7 <- Map 45 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 8 <- Map 46 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 9 <- Map 46 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
     limit:-1
     Stage-1
       Reducer 18 vectorized
-      File Output Operator [FS_1079]
-        Select Operator [SEL_1078] (rows=104628491644 width=1702)
+      File Output Operator [FS_1078]
+        Select Operator [SEL_1077] (rows=104628491644 width=1702)
           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20"]
         <-Reducer 17 [SIMPLE_EDGE]
           SHUFFLE [RS_201]
@@ -325,17 +325,17 @@ Stage-0
               Filter Operator [FIL_199] (rows=104628491644 width=1694)
                 predicate:(_col3 <= _col19)
                 Merge Join Operator [MERGEJOIN_977] (rows=313885474933 width=1694)
-                  Conds:RS_1052._col1, _col0, _col2=RS_1077._col2, _col1, _col3(Inner),Output:["_col3","_col4","_col5","_col6","_col7","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
+                  Conds:RS_1057._col1, _col0, _col2=RS_1076._col2, _col1, _col3(Inner),Output:["_col3","_col4","_col5","_col6","_col7","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21","_col22"]
                 <-Reducer 16 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_1052]
+                  SHUFFLE [RS_1057]
                     PartitionCols:_col1, _col0, _col2
-                    Select Operator [SEL_1051] (rows=21304422 width=525)
+                    Select Operator [SEL_1056] (rows=21304422 width=525)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
-                      Filter Operator [FIL_1050] (rows=21304422 width=1255)
+                      Filter Operator [FIL_1055] (rows=21304422 width=1255)
                         predicate:_col13 is not null
-                        Select Operator [SEL_1049] (rows=21304422 width=1255)
+                        Select Operator [SEL_1054] (rows=21304422 width=1255)
                           Output:["_col0","_col1","_col2","_col13","_col14","_col15","_col16"]
-                          Group By Operator [GBY_1048] (rows=21304422 width=1255)
+                          Group By Operator [GBY_1053] (rows=21304422 width=1255)
                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"],aggregations:["count(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4, KEY._col5, KEY._col6, KEY._col7, KEY._col8, KEY._col9, KEY._col10, KEY._col11, KEY._col12
                           <-Reducer 15 [SIMPLE_EDGE]
                             SHUFFLE [RS_93]
@@ -343,11 +343,11 @@ Stage-0
                               Group By Operator [GBY_92] (rows=21304422 width=1255)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"],aggregations:["count()","sum(_col8)","sum(_col9)","sum(_col10)"],keys:_col24, _col11, _col25, _col29, _col31, _col37, _col38, _col39, _col40, _col42, _col43, _col44, _col45
                                 Merge Join Operator [MERGEJOIN_961] (rows=21304422 width=1048)
-                                  Conds:RS_88._col17=RS_1045._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40","_col42","_col43","_col44","_col45"]
-                                <-Map 49 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_1045]
+                                  Conds:RS_88._col17=RS_1050._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40","_col42","_col43","_col44","_col45"]
+                                <-Map 51 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_1050]
                                     PartitionCols:_col0
-                                    Select Operator [SEL_1043] (rows=40000000 width=365)
+                                    Select Operator [SEL_1048] (rows=40000000 width=365)
                                       Output:["_col0","_col1","_col2","_col3","_col4"]
                                       TableScan [TS_44] (rows=40000000 width=365)
                                         default@customer_address,ad1,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_street_number","ca_street_name","ca_city","ca_zip"]
@@ -355,22 +355,22 @@ Stage-0
                                   SHUFFLE [RS_88]
                                     PartitionCols:_col17
                                     Merge Join Operator [MERGEJOIN_960] (rows=21304422 width=691)
-                                      Conds:RS_85._col5=RS_1044._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col17","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40"]
-                                    <-Map 49 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_1044]
+                                      Conds:RS_85._col5=RS_1049._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col17","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40"]
+                                    <-Map 51 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_1049]
                                         PartitionCols:_col0
-                                         Please refer to the previous Select Operator [SEL_1043]
+                                         Please refer to the previous Select Operator [SEL_1048]
                                     <-Reducer 13 [SIMPLE_EDGE]
                                       SHUFFLE [RS_85]
                                         PartitionCols:_col5
                                         Filter Operator [FIL_84] (rows=21304422 width=502)
                                           predicate:(_col33 <> _col35)
                                           Merge Join Operator [MERGEJOIN_959] (rows=21304422 width=502)
-                                            Conds:RS_81._col15=RS_1040._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col17","_col24","_col25","_col29","_col31","_col33","_col35"]
-                                          <-Map 48 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_1040]
+                                            Conds:RS_81._col15=RS_1045._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col17","_col24","_col25","_col29","_col31","_col33","_col35"]
+                                          <-Map 50 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_1045]
                                               PartitionCols:_col0
-                                              Select Operator [SEL_1038] (rows=1861800 width=89)
+                                              Select Operator [SEL_1043] (rows=1861800 width=89)
                                                 Output:["_col0","_col1"]
                                                 TableScan [TS_40] (rows=1861800 width=89)
                                                   default@customer_demographics,cd1,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_marital_status"]
@@ -378,17 +378,17 @@ Stage-0
                                             SHUFFLE [RS_81]
                                               PartitionCols:_col15
                                               Merge Join Operator [MERGEJOIN_958] (rows=21007353 width=418)
-                                                Conds:RS_78._col3=RS_1039._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col24","_col25","_col29","_col31","_col33"]
-                                              <-Map 48 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_1039]
+                                                Conds:RS_78._col3=RS_1044._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col24","_col25","_col29","_col31","_col33"]
+                                              <-Map 50 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_1044]
                                                   PartitionCols:_col0
-                                                   Please refer to the previous Select Operator [SEL_1038]
+                                                   Please refer to the previous Select Operator [SEL_1043]
                                               <-Reducer 11 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_78]
                                                   PartitionCols:_col3
                                                   Merge Join Operator [MERGEJOIN_957] (rows=20714426 width=331)
                                                     Conds:RS_75._col18=RS_984._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col24","_col25","_col29","_col31"]
-                                                  <-Map 44 [SIMPLE_EDGE] vectorized
+                                                  <-Map 47 [SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_984]
                                                       PartitionCols:_col0
                                                       Select Operator [SEL_978] (rows=73049 width=8)
@@ -400,7 +400,7 @@ Stage-0
                                                       PartitionCols:_col18
                                                       Merge Join Operator [MERGEJOIN_956] (rows=20714426 width=331)
                                                         Conds:RS_72._col19=RS_986._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col18","_col24","_col25","_col29"]
-                                                      <-Map 44 [SIMPLE_EDGE] vectorized
+                                                      <-Map 47 [SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_986]
                                                           PartitionCols:_col0
                                                           Select Operator [SEL_980] (rows=73049 width=8)
@@ -410,13 +410,13 @@ Stage-0
                                                         SHUFFLE [RS_72]
                                                           PartitionCols:_col19
                                                           Merge Join Operator [MERGEJOIN_955] (rows=20714426 width=330)
-                                                            Conds:RS_69._col16=RS_1035._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col18","_col19","_col24","_col25"]
-                                                          <-Map 43 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_1035]
+                                                            Conds:RS_69._col16=RS_1040._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col17","_col18","_col19","_col24","_col25"]
+                                                          <-Map 46 [SIMPLE_EDGE] vectorized
+                                                            SHUFFLE [RS_1040]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_1033] (rows=7200 width=4)
+                                                              Select Operator [SEL_1038] (rows=7200 width=4)
                                                                 Output:["_col0"]
-                                                                Filter Operator [FIL_1032] (rows=7200 width=8)
+                                                                Filter Operator [FIL_1037] (rows=7200 width=8)
                                                                   predicate:hd_income_band_sk is not null
                                                                   TableScan [TS_30] (rows=7200 width=8)
                                                                     default@household_demographics,hd1,Tbl:COMPLETE,Col:COMPLETE,Output:["hd_demo_sk","hd_income_band_sk"]
@@ -424,22 +424,22 @@ Stage-0
                                                             SHUFFLE [RS_69]
                                                               PartitionCols:_col16
                                                               Merge Join Operator [MERGEJOIN_954] (rows=20714426 width=334)
-                                                                Conds:RS_66._col4=RS_1034._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
-                                                              <-Map 43 [SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_1034]
+                                                                Conds:RS_66._col4=RS_1039._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
+                                                              <-Map 46 [SIMPLE_EDGE] vectorized
+                                                                SHUFFLE [RS_1039]
                                                                   PartitionCols:_col0
-                                                                   Please refer to the previous Select Operator [SEL_1033]
+                                                                   Please refer to the previous Select Operator [SEL_1038]
                                                               <-Reducer 7 [SIMPLE_EDGE]
                                                                 SHUFFLE [RS_66]
                                                                   PartitionCols:_col4
                                                                   Merge Join Operator [MERGEJOIN_953] (rows=20714426 width=336)
-                                                                    Conds:RS_63._col6=RS_1030._col0(Inner),Output:["_col3","_col4","_col5","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
-                                                                  <-Map 42 [SIMPLE_EDGE] vectorized
-                                                                    SHUFFLE [RS_1030]
+                                                                    Conds:RS_63._col6=RS_1035._col0(Inner),Output:["_col3","_col4","_col5","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
+                                                                  <-Map 45 [SIMPLE_EDGE] vectorized
+                                                                    SHUFFLE [RS_1035]
                                                                       PartitionCols:_col0
-                                                                      Select Operator [SEL_1029] (rows=1704 width=181)
+                                                                      Select Operator [SEL_1034] (rows=1704 width=181)
                                                                         Output:["_col0","_col1","_col2"]
-                                                                        Filter Operator [FIL_1028] (rows=1704 width=181)
+                                                                        Filter Operator [FIL_1033] (rows=1704 width=181)
                                                                           predicate:(s_store_name is not null and s_zip is not null)
                                                                           TableScan [TS_27] (rows=1704 width=181)
                                                                             default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_name","s_zip"]
@@ -447,11 +447,11 @@ Stage-0
                                                                     SHUFFLE [RS_63]
                                                                       PartitionCols:_col6
                                                                       Merge Join Operator [MERGEJOIN_952] (rows=20714426 width=160)
-                                                                        Conds:RS_60._col1, _col7=RS_1026._col0, _col1(Inner),Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
-                                                                      <-Map 41 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1026]
+                                                                        Conds:RS_60._col1, _col7=RS_1031._col0, _col1(Inner),Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
+                                                                      <-Map 44 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1031]
                                                                           PartitionCols:_col0, _col1
-                                                                          Select Operator [SEL_1025] (rows=57591150 width=8)
+                                                                          Select Operator [SEL_1030] (rows=57591150 width=8)
                                                                             Output:["_col0","_col1"]
                                                                             TableScan [TS_25] (rows=57591150 width=8)
                                                                               default@store_returns,store_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["sr_item_sk","sr_ticket_number"]
@@ -459,66 +459,18 @@ Stage-0
                                                                         SHUFFLE [RS_60]
                                                                           PartitionCols:_col1, _col7
                                                                           Merge Join Operator [MERGEJOIN_951] (rows=12564038 width=28)
-                                                                            Conds:RS_57._col1=RS_1024._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
-                                                                          <-Reducer 37 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1024]
-                                                                              PartitionCols:_col0
-                                                                              Select Operator [SEL_1023] (rows=13257 width=4)
-                                                                                Output:["_col0"]
-                                                                                Filter Operator [FIL_1022] (rows=13257 width=228)
-                                                                                  predicate:(_col1 > (2 * _col2))
-                                                                                  Group By Operator [GBY_1021] (rows=39773 width=228)
-                                                                                    Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0
-                                                                                  <-Reducer 36 [SIMPLE_EDGE]
-                                                                                    SHUFFLE [RS_21]
-                                                                                      PartitionCols:_col0
-                                                                                      Group By Operator [GBY_20] (rows=6482999 width=228)
-                                                                                        Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","sum(_col5)"],keys:_col0
-                                                                                        Merge Join Operator [MERGEJOIN_950] (rows=183085709 width=227)
-                                                                                          Conds:RS_1017._col0, _col1=RS_1019._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
-                                                                                        <-Map 38 [SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1019]
-                                                                                            PartitionCols:_col0, _col1
-                                                                                            Select Operator [SEL_1018] (rows=28798881 width=120)
-                                                                                              Output:["_col0","_col1","_col2"]
-                                                                                              TableScan [TS_14] (rows=28798881 width=337)
-                                                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_item_sk","cr_order_number","cr_refunded_cash","cr_reversed_charge","cr_store_credit"]
-                                                                                        <-Map 35 [SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1017]
-                                                                                            PartitionCols:_col0, _col1
-                                                                                            Select Operator [SEL_1016] (rows=287989836 width=119)
-                                                                                              Output:["_col0","_col1","_col2"]
-                                                                                              Filter Operator [FIL_1015] (rows=287989836 width=119)
-                                                                                                predicate:(cs_item_sk BETWEEN DynamicValue(RS_49_item_i_item_sk_min) AND DynamicValue(RS_49_item_i_item_sk_max) and in_bloom_filter(cs_item_sk, DynamicValue(RS_49_item_i_item_sk_bloom_filter)))
-                                                                                                TableScan [TS_12] (rows=287989836 width=119)
-                                                                                                  default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
-                                                                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
-                                                                                                  BROADCAST [RS_1014]
-                                                                                                    Group By Operator [GBY_1013] (rows=1 width=12)
-                                                                                                      Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                                    <-Map 19 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                                      PARTITION_ONLY_SHUFFLE [RS_1008]
-                                                                                                        Group By Operator [GBY_1007] (rows=1 width=12)
-                                                                                                          Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                                          Select Operator [SEL_1006] (rows=4667 width=4)
-                                                                                                            Output:["_col0"]
-                                                                                                            Select Operator [SEL_1004] (rows=4667 width=4)
-                                                                                                              Output:["_col0"]
-                                                                                                              Filter Operator [FIL_1003] (rows=4667 width=204)
-                                                                                                                predicate:(i_current_price BETWEEN 36 AND 45 and (i_color) IN ('maroon', 'burnished', 'dim', 'steel', 'navajo', 'chocolate'))
-                                                                                                                TableScan [TS_3] (rows=462000 width=204)
-                                                                                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_current_price","i_color"]
+                                                                            Conds:RS_57._col1=RS_1029._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
                                                                           <-Reducer 4 [SIMPLE_EDGE]
                                                                             SHUFFLE [RS_57]
                                                                               PartitionCols:_col1
                                                                               Merge Join Operator [MERGEJOIN_949] (rows=12564038 width=28)
-                                                                                Conds:RS_54._col2=RS_1011._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
-                                                                              <-Map 21 [SIMPLE_EDGE] vectorized
-                                                                                SHUFFLE [RS_1011]
+                                                                                Conds:RS_54._col2=RS_1016._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col15","_col16","_col17","_col18","_col19"]
+                                                                              <-Map 37 [SIMPLE_EDGE] vectorized
+                                                                                SHUFFLE [RS_1016]
                                                                                   PartitionCols:_col0
-                                                                                  Select Operator [SEL_1010] (rows=69376329 width=23)
+                                                                                  Select Operator [SEL_1015] (rows=69376329 width=23)
                                                                                     Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                                                                    Filter Operator [FIL_1009] (rows=69376329 width=23)
+                                                                                    Filter Operator [FIL_1014] (rows=69376329 width=23)
                                                                                       predicate:(c_first_shipto_date_sk is not null and c_first_sales_date_sk is not null and c_current_hdemo_sk is not null and c_current_cdemo_sk is not null and c_current_addr_sk is not null)
                                                                                       TableScan [TS_9] (rows=80000000 width=23)
                                                                                         default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_current_cdemo_sk","c_current_hdemo_sk","c_current_addr_sk","c_first_shipto_date_sk","c_first_sales_date_sk"]
@@ -527,7 +479,7 @@ Stage-0
                                                                                   PartitionCols:_col2
                                                                                   Merge Join Operator [MERGEJOIN_948] (rows=14487982 width=12)
                                                                                     Conds:RS_51._col0=RS_990._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
-                                                                                  <-Map 44 [SIMPLE_EDGE] vectorized
+                                                                                  <-Map 47 [SIMPLE_EDGE] vectorized
                                                                                     PARTITION_ONLY_SHUFFLE [RS_990]
                                                                                       PartitionCols:_col0
                                                                                       Select Operator [SEL_985] (rows=652 width=4)
@@ -539,11 +491,16 @@ Stage-0
                                                                                     SHUFFLE [RS_51]
                                                                                       PartitionCols:_col0
                                                                                       Merge Join Operator [MERGEJOIN_947] (rows=40575792 width=205)
-                                                                                        Conds:RS_1002._col1=RS_1005._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
+                                                                                        Conds:RS_1002._col1=RS_1006._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
                                                                                       <-Map 19 [SIMPLE_EDGE] vectorized
-                                                                                        PARTITION_ONLY_SHUFFLE [RS_1005]
+                                                                                        PARTITION_ONLY_SHUFFLE [RS_1006]
                                                                                           PartitionCols:_col0
-                                                                                           Please refer to the previous Select Operator [SEL_1004]
+                                                                                          Select Operator [SEL_1004] (rows=4667 width=4)
+                                                                                            Output:["_col0"]
+                                                                                            Filter Operator [FIL_1003] (rows=4667 width=204)
+                                                                                              predicate:(i_current_price BETWEEN 36 AND 45 and (i_color) IN ('maroon', 'burnished', 'dim', 'steel', 'navajo', 'chocolate'))
+                                                                                              TableScan [TS_3] (rows=462000 width=204)
+                                                                                                default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_current_price","i_color","i_product_name"]
                                                                                       <-Map 1 [SIMPLE_EDGE] vectorized
                                                                                         SHUFFLE [RS_1002]
                                                                                           PartitionCols:_col1
@@ -553,146 +510,189 @@ Stage-0
                                                                                               predicate:(ss_cdemo_sk is not null and ss_sold_date_sk is not null and ss_promo_sk is not null and ss_addr_sk is not null and ss_customer_sk is not null and ss_hdemo_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_52_d1_d_date_sk_min) AND DynamicValue(RS_52_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_52_d1_d_date_sk_bloom_filter)))
                                                                                               TableScan [TS_0] (rows=575995635 width=355)
                                                                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_wholesale_cost","ss_list_price","ss_coupon_amt"]
-                                                                                              <-Reducer 45 [BROADCAST_EDGE] vectorized
+                                                                                              <-Reducer 48 [BROADCAST_EDGE] vectorized
                                                                                                 BROADCAST [RS_999]
                                                                                                   Group By Operator [GBY_998] (rows=1 width=12)
                                                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                                  <-Map 44 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                                  <-Map 47 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                                                     PARTITION_ONLY_SHUFFLE [RS_996]
                                                                                                       Group By Operator [GBY_994] (rows=1 width=12)
                                                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
                                                                                                         Select Operator [SEL_991] (rows=652 width=4)
                                                                                                           Output:["_col0"]
                                                                                                            Please refer to the previous Select Operator [SEL_985]
-                <-Reducer 34 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_1077]
+                                                                          <-Reducer 40 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1029]
+                                                                              PartitionCols:_col0
+                                                                              Select Operator [SEL_1028] (rows=13257 width=4)
+                                                                                Output:["_col0"]
+                                                                                Filter Operator [FIL_1027] (rows=13257 width=228)
+                                                                                  predicate:(_col1 > (2 * _col2))
+                                                                                  Group By Operator [GBY_1026] (rows=39773 width=228)
+                                                                                    Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0
+                                                                                  <-Reducer 39 [SIMPLE_EDGE]
+                                                                                    SHUFFLE [RS_21]
+                                                                                      PartitionCols:_col0
+                                                                                      Group By Operator [GBY_20] (rows=6482999 width=228)
+                                                                                        Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","sum(_col5)"],keys:_col0
+                                                                                        Merge Join Operator [MERGEJOIN_950] (rows=183085709 width=227)
+                                                                                          Conds:RS_1022._col0, _col1=RS_1024._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
+                                                                                        <-Map 41 [SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1024]
+                                                                                            PartitionCols:_col0, _col1
+                                                                                            Select Operator [SEL_1023] (rows=28798881 width=120)
+                                                                                              Output:["_col0","_col1","_col2"]
+                                                                                              TableScan [TS_14] (rows=28798881 width=337)
+                                                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_item_sk","cr_order_number","cr_refunded_cash","cr_reversed_charge","cr_store_credit"]
+                                                                                        <-Map 38 [SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1022]
+                                                                                            PartitionCols:_col0, _col1
+                                                                                            Select Operator [SEL_1021] (rows=287989836 width=119)
+                                                                                              Output:["_col0","_col1","_col2"]
+                                                                                              Filter Operator [FIL_1020] (rows=287989836 width=119)
+                                                                                                predicate:(cs_item_sk BETWEEN DynamicValue(RS_49_item_i_item_sk_min) AND DynamicValue(RS_49_item_i_item_sk_max) and in_bloom_filter(cs_item_sk, DynamicValue(RS_49_item_i_item_sk_bloom_filter)))
+                                                                                                TableScan [TS_12] (rows=287989836 width=119)
+                                                                                                  default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
+                                                                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
+                                                                                                  BROADCAST [RS_1019]
+                                                                                                    Group By Operator [GBY_1018] (rows=1 width=12)
+                                                                                                      Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
+                                                                                                    <-Map 19 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                                      PARTITION_ONLY_SHUFFLE [RS_1012]
+                                                                                                        Group By Operator [GBY_1010] (rows=1 width=12)
+                                                                                                          Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
+                                                                                                          Select Operator [SEL_1007] (rows=4667 width=4)
+                                                                                                            Output:["_col0"]
+                                                                                                             Please refer to the previous Select Operator [SEL_1004]
+                <-Reducer 35 [SIMPLE_EDGE] vectorized
+                  SHUFFLE [RS_1076]
                     PartitionCols:_col2, _col1, _col3
-                    Select Operator [SEL_1076] (rows=21304422 width=1354)
+                    Select Operator [SEL_1075] (rows=21304422 width=1354)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15"]
-                      Filter Operator [FIL_1075] (rows=21304422 width=1362)
+                      Filter Operator [FIL_1074] (rows=21304422 width=1362)
                         predicate:_col14 is not null
-                        Select Operator [SEL_1074] (rows=21304422 width=1362)
+                        Select Operator [SEL_1073] (rows=21304422 width=1362)
                           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col14","_col15","_col16","_col17"]
-                          Group By Operator [GBY_1073] (rows=21304422 width=1362)
+                          Group By Operator [GBY_1072] (rows=21304422 width=1362)
                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"],aggregations:["count(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4, KEY._col5, KEY._col6, KEY._col7, KEY._col8, KEY._col9, KEY._col10, KEY._col11, KEY._col12, KEY._col13
-                          <-Reducer 33 [SIMPLE_EDGE]
+                          <-Reducer 34 [SIMPLE_EDGE]
                             SHUFFLE [RS_191]
                               PartitionCols:_col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
                               Group By Operator [GBY_190] (rows=21304422 width=1362)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"],aggregations:["count()","sum(_col8)","sum(_col9)","sum(_col10)"],keys:_col24, _col11, _col25, _col12, _col29, _col31, _col37, _col38, _col39, _col40, _col42, _col43, _col44, _col45
                                 Merge Join Operator [MERGEJOIN_976] (rows=21304422 width=1155)
-                                  Conds:RS_186._col17=RS_1047._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col12","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40","_col42","_col43","_col44","_col45"]
-                                <-Map 49 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_1047]
+                                  Conds:RS_186._col17=RS_1052._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col12","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40","_col42","_col43","_col44","_col45"]
+                                <-Map 51 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_1052]
                                     PartitionCols:_col0
-                                     Please refer to the previous Select Operator [SEL_1043]
-                                <-Reducer 32 [SIMPLE_EDGE]
+                                     Please refer to the previous Select Operator [SEL_1048]
+                                <-Reducer 33 [SIMPLE_EDGE]
                                   SHUFFLE [RS_186]
                                     PartitionCols:_col17
                                     Merge Join Operator [MERGEJOIN_975] (rows=21304422 width=798)
-                                      Conds:RS_183._col5=RS_1046._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col12","_col17","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40"]
-                                    <-Map 49 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_1046]
+                                      Conds:RS_183._col5=RS_1051._col0(Inner),Output:["_col8","_col9","_col10","_col11","_col12","_col17","_col24","_col25","_col29","_col31","_col37","_col38","_col39","_col40"]
+                                    <-Map 51 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_1051]
                                         PartitionCols:_col0
-                                         Please refer to the previous Select Operator [SEL_1043]
-                                    <-Reducer 31 [SIMPLE_EDGE]
+                                         Please refer to the previous Select Operator [SEL_1048]
+                                    <-Reducer 32 [SIMPLE_EDGE]
                                       SHUFFLE [RS_183]
                                         PartitionCols:_col5
                                         Filter Operator [FIL_182] (rows=21304422 width=609)
                                           predicate:(_col33 <> _col35)
                                           Merge Join Operator [MERGEJOIN_974] (rows=21304422 width=609)
-                                            Conds:RS_179._col15=RS_1042._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col12","_col17","_col24","_col25","_col29","_col31","_col33","_col35"]
-                                          <-Map 48 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_1042]
+                                            Conds:RS_179._col15=RS_1047._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col12","_col17","_col24","_col25","_col29","_col31","_col33","_col35"]
+                                          <-Map 50 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_1047]
                                               PartitionCols:_col0
-                                               Please refer to the previous Select Operator [SEL_1038]
-                                          <-Reducer 30 [SIMPLE_EDGE]
+                                               Please refer to the previous Select Operator [SEL_1043]
+                                          <-Reducer 31 [SIMPLE_EDGE]
                                             SHUFFLE [RS_179]
                                               PartitionCols:_col15
                                               Merge Join Operator [MERGEJOIN_973] (rows=21007353 width=525)
-                                                Conds:RS_176._col3=RS_1041._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col24","_col25","_col29","_col31","_col33"]
-                                              <-Map 48 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_1041]
+                                                Conds:RS_176._col3=RS_1046._col0(Inner),Output:["_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col24","_col25","_col29","_col31","_col33"]
+                                              <-Map 50 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_1046]
                                                   PartitionCols:_col0
-                                                   Please refer to the previous Select Operator [SEL_1038]
-                                              <-Reducer 29 [SIMPLE_EDGE]
+                                                   Please refer to the previous Select Operator [SEL_1043]
+                                              <-Reducer 30 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_176]
                                                   PartitionCols:_col3
                                                   Merge Join Operator [MERGEJOIN_972] (rows=20714426 width=438)
                                                     Conds:RS_173._col18=RS_988._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col24","_col25","_col29","_col31"]
-                                                  <-Map 44 [SIMPLE_EDGE] vectorized
+                                                  <-Map 47 [SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_988]
                                                       PartitionCols:_col0
                                                       Select Operator [SEL_982] (rows=73049 width=8)
                                                         Output:["_col0","_col1"]
                                                          Please refer to the previous TableScan [TS_38]
-                                                  <-Reducer 28 [SIMPLE_EDGE]
+                                                  <-Reducer 29 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_173]
                                                       PartitionCols:_col18
                                                       Merge Join Operator [MERGEJOIN_971] (rows=20714426 width=438)
                                                         Conds:RS_170._col19=RS_987._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col18","_col24","_col25","_col29"]
-                                                      <-Map 44 [SIMPLE_EDGE] vectorized
+                                                      <-Map 47 [SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_987]
                                                           PartitionCols:_col0
                                                           Select Operator [SEL_981] (rows=73049 width=8)
                                                             Output:["_col0","_col1"]
                                                              Please refer to the previous TableScan [TS_38]
-                                                      <-Reducer 27 [SIMPLE_EDGE]
+                                                      <-Reducer 28 [SIMPLE_EDGE]
                                                         SHUFFLE [RS_170]
                                                           PartitionCols:_col19
                                                           Merge Join Operator [MERGEJOIN_970] (rows=20714426 width=437)
-                                                            Conds:RS_167._col16=RS_1037._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col18","_col19","_col24","_col25"]
-                                                          <-Map 43 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_1037]
+                                                            Conds:RS_167._col16=RS_1042._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col17","_col18","_col19","_col24","_col25"]
+                                                          <-Map 46 [SIMPLE_EDGE] vectorized
+                                                            SHUFFLE [RS_1042]
                                                               PartitionCols:_col0
-                                                               Please refer to the previous Select Operator [SEL_1033]
-                                                          <-Reducer 26 [SIMPLE_EDGE]
+                                                               Please refer to the previous Select Operator [SEL_1038]
+                                                          <-Reducer 27 [SIMPLE_EDGE]
                                                             SHUFFLE [RS_167]
                                                               PartitionCols:_col16
                                                               Merge Join Operator [MERGEJOIN_969] (rows=20714426 width=441)
-                                                                Conds:RS_164._col4=RS_1036._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
-                                                              <-Map 43 [SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_1036]
+                                                                Conds:RS_164._col4=RS_1041._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
+                                                              <-Map 46 [SIMPLE_EDGE] vectorized
+                                                                SHUFFLE [RS_1041]
                                                                   PartitionCols:_col0
-                                                                   Please refer to the previous Select Operator [SEL_1033]
-                                                              <-Reducer 25 [SIMPLE_EDGE]
+                                                                   Please refer to the previous Select Operator [SEL_1038]
+                                                              <-Reducer 26 [SIMPLE_EDGE]
                                                                 SHUFFLE [RS_164]
                                                                   PartitionCols:_col4
                                                                   Merge Join Operator [MERGEJOIN_968] (rows=20714426 width=443)
-                                                                    Conds:RS_161._col6=RS_1031._col0(Inner),Output:["_col3","_col4","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
-                                                                  <-Map 42 [SIMPLE_EDGE] vectorized
-                                                                    SHUFFLE [RS_1031]
+                                                                    Conds:RS_161._col6=RS_1036._col0(Inner),Output:["_col3","_col4","_col5","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col24","_col25"]
+                                                                  <-Map 45 [SIMPLE_EDGE] vectorized
+                                                                    SHUFFLE [RS_1036]
                                                                       PartitionCols:_col0
-                                                                       Please refer to the previous Select Operator [SEL_1029]
-                                                                  <-Reducer 24 [SIMPLE_EDGE]
+                                                                       Please refer to the previous Select Operator [SEL_1034]
+                                                                  <-Reducer 25 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_161]
                                                                       PartitionCols:_col6
                                                                       Merge Join Operator [MERGEJOIN_967] (rows=20714426 width=267)
-                                                                        Conds:RS_158._col1, _col7=RS_1027._col0, _col1(Inner),Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
-                                                                      <-Map 41 [SIMPLE_EDGE] vectorized
-                                                                        SHUFFLE [RS_1027]
+                                                                        Conds:RS_158._col1, _col7=RS_1032._col0, _col1(Inner),Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
+                                                                      <-Map 44 [SIMPLE_EDGE] vectorized
+                                                                        SHUFFLE [RS_1032]
                                                                           PartitionCols:_col0, _col1
-                                                                           Please refer to the previous Select Operator [SEL_1025]
-                                                                      <-Reducer 23 [SIMPLE_EDGE]
+                                                                           Please refer to the previous Select Operator [SEL_1030]
+                                                                      <-Reducer 24 [SIMPLE_EDGE]
                                                                         SHUFFLE [RS_158]
                                                                           PartitionCols:_col1, _col7
                                                                           Merge Join Operator [MERGEJOIN_966] (rows=12564038 width=135)
-                                                                            Conds:RS_155._col1=RS_1072._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
-                                                                          <-Reducer 22 [SIMPLE_EDGE]
+                                                                            Conds:RS_155._col1=RS_1071._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
+                                                                          <-Reducer 23 [SIMPLE_EDGE]
                                                                             SHUFFLE [RS_155]
                                                                               PartitionCols:_col1
                                                                               Merge Join Operator [MERGEJOIN_964] (rows=12564038 width=135)
-                                                                                Conds:RS_152._col2=RS_1012._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
-                                                                              <-Map 21 [SIMPLE_EDGE] vectorized
-                                                                                SHUFFLE [RS_1012]
+                                                                                Conds:RS_152._col2=RS_1017._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col15","_col16","_col17","_col18","_col19"]
+                                                                              <-Map 37 [SIMPLE_EDGE] vectorized
+                                                                                SHUFFLE [RS_1017]
                                                                                   PartitionCols:_col0
-                                                                                   Please refer to the previous Select Operator [SEL_1010]
-                                                                              <-Reducer 46 [SIMPLE_EDGE]
+                                                                                   Please refer to the previous Select Operator [SEL_1015]
+                                                                              <-Reducer 22 [SIMPLE_EDGE]
                                                                                 SHUFFLE [RS_152]
                                                                                   PartitionCols:_col2
                                                                                   Merge Join Operator [MERGEJOIN_963] (rows=14487982 width=119)
                                                                                     Conds:RS_149._col0=RS_992._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"]
-                                                                                  <-Map 44 [SIMPLE_EDGE] vectorized
+                                                                                  <-Map 47 [SIMPLE_EDGE] vectorized
                                                                                     PARTITION_ONLY_SHUFFLE [RS_992]
                                                                                       PartitionCols:_col0
                                                                                       Select Operator [SEL_989] (rows=652 width=4)
@@ -700,78 +700,75 @@ Stage-0
                                                                                         Filter Operator [FIL_983] (rows=652 width=8)
                                                                                           predicate:(d_year = 2000)
                                                                                            Please refer to the previous TableScan [TS_38]
-                                                                                  <-Reducer 51 [SIMPLE_EDGE]
+                                                                                  <-Reducer 21 [SIMPLE_EDGE]
                                                                                     SHUFFLE [RS_149]
                                                                                       PartitionCols:_col0
                                                                                       Merge Join Operator [MERGEJOIN_962] (rows=40575792 width=312)
-                                                                                        Conds:RS_1057._col1=RS_1060._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"]
-                                                                                      <-Map 52 [SIMPLE_EDGE] vectorized
-                                                                                        PARTITION_ONLY_SHUFFLE [RS_1060]
+                                                                                        Conds:RS_1062._col1=RS_1008._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12"]
+                                                                                      <-Map 19 [SIMPLE_EDGE] vectorized
+                                                                                        PARTITION_ONLY_SHUFFLE [RS_1008]
                                                                                           PartitionCols:_col0
-                                                                                          Select Operator [SEL_1059] (rows=4667 width=111)
+                                                                                          Select Operator [SEL_1005] (rows=4667 width=111)
                                                                                             Output:["_col0","_col1"]
-                                                                                            Filter Operator [FIL_1058] (rows=4667 width=311)
-                                                                                              predicate:(i_current_price BETWEEN 36 AND 45 and (i_color) IN ('maroon', 'burnished', 'dim', 'steel', 'navajo', 'chocolate'))
-                                                                                              TableScan [TS_101] (rows=462000 width=311)
-                                                                                                default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_current_price","i_color","i_product_name"]
-                                                                                      <-Map 50 [SIMPLE_EDGE] vectorized
-                                                                                        SHUFFLE [RS_1057]
+                                                                                             Please refer to the previous Filter Operator [FIL_1003]
+                                                                                      <-Map 52 [SIMPLE_EDGE] vectorized
+                                                                                        SHUFFLE [RS_1062]
                                                                                           PartitionCols:_col1
-                                                                                          Select Operator [SEL_1056] (rows=417313408 width=351)
+                                                                                          Select Operator [SEL_1061] (rows=417313408 width=351)
                                                                                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
-                                                                                            Filter Operator [FIL_1055] (rows=417313408 width=355)
+                                                                                            Filter Operator [FIL_1060] (rows=417313408 width=355)
                                                                                               predicate:(ss_cdemo_sk is not null and ss_sold_date_sk is not null and ss_promo_sk is not null and ss_addr_sk is not null and ss_customer_sk is not null and ss_hdemo_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_150_d1_d_date_sk_min) AND DynamicValue(RS_150_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_150_d1_d_date_sk_bloom_filter)))
                                                                                               TableScan [TS_98] (rows=575995635 width=355)
                                                                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_wholesale_cost","ss_list_price","ss_coupon_amt"]
-                                                                                              <-Reducer 47 [BROADCAST_EDGE] vectorized
-                                                                                                BROADCAST [RS_1054]
-                                                                                                  Group By Operator [GBY_1053] (rows=1 width=12)
+                                                                                              <-Reducer 49 [BROADCAST_EDGE] vectorized
+                                                                                                BROADCAST [RS_1059]
+                                                                                                  Group By Operator [GBY_1058] (rows=1 width=12)
                                                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                                  <-Map 44 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                                  <-Map 47 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                                                     PARTITION_ONLY_SHUFFLE [RS_997]
                                                                                                       Group By Operator [GBY_995] (rows=1 width=12)
                                                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
                                                                                                         Select Operator [SEL_993] (rows=652 width=4)
                                                                                                           Output:["_col0"]
                                                                                                            Please refer to the previous Select Operator [SEL_989]
-                                                                          <-Reducer 40 [SIMPLE_EDGE] vectorized
-                                                                            SHUFFLE [RS_1072]
+                                                                          <-Reducer 43 [SIMPLE_EDGE] vectorized
+                                                                            SHUFFLE [RS_1071]
                                                                               PartitionCols:_col0
-                                                                              Select Operator [SEL_1071] (rows=13257 width=4)
+                                                                              Select Operator [SEL_1070] (rows=13257 width=4)
                                                                                 Output:["_col0"]
-                                                                                Filter Operator [FIL_1070] (rows=13257 width=228)
+                                                                                Filter Operator [FIL_1069] (rows=13257 width=228)
                                                                                   predicate:(_col1 > (2 * _col2))
-                                                                                  Group By Operator [GBY_1069] (rows=39773 width=228)
+                                                                                  Group By Operator [GBY_1068] (rows=39773 width=228)
                                                                                     Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0
-                                                                                  <-Reducer 39 [SIMPLE_EDGE]
+                                                                                  <-Reducer 42 [SIMPLE_EDGE]
                                                                                     SHUFFLE [RS_119]
                                                                                       PartitionCols:_col0
                                                                                       Group By Operator [GBY_118] (rows=6482999 width=228)
                                                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","sum(_col5)"],keys:_col0
                                                                                         Merge Join Operator [MERGEJOIN_965] (rows=183085709 width=227)
-                                                                                          Conds:RS_1068._col0, _col1=RS_1020._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
-                                                                                        <-Map 38 [SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1020]
+                                                                                          Conds:RS_1067._col0, _col1=RS_1025._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
+                                                                                        <-Map 41 [SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1025]
                                                                                             PartitionCols:_col0, _col1
-                                                                                             Please refer to the previous Select Operator [SEL_1018]
-                                                                                        <-Map 54 [SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1068]
+                                                                                             Please refer to the previous Select Operator [SEL_1023]
+                                                                                        <-Map 53 [SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1067]
                                                                                             PartitionCols:_col0, _col1
-                                                                                            Select Operator [SEL_1067] (rows=287989836 width=119)
+                                                                                            Select Operator [SEL_1066] (rows=287989836 width=119)
                                                                                               Output:["_col0","_col1","_col2"]
-                                                                                              Filter Operator [FIL_1066] (rows=287989836 width=119)
+                                                                                              Filter Operator [FIL_1065] (rows=287989836 width=119)
                                                                                                 predicate:(cs_item_sk BETWEEN DynamicValue(RS_147_item_i_item_sk_min) AND DynamicValue(RS_147_item_i_item_sk_max) and in_bloom_filter(cs_item_sk, DynamicValue(RS_147_item_i_item_sk_bloom_filter)))
                                                                                                 TableScan [TS_110] (rows=287989836 width=119)
                                                                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
-                                                                                                <-Reducer 53 [BROADCAST_EDGE] vectorized
-                                                                                                  BROADCAST [RS_1065]
-                                                                                                    Group By Operator [GBY_1064] (rows=1 width=12)
+                                                                                                <-Reducer 36 [BROADCAST_EDGE] vectorized
+                                                                                                  BROADCAST [RS_1064]
+                                                                                                    Group By Operator [GBY_1063] (rows=1 width=12)
                                                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                                    <-Map 52 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                                      PARTITION_ONLY_SHUFFLE [RS_1063]
-                                                                                                        Group By Operator [GBY_1062] (rows=1 width=12)
+                                                                                                    <-Map 19 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                                      PARTITION_ONLY_SHUFFLE [RS_1013]
+                                                                                                        Group By Operator [GBY_1011] (rows=1 width=12)
                                                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                                          Select Operator [SEL_1061] (rows=4667 width=4)
+                                                                                                          Select Operator [SEL_1009] (rows=4667 width=4)
                                                                                                             Output:["_col0"]
-                                                                                                             Please refer to the previous Select Operator [SEL_1059]
+                                                                                                             Please refer to the previous Select Operator [SEL_1005]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query70.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query70.q.out
@@ -91,7 +91,7 @@ Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 7 <- Map 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
@@ -100,27 +100,27 @@ Stage-0
     limit:-1
     Stage-1
       Reducer 6 vectorized
-      File Output Operator [FS_173]
-        Limit [LIM_172] (rows=100 width=492)
+      File Output Operator [FS_172]
+        Limit [LIM_171] (rows=100 width=492)
           Number of rows:100
-          Select Operator [SEL_171] (rows=720 width=492)
+          Select Operator [SEL_170] (rows=720 width=492)
             Output:["_col0","_col1","_col2","_col3","_col4"]
           <-Reducer 5 [SIMPLE_EDGE] vectorized
-            SHUFFLE [RS_170]
-              Select Operator [SEL_169] (rows=720 width=492)
+            SHUFFLE [RS_169]
+              Select Operator [SEL_168] (rows=720 width=492)
                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                Top N Key Operator [TNK_168] (rows=720 width=304)
+                Top N Key Operator [TNK_167] (rows=720 width=304)
                   keys:(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN (((grouping(_col3, 1L) + grouping(_col3, 0L)) = 0L)) THEN (_col0) ELSE (null) END, rank_window_0,top n:100
-                  PTF Operator [PTF_167] (rows=720 width=304)
+                  PTF Operator [PTF_166] (rows=720 width=304)
                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col2 DESC NULLS FIRST","partition by:":"(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN ((grouping(_col3, 0L) = UDFToLong(0))) THEN (_col0) ELSE (CAST( null AS STRING)) END"}]
-                    Select Operator [SEL_166] (rows=720 width=304)
+                    Select Operator [SEL_165] (rows=720 width=304)
                       Output:["_col0","_col1","_col2","_col3"]
                     <-Reducer 4 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_165]
+                      SHUFFLE [RS_164]
                         PartitionCols:(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN ((grouping(_col3, 0L) = UDFToLong(0))) THEN (_col0) ELSE (CAST( null AS STRING)) END
-                        Select Operator [SEL_164] (rows=720 width=304)
+                        Select Operator [SEL_163] (rows=720 width=304)
                           Output:["_col0","_col1","_col2","_col3"]
-                          Group By Operator [GBY_163] (rows=720 width=304)
+                          Group By Operator [GBY_162] (rows=720 width=304)
                             Output:["_col0","_col1","_col2","_col3"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                           <-Reducer 3 [SIMPLE_EDGE]
                             SHUFFLE [RS_49]
@@ -169,33 +169,33 @@ Stage-0
                                     SHUFFLE [RS_44]
                                       PartitionCols:_col0
                                       Merge Join Operator [MERGEJOIN_136] (rows=556 width=188)
-                                        Conds:RS_162._col2=RS_159._col0(Inner),Output:["_col0","_col1","_col2"]
+                                        Conds:RS_152._col2=RS_161._col0(Inner),Output:["_col0","_col1","_col2"]
                                       <-Map 13 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_162]
+                                        SHUFFLE [RS_152]
                                           PartitionCols:_col2
-                                          Select Operator [SEL_161] (rows=1704 width=188)
+                                          Select Operator [SEL_150] (rows=1704 width=188)
                                             Output:["_col0","_col1","_col2"]
-                                            Filter Operator [FIL_160] (rows=1704 width=188)
+                                            Filter Operator [FIL_149] (rows=1704 width=188)
                                               predicate:s_state is not null
                                               TableScan [TS_6] (rows=1704 width=188)
                                                 default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_county","s_state"]
                                       <-Reducer 9 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_159]
+                                        SHUFFLE [RS_161]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_158] (rows=16 width=86)
+                                          Select Operator [SEL_160] (rows=16 width=86)
                                             Output:["_col0"]
-                                            Filter Operator [FIL_157] (rows=16 width=198)
+                                            Filter Operator [FIL_159] (rows=16 width=198)
                                               predicate:(rank_window_0 <= 5)
-                                              PTF Operator [PTF_156] (rows=49 width=198)
+                                              PTF Operator [PTF_158] (rows=49 width=198)
                                                 Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 DESC NULLS FIRST","partition by:":"_col0"}]
-                                                Select Operator [SEL_155] (rows=49 width=198)
+                                                Select Operator [SEL_157] (rows=49 width=198)
                                                   Output:["_col0","_col1"]
                                                 <-Reducer 8 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_154]
+                                                  SHUFFLE [RS_156]
                                                     PartitionCols:_col0
-                                                    Top N Key Operator [TNK_153] (rows=49 width=198)
+                                                    Top N Key Operator [TNK_155] (rows=49 width=198)
                                                       PartitionCols:_col0,keys:_col0, _col1,top n:6
-                                                      Group By Operator [GBY_152] (rows=49 width=198)
+                                                      Group By Operator [GBY_154] (rows=49 width=198)
                                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                                       <-Reducer 7 [SIMPLE_EDGE]
                                                         SHUFFLE [RS_26]
@@ -203,18 +203,15 @@ Stage-0
                                                           Group By Operator [GBY_25] (rows=2989 width=198)
                                                             Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                                             Merge Join Operator [MERGEJOIN_135] (rows=91197860 width=168)
-                                                              Conds:RS_21._col1=RS_151._col0(Inner),Output:["_col2","_col5"]
+                                                              Conds:RS_21._col1=RS_153._col0(Inner),Output:["_col2","_col5"]
+                                                            <-Map 13 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_153]
+                                                                PartitionCols:_col0
+                                                                Select Operator [SEL_151] (rows=1704 width=90)
+                                                                  Output:["_col0","_col1"]
+                                                                   Please refer to the previous Filter Operator [FIL_149]
                                                             <-Reducer 2 [SIMPLE_EDGE]
                                                               SHUFFLE [RS_21]
                                                                 PartitionCols:_col1
                                                                  Please refer to the previous Merge Join Operator [MERGEJOIN_133]
-                                                            <-Map 14 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_151]
-                                                                PartitionCols:_col0
-                                                                Select Operator [SEL_150] (rows=1704 width=90)
-                                                                  Output:["_col0","_col1"]
-                                                                  Filter Operator [FIL_149] (rows=1704 width=90)
-                                                                    predicate:s_state is not null
-                                                                    TableScan [TS_15] (rows=1704 width=90)
-                                                                      default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_state"]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query72.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query72.q.out
@@ -82,7 +82,7 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 17 (BROADCAST_EDGE)
-Reducer 10 <- Map 24 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 10 <- Map 23 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
 Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
 Reducer 16 <- Map 15 (SIMPLE_EDGE), Map 18 (SIMPLE_EDGE)
@@ -93,8 +93,8 @@ Reducer 4 <- Reducer 16 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Map 19 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Map 20 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Map 21 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 22 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Map 23 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
+Reducer 8 <- Map 15 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 9 <- Map 22 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -121,7 +121,7 @@ Stage-0
                         Output:["_col0","_col1","_col2","_col3","_col4"]
                         Merge Join Operator [MERGEJOIN_248] (rows=471834849 width=292)
                           Conds:RS_60._col4, _col6=RS_279._col0, _col1(Left Outer),Output:["_col13","_col15","_col19","_col25"]
-                        <-Map 24 [SIMPLE_EDGE] vectorized
+                        <-Map 23 [SIMPLE_EDGE] vectorized
                           SHUFFLE [RS_279]
                             PartitionCols:_col0, _col1
                             Select Operator [SEL_278] (rows=28798881 width=8)
@@ -135,7 +135,7 @@ Stage-0
                               Output:["_col4","_col6","_col13","_col15","_col19","_col25"]
                               Merge Join Operator [MERGEJOIN_247] (rows=182953402 width=300)
                                 Conds:RS_54._col4=RS_277._col0(Inner),Output:["_col4","_col6","_col13","_col20","_col21","_col25"]
-                              <-Map 23 [SIMPLE_EDGE] vectorized
+                              <-Map 22 [SIMPLE_EDGE] vectorized
                                 SHUFFLE [RS_277]
                                   PartitionCols:_col0
                                   Select Operator [SEL_276] (rows=462000 width=188)
@@ -148,25 +148,25 @@ Stage-0
                                   Filter Operator [FIL_53] (rows=182953402 width=132)
                                     predicate:(_col23 > _col14)
                                     Merge Join Operator [MERGEJOIN_246] (rows=548860207 width=132)
-                                      Conds:RS_50._col1=RS_275._col0(Inner),Output:["_col4","_col6","_col13","_col14","_col20","_col21","_col23"]
-                                    <-Map 22 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_275]
+                                      Conds:RS_50._col1=RS_254._col0(Inner),Output:["_col4","_col6","_col13","_col14","_col20","_col21","_col23"]
+                                    <-Map 15 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_254]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_274] (rows=73049 width=12)
+                                        Select Operator [SEL_252] (rows=73049 width=12)
                                           Output:["_col0","_col1"]
-                                          Filter Operator [FIL_273] (rows=73049 width=98)
+                                          Filter Operator [FIL_250] (rows=73049 width=98)
                                             predicate:UDFToDouble(d_date) is not null
-                                            TableScan [TS_26] (rows=73049 width=98)
-                                              default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
+                                            TableScan [TS_9] (rows=73049 width=8)
+                                              default@date_dim,d2,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_date"]
                                     <-Reducer 7 [SIMPLE_EDGE]
                                       SHUFFLE [RS_50]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_245] (rows=548860207 width=127)
-                                          Conds:RS_47._col5=RS_272._col0(Left Outer),Output:["_col1","_col4","_col6","_col13","_col14","_col20","_col21"]
+                                          Conds:RS_47._col5=RS_275._col0(Left Outer),Output:["_col1","_col4","_col6","_col13","_col14","_col20","_col21"]
                                         <-Map 21 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_272]
+                                          SHUFFLE [RS_275]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_271] (rows=2300 width=4)
+                                            Select Operator [SEL_274] (rows=2300 width=4)
                                               Output:["_col0"]
                                               TableScan [TS_24] (rows=2300 width=4)
                                                 default@promotion,promotion,Tbl:COMPLETE,Col:COMPLETE,Output:["p_promo_sk"]
@@ -174,11 +174,11 @@ Stage-0
                                           SHUFFLE [RS_47]
                                             PartitionCols:_col5
                                             Merge Join Operator [MERGEJOIN_244] (rows=548860207 width=127)
-                                              Conds:RS_44._col17=RS_270._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col13","_col14","_col20"]
+                                              Conds:RS_44._col17=RS_273._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col13","_col14","_col20"]
                                             <-Map 20 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_270]
+                                              SHUFFLE [RS_273]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_269] (rows=27 width=104)
+                                                Select Operator [SEL_272] (rows=27 width=104)
                                                   Output:["_col0","_col1"]
                                                   TableScan [TS_22] (rows=27 width=104)
                                                     default@warehouse,warehouse,Tbl:COMPLETE,Col:COMPLETE,Output:["w_warehouse_sk","w_warehouse_name"]
@@ -188,13 +188,13 @@ Stage-0
                                                 Filter Operator [FIL_43] (rows=548860207 width=39)
                                                   predicate:(_col18 < _col7)
                                                   Merge Join Operator [MERGEJOIN_243] (rows=1646580622 width=39)
-                                                    Conds:RS_40._col10, _col4=RS_268._col0, _col1(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col13","_col14","_col17","_col18"]
+                                                    Conds:RS_40._col10, _col4=RS_271._col0, _col1(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col13","_col14","_col17","_col18"]
                                                   <-Map 19 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_268]
+                                                    SHUFFLE [RS_271]
                                                       PartitionCols:_col0, _col1
-                                                      Select Operator [SEL_267] (rows=35703276 width=15)
+                                                      Select Operator [SEL_270] (rows=35703276 width=15)
                                                         Output:["_col0","_col1","_col2","_col3"]
-                                                        Filter Operator [FIL_266] (rows=35703276 width=15)
+                                                        Filter Operator [FIL_269] (rows=35703276 width=15)
                                                           predicate:inv_quantity_on_hand is not null
                                                           TableScan [TS_19] (rows=37584000 width=15)
                                                             default@inventory,inventory,Tbl:COMPLETE,Col:COMPLETE,Output:["inv_date_sk","inv_item_sk","inv_warehouse_sk","inv_quantity_on_hand"]
@@ -207,22 +207,21 @@ Stage-0
                                                         SHUFFLE [RS_38]
                                                           PartitionCols:_col2
                                                           Merge Join Operator [MERGEJOIN_241] (rows=3621 width=20)
-                                                            Conds:RS_251._col1=RS_254._col1(Inner),Output:["_col0","_col2","_col3","_col4"]
+                                                            Conds:RS_253._col1=RS_257._col1(Inner),Output:["_col0","_col2","_col3","_col4"]
                                                           <-Map 15 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_251]
+                                                            SHUFFLE [RS_253]
                                                               PartitionCols:_col1
-                                                              Select Operator [SEL_250] (rows=73049 width=8)
+                                                              Select Operator [SEL_251] (rows=73049 width=8)
                                                                 Output:["_col0","_col1"]
                                                                 Filter Operator [FIL_249] (rows=73049 width=8)
                                                                   predicate:d_week_seq is not null
-                                                                  TableScan [TS_9] (rows=73049 width=8)
-                                                                    default@date_dim,d2,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq"]
+                                                                   Please refer to the previous TableScan [TS_9]
                                                           <-Map 18 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_254]
+                                                            SHUFFLE [RS_257]
                                                               PartitionCols:_col1
-                                                              Select Operator [SEL_253] (rows=652 width=16)
+                                                              Select Operator [SEL_256] (rows=652 width=16)
                                                                 Output:["_col0","_col1","_col2"]
-                                                                Filter Operator [FIL_252] (rows=652 width=106)
+                                                                Filter Operator [FIL_255] (rows=652 width=106)
                                                                   predicate:((d_year = 2001) and d_week_seq is not null and UDFToDouble(d_date) is not null)
                                                                   TableScan [TS_12] (rows=73049 width=106)
                                                                     default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq","d_year"]
@@ -230,13 +229,13 @@ Stage-0
                                                         SHUFFLE [RS_37]
                                                           PartitionCols:_col0
                                                           Merge Join Operator [MERGEJOIN_240] (rows=8138146 width=21)
-                                                            Conds:RS_34._col3=RS_265._col0(Inner),Output:["_col0","_col1","_col4","_col5","_col6","_col7"]
+                                                            Conds:RS_34._col3=RS_268._col0(Inner),Output:["_col0","_col1","_col4","_col5","_col6","_col7"]
                                                           <-Map 14 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_265]
+                                                            SHUFFLE [RS_268]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_264] (rows=1440 width=4)
+                                                              Select Operator [SEL_267] (rows=1440 width=4)
                                                                 Output:["_col0"]
-                                                                Filter Operator [FIL_263] (rows=1440 width=96)
+                                                                Filter Operator [FIL_266] (rows=1440 width=96)
                                                                   predicate:(hd_buy_potential = '1001-5000')
                                                                   TableScan [TS_6] (rows=7200 width=96)
                                                                     default@household_demographics,household_demographics,Tbl:COMPLETE,Col:COMPLETE,Output:["hd_demo_sk","hd_buy_potential"]
@@ -244,19 +243,19 @@ Stage-0
                                                             SHUFFLE [RS_34]
                                                               PartitionCols:_col3
                                                               Merge Join Operator [MERGEJOIN_239] (rows=40690727 width=27)
-                                                                Conds:RS_259._col2=RS_262._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col6","_col7"]
+                                                                Conds:RS_262._col2=RS_265._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col6","_col7"]
                                                               <-Map 1 [SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_259]
+                                                                SHUFFLE [RS_262]
                                                                   PartitionCols:_col2
-                                                                  Select Operator [SEL_258] (rows=280863798 width=31)
+                                                                  Select Operator [SEL_261] (rows=280863798 width=31)
                                                                     Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                                                                    Filter Operator [FIL_257] (rows=280863798 width=31)
+                                                                    Filter Operator [FIL_260] (rows=280863798 width=31)
                                                                       predicate:(cs_sold_date_sk is not null and cs_bill_cdemo_sk is not null and cs_ship_date_sk is not null and cs_quantity is not null and cs_bill_hdemo_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_38_d1_d_date_sk_min) AND DynamicValue(RS_38_d1_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_38_d1_d_date_sk_bloom_filter)))
                                                                       TableScan [TS_0] (rows=287989836 width=31)
                                                                         default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_ship_date_sk","cs_bill_cdemo_sk","cs_bill_hdemo_sk","cs_item_sk","cs_promo_sk","cs_order_number","cs_quantity"]
                                                                       <-Reducer 17 [BROADCAST_EDGE] vectorized
-                                                                        BROADCAST [RS_256]
-                                                                          Group By Operator [GBY_255] (rows=1 width=12)
+                                                                        BROADCAST [RS_259]
+                                                                          Group By Operator [GBY_258] (rows=1 width=12)
                                                                             Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                           <-Reducer 16 [CUSTOM_SIMPLE_EDGE]
                                                                             SHUFFLE [RS_143]
@@ -266,11 +265,11 @@ Stage-0
                                                                                   Output:["_col0"]
                                                                                    Please refer to the previous Merge Join Operator [MERGEJOIN_241]
                                                               <-Map 13 [SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_262]
+                                                                SHUFFLE [RS_265]
                                                                   PartitionCols:_col0
-                                                                  Select Operator [SEL_261] (rows=265971 width=4)
+                                                                  Select Operator [SEL_264] (rows=265971 width=4)
                                                                     Output:["_col0"]
-                                                                    Filter Operator [FIL_260] (rows=265971 width=89)
+                                                                    Filter Operator [FIL_263] (rows=265971 width=89)
                                                                       predicate:(cd_marital_status = 'M')
                                                                       TableScan [TS_3] (rows=1861800 width=89)
                                                                         default@customer_demographics,customer_demographics,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_marital_status"]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query74.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query74.q.out
@@ -154,7 +154,7 @@ Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 14 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 18 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 22 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 28 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 8 <- Map 24 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -174,14 +174,14 @@ Stage-0
                 Top N Key Operator [TNK_180] (rows=13333332 width=280)
                   keys:_col3, _col0, _col2,top n:100
                   Merge Join Operator [MERGEJOIN_330] (rows=13333332 width=280)
-                    Conds:RS_99._col0=RS_397._col0(Inner),Output:["_col0","_col2","_col3"]
-                  <-Map 28 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_397]
+                    Conds:RS_99._col0=RS_368._col0(Inner),Output:["_col0","_col2","_col3"]
+                  <-Map 24 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_368]
                       PartitionCols:_col0
-                      Select Operator [SEL_396] (rows=80000000 width=280)
+                      Select Operator [SEL_363] (rows=80000000 width=280)
                         Output:["_col0","_col1","_col2"]
-                        TableScan [TS_97] (rows=80000000 width=280)
-                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_id","c_first_name","c_last_name"]
+                        TableScan [TS_8] (rows=80000000 width=104)
+                          default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_first_name","c_last_name"]
                   <-Reducer 7 [SIMPLE_EDGE]
                     SHUFFLE [RS_99]
                       PartitionCols:_col0
@@ -190,15 +190,15 @@ Stage-0
                         Filter Operator [FIL_95] (rows=11150040 width=552)
                           predicate:CASE WHEN (_col3 is not null) THEN (CASE WHEN (_col8) THEN (((_col5 / _col7) > (_col1 / _col3))) ELSE (false) END) ELSE (false) END
                           Merge Join Operator [MERGEJOIN_329] (rows=22300081 width=552)
-                            Conds:RS_92._col0=RS_395._col0(Inner),Output:["_col0","_col1","_col3","_col5","_col7","_col8"]
+                            Conds:RS_92._col0=RS_397._col0(Inner),Output:["_col0","_col1","_col3","_col5","_col7","_col8"]
                           <-Reducer 22 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_395]
+                            SHUFFLE [RS_397]
                               PartitionCols:_col0
-                              Select Operator [SEL_394] (rows=14325562 width=216)
+                              Select Operator [SEL_396] (rows=14325562 width=216)
                                 Output:["_col0","_col1","_col2"]
-                                Filter Operator [FIL_393] (rows=14325562 width=212)
+                                Filter Operator [FIL_395] (rows=14325562 width=212)
                                   predicate:(_col1 > 0)
-                                  Group By Operator [GBY_392] (rows=42976686 width=212)
+                                  Group By Operator [GBY_394] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                   <-Reducer 21 [SIMPLE_EDGE]
                                     SHUFFLE [RS_82]
@@ -206,19 +206,18 @@ Stage-0
                                       Group By Operator [GBY_81] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_326] (rows=51391963 width=211)
-                                          Conds:RS_77._col1=RS_366._col0(Inner),Output:["_col2","_col5"]
+                                          Conds:RS_77._col1=RS_367._col0(Inner),Output:["_col2","_col5"]
                                         <-Map 24 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_366]
+                                          SHUFFLE [RS_367]
                                             PartitionCols:_col0
                                             Select Operator [SEL_362] (rows=80000000 width=104)
                                               Output:["_col0","_col1"]
-                                              TableScan [TS_8] (rows=80000000 width=104)
-                                                default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id"]
+                                               Please refer to the previous TableScan [TS_8]
                                         <-Reducer 20 [SIMPLE_EDGE]
                                           SHUFFLE [RS_77]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_325] (rows=51391963 width=115)
-                                              Conds:RS_391._col0=RS_346._col0(Inner),Output:["_col1","_col2"]
+                                              Conds:RS_393._col0=RS_346._col0(Inner),Output:["_col1","_col2"]
                                             <-Map 10 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_346]
                                                 PartitionCols:_col0
@@ -231,19 +230,19 @@ Stage-0
                                                       TableScan [TS_4] (rows=73049 width=8)
                                                         default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
                                             <-Map 27 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_391]
+                                              SHUFFLE [RS_393]
                                                 PartitionCols:_col0
-                                                Filter Operator [FIL_390] (rows=143930993 width=119)
+                                                Filter Operator [FIL_392] (rows=143930993 width=119)
                                                   predicate:(_col0 is not null and _col1 is not null)
-                                                  Select Operator [SEL_389] (rows=144002668 width=119)
+                                                  Select Operator [SEL_391] (rows=144002668 width=119)
                                                     Output:["_col0","_col1","_col2"]
-                                                    Filter Operator [FIL_388] (rows=144002668 width=119)
+                                                    Filter Operator [FIL_390] (rows=144002668 width=119)
                                                       predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_75_date_dim_d_date_sk_min) AND DynamicValue(RS_75_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_75_date_dim_d_date_sk_bloom_filter)))
                                                       TableScan [TS_64] (rows=144002668 width=119)
                                                         default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_net_paid"]
                                                       <-Reducer 23 [BROADCAST_EDGE] vectorized
-                                                        BROADCAST [RS_387]
-                                                          Group By Operator [GBY_386] (rows=1 width=12)
+                                                        BROADCAST [RS_389]
+                                                          Group By Operator [GBY_388] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                           <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                             PARTITION_ONLY_SHUFFLE [RS_355]
@@ -256,11 +255,11 @@ Stage-0
                             SHUFFLE [RS_92]
                               PartitionCols:_col0
                               Merge Join Operator [MERGEJOIN_328] (rows=22300081 width=436)
-                                Conds:RS_89._col0=RS_385._col0(Inner),Output:["_col0","_col1","_col3","_col5"]
+                                Conds:RS_89._col0=RS_387._col0(Inner),Output:["_col0","_col1","_col3","_col5"]
                               <-Reducer 18 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_385]
+                                SHUFFLE [RS_387]
                                   PartitionCols:_col0
-                                  Group By Operator [GBY_384] (rows=42976686 width=212)
+                                  Group By Operator [GBY_386] (rows=42976686 width=212)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                   <-Reducer 17 [SIMPLE_EDGE]
                                     SHUFFLE [RS_61]
@@ -268,16 +267,16 @@ Stage-0
                                       Group By Operator [GBY_60] (rows=51391963 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                         Merge Join Operator [MERGEJOIN_324] (rows=51391963 width=211)
-                                          Conds:RS_56._col1=RS_365._col0(Inner),Output:["_col2","_col5"]
+                                          Conds:RS_56._col1=RS_366._col0(Inner),Output:["_col2","_col5"]
                                         <-Map 24 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_365]
+                                          SHUFFLE [RS_366]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_362]
                                         <-Reducer 16 [SIMPLE_EDGE]
                                           SHUFFLE [RS_56]
                                             PartitionCols:_col1
                                             Merge Join Operator [MERGEJOIN_323] (rows=51391963 width=115)
-                                              Conds:RS_383._col0=RS_344._col0(Inner),Output:["_col1","_col2"]
+                                              Conds:RS_385._col0=RS_344._col0(Inner),Output:["_col1","_col2"]
                                             <-Map 10 [SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_344]
                                                 PartitionCols:_col0
@@ -287,19 +286,19 @@ Stage-0
                                                     predicate:((_col1 = 1999) and (_col1) IN (1998, 1999))
                                                      Please refer to the previous Select Operator [SEL_331]
                                             <-Map 26 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_383]
+                                              SHUFFLE [RS_385]
                                                 PartitionCols:_col0
-                                                Filter Operator [FIL_382] (rows=143930993 width=119)
+                                                Filter Operator [FIL_384] (rows=143930993 width=119)
                                                   predicate:(_col0 is not null and _col1 is not null)
-                                                  Select Operator [SEL_381] (rows=144002668 width=119)
+                                                  Select Operator [SEL_383] (rows=144002668 width=119)
                                                     Output:["_col0","_col1","_col2"]
-                                                    Filter Operator [FIL_380] (rows=144002668 width=119)
+                                                    Filter Operator [FIL_382] (rows=144002668 width=119)
                                                       predicate:(ws_sold_date_sk BETWEEN DynamicValue(RS_54_date_dim_d_date_sk_min) AND DynamicValue(RS_54_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_54_date_dim_d_date_sk_bloom_filter)))
                                                       TableScan [TS_43] (rows=144002668 width=119)
                                                         default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_bill_customer_sk","ws_net_paid"]
                                                       <-Reducer 19 [BROADCAST_EDGE] vectorized
-                                                        BROADCAST [RS_379]
-                                                          Group By Operator [GBY_378] (rows=1 width=12)
+                                                        BROADCAST [RS_381]
+                                                          Group By Operator [GBY_380] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                           <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                             PARTITION_ONLY_SHUFFLE [RS_354]
@@ -312,13 +311,13 @@ Stage-0
                                 SHUFFLE [RS_89]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_327] (rows=22300081 width=324)
-                                    Conds:RS_368._col0=RS_377._col0(Inner),Output:["_col0","_col1","_col3"]
+                                    Conds:RS_370._col0=RS_379._col0(Inner),Output:["_col0","_col1","_col3"]
                                   <-Reducer 14 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_377]
+                                    SHUFFLE [RS_379]
                                       PartitionCols:_col0
-                                      Filter Operator [FIL_376] (rows=22300081 width=212)
+                                      Filter Operator [FIL_378] (rows=22300081 width=212)
                                         predicate:(_col1 > 0)
-                                        Group By Operator [GBY_375] (rows=66900244 width=212)
+                                        Group By Operator [GBY_377] (rows=66900244 width=212)
                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                         <-Reducer 13 [SIMPLE_EDGE]
                                           SHUFFLE [RS_39]
@@ -326,16 +325,16 @@ Stage-0
                                             Group By Operator [GBY_38] (rows=80000000 width=212)
                                               Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                               Merge Join Operator [MERGEJOIN_322] (rows=187573258 width=197)
-                                                Conds:RS_34._col1=RS_364._col0(Inner),Output:["_col2","_col5"]
+                                                Conds:RS_34._col1=RS_365._col0(Inner),Output:["_col2","_col5"]
                                               <-Map 24 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_364]
+                                                SHUFFLE [RS_365]
                                                   PartitionCols:_col0
                                                    Please refer to the previous Select Operator [SEL_362]
                                               <-Reducer 12 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_34]
                                                   PartitionCols:_col1
                                                   Merge Join Operator [MERGEJOIN_321] (rows=187573258 width=101)
-                                                    Conds:RS_374._col0=RS_342._col0(Inner),Output:["_col1","_col2"]
+                                                    Conds:RS_376._col0=RS_342._col0(Inner),Output:["_col1","_col2"]
                                                   <-Map 10 [SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_342]
                                                       PartitionCols:_col0
@@ -345,19 +344,19 @@ Stage-0
                                                           predicate:((_col1 = 1998) and (_col1) IN (1998, 1999))
                                                            Please refer to the previous Select Operator [SEL_331]
                                                   <-Map 25 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_374]
+                                                    SHUFFLE [RS_376]
                                                       PartitionCols:_col0
-                                                      Filter Operator [FIL_373] (rows=525327388 width=114)
+                                                      Filter Operator [FIL_375] (rows=525327388 width=114)
                                                         predicate:(_col0 is not null and _col1 is not null)
-                                                        Select Operator [SEL_372] (rows=575995635 width=114)
+                                                        Select Operator [SEL_374] (rows=575995635 width=114)
                                                           Output:["_col0","_col1","_col2"]
-                                                          Filter Operator [FIL_371] (rows=575995635 width=114)
+                                                          Filter Operator [FIL_373] (rows=575995635 width=114)
                                                             predicate:(ss_sold_date_sk BETWEEN DynamicValue(RS_32_date_dim_d_date_sk_min) AND DynamicValue(RS_32_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_32_date_dim_d_date_sk_bloom_filter)))
                                                             TableScan [TS_21] (rows=575995635 width=114)
                                                               default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_net_paid"]
                                                             <-Reducer 15 [BROADCAST_EDGE] vectorized
-                                                              BROADCAST [RS_370]
-                                                                Group By Operator [GBY_369] (rows=1 width=12)
+                                                              BROADCAST [RS_372]
+                                                                Group By Operator [GBY_371] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                 <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                   PARTITION_ONLY_SHUFFLE [RS_353]
@@ -367,9 +366,9 @@ Stage-0
                                                                         Output:["_col0"]
                                                                          Please refer to the previous Select Operator [SEL_337]
                                   <-Reducer 4 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_368]
+                                    SHUFFLE [RS_370]
                                       PartitionCols:_col0
-                                      Group By Operator [GBY_367] (rows=66900244 width=212)
+                                      Group By Operator [GBY_369] (rows=66900244 width=212)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                       <-Reducer 3 [SIMPLE_EDGE]
                                         SHUFFLE [RS_18]
@@ -377,9 +376,9 @@ Stage-0
                                           Group By Operator [GBY_17] (rows=80000000 width=212)
                                             Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                             Merge Join Operator [MERGEJOIN_320] (rows=187573258 width=197)
-                                              Conds:RS_13._col1=RS_363._col0(Inner),Output:["_col2","_col5"]
+                                              Conds:RS_13._col1=RS_364._col0(Inner),Output:["_col2","_col5"]
                                             <-Map 24 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_363]
+                                              SHUFFLE [RS_364]
                                                 PartitionCols:_col0
                                                  Please refer to the previous Select Operator [SEL_362]
                                             <-Reducer 2 [SIMPLE_EDGE]

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query8.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query8.q.out
@@ -229,10 +229,10 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Map 1 <- Reducer 7 (BROADCAST_EDGE)
 Reducer 11 <- Union 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 18 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (SIMPLE_EDGE), Union 10 (CONTAINS)
+Reducer 12 <- Map 17 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 16 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (SIMPLE_EDGE), Union 10 (CONTAINS)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
@@ -268,7 +268,7 @@ Stage-0
                           PartitionCols:_col1
                           Merge Join Operator [MERGEJOIN_122] (rows=1 width=92)
                             Conds:RS_146._col0=RS_149._col2(Inner),Output:["_col1","_col2"]
-                          <-Map 18 [SIMPLE_EDGE] vectorized
+                          <-Map 17 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_149]
                               PartitionCols:_col2
                               Select Operator [SEL_148] (rows=1704 width=178)
@@ -287,14 +287,14 @@ Stage-0
                                   Group By Operator [GBY_143] (rows=5633 width=96)
                                     Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
                                   <-Union 10 [SIMPLE_EDGE]
-                                    <-Reducer 16 [CONTAINS] vectorized
+                                    <-Reducer 15 [CONTAINS] vectorized
                                       Reduce Output Operator [RS_175]
                                         PartitionCols:_col0
                                         Group By Operator [GBY_174] (rows=5633 width=96)
                                           Output:["_col0","_col1"],aggregations:["count(_col1)"],keys:_col0
                                           Group By Operator [GBY_173] (rows=1126 width=96)
                                             Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                                          <-Reducer 15 [SIMPLE_EDGE] vectorized
+                                          <-Reducer 14 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_172]
                                               PartitionCols:_col0
                                               Group By Operator [GBY_171] (rows=1126 width=96)
@@ -305,23 +305,23 @@ Stage-0
                                                     predicate:(_col1 > 10L)
                                                     Group By Operator [GBY_168] (rows=6761 width=97)
                                                       Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                                                    <-Reducer 14 [SIMPLE_EDGE]
+                                                    <-Reducer 13 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_25]
                                                         PartitionCols:_col0
                                                         Group By Operator [GBY_24] (rows=67610 width=97)
                                                           Output:["_col0","_col1"],aggregations:["count()"],keys:_col1
                                                           Merge Join Operator [MERGEJOIN_121] (rows=26666667 width=89)
-                                                            Conds:RS_164._col0=RS_167._col0(Inner),Output:["_col1"]
-                                                          <-Map 13 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_164]
+                                                            Conds:RS_160._col0=RS_167._col0(Inner),Output:["_col1"]
+                                                          <-Map 8 [SIMPLE_EDGE] vectorized
+                                                            SHUFFLE [RS_160]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_163] (rows=40000000 width=93)
+                                                              Select Operator [SEL_158] (rows=40000000 width=93)
                                                                 Output:["_col0","_col1"]
-                                                                Filter Operator [FIL_162] (rows=40000000 width=93)
+                                                                Filter Operator [FIL_156] (rows=40000000 width=93)
                                                                   predicate:substr(substr(ca_zip, 1, 5), 1, 2) is not null
-                                                                  TableScan [TS_14] (rows=40000000 width=93)
-                                                                    default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_zip"]
-                                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                                                  TableScan [TS_6] (rows=40000000 width=89)
+                                                                    default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_zip","ca_address_sk"]
+                                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                                             SHUFFLE [RS_167]
                                                               PartitionCols:_col0
                                                               Select Operator [SEL_166] (rows=26666667 width=4)
@@ -331,23 +331,22 @@ Stage-0
                                                                   TableScan [TS_17] (rows=80000000 width=89)
                                                                     default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_current_addr_sk","c_preferred_cust_flag"]
                                     <-Reducer 9 [CONTAINS] vectorized
-                                      Reduce Output Operator [RS_161]
+                                      Reduce Output Operator [RS_164]
                                         PartitionCols:_col0
-                                        Group By Operator [GBY_160] (rows=5633 width=96)
+                                        Group By Operator [GBY_163] (rows=5633 width=96)
                                           Output:["_col0","_col1"],aggregations:["count(_col1)"],keys:_col0
-                                          Group By Operator [GBY_159] (rows=10141 width=96)
+                                          Group By Operator [GBY_162] (rows=10141 width=96)
                                             Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
                                           <-Map 8 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_158]
+                                            SHUFFLE [RS_161]
                                               PartitionCols:_col0
-                                              Group By Operator [GBY_157] (rows=141974 width=96)
+                                              Group By Operator [GBY_159] (rows=141974 width=96)
                                                 Output:["_col0","_col1"],aggregations:["count()"],keys:_col0
-                                                Select Operator [SEL_156] (rows=20000000 width=89)
+                                                Select Operator [SEL_157] (rows=20000000 width=89)
                                                   Output:["_col0"]
                                                   Filter Operator [FIL_155] (rows=20000000 width=89)
                                                     predicate:((substr(ca_zip, 1, 5)) IN ('89436', '30868', '65085', '22977', '83927', '77557', '58429', '40697', '80614', '10502', '32779', '91137', '61265', '98294', '17921', '18427', '21203', '59362', '87291', '84093', '21505', '17184', '10866', '67898', '25797', '28055', '18377', '80332', '74535', '21757', '29742', '90885', '29898', '17819', '40811', '25990', '47513', '89531', '91068', '10391', '18846', '99223', '82637', '41368', '83658', '86199', '81625', '26696', '89338', '88425', '32200', '81427', '19053', '77471', '36610', '99823', '43276', '41249', '48584', '83550', '82276', '18842', '78890', '14090', '38123', '40936', '34425', '19850', '43286', '80072', '79188', '54191', '11395', '50497', '84861', '90733', '21068', '57666', '37119', '25004', '57835', '70067', '62878', '95806', '19303', '18840', '19124', '29785', '16737', '16022', '49613', '89977', '68310', '60069', '98360', '48649', '39050', '41793', '25002', '27413', '39736', '47208', '16515', '94808', '57648', '15009', '80015', '42961', '63982', '21744', '71853', '81087', '67468', '34175', '64008', '20261', '11201', '51799', '48043', '45645', '61163', '48375', '36447', '57042', '21218', '41100', '89951', '22745', '35851', '83326', '61125', '78298', '80752', '49858', '52940', '96976', '63792', '11376', '53582', '18717', '90226', '50530', '94203', '99447', '27670', '96577', '57856', '56372', '16165', '23427', '54561', '28806', '44439', '22926', '30123', '61451', '92397', '56979', '92309', '70873', '13355', '21801', '46346', '37562', '56458', '28286', '47306', '99555', '69399', '26234', '47546', '49661', '88601', '35943', '39936', '25632', '24611', '44166', '56648', '30379', '59785', '11110', '14329', '93815', '52226', '71381', '13842', '25612', '63294', '14664', '21077', '82626', '18799', '60915', '81020', '56447', '76619', '11433', '13414', '42548', '92713', '70467', '30884', '47484', '16072', '38936', '13036', '88376', '45539', '35901', '19506', '65690', '73957', '71850', '49231', '14276', '20005', '18384', '76615', '11635', '38177', '55607', '41369', '95447', '58581', '58149', '91946', '33790', '76232', '75692', '95464', '22246', '51061', '56692', '53121', '77209', '15482', '10688', '14868', '45907', '73520', '72666', '25734', '17959', '24677', '66446', '94627', '53535', '15560', '41967', '69297', '11929', '59403', '33283', '52232', '57350', '43933', '40921', '36635', '10827', '71286', '19736', '80619', '25251', '95042', '15526', '36496', '55854', '49124', '81980', '35375', '49157', '63512', '28944', '14946', '36503', '54010', '18767', '23969', '43905', '66979', '33113', '21286', '58471', '59080', '13395', '79144', '70373', '67031', '38360', '26705', '50906', '52406', '26066', '73146', '15884', '31897', '30045', '61068', '45550', '92454', '13376', '14354', '19770', '22928', '97790', '50723', '46081', '30202', '14410', '20223', '88500', '67298', '13261', '14172', '81410', '93578', '83583', '46047', '94167', '82564', '21156', '15799', '86709', '37931', '74703', '83103', '23054', '70470', '72008', '49247', '91911', '69998', '20961', '70070', '63197', '54853', '88191', '91830', '49521', '19454', '81450', '89091', '62378', '25683', '61869', '51744', '36580', '85778', '36871', '48121', '28810', '83712', '45486', '67393', '26935', '42393', '20132', '55349', '86057', '21309', '80218', '10094', '11357', '48819', '39734', '40758', '30432', '21204', '29467', '30214', '61024', '55307', '74621', '11622', '68908', '33032', '52868', '99194', '99900', '84936', '69036', '99149', '45013', '32895', '59004', '32322', '14933', '32936', '33562', '72550', '27385', '58049', '58200', '16808', '21360', '32961', '18586', '79307', '15492') and substr(substr(ca_zip, 1, 5), 1, 2) is not null)
-                                                    TableScan [TS_6] (rows=40000000 width=89)
-                                                      default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_zip"]
+                                                     Please refer to the previous TableScan [TS_6]
                       <-Reducer 2 [SIMPLE_EDGE]
                         SHUFFLE [RS_52]
                           PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query81.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query81.q.out
@@ -71,17 +71,17 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Reducer 14 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 15 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-Reducer 12 <- Map 16 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Reducer 12 (SIMPLE_EDGE)
-Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
+Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 14 <- Map 12 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 7 <- Map 15 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 16 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+Reducer 6 <- Map 5 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 11 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 9 <- Map 5 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -103,114 +103,20 @@ Stage-0
                     keys:_col1, _col3, _col4, _col5, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col19,top n:100
                     Merge Join Operator [MERGEJOIN_182] (rows=1609248 width=1418)
                       Conds:RS_62._col0=RS_63._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col19"]
-                    <-Reducer 10 [SIMPLE_EDGE]
-                      SHUFFLE [RS_63]
-                        PartitionCols:_col0
-                        Select Operator [SEL_58] (rows=1609248 width=227)
-                          Output:["_col0","_col2"]
-                          Filter Operator [FIL_57] (rows=1609248 width=227)
-                            predicate:(_col2 > _col3)
-                            Merge Join Operator [MERGEJOIN_181] (rows=4827746 width=227)
-                              Conds:RS_206._col1=RS_214._col1(Inner),Output:["_col0","_col2","_col3"]
-                            <-Reducer 14 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_214]
-                                PartitionCols:_col1
-                                Select Operator [SEL_213] (rows=12 width=198)
-                                  Output:["_col0","_col1"]
-                                  Filter Operator [FIL_212] (rows=12 width=206)
-                                    predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
-                                    Group By Operator [GBY_211] (rows=12 width=206)
-                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                    <-Reducer 13 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_210]
-                                        PartitionCols:_col0
-                                        Group By Operator [GBY_209] (rows=60 width=206)
-                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col0
-                                          Select Operator [SEL_208] (rows=5266632 width=201)
-                                            Output:["_col0","_col2"]
-                                            Group By Operator [GBY_207] (rows=5266632 width=201)
-                                              Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                                            <-Reducer 12 [SIMPLE_EDGE]
-                                              SHUFFLE [RS_45]
-                                                PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_44] (rows=8749496 width=201)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
-                                                  Merge Join Operator [MERGEJOIN_180] (rows=8749496 width=194)
-                                                    Conds:RS_40._col2=RS_202._col0(Inner),Output:["_col1","_col3","_col6"]
-                                                  <-Map 16 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_202]
-                                                      PartitionCols:_col0
-                                                      Select Operator [SEL_200] (rows=40000000 width=90)
-                                                        Output:["_col0","_col1"]
-                                                        Filter Operator [FIL_199] (rows=40000000 width=90)
-                                                          predicate:ca_state is not null
-                                                          TableScan [TS_12] (rows=40000000 width=90)
-                                                            default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_state"]
-                                                  <-Reducer 11 [SIMPLE_EDGE]
-                                                    SHUFFLE [RS_40]
-                                                      PartitionCols:_col2
-                                                      Merge Join Operator [MERGEJOIN_179] (rows=8749496 width=112)
-                                                        Conds:RS_194._col0=RS_198._col0(Inner),Output:["_col1","_col2","_col3"]
-                                                      <-Map 15 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_198]
-                                                          PartitionCols:_col0
-                                                          Select Operator [SEL_196] (rows=652 width=4)
-                                                            Output:["_col0"]
-                                                            Filter Operator [FIL_195] (rows=652 width=8)
-                                                              predicate:(d_year = 1998)
-                                                              TableScan [TS_9] (rows=73049 width=8)
-                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                      <-Map 6 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_194]
-                                                          PartitionCols:_col0
-                                                          Select Operator [SEL_192] (rows=28221532 width=121)
-                                                            Output:["_col0","_col1","_col2","_col3"]
-                                                            Filter Operator [FIL_190] (rows=28221532 width=121)
-                                                              predicate:(cr_returning_addr_sk is not null and cr_returned_date_sk is not null)
-                                                              TableScan [TS_6] (rows=28798881 width=121)
-                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_returned_date_sk","cr_returning_customer_sk","cr_returning_addr_sk","cr_return_amt_inc_tax"]
-                            <-Reducer 9 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_206]
-                                PartitionCols:_col1
-                                Filter Operator [FIL_205] (rows=4827746 width=201)
-                                  predicate:_col2 is not null
-                                  Select Operator [SEL_204] (rows=4827746 width=201)
-                                    Output:["_col0","_col1","_col2"]
-                                    Group By Operator [GBY_203] (rows=4827746 width=201)
-                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                                    <-Reducer 8 [SIMPLE_EDGE]
-                                      SHUFFLE [RS_23]
-                                        PartitionCols:_col0, _col1
-                                        Group By Operator [GBY_22] (rows=8574602 width=201)
-                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
-                                          Merge Join Operator [MERGEJOIN_178] (rows=8574602 width=194)
-                                            Conds:RS_18._col2=RS_201._col0(Inner),Output:["_col1","_col3","_col6"]
-                                          <-Map 16 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_201]
-                                              PartitionCols:_col0
-                                               Please refer to the previous Select Operator [SEL_200]
-                                          <-Reducer 7 [SIMPLE_EDGE]
-                                            SHUFFLE [RS_18]
-                                              PartitionCols:_col2
-                                              Merge Join Operator [MERGEJOIN_177] (rows=8574602 width=112)
-                                                Conds:RS_193._col0=RS_197._col0(Inner),Output:["_col1","_col2","_col3"]
-                                              <-Map 15 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_197]
-                                                  PartitionCols:_col0
-                                                   Please refer to the previous Select Operator [SEL_196]
-                                              <-Map 6 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_193]
-                                                  PartitionCols:_col0
-                                                  Select Operator [SEL_191] (rows=27657410 width=121)
-                                                    Output:["_col0","_col1","_col2","_col3"]
-                                                    Filter Operator [FIL_189] (rows=27657410 width=121)
-                                                      predicate:(cr_returning_addr_sk is not null and cr_returning_customer_sk is not null and cr_returned_date_sk is not null)
-                                                       Please refer to the previous TableScan [TS_6]
                     <-Reducer 2 [SIMPLE_EDGE]
                       SHUFFLE [RS_62]
                         PartitionCols:_col0
                         Merge Join Operator [MERGEJOIN_176] (rows=1568628 width=1310)
-                          Conds:RS_185._col2=RS_188._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"]
+                          Conds:RS_185._col2=RS_190._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"]
+                        <-Map 5 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_190]
+                            PartitionCols:_col0
+                            Select Operator [SEL_188] (rows=784314 width=941)
+                              Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
+                              Filter Operator [FIL_186] (rows=784314 width=1027)
+                                predicate:(ca_state = 'IL')
+                                TableScan [TS_3] (rows=40000000 width=1027)
+                                  default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_street_number","ca_street_name","ca_street_type","ca_suite_number","ca_city","ca_county","ca_state","ca_zip","ca_country","ca_gmt_offset","ca_location_type"]
                         <-Map 1 [SIMPLE_EDGE] vectorized
                           SHUFFLE [RS_185]
                             PartitionCols:_col2
@@ -220,13 +126,106 @@ Stage-0
                                 predicate:c_current_addr_sk is not null
                                 TableScan [TS_0] (rows=80000000 width=375)
                                   default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_current_addr_sk","c_salutation","c_first_name","c_last_name"]
-                        <-Map 5 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_188]
-                            PartitionCols:_col0
-                            Select Operator [SEL_187] (rows=784314 width=941)
-                              Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
-                              Filter Operator [FIL_186] (rows=784314 width=1027)
-                                predicate:(ca_state = 'IL')
-                                TableScan [TS_3] (rows=40000000 width=1027)
-                                  default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_street_number","ca_street_name","ca_street_type","ca_suite_number","ca_city","ca_county","ca_state","ca_zip","ca_country","ca_gmt_offset","ca_location_type"]
+                    <-Reducer 8 [SIMPLE_EDGE]
+                      SHUFFLE [RS_63]
+                        PartitionCols:_col0
+                        Select Operator [SEL_58] (rows=1609248 width=227)
+                          Output:["_col0","_col2"]
+                          Filter Operator [FIL_57] (rows=1609248 width=227)
+                            predicate:(_col2 > _col3)
+                            Merge Join Operator [MERGEJOIN_181] (rows=4827746 width=227)
+                              Conds:RS_206._col1=RS_214._col1(Inner),Output:["_col0","_col2","_col3"]
+                            <-Reducer 11 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_214]
+                                PartitionCols:_col1
+                                Select Operator [SEL_213] (rows=12 width=198)
+                                  Output:["_col0","_col1"]
+                                  Filter Operator [FIL_212] (rows=12 width=206)
+                                    predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
+                                    Group By Operator [GBY_211] (rows=12 width=206)
+                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+                                    <-Reducer 10 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_210]
+                                        PartitionCols:_col0
+                                        Group By Operator [GBY_209] (rows=60 width=206)
+                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col0
+                                          Select Operator [SEL_208] (rows=5266632 width=201)
+                                            Output:["_col0","_col2"]
+                                            Group By Operator [GBY_207] (rows=5266632 width=201)
+                                              Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
+                                            <-Reducer 9 [SIMPLE_EDGE]
+                                              SHUFFLE [RS_45]
+                                                PartitionCols:_col0, _col1
+                                                Group By Operator [GBY_44] (rows=8749496 width=201)
+                                                  Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
+                                                  Merge Join Operator [MERGEJOIN_180] (rows=8749496 width=194)
+                                                    Conds:RS_40._col2=RS_192._col0(Inner),Output:["_col1","_col3","_col6"]
+                                                  <-Map 5 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_192]
+                                                      PartitionCols:_col0
+                                                      Select Operator [SEL_189] (rows=40000000 width=90)
+                                                        Output:["_col0","_col1"]
+                                                        Filter Operator [FIL_187] (rows=40000000 width=90)
+                                                          predicate:ca_state is not null
+                                                           Please refer to the previous TableScan [TS_3]
+                                                  <-Reducer 14 [SIMPLE_EDGE]
+                                                    SHUFFLE [RS_40]
+                                                      PartitionCols:_col2
+                                                      Merge Join Operator [MERGEJOIN_179] (rows=8749496 width=112)
+                                                        Conds:RS_198._col0=RS_202._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_198]
+                                                          PartitionCols:_col0
+                                                          Select Operator [SEL_196] (rows=28221532 width=121)
+                                                            Output:["_col0","_col1","_col2","_col3"]
+                                                            Filter Operator [FIL_194] (rows=28221532 width=121)
+                                                              predicate:(cr_returning_addr_sk is not null and cr_returned_date_sk is not null)
+                                                              TableScan [TS_6] (rows=28798881 width=121)
+                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_returned_date_sk","cr_returning_customer_sk","cr_returning_addr_sk","cr_return_amt_inc_tax"]
+                                                      <-Map 15 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_202]
+                                                          PartitionCols:_col0
+                                                          Select Operator [SEL_200] (rows=652 width=4)
+                                                            Output:["_col0"]
+                                                            Filter Operator [FIL_199] (rows=652 width=8)
+                                                              predicate:(d_year = 1998)
+                                                              TableScan [TS_9] (rows=73049 width=8)
+                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
+                            <-Reducer 7 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_206]
+                                PartitionCols:_col1
+                                Filter Operator [FIL_205] (rows=4827746 width=201)
+                                  predicate:_col2 is not null
+                                  Select Operator [SEL_204] (rows=4827746 width=201)
+                                    Output:["_col0","_col1","_col2"]
+                                    Group By Operator [GBY_203] (rows=4827746 width=201)
+                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
+                                    <-Reducer 6 [SIMPLE_EDGE]
+                                      SHUFFLE [RS_23]
+                                        PartitionCols:_col0, _col1
+                                        Group By Operator [GBY_22] (rows=8574602 width=201)
+                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
+                                          Merge Join Operator [MERGEJOIN_178] (rows=8574602 width=194)
+                                            Conds:RS_18._col2=RS_191._col0(Inner),Output:["_col1","_col3","_col6"]
+                                          <-Map 5 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_191]
+                                              PartitionCols:_col0
+                                               Please refer to the previous Select Operator [SEL_189]
+                                          <-Reducer 13 [SIMPLE_EDGE]
+                                            SHUFFLE [RS_18]
+                                              PartitionCols:_col2
+                                              Merge Join Operator [MERGEJOIN_177] (rows=8574602 width=112)
+                                                Conds:RS_197._col0=RS_201._col0(Inner),Output:["_col1","_col2","_col3"]
+                                              <-Map 12 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_197]
+                                                  PartitionCols:_col0
+                                                  Select Operator [SEL_195] (rows=27657410 width=121)
+                                                    Output:["_col0","_col1","_col2","_col3"]
+                                                    Filter Operator [FIL_193] (rows=27657410 width=121)
+                                                      predicate:(cr_returning_addr_sk is not null and cr_returning_customer_sk is not null and cr_returned_date_sk is not null)
+                                                       Please refer to the previous TableScan [TS_6]
+                                              <-Map 15 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_201]
+                                                  PartitionCols:_col0
+                                                   Please refer to the previous Select Operator [SEL_200]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query83.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query83.q.out
@@ -145,21 +145,21 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Map 20 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 10 <- Map 19 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 22 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 13 <- Map 20 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 12 <- Map 21 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 13 <- Map 19 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
-Reducer 16 <- Map 15 (SIMPLE_EDGE), Map 18 (SIMPLE_EDGE)
-Reducer 17 <- Reducer 16 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 17 (SIMPLE_EDGE)
-Reducer 3 <- Map 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 20 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 15 <- Map 1 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
+Reducer 3 <- Map 18 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 4 <- Map 19 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 11 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 14 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Map 21 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 9 <- Map 20 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -193,7 +193,7 @@ Stage-0
                               Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                               Merge Join Operator [MERGEJOIN_362] (rows=2521 width=100)
                                 Conds:RS_106._col4=RS_383._col0(Inner),Output:["_col5","_col7"]
-                              <-Map 20 [SIMPLE_EDGE] vectorized
+                              <-Map 19 [SIMPLE_EDGE] vectorized
                                 SHUFFLE [RS_383]
                                   PartitionCols:_col0
                                   Select Operator [SEL_380] (rows=462000 width=104)
@@ -209,38 +209,37 @@ Stage-0
                                     SHUFFLE [RS_103]
                                       PartitionCols:_col0
                                       Merge Join Operator [MERGEJOIN_352] (rows=2 width=4)
-                                        Conds:RS_367._col1=RS_376._col0(Inner),Output:["_col0"]
+                                        Conds:RS_369._col1=RS_376._col0(Inner),Output:["_col0"]
                                       <-Map 1 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_367]
+                                        SHUFFLE [RS_369]
                                           PartitionCols:_col1
-                                          Select Operator [SEL_366] (rows=73049 width=98)
+                                          Select Operator [SEL_367] (rows=73049 width=98)
                                             Output:["_col0","_col1"]
                                             Filter Operator [FIL_365] (rows=73049 width=98)
                                               predicate:d_date is not null
                                               TableScan [TS_0] (rows=73049 width=98)
-                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
-                                      <-Reducer 17 [SIMPLE_EDGE] vectorized
+                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq"]
+                                      <-Reducer 16 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_376]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_375] (rows=2 width=94)
                                             Output:["_col0"],keys:KEY._col0
-                                          <-Reducer 16 [SIMPLE_EDGE]
+                                          <-Reducer 15 [SIMPLE_EDGE]
                                             SHUFFLE [RS_16]
                                               PartitionCols:_col0
                                               Group By Operator [GBY_15] (rows=2 width=94)
                                                 Output:["_col0"],keys:_col0
                                                 Merge Join Operator [MERGEJOIN_351] (rows=5 width=94)
                                                   Conds:RS_370._col1=RS_374._col0(Left Semi),Output:["_col0"]
-                                                <-Map 15 [SIMPLE_EDGE] vectorized
+                                                <-Map 1 [SIMPLE_EDGE] vectorized
                                                   SHUFFLE [RS_370]
                                                     PartitionCols:_col1
-                                                    Select Operator [SEL_369] (rows=73049 width=98)
+                                                    Select Operator [SEL_368] (rows=73049 width=98)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_368] (rows=73049 width=98)
+                                                      Filter Operator [FIL_366] (rows=73049 width=98)
                                                         predicate:(d_week_seq is not null and d_date is not null)
-                                                        TableScan [TS_3] (rows=73049 width=98)
-                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date","d_week_seq"]
-                                                <-Map 18 [SIMPLE_EDGE] vectorized
+                                                         Please refer to the previous TableScan [TS_0]
+                                                <-Map 17 [SIMPLE_EDGE] vectorized
                                                   SHUFFLE [RS_374]
                                                     PartitionCols:_col0
                                                     Group By Operator [GBY_373] (rows=1 width=4)
@@ -251,7 +250,7 @@ Stage-0
                                                           predicate:((d_date) IN ('1998-01-02', '1998-10-15', '1998-11-10') and d_week_seq is not null)
                                                           TableScan [TS_6] (rows=73049 width=98)
                                                             default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date","d_week_seq"]
-                                  <-Map 22 [SIMPLE_EDGE] vectorized
+                                  <-Map 21 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_393]
                                       PartitionCols:_col0
                                       Select Operator [SEL_392] (rows=13749816 width=11)
@@ -277,7 +276,7 @@ Stage-0
                                 Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                                 Merge Join Operator [MERGEJOIN_358] (rows=11105 width=100)
                                   Conds:RS_68._col4=RS_382._col0(Inner),Output:["_col5","_col7"]
-                                <-Map 20 [SIMPLE_EDGE] vectorized
+                                <-Map 19 [SIMPLE_EDGE] vectorized
                                   SHUFFLE [RS_382]
                                     PartitionCols:_col0
                                      Please refer to the previous Select Operator [SEL_380]
@@ -290,7 +289,7 @@ Stage-0
                                       SHUFFLE [RS_65]
                                         PartitionCols:_col0
                                          Please refer to the previous Merge Join Operator [MERGEJOIN_352]
-                                    <-Map 21 [SIMPLE_EDGE] vectorized
+                                    <-Map 20 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_388]
                                         PartitionCols:_col0
                                         Select Operator [SEL_387] (rows=55578005 width=11)
@@ -311,7 +310,7 @@ Stage-0
                                 Output:["_col0","_col1"],aggregations:["sum(_col5)"],keys:_col7
                                 Merge Join Operator [MERGEJOIN_354] (rows=5478 width=100)
                                   Conds:RS_30._col4=RS_381._col0(Inner),Output:["_col5","_col7"]
-                                <-Map 20 [SIMPLE_EDGE] vectorized
+                                <-Map 19 [SIMPLE_EDGE] vectorized
                                   SHUFFLE [RS_381]
                                     PartitionCols:_col0
                                      Please refer to the previous Select Operator [SEL_380]
@@ -324,7 +323,7 @@ Stage-0
                                       SHUFFLE [RS_27]
                                         PartitionCols:_col0
                                          Please refer to the previous Merge Join Operator [MERGEJOIN_352]
-                                    <-Map 19 [SIMPLE_EDGE] vectorized
+                                    <-Map 18 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_379]
                                         PartitionCols:_col0
                                         Select Operator [SEL_378] (rows=28798881 width=11)

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query9.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query9.q.out
@@ -120,36 +120,36 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Reducer 34 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
+Reducer 10 <- Reducer 32 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 18 (CUSTOM_SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
-Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 30 (CUSTOM_SIMPLE_EDGE)
+Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 28 (CUSTOM_SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 25 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 31 (CUSTOM_SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 29 (CUSTOM_SIMPLE_EDGE)
 Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 19 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 20 (CUSTOM_SIMPLE_EDGE)
 Reducer 20 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 22 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 24 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 25 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 26 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 27 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 26 (CUSTOM_SIMPLE_EDGE)
-Reducer 30 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 31 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 32 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 33 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 34 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 32 (CUSTOM_SIMPLE_EDGE)
+Reducer 23 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 25 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 26 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 27 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 28 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 29 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 25 (CUSTOM_SIMPLE_EDGE)
+Reducer 30 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 31 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 32 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 30 (CUSTOM_SIMPLE_EDGE)
 Reducer 5 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-Reducer 7 <- Reducer 33 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 6 <- Reducer 26 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 7 <- Reducer 31 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
 Reducer 8 <- Reducer 22 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Reducer 28 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 9 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -185,42 +185,41 @@ Stage-0
                                 PARTITION_ONLY_SHUFFLE [RS_135]
                                   Merge Join Operator [MERGEJOIN_179] (rows=2 width=684)
                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9"]
-                                  <-Reducer 34 [CUSTOM_SIMPLE_EDGE] vectorized
+                                  <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
                                     PARTITION_ONLY_SHUFFLE [RS_275]
                                       Select Operator [SEL_274] (rows=1 width=112)
                                         Output:["_col0"]
                                         Group By Operator [GBY_273] (rows=1 width=120)
                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                        <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_254]
-                                            Group By Operator [GBY_249] (rows=1 width=120)
+                                        <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                          PARTITION_ONLY_SHUFFLE [RS_248]
+                                            Group By Operator [GBY_233] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                              Select Operator [SEL_244] (rows=182855757 width=110)
+                                              Select Operator [SEL_218] (rows=182855757 width=110)
                                                 Output:["ss_net_paid_inc_tax"]
-                                                Filter Operator [FIL_239] (rows=182855757 width=110)
+                                                Filter Operator [FIL_203] (rows=182855757 width=110)
                                                   predicate:ss_quantity BETWEEN 41 AND 60
-                                                  TableScan [TS_80] (rows=575995635 width=110)
-                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_net_paid_inc_tax"]
+                                                  TableScan [TS_66] (rows=575995635 width=3)
+                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_ext_list_price","ss_net_paid_inc_tax"]
                                   <-Reducer 9 [CUSTOM_SIMPLE_EDGE]
                                     PARTITION_ONLY_SHUFFLE [RS_132]
                                       Merge Join Operator [MERGEJOIN_178] (rows=2 width=572)
                                         Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                      <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
                                         PARTITION_ONLY_SHUFFLE [RS_272]
                                           Select Operator [SEL_271] (rows=1 width=112)
                                             Output:["_col0"]
                                             Group By Operator [GBY_270] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                            <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_231]
-                                                Group By Operator [GBY_226] (rows=1 width=120)
+                                            <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              PARTITION_ONLY_SHUFFLE [RS_243]
+                                                Group By Operator [GBY_228] (rows=1 width=120)
                                                   Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                  Select Operator [SEL_221] (rows=182855757 width=110)
+                                                  Select Operator [SEL_213] (rows=182855757 width=110)
                                                     Output:["ss_ext_list_price"]
-                                                    Filter Operator [FIL_216] (rows=182855757 width=110)
+                                                    Filter Operator [FIL_198] (rows=182855757 width=110)
                                                       predicate:ss_quantity BETWEEN 41 AND 60
-                                                      TableScan [TS_73] (rows=575995635 width=110)
-                                                        default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_ext_list_price"]
+                                                       Please refer to the previous TableScan [TS_66]
                                       <-Reducer 8 [CUSTOM_SIMPLE_EDGE]
                                         PARTITION_ONLY_SHUFFLE [RS_129]
                                           Merge Join Operator [MERGEJOIN_177] (rows=2 width=460)
@@ -232,52 +231,51 @@ Stage-0
                                                 Group By Operator [GBY_267] (rows=1 width=8)
                                                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                 <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_208]
-                                                    Group By Operator [GBY_203] (rows=1 width=8)
+                                                  PARTITION_ONLY_SHUFFLE [RS_238]
+                                                    Group By Operator [GBY_223] (rows=1 width=8)
                                                       Output:["_col0"],aggregations:["count()"]
-                                                      Select Operator [SEL_198] (rows=182855757 width=3)
+                                                      Select Operator [SEL_208] (rows=182855757 width=3)
                                                         Filter Operator [FIL_193] (rows=182855757 width=3)
                                                           predicate:ss_quantity BETWEEN 41 AND 60
-                                                          TableScan [TS_66] (rows=575995635 width=3)
-                                                            default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity"]
+                                                           Please refer to the previous TableScan [TS_66]
                                           <-Reducer 7 [CUSTOM_SIMPLE_EDGE]
                                             PARTITION_ONLY_SHUFFLE [RS_126]
                                               Merge Join Operator [MERGEJOIN_176] (rows=2 width=456)
                                                 Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6"]
-                                              <-Reducer 33 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
                                                 PARTITION_ONLY_SHUFFLE [RS_266]
                                                   Select Operator [SEL_265] (rows=1 width=112)
                                                     Output:["_col0"]
                                                     Group By Operator [GBY_264] (rows=1 width=120)
                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                    <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_253]
-                                                        Group By Operator [GBY_248] (rows=1 width=120)
+                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      PARTITION_ONLY_SHUFFLE [RS_247]
+                                                        Group By Operator [GBY_232] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                          Select Operator [SEL_243] (rows=182855757 width=110)
+                                                          Select Operator [SEL_217] (rows=182855757 width=110)
                                                             Output:["ss_net_paid_inc_tax"]
-                                                            Filter Operator [FIL_238] (rows=182855757 width=110)
+                                                            Filter Operator [FIL_202] (rows=182855757 width=110)
                                                               predicate:ss_quantity BETWEEN 21 AND 40
-                                                               Please refer to the previous TableScan [TS_80]
+                                                               Please refer to the previous TableScan [TS_66]
                                               <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                                                 PARTITION_ONLY_SHUFFLE [RS_123]
                                                   Merge Join Operator [MERGEJOIN_175] (rows=2 width=344)
                                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                                  <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                  <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_263]
                                                       Select Operator [SEL_262] (rows=1 width=112)
                                                         Output:["_col0"]
                                                         Group By Operator [GBY_261] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                        <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                          PARTITION_ONLY_SHUFFLE [RS_230]
-                                                            Group By Operator [GBY_225] (rows=1 width=120)
+                                                        <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                          PARTITION_ONLY_SHUFFLE [RS_242]
+                                                            Group By Operator [GBY_227] (rows=1 width=120)
                                                               Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                              Select Operator [SEL_220] (rows=182855757 width=110)
+                                                              Select Operator [SEL_212] (rows=182855757 width=110)
                                                                 Output:["ss_ext_list_price"]
-                                                                Filter Operator [FIL_215] (rows=182855757 width=110)
+                                                                Filter Operator [FIL_197] (rows=182855757 width=110)
                                                                   predicate:ss_quantity BETWEEN 21 AND 40
-                                                                   Please refer to the previous TableScan [TS_73]
+                                                                   Please refer to the previous TableScan [TS_66]
                                                   <-Reducer 5 [CUSTOM_SIMPLE_EDGE]
                                                     PARTITION_ONLY_SHUFFLE [RS_120]
                                                       Merge Join Operator [MERGEJOIN_174] (rows=2 width=232)
@@ -289,10 +287,10 @@ Stage-0
                                                             Group By Operator [GBY_258] (rows=1 width=8)
                                                               Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                             <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                              PARTITION_ONLY_SHUFFLE [RS_207]
-                                                                Group By Operator [GBY_202] (rows=1 width=8)
+                                                              PARTITION_ONLY_SHUFFLE [RS_237]
+                                                                Group By Operator [GBY_222] (rows=1 width=8)
                                                                   Output:["_col0"],aggregations:["count()"]
-                                                                  Select Operator [SEL_197] (rows=182855757 width=3)
+                                                                  Select Operator [SEL_207] (rows=182855757 width=3)
                                                                     Filter Operator [FIL_192] (rows=182855757 width=3)
                                                                       predicate:ss_quantity BETWEEN 21 AND 40
                                                                        Please refer to the previous TableScan [TS_66]
@@ -316,49 +314,49 @@ Stage-0
                                                                           TableScan [TS_0] (rows=72 width=4)
                                                                             default@reason,reason,Tbl:COMPLETE,Col:COMPLETE,Output:["r_reason_sk"]
                                                                   <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                    PARTITION_ONLY_SHUFFLE [RS_211]
-                                                                      Select Operator [SEL_210] (rows=1 width=4)
+                                                                    PARTITION_ONLY_SHUFFLE [RS_251]
+                                                                      Select Operator [SEL_250] (rows=1 width=4)
                                                                         Output:["_col0"]
-                                                                        Group By Operator [GBY_209] (rows=1 width=8)
+                                                                        Group By Operator [GBY_249] (rows=1 width=8)
                                                                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                          PARTITION_ONLY_SHUFFLE [RS_206]
-                                                                            Group By Operator [GBY_201] (rows=1 width=8)
+                                                                          PARTITION_ONLY_SHUFFLE [RS_236]
+                                                                            Group By Operator [GBY_221] (rows=1 width=8)
                                                                               Output:["_col0"],aggregations:["count()"]
-                                                                              Select Operator [SEL_196] (rows=182855757 width=3)
+                                                                              Select Operator [SEL_206] (rows=182855757 width=3)
                                                                                 Filter Operator [FIL_191] (rows=182855757 width=3)
                                                                                   predicate:ss_quantity BETWEEN 1 AND 20
                                                                                    Please refer to the previous TableScan [TS_66]
-                                                              <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_234]
-                                                                  Select Operator [SEL_233] (rows=1 width=112)
+                                                              <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_254]
+                                                                  Select Operator [SEL_253] (rows=1 width=112)
                                                                     Output:["_col0"]
-                                                                    Group By Operator [GBY_232] (rows=1 width=120)
+                                                                    Group By Operator [GBY_252] (rows=1 width=120)
                                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                                    <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_229]
-                                                                        Group By Operator [GBY_224] (rows=1 width=120)
+                                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                      PARTITION_ONLY_SHUFFLE [RS_241]
+                                                                        Group By Operator [GBY_226] (rows=1 width=120)
                                                                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                                          Select Operator [SEL_219] (rows=182855757 width=110)
+                                                                          Select Operator [SEL_211] (rows=182855757 width=110)
                                                                             Output:["ss_ext_list_price"]
-                                                                            Filter Operator [FIL_214] (rows=182855757 width=110)
+                                                                            Filter Operator [FIL_196] (rows=182855757 width=110)
                                                                               predicate:ss_quantity BETWEEN 1 AND 20
-                                                                               Please refer to the previous TableScan [TS_73]
-                                                          <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                               Please refer to the previous TableScan [TS_66]
+                                                          <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
                                                             PARTITION_ONLY_SHUFFLE [RS_257]
                                                               Select Operator [SEL_256] (rows=1 width=112)
                                                                 Output:["_col0"]
                                                                 Group By Operator [GBY_255] (rows=1 width=120)
                                                                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                                <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_252]
-                                                                    Group By Operator [GBY_247] (rows=1 width=120)
+                                                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                  PARTITION_ONLY_SHUFFLE [RS_246]
+                                                                    Group By Operator [GBY_231] (rows=1 width=120)
                                                                       Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                                      Select Operator [SEL_242] (rows=182855757 width=110)
+                                                                      Select Operator [SEL_216] (rows=182855757 width=110)
                                                                         Output:["ss_net_paid_inc_tax"]
-                                                                        Filter Operator [FIL_237] (rows=182855757 width=110)
+                                                                        Filter Operator [FIL_201] (rows=182855757 width=110)
                                                                           predicate:ss_quantity BETWEEN 1 AND 20
-                                                                           Please refer to the previous TableScan [TS_80]
+                                                                           Please refer to the previous TableScan [TS_66]
                               <-Reducer 18 [CUSTOM_SIMPLE_EDGE] vectorized
                                 PARTITION_ONLY_SHUFFLE [RS_278]
                                   Select Operator [SEL_277] (rows=1 width=4)
@@ -366,43 +364,43 @@ Stage-0
                                     Group By Operator [GBY_276] (rows=1 width=8)
                                       Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_204]
-                                        Group By Operator [GBY_199] (rows=1 width=8)
+                                      PARTITION_ONLY_SHUFFLE [RS_234]
+                                        Group By Operator [GBY_219] (rows=1 width=8)
                                           Output:["_col0"],aggregations:["count()"]
-                                          Select Operator [SEL_194] (rows=182855757 width=3)
+                                          Select Operator [SEL_204] (rows=182855757 width=3)
                                             Filter Operator [FIL_189] (rows=182855757 width=3)
                                               predicate:ss_quantity BETWEEN 61 AND 80
                                                Please refer to the previous TableScan [TS_66]
-                          <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
+                          <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
                             PARTITION_ONLY_SHUFFLE [RS_281]
                               Select Operator [SEL_280] (rows=1 width=112)
                                 Output:["_col0"]
                                 Group By Operator [GBY_279] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_227]
-                                    Group By Operator [GBY_222] (rows=1 width=120)
+                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                  PARTITION_ONLY_SHUFFLE [RS_239]
+                                    Group By Operator [GBY_224] (rows=1 width=120)
                                       Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                      Select Operator [SEL_217] (rows=182855757 width=110)
+                                      Select Operator [SEL_209] (rows=182855757 width=110)
                                         Output:["ss_ext_list_price"]
-                                        Filter Operator [FIL_212] (rows=182855757 width=110)
+                                        Filter Operator [FIL_194] (rows=182855757 width=110)
                                           predicate:ss_quantity BETWEEN 61 AND 80
-                                           Please refer to the previous TableScan [TS_73]
-                      <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
+                                           Please refer to the previous TableScan [TS_66]
+                      <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
                         PARTITION_ONLY_SHUFFLE [RS_284]
                           Select Operator [SEL_283] (rows=1 width=112)
                             Output:["_col0"]
                             Group By Operator [GBY_282] (rows=1 width=120)
                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_250]
-                                Group By Operator [GBY_245] (rows=1 width=120)
+                            <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                              PARTITION_ONLY_SHUFFLE [RS_244]
+                                Group By Operator [GBY_229] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                  Select Operator [SEL_240] (rows=182855757 width=110)
+                                  Select Operator [SEL_214] (rows=182855757 width=110)
                                     Output:["ss_net_paid_inc_tax"]
-                                    Filter Operator [FIL_235] (rows=182855757 width=110)
+                                    Filter Operator [FIL_199] (rows=182855757 width=110)
                                       predicate:ss_quantity BETWEEN 61 AND 80
-                                       Please refer to the previous TableScan [TS_80]
+                                       Please refer to the previous TableScan [TS_66]
                   <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
                     PARTITION_ONLY_SHUFFLE [RS_287]
                       Select Operator [SEL_286] (rows=1 width=4)
@@ -410,41 +408,41 @@ Stage-0
                         Group By Operator [GBY_285] (rows=1 width=8)
                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                          PARTITION_ONLY_SHUFFLE [RS_205]
-                            Group By Operator [GBY_200] (rows=1 width=8)
+                          PARTITION_ONLY_SHUFFLE [RS_235]
+                            Group By Operator [GBY_220] (rows=1 width=8)
                               Output:["_col0"],aggregations:["count()"]
-                              Select Operator [SEL_195] (rows=182855757 width=3)
+                              Select Operator [SEL_205] (rows=182855757 width=3)
                                 Filter Operator [FIL_190] (rows=182855757 width=3)
                                   predicate:ss_quantity BETWEEN 81 AND 100
                                    Please refer to the previous TableScan [TS_66]
-              <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
+              <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
                 PARTITION_ONLY_SHUFFLE [RS_290]
                   Select Operator [SEL_289] (rows=1 width=112)
                     Output:["_col0"]
                     Group By Operator [GBY_288] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                    <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                      PARTITION_ONLY_SHUFFLE [RS_228]
-                        Group By Operator [GBY_223] (rows=1 width=120)
+                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                      PARTITION_ONLY_SHUFFLE [RS_240]
+                        Group By Operator [GBY_225] (rows=1 width=120)
                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                          Select Operator [SEL_218] (rows=182855757 width=110)
+                          Select Operator [SEL_210] (rows=182855757 width=110)
                             Output:["ss_ext_list_price"]
-                            Filter Operator [FIL_213] (rows=182855757 width=110)
+                            Filter Operator [FIL_195] (rows=182855757 width=110)
                               predicate:ss_quantity BETWEEN 81 AND 100
-                               Please refer to the previous TableScan [TS_73]
-          <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
+                               Please refer to the previous TableScan [TS_66]
+          <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
             PARTITION_ONLY_SHUFFLE [RS_293]
               Select Operator [SEL_292] (rows=1 width=112)
                 Output:["_col0"]
                 Group By Operator [GBY_291] (rows=1 width=120)
                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                  PARTITION_ONLY_SHUFFLE [RS_251]
-                    Group By Operator [GBY_246] (rows=1 width=120)
+                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                  PARTITION_ONLY_SHUFFLE [RS_245]
+                    Group By Operator [GBY_230] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                      Select Operator [SEL_241] (rows=182855757 width=110)
+                      Select Operator [SEL_215] (rows=182855757 width=110)
                         Output:["ss_net_paid_inc_tax"]
-                        Filter Operator [FIL_236] (rows=182855757 width=110)
+                        Filter Operator [FIL_200] (rows=182855757 width=110)
                           predicate:ss_quantity BETWEEN 81 AND 100
-                           Please refer to the previous TableScan [TS_80]
+                           Please refer to the previous TableScan [TS_66]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query14.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query14.q.out
@@ -223,71 +223,67 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 11 (BROADCAST_EDGE)
-Map 46 <- Reducer 49 (BROADCAST_EDGE)
-Map 64 <- Reducer 51 (BROADCAST_EDGE)
-Map 65 <- Reducer 53 (BROADCAST_EDGE)
-Map 66 <- Reducer 57 (BROADCAST_EDGE)
-Map 67 <- Reducer 72 (BROADCAST_EDGE)
-Map 73 <- Reducer 78 (BROADCAST_EDGE)
-Map 79 <- Reducer 17 (BROADCAST_EDGE)
-Map 80 <- Reducer 23 (BROADCAST_EDGE)
+Map 61 <- Reducer 43 (BROADCAST_EDGE)
+Map 62 <- Reducer 49 (BROADCAST_EDGE)
+Map 63 <- Reducer 68 (BROADCAST_EDGE)
+Map 69 <- Reducer 74 (BROADCAST_EDGE)
+Map 75 <- Reducer 17 (BROADCAST_EDGE)
+Map 76 <- Reducer 23 (BROADCAST_EDGE)
 Reducer 11 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-Reducer 12 <- Map 10 (SIMPLE_EDGE), Map 79 (SIMPLE_EDGE)
-Reducer 13 <- Map 24 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 12 <- Map 10 (SIMPLE_EDGE), Map 75 (SIMPLE_EDGE)
+Reducer 13 <- Map 59 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (SIMPLE_EDGE), Reducer 33 (SIMPLE_EDGE)
 Reducer 15 <- Reducer 14 (SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 60 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
+Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 55 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
 Reducer 17 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-Reducer 18 <- Map 10 (SIMPLE_EDGE), Map 80 (SIMPLE_EDGE)
-Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 18 <- Map 10 (SIMPLE_EDGE), Map 76 (SIMPLE_EDGE)
+Reducer 19 <- Map 59 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 10 (SIMPLE_EDGE)
 Reducer 20 <- Reducer 19 (SIMPLE_EDGE), Reducer 37 (SIMPLE_EDGE)
 Reducer 21 <- Reducer 20 (SIMPLE_EDGE)
-Reducer 22 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 63 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
+Reducer 22 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 58 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
 Reducer 23 <- Map 10 (CUSTOM_SIMPLE_EDGE)
-Reducer 25 <- Map 24 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE)
-Reducer 26 <- Map 24 (SIMPLE_EDGE), Reducer 47 (SIMPLE_EDGE)
-Reducer 27 <- Reducer 26 (SIMPLE_EDGE), Union 28 (CONTAINS)
-Reducer 29 <- Union 28 (SIMPLE_EDGE)
-Reducer 3 <- Map 24 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Reducer 26 (SIMPLE_EDGE), Union 31 (CONTAINS)
+Reducer 24 <- Map 10 (SIMPLE_EDGE), Map 60 (SIMPLE_EDGE)
+Reducer 25 <- Map 59 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
+Reducer 26 <- Reducer 25 (SIMPLE_EDGE), Union 27 (CONTAINS)
+Reducer 28 <- Union 27 (SIMPLE_EDGE)
+Reducer 29 <- Map 59 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE)
+Reducer 3 <- Map 59 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 30 <- Reducer 25 (SIMPLE_EDGE), Union 31 (CONTAINS)
 Reducer 32 <- Union 31 (SIMPLE_EDGE)
-Reducer 33 <- Map 24 (SIMPLE_EDGE), Reducer 32 (SIMPLE_EDGE)
-Reducer 34 <- Reducer 26 (SIMPLE_EDGE), Union 35 (CONTAINS)
+Reducer 33 <- Map 59 (SIMPLE_EDGE), Reducer 32 (SIMPLE_EDGE)
+Reducer 34 <- Reducer 25 (SIMPLE_EDGE), Union 35 (CONTAINS)
 Reducer 36 <- Union 35 (SIMPLE_EDGE)
-Reducer 37 <- Map 24 (SIMPLE_EDGE), Reducer 36 (SIMPLE_EDGE)
-Reducer 38 <- Map 24 (SIMPLE_EDGE), Reducer 50 (SIMPLE_EDGE)
-Reducer 39 <- Reducer 38 (SIMPLE_EDGE), Union 28 (CONTAINS)
-Reducer 4 <- Reducer 25 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 40 <- Reducer 38 (SIMPLE_EDGE), Union 31 (CONTAINS)
-Reducer 41 <- Reducer 38 (SIMPLE_EDGE), Union 35 (CONTAINS)
-Reducer 42 <- Map 24 (SIMPLE_EDGE), Reducer 52 (SIMPLE_EDGE)
-Reducer 43 <- Reducer 42 (SIMPLE_EDGE), Union 28 (CONTAINS)
-Reducer 44 <- Reducer 42 (SIMPLE_EDGE), Union 31 (CONTAINS)
-Reducer 45 <- Reducer 42 (SIMPLE_EDGE), Union 35 (CONTAINS)
-Reducer 47 <- Map 46 (SIMPLE_EDGE), Map 48 (SIMPLE_EDGE)
-Reducer 49 <- Map 48 (CUSTOM_SIMPLE_EDGE)
+Reducer 37 <- Map 59 (SIMPLE_EDGE), Reducer 36 (SIMPLE_EDGE)
+Reducer 38 <- Map 10 (SIMPLE_EDGE), Map 61 (SIMPLE_EDGE)
+Reducer 39 <- Map 59 (SIMPLE_EDGE), Reducer 38 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 29 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 40 <- Reducer 39 (SIMPLE_EDGE), Union 27 (CONTAINS)
+Reducer 41 <- Reducer 39 (SIMPLE_EDGE), Union 31 (CONTAINS)
+Reducer 42 <- Reducer 39 (SIMPLE_EDGE), Union 35 (CONTAINS)
+Reducer 43 <- Map 10 (CUSTOM_SIMPLE_EDGE)
+Reducer 44 <- Map 10 (SIMPLE_EDGE), Map 62 (SIMPLE_EDGE)
+Reducer 45 <- Map 59 (SIMPLE_EDGE), Reducer 44 (SIMPLE_EDGE)
+Reducer 46 <- Reducer 45 (SIMPLE_EDGE), Union 27 (CONTAINS)
+Reducer 47 <- Reducer 45 (SIMPLE_EDGE), Union 31 (CONTAINS)
+Reducer 48 <- Reducer 45 (SIMPLE_EDGE), Union 35 (CONTAINS)
+Reducer 49 <- Map 10 (CUSTOM_SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
-Reducer 50 <- Map 48 (SIMPLE_EDGE), Map 64 (SIMPLE_EDGE)
-Reducer 51 <- Map 48 (CUSTOM_SIMPLE_EDGE)
-Reducer 52 <- Map 48 (SIMPLE_EDGE), Map 65 (SIMPLE_EDGE)
-Reducer 53 <- Map 48 (CUSTOM_SIMPLE_EDGE)
-Reducer 54 <- Map 48 (SIMPLE_EDGE), Map 66 (SIMPLE_EDGE), Union 55 (CONTAINS)
-Reducer 56 <- Union 55 (CUSTOM_SIMPLE_EDGE)
-Reducer 57 <- Map 48 (CUSTOM_SIMPLE_EDGE)
-Reducer 58 <- Map 48 (SIMPLE_EDGE), Map 66 (SIMPLE_EDGE), Union 59 (CONTAINS)
-Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE), Reducer 56 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
-Reducer 60 <- Union 59 (CUSTOM_SIMPLE_EDGE)
-Reducer 61 <- Map 48 (SIMPLE_EDGE), Map 66 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 63 <- Union 62 (CUSTOM_SIMPLE_EDGE)
-Reducer 68 <- Map 67 (SIMPLE_EDGE), Map 71 (SIMPLE_EDGE), Union 55 (CONTAINS)
-Reducer 69 <- Map 67 (SIMPLE_EDGE), Map 71 (SIMPLE_EDGE), Union 59 (CONTAINS)
-Reducer 70 <- Map 67 (SIMPLE_EDGE), Map 71 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 72 <- Map 71 (CUSTOM_SIMPLE_EDGE)
-Reducer 74 <- Map 73 (SIMPLE_EDGE), Map 77 (SIMPLE_EDGE), Union 55 (CONTAINS)
-Reducer 75 <- Map 73 (SIMPLE_EDGE), Map 77 (SIMPLE_EDGE), Union 59 (CONTAINS)
-Reducer 76 <- Map 73 (SIMPLE_EDGE), Map 77 (SIMPLE_EDGE), Union 62 (CONTAINS)
-Reducer 78 <- Map 77 (CUSTOM_SIMPLE_EDGE)
+Reducer 50 <- Map 10 (SIMPLE_EDGE), Map 60 (SIMPLE_EDGE), Union 51 (CONTAINS)
+Reducer 52 <- Union 51 (CUSTOM_SIMPLE_EDGE)
+Reducer 53 <- Map 10 (SIMPLE_EDGE), Map 60 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 55 <- Union 54 (CUSTOM_SIMPLE_EDGE)
+Reducer 56 <- Map 10 (SIMPLE_EDGE), Map 60 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 58 <- Union 57 (CUSTOM_SIMPLE_EDGE)
+Reducer 6 <- Reducer 5 (CUSTOM_SIMPLE_EDGE), Reducer 52 (CUSTOM_SIMPLE_EDGE), Union 7 (CONTAINS)
+Reducer 64 <- Map 63 (SIMPLE_EDGE), Map 67 (SIMPLE_EDGE), Union 51 (CONTAINS)
+Reducer 65 <- Map 63 (SIMPLE_EDGE), Map 67 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 66 <- Map 63 (SIMPLE_EDGE), Map 67 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 68 <- Map 67 (CUSTOM_SIMPLE_EDGE)
+Reducer 70 <- Map 69 (SIMPLE_EDGE), Map 73 (SIMPLE_EDGE), Union 51 (CONTAINS)
+Reducer 71 <- Map 69 (SIMPLE_EDGE), Map 73 (SIMPLE_EDGE), Union 54 (CONTAINS)
+Reducer 72 <- Map 69 (SIMPLE_EDGE), Map 73 (SIMPLE_EDGE), Union 57 (CONTAINS)
+Reducer 74 <- Map 73 (CUSTOM_SIMPLE_EDGE)
 Reducer 8 <- Union 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
@@ -296,16 +292,16 @@ Stage-0
     limit:100
     Stage-1
       Reducer 9 vectorized
-      File Output Operator [FS_1351]
-        Limit [LIM_1350] (rows=100 width=223)
+      File Output Operator [FS_1365]
+        Limit [LIM_1364] (rows=100 width=223)
           Number of rows:100
-          Select Operator [SEL_1349] (rows=304320 width=222)
+          Select Operator [SEL_1363] (rows=304320 width=222)
             Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
           <-Reducer 8 [SIMPLE_EDGE] vectorized
-            SHUFFLE [RS_1348]
-              Select Operator [SEL_1347] (rows=304320 width=222)
+            SHUFFLE [RS_1362]
+              Select Operator [SEL_1361] (rows=304320 width=222)
                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                Group By Operator [GBY_1346] (rows=304320 width=230)
+                Group By Operator [GBY_1360] (rows=304320 width=230)
                   Output:["_col0","_col1","_col2","_col3","_col5","_col6"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4
                 <-Union 7 [SIMPLE_EDGE]
                   <-Reducer 16 [CONTAINS]
@@ -322,10 +318,10 @@ Stage-0
                               Merge Join Operator [MERGEJOIN_1185] (rows=121728 width=243)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                               <-Reducer 15 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1363]
-                                  Filter Operator [FIL_1362] (rows=121728 width=131)
+                                PARTITION_ONLY_SHUFFLE [RS_1377]
+                                  Filter Operator [FIL_1376] (rows=121728 width=131)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1361] (rows=121728 width=131)
+                                    Group By Operator [GBY_1375] (rows=121728 width=131)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_244]
@@ -340,13 +336,13 @@ Stage-0
                                               SHUFFLE [RS_238]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1149] (rows=7790806 width=110)
-                                                  Conds:RS_233._col1=RS_1331._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                <-Map 24 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1331]
+                                                  Conds:RS_233._col1=RS_1345._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                <-Map 59 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1345]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_1322] (rows=462000 width=15)
+                                                    Select Operator [SEL_1336] (rows=462000 width=15)
                                                       Output:["_col0","_col1","_col2","_col3"]
-                                                      Filter Operator [FIL_1313] (rows=462000 width=15)
+                                                      Filter Operator [FIL_1327] (rows=462000 width=15)
                                                         predicate:i_item_sk is not null
                                                         TableScan [TS_6] (rows=462000 width=15)
                                                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_brand_id","i_class_id","i_category_id"]
@@ -354,229 +350,217 @@ Stage-0
                                                   SHUFFLE [RS_233]
                                                     PartitionCols:_col1
                                                     Merge Join Operator [MERGEJOIN_1148] (rows=7790806 width=98)
-                                                      Conds:RS_1356._col0=RS_1293._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                      Conds:RS_1370._col0=RS_1295._col0(Inner),Output:["_col1","_col2","_col3"]
                                                     <-Map 10 [SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_1293]
+                                                      SHUFFLE [RS_1295]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1290] (rows=50 width=4)
+                                                        Select Operator [SEL_1291] (rows=50 width=4)
                                                           Output:["_col0"]
                                                           Filter Operator [FIL_1289] (rows=50 width=12)
                                                             predicate:((d_year = 2000) and (d_moy = 11) and d_date_sk is not null)
                                                             TableScan [TS_3] (rows=73049 width=12)
                                                               default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                                    <-Map 79 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1356]
+                                                    <-Map 75 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_1370]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1355] (rows=286549727 width=123)
+                                                        Select Operator [SEL_1369] (rows=286549727 width=123)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1354] (rows=286549727 width=123)
+                                                          Filter Operator [FIL_1368] (rows=286549727 width=123)
                                                             predicate:(cs_sold_date_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_231_date_dim_d_date_sk_min) AND DynamicValue(RS_231_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_231_date_dim_d_date_sk_bloom_filter)))
                                                             TableScan [TS_146] (rows=287989836 width=123)
                                                               default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_item_sk","cs_quantity","cs_list_price"]
                                                             <-Reducer 17 [BROADCAST_EDGE] vectorized
-                                                              BROADCAST [RS_1353]
-                                                                Group By Operator [GBY_1352] (rows=1 width=12)
+                                                              BROADCAST [RS_1367]
+                                                                Group By Operator [GBY_1366] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                 <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_1301]
-                                                                    Group By Operator [GBY_1298] (rows=1 width=12)
+                                                                  SHUFFLE [RS_1313]
+                                                                    Group By Operator [GBY_1308] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                      Select Operator [SEL_1294] (rows=50 width=4)
+                                                                      Select Operator [SEL_1296] (rows=50 width=4)
                                                                         Output:["_col0"]
-                                                                         Please refer to the previous Select Operator [SEL_1290]
+                                                                         Please refer to the previous Select Operator [SEL_1291]
                                             <-Reducer 33 [SIMPLE_EDGE]
                                               SHUFFLE [RS_239]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_237] (rows=362 width=4)
                                                   Output:["_col0"],keys:_col0
                                                   Merge Join Operator [MERGEJOIN_1156] (rows=724 width=4)
-                                                    Conds:RS_1332._col1, _col2, _col3=RS_1360._col0, _col1, _col2(Inner),Output:["_col0"]
-                                                  <-Map 24 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1332]
+                                                    Conds:RS_1346._col1, _col2, _col3=RS_1374._col0, _col1, _col2(Inner),Output:["_col0"]
+                                                  <-Map 59 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1346]
                                                       PartitionCols:_col1, _col2, _col3
-                                                      Select Operator [SEL_1323] (rows=458612 width=15)
+                                                      Select Operator [SEL_1337] (rows=458612 width=15)
                                                         Output:["_col0","_col1","_col2","_col3"]
-                                                        Filter Operator [FIL_1314] (rows=458612 width=15)
+                                                        Filter Operator [FIL_1328] (rows=458612 width=15)
                                                           predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                            Please refer to the previous TableScan [TS_6]
                                                   <-Reducer 32 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1360]
+                                                    SHUFFLE [RS_1374]
                                                       PartitionCols:_col0, _col1, _col2
-                                                      Select Operator [SEL_1359] (rows=1 width=12)
+                                                      Select Operator [SEL_1373] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1358] (rows=1 width=20)
+                                                        Filter Operator [FIL_1372] (rows=1 width=20)
                                                           predicate:(_col3 = 3L)
-                                                          Group By Operator [GBY_1357] (rows=121728 width=19)
+                                                          Group By Operator [GBY_1371] (rows=121728 width=19)
                                                             Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                                                           <-Union 31 [SIMPLE_EDGE]
                                                             <-Reducer 30 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1414]
+                                                              Reduce Output Operator [RS_1411]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1413] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1410] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1412] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1409] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 26 [SIMPLE_EDGE]
+                                                                  <-Reducer 25 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_175]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                       Group By Operator [GBY_28] (rows=121728 width=19)
                                                                         Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                         Merge Join Operator [MERGEJOIN_1139] (rows=14628613 width=11)
-                                                                          Conds:RS_24._col1=RS_1328._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                        <-Map 24 [SIMPLE_EDGE] vectorized
-                                                                          SHUFFLE [RS_1328]
+                                                                          Conds:RS_24._col1=RS_1342._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                        <-Map 59 [SIMPLE_EDGE] vectorized
+                                                                          SHUFFLE [RS_1342]
                                                                             PartitionCols:_col0
-                                                                            Select Operator [SEL_1319] (rows=458612 width=15)
+                                                                            Select Operator [SEL_1333] (rows=458612 width=15)
                                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                                              Filter Operator [FIL_1310] (rows=458612 width=15)
+                                                                              Filter Operator [FIL_1324] (rows=458612 width=15)
                                                                                 predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                                                  Please refer to the previous TableScan [TS_6]
-                                                                        <-Reducer 47 [SIMPLE_EDGE]
+                                                                        <-Reducer 24 [SIMPLE_EDGE]
                                                                           SHUFFLE [RS_24]
                                                                             PartitionCols:_col1
                                                                             Merge Join Operator [MERGEJOIN_1138] (rows=14736682 width=4)
-                                                                              Conds:RS_1408._col0=RS_1386._col0(Inner),Output:["_col1"]
-                                                                            <-Map 48 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1386]
+                                                                              Conds:RS_1402._col0=RS_1299._col0(Inner),Output:["_col1"]
+                                                                            <-Map 10 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1299]
                                                                                 PartitionCols:_col0
-                                                                                Select Operator [SEL_1385] (rows=1957 width=4)
+                                                                                Select Operator [SEL_1292] (rows=1957 width=4)
                                                                                   Output:["_col0"]
-                                                                                  Filter Operator [FIL_1384] (rows=1957 width=8)
+                                                                                  Filter Operator [FIL_1290] (rows=1957 width=8)
                                                                                     predicate:(d_year BETWEEN 1999 AND 2001 and d_date_sk is not null)
-                                                                                    TableScan [TS_15] (rows=73049 width=8)
-                                                                                      default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                                            <-Map 46 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1408]
+                                                                                     Please refer to the previous TableScan [TS_3]
+                                                                            <-Map 60 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1402]
                                                                                 PartitionCols:_col0
-                                                                                Select Operator [SEL_1407] (rows=550076554 width=7)
+                                                                                Select Operator [SEL_1400] (rows=550076554 width=7)
                                                                                   Output:["_col0","_col1"]
-                                                                                  Filter Operator [FIL_1406] (rows=550076554 width=7)
-                                                                                    predicate:(ss_sold_date_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_22_d1_d_date_sk_min) AND DynamicValue(RS_22_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_22_d1_d_date_sk_bloom_filter)))
+                                                                                  Filter Operator [FIL_1398] (rows=550076554 width=7)
+                                                                                    predicate:(ss_sold_date_sk is not null and ss_item_sk is not null)
                                                                                     TableScan [TS_12] (rows=575995635 width=7)
-                                                                                      default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk"]
-                                                                                    <-Reducer 49 [BROADCAST_EDGE] vectorized
-                                                                                      BROADCAST [RS_1405]
-                                                                                        Group By Operator [GBY_1404] (rows=1 width=12)
-                                                                                          Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                        <-Map 48 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1400]
-                                                                                            Group By Operator [GBY_1396] (rows=1 width=12)
-                                                                                              Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                              Select Operator [SEL_1387] (rows=1957 width=4)
-                                                                                                Output:["_col0"]
-                                                                                                 Please refer to the previous Select Operator [SEL_1385]
-                                                            <-Reducer 40 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1428]
+                                                                                      default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_quantity","ss_list_price"]
+                                                            <-Reducer 41 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1425]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1427] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1424] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1426] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1423] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 38 [SIMPLE_EDGE]
+                                                                  <-Reducer 39 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_195]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                       Group By Operator [GBY_48] (rows=121728 width=19)
                                                                         Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                         Merge Join Operator [MERGEJOIN_1141] (rows=7620440 width=11)
-                                                                          Conds:RS_44._col1=RS_1329._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                        <-Map 24 [SIMPLE_EDGE] vectorized
-                                                                          SHUFFLE [RS_1329]
+                                                                          Conds:RS_44._col1=RS_1343._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                        <-Map 59 [SIMPLE_EDGE] vectorized
+                                                                          SHUFFLE [RS_1343]
                                                                             PartitionCols:_col0
-                                                                            Select Operator [SEL_1320] (rows=458612 width=15)
+                                                                            Select Operator [SEL_1334] (rows=458612 width=15)
                                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                                              Filter Operator [FIL_1311] (rows=458612 width=15)
+                                                                              Filter Operator [FIL_1325] (rows=458612 width=15)
                                                                                 predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                                                  Please refer to the previous TableScan [TS_6]
-                                                                        <-Reducer 50 [SIMPLE_EDGE]
+                                                                        <-Reducer 38 [SIMPLE_EDGE]
                                                                           SHUFFLE [RS_44]
                                                                             PartitionCols:_col1
                                                                             Merge Join Operator [MERGEJOIN_1140] (rows=7676736 width=4)
-                                                                              Conds:RS_1422._col0=RS_1388._col0(Inner),Output:["_col1"]
-                                                                            <-Map 48 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1388]
+                                                                              Conds:RS_1419._col0=RS_1300._col0(Inner),Output:["_col1"]
+                                                                            <-Map 10 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1300]
                                                                                 PartitionCols:_col0
-                                                                                 Please refer to the previous Select Operator [SEL_1385]
-                                                                            <-Map 64 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1422]
+                                                                                 Please refer to the previous Select Operator [SEL_1292]
+                                                                            <-Map 61 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1419]
                                                                                 PartitionCols:_col0
-                                                                                Select Operator [SEL_1421] (rows=286549727 width=7)
+                                                                                Select Operator [SEL_1418] (rows=286549727 width=7)
                                                                                   Output:["_col0","_col1"]
-                                                                                  Filter Operator [FIL_1420] (rows=286549727 width=7)
+                                                                                  Filter Operator [FIL_1417] (rows=286549727 width=7)
                                                                                     predicate:(cs_sold_date_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_42_d2_d_date_sk_min) AND DynamicValue(RS_42_d2_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_42_d2_d_date_sk_bloom_filter)))
                                                                                     TableScan [TS_32] (rows=287989836 width=7)
                                                                                       default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_item_sk"]
-                                                                                    <-Reducer 51 [BROADCAST_EDGE] vectorized
-                                                                                      BROADCAST [RS_1419]
-                                                                                        Group By Operator [GBY_1418] (rows=1 width=12)
+                                                                                    <-Reducer 43 [BROADCAST_EDGE] vectorized
+                                                                                      BROADCAST [RS_1416]
+                                                                                        Group By Operator [GBY_1415] (rows=1 width=12)
                                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                        <-Map 48 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1401]
-                                                                                            Group By Operator [GBY_1397] (rows=1 width=12)
+                                                                                        <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1315]
+                                                                                            Group By Operator [GBY_1310] (rows=1 width=12)
                                                                                               Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                              Select Operator [SEL_1389] (rows=1957 width=4)
+                                                                                              Select Operator [SEL_1301] (rows=1957 width=4)
                                                                                                 Output:["_col0"]
-                                                                                                 Please refer to the previous Select Operator [SEL_1385]
-                                                            <-Reducer 44 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1442]
+                                                                                                 Please refer to the previous Select Operator [SEL_1292]
+                                                            <-Reducer 47 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1439]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1441] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1438] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1440] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1437] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 42 [SIMPLE_EDGE]
+                                                                  <-Reducer 45 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_216]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                       Group By Operator [GBY_69] (rows=121728 width=19)
                                                                         Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col5, _col6
                                                                         Merge Join Operator [MERGEJOIN_1143] (rows=3828623 width=11)
-                                                                          Conds:RS_65._col1=RS_1330._col0(Inner),Output:["_col4","_col5","_col6"]
-                                                                        <-Map 24 [SIMPLE_EDGE] vectorized
-                                                                          SHUFFLE [RS_1330]
+                                                                          Conds:RS_65._col1=RS_1344._col0(Inner),Output:["_col4","_col5","_col6"]
+                                                                        <-Map 59 [SIMPLE_EDGE] vectorized
+                                                                          SHUFFLE [RS_1344]
                                                                             PartitionCols:_col0
-                                                                            Select Operator [SEL_1321] (rows=458612 width=15)
+                                                                            Select Operator [SEL_1335] (rows=458612 width=15)
                                                                               Output:["_col0","_col1","_col2","_col3"]
-                                                                              Filter Operator [FIL_1312] (rows=458612 width=15)
+                                                                              Filter Operator [FIL_1326] (rows=458612 width=15)
                                                                                 predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                                                  Please refer to the previous TableScan [TS_6]
-                                                                        <-Reducer 52 [SIMPLE_EDGE]
+                                                                        <-Reducer 44 [SIMPLE_EDGE]
                                                                           SHUFFLE [RS_65]
                                                                             PartitionCols:_col1
                                                                             Merge Join Operator [MERGEJOIN_1142] (rows=3856907 width=4)
-                                                                              Conds:RS_1436._col0=RS_1390._col0(Inner),Output:["_col1"]
-                                                                            <-Map 48 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1390]
+                                                                              Conds:RS_1433._col0=RS_1302._col0(Inner),Output:["_col1"]
+                                                                            <-Map 10 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1302]
                                                                                 PartitionCols:_col0
-                                                                                 Please refer to the previous Select Operator [SEL_1385]
-                                                                            <-Map 65 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1436]
+                                                                                 Please refer to the previous Select Operator [SEL_1292]
+                                                                            <-Map 62 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1433]
                                                                                 PartitionCols:_col0
-                                                                                Select Operator [SEL_1435] (rows=143966864 width=7)
+                                                                                Select Operator [SEL_1432] (rows=143966864 width=7)
                                                                                   Output:["_col0","_col1"]
-                                                                                  Filter Operator [FIL_1434] (rows=143966864 width=7)
+                                                                                  Filter Operator [FIL_1431] (rows=143966864 width=7)
                                                                                     predicate:(ws_sold_date_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_63_d3_d_date_sk_min) AND DynamicValue(RS_63_d3_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_63_d3_d_date_sk_bloom_filter)))
                                                                                     TableScan [TS_53] (rows=144002668 width=7)
                                                                                       default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk"]
-                                                                                    <-Reducer 53 [BROADCAST_EDGE] vectorized
-                                                                                      BROADCAST [RS_1433]
-                                                                                        Group By Operator [GBY_1432] (rows=1 width=12)
+                                                                                    <-Reducer 49 [BROADCAST_EDGE] vectorized
+                                                                                      BROADCAST [RS_1430]
+                                                                                        Group By Operator [GBY_1429] (rows=1 width=12)
                                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                        <-Map 48 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                          SHUFFLE [RS_1402]
-                                                                                            Group By Operator [GBY_1398] (rows=1 width=12)
+                                                                                        <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                          SHUFFLE [RS_1316]
+                                                                                            Group By Operator [GBY_1311] (rows=1 width=12)
                                                                                               Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                              Select Operator [SEL_1391] (rows=1957 width=4)
+                                                                                              Select Operator [SEL_1303] (rows=1957 width=4)
                                                                                                 Output:["_col0"]
-                                                                                                 Please refer to the previous Select Operator [SEL_1385]
-                              <-Reducer 60 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1367]
-                                  Select Operator [SEL_1366] (rows=1 width=112)
+                                                                                                 Please refer to the previous Select Operator [SEL_1292]
+                              <-Reducer 55 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1381]
+                                  Select Operator [SEL_1380] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1365] (rows=1 width=120)
+                                    Filter Operator [FIL_1379] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1364] (rows=1 width=120)
+                                      Group By Operator [GBY_1378] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 59 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 58 [CONTAINS]
+                                      <-Union 54 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 53 [CONTAINS]
                                           Reduce Output Operator [RS_1246]
                                             Group By Operator [GBY_1245] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -585,32 +569,20 @@ Stage-0
                                                 Select Operator [SEL_1242] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1241] (rows=14736682 width=0)
-                                                    Conds:RS_1451._col0=RS_1394._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 48 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1394]
+                                                    Conds:RS_1404._col0=RS_1305._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 10 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1305]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1385]
-                                                  <-Map 66 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1451]
+                                                       Please refer to the previous Select Operator [SEL_1292]
+                                                  <-Map 60 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1404]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1449] (rows=550076554 width=114)
+                                                      Select Operator [SEL_1401] (rows=550076554 width=114)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1448] (rows=550076554 width=114)
-                                                          predicate:(ss_sold_date_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_109_date_dim_d_date_sk_min) AND DynamicValue(RS_109_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_109_date_dim_d_date_sk_bloom_filter)))
-                                                          TableScan [TS_102] (rows=575995635 width=114)
-                                                            default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_quantity","ss_list_price"]
-                                                          <-Reducer 57 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1447]
-                                                              Group By Operator [GBY_1446] (rows=1 width=12)
-                                                                Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 48 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                SHUFFLE [RS_1403]
-                                                                  Group By Operator [GBY_1399] (rows=1 width=12)
-                                                                    Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1393] (rows=1957 width=4)
-                                                                      Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1385]
-                                        <-Reducer 69 [CONTAINS]
+                                                        Filter Operator [FIL_1399] (rows=550076554 width=114)
+                                                          predicate:(ss_sold_date_sk is not null and ss_sold_date_sk is not null)
+                                                           Please refer to the previous TableScan [TS_12]
+                                        <-Reducer 65 [CONTAINS]
                                           Reduce Output Operator [RS_1264]
                                             Group By Operator [GBY_1263] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -619,37 +591,37 @@ Stage-0
                                                 Select Operator [SEL_1260] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1259] (rows=7676736 width=94)
-                                                    Conds:RS_1466._col0=RS_1457._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 71 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1457]
+                                                    Conds:RS_1456._col0=RS_1447._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 67 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1447]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1454] (rows=1957 width=4)
+                                                      Select Operator [SEL_1444] (rows=1957 width=4)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_1453] (rows=1957 width=8)
+                                                        Filter Operator [FIL_1443] (rows=1957 width=8)
                                                           predicate:(d_year BETWEEN 1998 AND 2000 and d_date_sk is not null)
                                                           TableScan [TS_115] (rows=73049 width=8)
                                                             default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                  <-Map 67 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1466]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1456]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1464] (rows=286549727 width=119)
+                                                      Select Operator [SEL_1454] (rows=286549727 width=119)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1463] (rows=286549727 width=119)
+                                                        Filter Operator [FIL_1453] (rows=286549727 width=119)
                                                           predicate:(cs_sold_date_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_119_date_dim_d_date_sk_min) AND DynamicValue(RS_119_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_119_date_dim_d_date_sk_bloom_filter)))
                                                           TableScan [TS_112] (rows=287989836 width=119)
                                                             default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_quantity","cs_list_price"]
-                                                          <-Reducer 72 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1462]
-                                                              Group By Operator [GBY_1461] (rows=1 width=12)
+                                                          <-Reducer 68 [BROADCAST_EDGE] vectorized
+                                                            BROADCAST [RS_1452]
+                                                              Group By Operator [GBY_1451] (rows=1 width=12)
                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 71 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_1460]
-                                                                  Group By Operator [GBY_1459] (rows=1 width=12)
+                                                              <-Map 67 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_1450]
+                                                                  Group By Operator [GBY_1449] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1456] (rows=1957 width=4)
+                                                                    Select Operator [SEL_1446] (rows=1957 width=4)
                                                                       Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1454]
-                                        <-Reducer 75 [CONTAINS]
+                                                                       Please refer to the previous Select Operator [SEL_1444]
+                                        <-Reducer 71 [CONTAINS]
                                           Reduce Output Operator [RS_1282]
                                             Group By Operator [GBY_1281] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -658,36 +630,36 @@ Stage-0
                                                 Select Operator [SEL_1278] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1277] (rows=3856907 width=114)
-                                                    Conds:RS_1481._col0=RS_1472._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 77 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1472]
+                                                    Conds:RS_1471._col0=RS_1462._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 73 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1462]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1469] (rows=1957 width=4)
+                                                      Select Operator [SEL_1459] (rows=1957 width=4)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_1468] (rows=1957 width=8)
+                                                        Filter Operator [FIL_1458] (rows=1957 width=8)
                                                           predicate:(d_year BETWEEN 1998 AND 2000 and d_date_sk is not null)
                                                           TableScan [TS_126] (rows=73049 width=8)
                                                             default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                  <-Map 73 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1481]
+                                                  <-Map 69 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1471]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_1479] (rows=143966864 width=119)
+                                                      Select Operator [SEL_1469] (rows=143966864 width=119)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1478] (rows=143966864 width=119)
+                                                        Filter Operator [FIL_1468] (rows=143966864 width=119)
                                                           predicate:(ws_sold_date_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_130_date_dim_d_date_sk_min) AND DynamicValue(RS_130_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_130_date_dim_d_date_sk_bloom_filter)))
                                                           TableScan [TS_123] (rows=144002668 width=119)
                                                             default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_quantity","ws_list_price"]
-                                                          <-Reducer 78 [BROADCAST_EDGE] vectorized
-                                                            BROADCAST [RS_1477]
-                                                              Group By Operator [GBY_1476] (rows=1 width=12)
+                                                          <-Reducer 74 [BROADCAST_EDGE] vectorized
+                                                            BROADCAST [RS_1467]
+                                                              Group By Operator [GBY_1466] (rows=1 width=12)
                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                              <-Map 77 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_1475]
-                                                                  Group By Operator [GBY_1474] (rows=1 width=12)
+                                                              <-Map 73 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_1465]
+                                                                  Group By Operator [GBY_1464] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                    Select Operator [SEL_1471] (rows=1957 width=4)
+                                                                    Select Operator [SEL_1461] (rows=1957 width=4)
                                                                       Output:["_col0"]
-                                                                       Please refer to the previous Select Operator [SEL_1469]
+                                                                       Please refer to the previous Select Operator [SEL_1459]
                   <-Reducer 22 [CONTAINS]
                     Reduce Output Operator [RS_1198]
                       PartitionCols:_col0, _col1, _col2, _col3, _col4
@@ -702,10 +674,10 @@ Stage-0
                               Merge Join Operator [MERGEJOIN_1192] (rows=121728 width=243)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                               <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1379]
-                                  Filter Operator [FIL_1378] (rows=121728 width=131)
+                                PARTITION_ONLY_SHUFFLE [RS_1393]
+                                  Filter Operator [FIL_1392] (rows=121728 width=131)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1377] (rows=121728 width=131)
+                                    Group By Operator [GBY_1391] (rows=121728 width=131)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 20 [SIMPLE_EDGE]
                                       SHUFFLE [RS_391]
@@ -720,112 +692,112 @@ Stage-0
                                               SHUFFLE [RS_385]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1161] (rows=3942084 width=130)
-                                                  Conds:RS_380._col1=RS_1333._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                <-Map 24 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1333]
+                                                  Conds:RS_380._col1=RS_1347._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                <-Map 59 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1347]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_1324] (rows=462000 width=15)
+                                                    Select Operator [SEL_1338] (rows=462000 width=15)
                                                       Output:["_col0","_col1","_col2","_col3"]
-                                                      Filter Operator [FIL_1315] (rows=462000 width=15)
+                                                      Filter Operator [FIL_1329] (rows=462000 width=15)
                                                         predicate:i_item_sk is not null
                                                          Please refer to the previous TableScan [TS_6]
                                                 <-Reducer 18 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_380]
                                                     PartitionCols:_col1
                                                     Merge Join Operator [MERGEJOIN_1160] (rows=3942084 width=118)
-                                                      Conds:RS_1372._col0=RS_1295._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                      Conds:RS_1386._col0=RS_1297._col0(Inner),Output:["_col1","_col2","_col3"]
                                                     <-Map 10 [SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_1295]
+                                                      SHUFFLE [RS_1297]
                                                         PartitionCols:_col0
-                                                         Please refer to the previous Select Operator [SEL_1290]
-                                                    <-Map 80 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1372]
+                                                         Please refer to the previous Select Operator [SEL_1291]
+                                                    <-Map 76 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_1386]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1371] (rows=143966864 width=123)
+                                                        Select Operator [SEL_1385] (rows=143966864 width=123)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1370] (rows=143966864 width=123)
+                                                          Filter Operator [FIL_1384] (rows=143966864 width=123)
                                                             predicate:(ws_sold_date_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_378_date_dim_d_date_sk_min) AND DynamicValue(RS_378_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_378_date_dim_d_date_sk_bloom_filter)))
                                                             TableScan [TS_293] (rows=144002668 width=123)
                                                               default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_quantity","ws_list_price"]
                                                             <-Reducer 23 [BROADCAST_EDGE] vectorized
-                                                              BROADCAST [RS_1369]
-                                                                Group By Operator [GBY_1368] (rows=1 width=12)
+                                                              BROADCAST [RS_1383]
+                                                                Group By Operator [GBY_1382] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                 <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_1302]
-                                                                    Group By Operator [GBY_1299] (rows=1 width=12)
+                                                                  SHUFFLE [RS_1314]
+                                                                    Group By Operator [GBY_1309] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                      Select Operator [SEL_1296] (rows=50 width=4)
+                                                                      Select Operator [SEL_1298] (rows=50 width=4)
                                                                         Output:["_col0"]
-                                                                         Please refer to the previous Select Operator [SEL_1290]
+                                                                         Please refer to the previous Select Operator [SEL_1291]
                                             <-Reducer 37 [SIMPLE_EDGE]
                                               SHUFFLE [RS_386]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_384] (rows=362 width=4)
                                                   Output:["_col0"],keys:_col0
                                                   Merge Join Operator [MERGEJOIN_1168] (rows=724 width=4)
-                                                    Conds:RS_1334._col1, _col2, _col3=RS_1376._col0, _col1, _col2(Inner),Output:["_col0"]
-                                                  <-Map 24 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1334]
+                                                    Conds:RS_1348._col1, _col2, _col3=RS_1390._col0, _col1, _col2(Inner),Output:["_col0"]
+                                                  <-Map 59 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1348]
                                                       PartitionCols:_col1, _col2, _col3
-                                                      Select Operator [SEL_1325] (rows=458612 width=15)
+                                                      Select Operator [SEL_1339] (rows=458612 width=15)
                                                         Output:["_col0","_col1","_col2","_col3"]
-                                                        Filter Operator [FIL_1316] (rows=458612 width=15)
+                                                        Filter Operator [FIL_1330] (rows=458612 width=15)
                                                           predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                            Please refer to the previous TableScan [TS_6]
                                                   <-Reducer 36 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1376]
+                                                    SHUFFLE [RS_1390]
                                                       PartitionCols:_col0, _col1, _col2
-                                                      Select Operator [SEL_1375] (rows=1 width=12)
+                                                      Select Operator [SEL_1389] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1374] (rows=1 width=20)
+                                                        Filter Operator [FIL_1388] (rows=1 width=20)
                                                           predicate:(_col3 = 3L)
-                                                          Group By Operator [GBY_1373] (rows=121728 width=19)
+                                                          Group By Operator [GBY_1387] (rows=121728 width=19)
                                                             Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                                                           <-Union 35 [SIMPLE_EDGE]
                                                             <-Reducer 34 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1417]
+                                                              Reduce Output Operator [RS_1414]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1416] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1413] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1415] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1412] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 26 [SIMPLE_EDGE]
+                                                                  <-Reducer 25 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_322]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_28]
-                                                            <-Reducer 41 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1431]
+                                                            <-Reducer 42 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1428]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1430] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1427] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1429] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1426] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 38 [SIMPLE_EDGE]
+                                                                  <-Reducer 39 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_342]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_48]
-                                                            <-Reducer 45 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1445]
+                                                            <-Reducer 48 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1442]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1444] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1441] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1443] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1440] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 42 [SIMPLE_EDGE]
+                                                                  <-Reducer 45 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_363]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_69]
-                              <-Reducer 63 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1383]
-                                  Select Operator [SEL_1382] (rows=1 width=112)
+                              <-Reducer 58 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1397]
+                                  Select Operator [SEL_1396] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1381] (rows=1 width=120)
+                                    Filter Operator [FIL_1395] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1380] (rows=1 width=120)
+                                      Group By Operator [GBY_1394] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 62 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 61 [CONTAINS]
+                                      <-Union 57 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 56 [CONTAINS]
                                           Reduce Output Operator [RS_1252]
                                             Group By Operator [GBY_1251] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -834,16 +806,16 @@ Stage-0
                                                 Select Operator [SEL_1248] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1247] (rows=14736682 width=0)
-                                                    Conds:RS_1452._col0=RS_1395._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 48 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1395]
+                                                    Conds:RS_1405._col0=RS_1306._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 10 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1306]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1385]
-                                                  <-Map 66 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1452]
+                                                       Please refer to the previous Select Operator [SEL_1292]
+                                                  <-Map 60 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1405]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1449]
-                                        <-Reducer 70 [CONTAINS]
+                                                       Please refer to the previous Select Operator [SEL_1401]
+                                        <-Reducer 66 [CONTAINS]
                                           Reduce Output Operator [RS_1270]
                                             Group By Operator [GBY_1269] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -852,16 +824,16 @@ Stage-0
                                                 Select Operator [SEL_1266] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1265] (rows=7676736 width=94)
-                                                    Conds:RS_1467._col0=RS_1458._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 71 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1458]
+                                                    Conds:RS_1457._col0=RS_1448._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 67 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1448]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1444]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1457]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1454]
-                                                  <-Map 67 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1467]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1464]
-                                        <-Reducer 76 [CONTAINS]
+                                        <-Reducer 72 [CONTAINS]
                                           Reduce Output Operator [RS_1288]
                                             Group By Operator [GBY_1287] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -870,15 +842,15 @@ Stage-0
                                                 Select Operator [SEL_1284] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1283] (rows=3856907 width=114)
-                                                    Conds:RS_1482._col0=RS_1473._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 77 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1473]
+                                                    Conds:RS_1472._col0=RS_1463._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 73 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1463]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1459]
+                                                  <-Map 69 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1472]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1469]
-                                                  <-Map 73 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1482]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1479]
                   <-Reducer 6 [CONTAINS]
                     Reduce Output Operator [RS_1184]
                       PartitionCols:_col0, _col1, _col2, _col3, _col4
@@ -893,10 +865,10 @@ Stage-0
                               Merge Join Operator [MERGEJOIN_1178] (rows=121728 width=243)
                                 Conds:(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                               <-Reducer 5 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1341]
-                                  Filter Operator [FIL_1340] (rows=121728 width=131)
+                                PARTITION_ONLY_SHUFFLE [RS_1355]
+                                  Filter Operator [FIL_1354] (rows=121728 width=131)
                                     predicate:_col3 is not null
-                                    Group By Operator [GBY_1339] (rows=121728 width=131)
+                                    Group By Operator [GBY_1353] (rows=121728 width=131)
                                       Output:["_col0","_col1","_col2","_col3","_col4"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0, KEY._col1, KEY._col2
                                     <-Reducer 4 [SIMPLE_EDGE]
                                       SHUFFLE [RS_98]
@@ -907,61 +879,61 @@ Stage-0
                                             Output:["_col0","_col1","_col2","_col3"]
                                             Merge Join Operator [MERGEJOIN_1172] (rows=15062131 width=11)
                                               Conds:RS_92._col1=RS_93._col0(Left Semi),Output:["_col2","_col3","_col6","_col7","_col8"]
-                                            <-Reducer 25 [SIMPLE_EDGE]
+                                            <-Reducer 29 [SIMPLE_EDGE]
                                               SHUFFLE [RS_93]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_91] (rows=362 width=4)
                                                   Output:["_col0"],keys:_col0
                                                   Merge Join Operator [MERGEJOIN_1144] (rows=724 width=4)
-                                                    Conds:RS_1327._col1, _col2, _col3=RS_1338._col0, _col1, _col2(Inner),Output:["_col0"]
-                                                  <-Map 24 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1327]
+                                                    Conds:RS_1341._col1, _col2, _col3=RS_1352._col0, _col1, _col2(Inner),Output:["_col0"]
+                                                  <-Map 59 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1341]
                                                       PartitionCols:_col1, _col2, _col3
-                                                      Select Operator [SEL_1318] (rows=458612 width=15)
+                                                      Select Operator [SEL_1332] (rows=458612 width=15)
                                                         Output:["_col0","_col1","_col2","_col3"]
-                                                        Filter Operator [FIL_1309] (rows=458612 width=15)
+                                                        Filter Operator [FIL_1323] (rows=458612 width=15)
                                                           predicate:(i_category_id is not null and i_brand_id is not null and i_class_id is not null and i_item_sk is not null)
                                                            Please refer to the previous TableScan [TS_6]
-                                                  <-Reducer 29 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1338]
+                                                  <-Reducer 28 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1352]
                                                       PartitionCols:_col0, _col1, _col2
-                                                      Select Operator [SEL_1337] (rows=1 width=12)
+                                                      Select Operator [SEL_1351] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"]
-                                                        Filter Operator [FIL_1336] (rows=1 width=20)
+                                                        Filter Operator [FIL_1350] (rows=1 width=20)
                                                           predicate:(_col3 = 3L)
-                                                          Group By Operator [GBY_1335] (rows=121728 width=19)
+                                                          Group By Operator [GBY_1349] (rows=121728 width=19)
                                                             Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                          <-Union 28 [SIMPLE_EDGE]
-                                                            <-Reducer 27 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1411]
+                                                          <-Union 27 [SIMPLE_EDGE]
+                                                            <-Reducer 26 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1408]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1410] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1407] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1409] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1406] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 26 [SIMPLE_EDGE]
+                                                                  <-Reducer 25 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_29]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_28]
-                                                            <-Reducer 39 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1425]
+                                                            <-Reducer 40 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1422]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1424] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1421] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1423] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1420] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 38 [SIMPLE_EDGE]
+                                                                  <-Reducer 39 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_49]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_48]
-                                                            <-Reducer 43 [CONTAINS] vectorized
-                                                              Reduce Output Operator [RS_1439]
+                                                            <-Reducer 46 [CONTAINS] vectorized
+                                                              Reduce Output Operator [RS_1436]
                                                                 PartitionCols:_col0, _col1, _col2
-                                                                Group By Operator [GBY_1438] (rows=121728 width=19)
+                                                                Group By Operator [GBY_1435] (rows=121728 width=19)
                                                                   Output:["_col0","_col1","_col2","_col3"],aggregations:["count(_col3)"],keys:_col0, _col1, _col2
-                                                                  Group By Operator [GBY_1437] (rows=121728 width=19)
+                                                                  Group By Operator [GBY_1434] (rows=121728 width=19)
                                                                     Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                                                  <-Reducer 42 [SIMPLE_EDGE]
+                                                                  <-Reducer 45 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_70]
                                                                       PartitionCols:_col0, _col1, _col2
                                                                        Please refer to the previous Group By Operator [GBY_69]
@@ -969,54 +941,54 @@ Stage-0
                                               SHUFFLE [RS_92]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_1137] (rows=15062131 width=15)
-                                                  Conds:RS_87._col1=RS_1326._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
-                                                <-Map 24 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1326]
+                                                  Conds:RS_87._col1=RS_1340._col0(Inner),Output:["_col1","_col2","_col3","_col6","_col7","_col8"]
+                                                <-Map 59 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1340]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_1317] (rows=462000 width=15)
+                                                    Select Operator [SEL_1331] (rows=462000 width=15)
                                                       Output:["_col0","_col1","_col2","_col3"]
-                                                      Filter Operator [FIL_1308] (rows=462000 width=15)
+                                                      Filter Operator [FIL_1322] (rows=462000 width=15)
                                                         predicate:i_item_sk is not null
                                                          Please refer to the previous TableScan [TS_6]
                                                 <-Reducer 2 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_87]
                                                     PartitionCols:_col1
                                                     Merge Join Operator [MERGEJOIN_1136] (rows=15062131 width=4)
-                                                      Conds:RS_1307._col0=RS_1291._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                      Conds:RS_1321._col0=RS_1293._col0(Inner),Output:["_col1","_col2","_col3"]
                                                     <-Map 10 [SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_1291]
+                                                      SHUFFLE [RS_1293]
                                                         PartitionCols:_col0
-                                                         Please refer to the previous Select Operator [SEL_1290]
+                                                         Please refer to the previous Select Operator [SEL_1291]
                                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_1307]
+                                                      SHUFFLE [RS_1321]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_1306] (rows=550076554 width=118)
+                                                        Select Operator [SEL_1320] (rows=550076554 width=118)
                                                           Output:["_col0","_col1","_col2","_col3"]
-                                                          Filter Operator [FIL_1305] (rows=550076554 width=118)
+                                                          Filter Operator [FIL_1319] (rows=550076554 width=118)
                                                             predicate:(ss_sold_date_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_85_date_dim_d_date_sk_min) AND DynamicValue(RS_85_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_85_date_dim_d_date_sk_bloom_filter)))
                                                             TableScan [TS_0] (rows=575995635 width=118)
                                                               default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_quantity","ss_list_price"]
                                                             <-Reducer 11 [BROADCAST_EDGE] vectorized
-                                                              BROADCAST [RS_1304]
-                                                                Group By Operator [GBY_1303] (rows=1 width=12)
+                                                              BROADCAST [RS_1318]
+                                                                Group By Operator [GBY_1317] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                 <-Map 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_1300]
-                                                                    Group By Operator [GBY_1297] (rows=1 width=12)
+                                                                  SHUFFLE [RS_1312]
+                                                                    Group By Operator [GBY_1307] (rows=1 width=12)
                                                                       Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                      Select Operator [SEL_1292] (rows=50 width=4)
+                                                                      Select Operator [SEL_1294] (rows=50 width=4)
                                                                         Output:["_col0"]
-                                                                         Please refer to the previous Select Operator [SEL_1290]
-                              <-Reducer 56 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_1345]
-                                  Select Operator [SEL_1344] (rows=1 width=112)
+                                                                         Please refer to the previous Select Operator [SEL_1291]
+                              <-Reducer 52 [CUSTOM_SIMPLE_EDGE] vectorized
+                                PARTITION_ONLY_SHUFFLE [RS_1359]
+                                  Select Operator [SEL_1358] (rows=1 width=112)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_1343] (rows=1 width=120)
+                                    Filter Operator [FIL_1357] (rows=1 width=120)
                                       predicate:CAST( (_col0 / _col1) AS decimal(22,6)) is not null
-                                      Group By Operator [GBY_1342] (rows=1 width=120)
+                                      Group By Operator [GBY_1356] (rows=1 width=120)
                                         Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                      <-Union 55 [CUSTOM_SIMPLE_EDGE]
-                                        <-Reducer 54 [CONTAINS]
+                                      <-Union 51 [CUSTOM_SIMPLE_EDGE]
+                                        <-Reducer 50 [CONTAINS]
                                           Reduce Output Operator [RS_1240]
                                             Group By Operator [GBY_1239] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -1025,16 +997,16 @@ Stage-0
                                                 Select Operator [SEL_1236] (rows=14736682 width=0)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1235] (rows=14736682 width=0)
-                                                    Conds:RS_1450._col0=RS_1392._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 48 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1392]
+                                                    Conds:RS_1403._col0=RS_1304._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 10 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1304]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1385]
-                                                  <-Map 66 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1450]
+                                                       Please refer to the previous Select Operator [SEL_1292]
+                                                  <-Map 60 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1403]
                                                       PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1449]
-                                        <-Reducer 68 [CONTAINS]
+                                                       Please refer to the previous Select Operator [SEL_1401]
+                                        <-Reducer 64 [CONTAINS]
                                           Reduce Output Operator [RS_1258]
                                             Group By Operator [GBY_1257] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -1043,16 +1015,16 @@ Stage-0
                                                 Select Operator [SEL_1254] (rows=7676736 width=94)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1253] (rows=7676736 width=94)
-                                                    Conds:RS_1465._col0=RS_1455._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 71 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1455]
+                                                    Conds:RS_1455._col0=RS_1445._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 67 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1445]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1444]
+                                                  <-Map 63 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1455]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1454]
-                                                  <-Map 67 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1465]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1464]
-                                        <-Reducer 74 [CONTAINS]
+                                        <-Reducer 70 [CONTAINS]
                                           Reduce Output Operator [RS_1276]
                                             Group By Operator [GBY_1275] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(_col0)","count(_col0)"]
@@ -1061,13 +1033,13 @@ Stage-0
                                                 Select Operator [SEL_1272] (rows=3856907 width=114)
                                                   Output:["_col0","_col1"]
                                                   Merge Join Operator [MERGEJOIN_1271] (rows=3856907 width=114)
-                                                    Conds:RS_1480._col0=RS_1470._col0(Inner),Output:["_col1","_col2"]
-                                                  <-Map 77 [SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_1470]
+                                                    Conds:RS_1470._col0=RS_1460._col0(Inner),Output:["_col1","_col2"]
+                                                  <-Map 73 [SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_1460]
+                                                      PartitionCols:_col0
+                                                       Please refer to the previous Select Operator [SEL_1459]
+                                                  <-Map 69 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_1470]
                                                       PartitionCols:_col0
                                                        Please refer to the previous Select Operator [SEL_1469]
-                                                  <-Map 73 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_1480]
-                                                      PartitionCols:_col0
-                                                       Please refer to the previous Select Operator [SEL_1479]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query18.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query18.q.out
@@ -81,16 +81,16 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 9 <- Reducer 14 (BROADCAST_EDGE)
-Reducer 10 <- Map 13 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 15 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 16 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Map 11 <- Reducer 14 (BROADCAST_EDGE)
+Reducer 10 <- Map 15 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 12 <- Map 11 (SIMPLE_EDGE), Map 13 (SIMPLE_EDGE)
 Reducer 14 <- Map 13 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 Reducer 3 <- Map 8 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Reducer 12 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+Reducer 9 <- Map 8 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -117,14 +117,14 @@ Stage-0
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18"],aggregations:["sum(_col15)","count(_col15)","sum(_col16)","count(_col16)","sum(_col17)","count(_col17)","sum(_col18)","count(_col18)","sum(_col19)","count(_col19)","sum(_col3)","count(_col3)","sum(_col22)","count(_col22)"],keys:_col5, _col6, _col7, _col10, 0L
                         Merge Join Operator [MERGEJOIN_143] (rows=15983636 width=1116)
                           Conds:RS_37._col0=RS_38._col3(Inner),Output:["_col3","_col5","_col6","_col7","_col10","_col15","_col16","_col17","_col18","_col19","_col22"]
-                        <-Reducer 12 [SIMPLE_EDGE]
+                        <-Reducer 10 [SIMPLE_EDGE]
                           SHUFFLE [RS_38]
                             PartitionCols:_col3
                             Select Operator [SEL_30] (rows=15983636 width=735)
                               Output:["_col1","_col3","_col6","_col7","_col8","_col9","_col10","_col13"]
                               Merge Join Operator [MERGEJOIN_142] (rows=15983636 width=735)
                                 Conds:RS_27._col3=RS_169._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col8","_col11","_col13"]
-                              <-Map 16 [SIMPLE_EDGE] vectorized
+                              <-Map 15 [SIMPLE_EDGE] vectorized
                                 SHUFFLE [RS_169]
                                   PartitionCols:_col0
                                   Select Operator [SEL_168] (rows=462000 width=104)
@@ -133,68 +133,67 @@ Stage-0
                                       predicate:i_item_sk is not null
                                       TableScan [TS_18] (rows=462000 width=104)
                                         default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                              <-Reducer 11 [SIMPLE_EDGE]
+                              <-Reducer 9 [SIMPLE_EDGE]
                                 SHUFFLE [RS_27]
                                   PartitionCols:_col3
                                   Merge Join Operator [MERGEJOIN_141] (rows=15983636 width=639)
-                                    Conds:RS_24._col2=RS_166._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
-                                  <-Map 15 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_166]
+                                    Conds:RS_24._col2=RS_155._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
+                                  <-Map 8 [SIMPLE_EDGE] vectorized
+                                    SHUFFLE [RS_155]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_165] (rows=103434 width=116)
+                                      Select Operator [SEL_153] (rows=103434 width=116)
                                         Output:["_col0","_col1"]
-                                        Filter Operator [FIL_164] (rows=103434 width=187)
+                                        Filter Operator [FIL_151] (rows=103434 width=187)
                                           predicate:((cd_education_status = 'College') and (cd_gender = 'M') and cd_demo_sk is not null)
-                                          TableScan [TS_15] (rows=1861800 width=187)
-                                            default@customer_demographics,cd1,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_gender","cd_education_status","cd_dep_count"]
-                                  <-Reducer 10 [SIMPLE_EDGE]
+                                          TableScan [TS_6] (rows=1861800 width=4)
+                                            default@customer_demographics,cd2,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_gender","cd_education_status","cd_dep_count"]
+                                  <-Reducer 12 [SIMPLE_EDGE]
                                     SHUFFLE [RS_24]
                                       PartitionCols:_col2
                                       Merge Join Operator [MERGEJOIN_140] (rows=100578970 width=565)
-                                        Conds:RS_163._col0=RS_155._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                                        Conds:RS_166._col0=RS_158._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                       <-Map 13 [SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_155]
+                                        PARTITION_ONLY_SHUFFLE [RS_158]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_154] (rows=652 width=4)
+                                          Select Operator [SEL_157] (rows=652 width=4)
                                             Output:["_col0"]
-                                            Filter Operator [FIL_153] (rows=652 width=8)
+                                            Filter Operator [FIL_156] (rows=652 width=8)
                                               predicate:((d_year = 2001) and d_date_sk is not null)
                                               TableScan [TS_12] (rows=73049 width=8)
                                                 default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                      <-Map 9 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_163]
+                                      <-Map 11 [SIMPLE_EDGE] vectorized
+                                        SHUFFLE [RS_166]
                                           PartitionCols:_col0
-                                          Select Operator [SEL_162] (rows=283692098 width=573)
+                                          Select Operator [SEL_165] (rows=283692098 width=573)
                                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                            Filter Operator [FIL_161] (rows=283692098 width=466)
+                                            Filter Operator [FIL_164] (rows=283692098 width=466)
                                               predicate:(cs_sold_date_sk is not null and cs_bill_cdemo_sk is not null and cs_bill_customer_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_22_date_dim_d_date_sk_min) AND DynamicValue(RS_22_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_22_date_dim_d_date_sk_bloom_filter)))
                                               TableScan [TS_9] (rows=287989836 width=466)
                                                 default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_bill_cdemo_sk","cs_item_sk","cs_quantity","cs_list_price","cs_sales_price","cs_coupon_amt","cs_net_profit"]
                                               <-Reducer 14 [BROADCAST_EDGE] vectorized
-                                                BROADCAST [RS_160]
-                                                  Group By Operator [GBY_159] (rows=1 width=12)
+                                                BROADCAST [RS_163]
+                                                  Group By Operator [GBY_162] (rows=1 width=12)
                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                   <-Map 13 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_158]
-                                                      Group By Operator [GBY_157] (rows=1 width=12)
+                                                    PARTITION_ONLY_SHUFFLE [RS_161]
+                                                      Group By Operator [GBY_160] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                        Select Operator [SEL_156] (rows=652 width=4)
+                                                        Select Operator [SEL_159] (rows=652 width=4)
                                                           Output:["_col0"]
-                                                           Please refer to the previous Select Operator [SEL_154]
+                                                           Please refer to the previous Select Operator [SEL_157]
                         <-Reducer 3 [SIMPLE_EDGE]
                           SHUFFLE [RS_37]
                             PartitionCols:_col0
                             Merge Join Operator [MERGEJOIN_139] (rows=4959744 width=368)
-                              Conds:RS_34._col1=RS_152._col0(Inner),Output:["_col0","_col3","_col5","_col6","_col7"]
+                              Conds:RS_34._col1=RS_154._col0(Inner),Output:["_col0","_col3","_col5","_col6","_col7"]
                             <-Map 8 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_152]
+                              SHUFFLE [RS_154]
                                 PartitionCols:_col0
-                                Select Operator [SEL_151] (rows=1861800 width=4)
+                                Select Operator [SEL_152] (rows=1861800 width=4)
                                   Output:["_col0"]
                                   Filter Operator [FIL_150] (rows=1861800 width=4)
                                     predicate:cd_demo_sk is not null
-                                    TableScan [TS_6] (rows=1861800 width=4)
-                                      default@customer_demographics,cd2,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk"]
+                                     Please refer to the previous TableScan [TS_6]
                             <-Reducer 2 [SIMPLE_EDGE]
                               SHUFFLE [RS_34]
                                 PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/query2.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query2.q.out
@@ -131,10 +131,10 @@ Map 1 <- Union 2 (CONTAINS)
 Map 9 <- Union 2 (CONTAINS)
 Reducer 3 <- Map 10 (SIMPLE_EDGE), Union 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 5 <- Map 10 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 8 <- Map 10 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -154,20 +154,20 @@ Stage-0
                 SHUFFLE [RS_53]
                   PartitionCols:(_col0 - 53)
                   Merge Join Operator [MERGEJOIN_143] (rows=652 width=788)
-                    Conds:RS_164._col0=RS_170._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                  <-Map 11 [SIMPLE_EDGE] vectorized
+                    Conds:RS_170._col0=RS_167._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                  <-Map 10 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_167]
+                      PartitionCols:_col0
+                      Select Operator [SEL_164] (rows=652 width=4)
+                        Output:["_col0"]
+                        Filter Operator [FIL_161] (rows=652 width=8)
+                          predicate:((d_year = 2002) and d_week_seq is not null)
+                          TableScan [TS_8] (rows=73049 width=99)
+                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name","d_year"]
+                  <-Reducer 4 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_170]
                       PartitionCols:_col0
-                      Select Operator [SEL_168] (rows=652 width=4)
-                        Output:["_col0"]
-                        Filter Operator [FIL_166] (rows=652 width=8)
-                          predicate:((d_year = 2002) and d_week_seq is not null)
-                          TableScan [TS_20] (rows=73049 width=8)
-                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_week_seq","d_year"]
-                  <-Reducer 4 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_164]
-                      PartitionCols:_col0
-                      Group By Operator [GBY_163] (rows=13152 width=788)
+                      Group By Operator [GBY_169] (rows=13152 width=788)
                         Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)","sum(VALUE._col5)","sum(VALUE._col6)"],keys:KEY._col0
                       <-Reducer 3 [SIMPLE_EDGE]
                         SHUFFLE [RS_17]
@@ -177,16 +177,15 @@ Stage-0
                             Select Operator [SEL_14] (rows=430516591 width=143)
                               Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
                               Merge Join Operator [MERGEJOIN_142] (rows=430516591 width=143)
-                                Conds:Union 2._col0=RS_162._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
+                                Conds:Union 2._col0=RS_166._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
                               <-Map 10 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_162]
+                                SHUFFLE [RS_166]
                                   PartitionCols:_col0
-                                  Select Operator [SEL_161] (rows=73049 width=36)
+                                  Select Operator [SEL_163] (rows=73049 width=36)
                                     Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                     Filter Operator [FIL_160] (rows=73049 width=99)
                                       predicate:(d_date_sk is not null and d_week_seq is not null)
-                                      TableScan [TS_8] (rows=73049 width=99)
-                                        default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name"]
+                                       Please refer to the previous TableScan [TS_8]
                               <-Union 2 [SIMPLE_EDGE]
                                 <-Map 1 [CONTAINS] vectorized
                                   Reduce Output Operator [RS_159]
@@ -210,17 +209,17 @@ Stage-0
                 SHUFFLE [RS_54]
                   PartitionCols:_col0
                   Merge Join Operator [MERGEJOIN_145] (rows=652 width=788)
-                    Conds:RS_165._col0=RS_171._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                  <-Map 11 [SIMPLE_EDGE] vectorized
+                    Conds:RS_171._col0=RS_168._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                  <-Map 10 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_168]
+                      PartitionCols:_col0
+                      Select Operator [SEL_165] (rows=652 width=4)
+                        Output:["_col0"]
+                        Filter Operator [FIL_162] (rows=652 width=8)
+                          predicate:((d_year = 2001) and d_week_seq is not null)
+                           Please refer to the previous TableScan [TS_8]
+                  <-Reducer 4 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_171]
                       PartitionCols:_col0
-                      Select Operator [SEL_169] (rows=652 width=4)
-                        Output:["_col0"]
-                        Filter Operator [FIL_167] (rows=652 width=8)
-                          predicate:((d_year = 2001) and d_week_seq is not null)
-                           Please refer to the previous TableScan [TS_20]
-                  <-Reducer 4 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_165]
-                      PartitionCols:_col0
-                       Please refer to the previous Group By Operator [GBY_163]
+                       Please refer to the previous Group By Operator [GBY_169]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query23.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query23.q.out
@@ -1,5 +1,5 @@
-Warning: Shuffle Join MERGEJOIN[454][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 26' is a cross product
-Warning: Shuffle Join MERGEJOIN[456][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 31' is a cross product
+Warning: Shuffle Join MERGEJOIN[454][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 25' is a cross product
+Warning: Shuffle Join MERGEJOIN[456][tables = [$hdt$_3, $hdt$_4]] in Stage 'Reducer 26' is a cross product
 PREHOOK: query: explain
 with frequent_ss_items as 
  (select substr(i_item_desc,1,30) itemdesc,i_item_sk item_sk,d_date solddate,count(*) cnt
@@ -119,39 +119,39 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 1 <- Reducer 9 (BROADCAST_EDGE)
-Map 15 <- Reducer 21 (BROADCAST_EDGE)
-Map 23 <- Reducer 7 (BROADCAST_EDGE)
-Map 34 <- Reducer 37 (BROADCAST_EDGE)
-Map 38 <- Reducer 14 (BROADCAST_EDGE)
-Map 39 <- Reducer 13 (BROADCAST_EDGE)
-Reducer 10 <- Map 38 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Reducer 11 (CUSTOM_SIMPLE_EDGE)
-Reducer 14 <- Map 8 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Map 15 (SIMPLE_EDGE), Map 20 (SIMPLE_EDGE)
-Reducer 17 <- Map 22 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
-Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
-Reducer 19 <- Reducer 18 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 21 <- Map 20 (CUSTOM_SIMPLE_EDGE)
-Reducer 24 <- Map 23 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 25 <- Reducer 24 (SIMPLE_EDGE)
-Reducer 26 <- Reducer 25 (CUSTOM_SIMPLE_EDGE), Reducer 30 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 27 (SIMPLE_EDGE), Reducer 35 (SIMPLE_EDGE)
-Reducer 29 <- Reducer 28 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Reducer 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 31 <- Reducer 30 (CUSTOM_SIMPLE_EDGE), Reducer 33 (CUSTOM_SIMPLE_EDGE)
-Reducer 32 <- Map 27 (SIMPLE_EDGE), Map 39 (SIMPLE_EDGE)
-Reducer 33 <- Reducer 32 (SIMPLE_EDGE)
-Reducer 35 <- Map 34 (SIMPLE_EDGE), Map 36 (SIMPLE_EDGE)
-Reducer 37 <- Map 36 (CUSTOM_SIMPLE_EDGE)
-Reducer 4 <- Reducer 26 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
+Map 1 <- Reducer 18 (BROADCAST_EDGE)
+Map 29 <- Reducer 7 (BROADCAST_EDGE)
+Map 35 <- Reducer 27 (BROADCAST_EDGE)
+Map 36 <- Reducer 20 (BROADCAST_EDGE)
+Map 37 <- Reducer 15 (BROADCAST_EDGE)
+Map 8 <- Reducer 17 (BROADCAST_EDGE)
+Reducer 10 <- Map 28 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
+Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Reducer 12 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (SIMPLE_EDGE), Reducer 26 (SIMPLE_EDGE), Union 5 (CONTAINS)
+Reducer 15 <- Reducer 13 (CUSTOM_SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 19 <- Map 16 (SIMPLE_EDGE), Map 36 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 35 (SIMPLE_EDGE)
+Reducer 22 <- Map 32 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Reducer 22 (SIMPLE_EDGE)
+Reducer 24 <- Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 25 <- Reducer 24 (CUSTOM_SIMPLE_EDGE), Reducer 31 (CUSTOM_SIMPLE_EDGE)
+Reducer 26 <- Reducer 24 (CUSTOM_SIMPLE_EDGE), Reducer 34 (CUSTOM_SIMPLE_EDGE)
+Reducer 27 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 30 <- Map 29 (SIMPLE_EDGE), Map 32 (SIMPLE_EDGE)
+Reducer 31 <- Reducer 30 (SIMPLE_EDGE)
+Reducer 33 <- Map 32 (SIMPLE_EDGE), Map 37 (SIMPLE_EDGE)
+Reducer 34 <- Reducer 33 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 25 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (CUSTOM_SIMPLE_EDGE)
 Reducer 7 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 9 <- Map 16 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -162,7 +162,7 @@ Stage-0
         Group By Operator [GBY_539] (rows=1 width=112)
           Output:["_col0"],aggregations:["sum(VALUE._col0)"]
         <-Union 5 [CUSTOM_SIMPLE_EDGE]
-          <-Reducer 12 [CONTAINS]
+          <-Reducer 14 [CONTAINS]
             Reduce Output Operator [RS_467]
               Group By Operator [GBY_466] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(_col0)"]
@@ -170,94 +170,93 @@ Stage-0
                   Output:["_col0"]
                   Merge Join Operator [MERGEJOIN_463] (rows=3941102 width=114)
                     Conds:RS_178._col2=RS_179._col0(Left Semi),Output:["_col3","_col4"]
-                  <-Reducer 11 [SIMPLE_EDGE]
+                  <-Reducer 13 [SIMPLE_EDGE]
                     PARTITION_ONLY_SHUFFLE [RS_178]
                       PartitionCols:_col2
                       Merge Join Operator [MERGEJOIN_453] (rows=3941102 width=118)
-                        Conds:RS_173._col1=RS_505._col0(Inner),Output:["_col2","_col3","_col4"]
-                      <-Reducer 19 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_505]
+                        Conds:RS_173._col1=RS_511._col0(Inner),Output:["_col2","_col3","_col4"]
+                      <-Reducer 12 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_511]
                           PartitionCols:_col0
-                          Group By Operator [GBY_503] (rows=2235 width=4)
+                          Group By Operator [GBY_509] (rows=2235 width=4)
                             Output:["_col0"],keys:KEY._col0
-                          <-Reducer 18 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_502]
+                          <-Reducer 11 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_508]
                               PartitionCols:_col0
-                              Group By Operator [GBY_501] (rows=13410 width=4)
+                              Group By Operator [GBY_507] (rows=13410 width=4)
                                 Output:["_col0"],keys:_col1
-                                Select Operator [SEL_500] (rows=6548799 width=220)
+                                Select Operator [SEL_506] (rows=6548799 width=220)
                                   Output:["_col1"]
-                                  Filter Operator [FIL_499] (rows=6548799 width=220)
+                                  Filter Operator [FIL_505] (rows=6548799 width=220)
                                     predicate:(_col3 > 4L)
-                                    Select Operator [SEL_498] (rows=19646398 width=220)
+                                    Select Operator [SEL_504] (rows=19646398 width=220)
                                       Output:["_col1","_col3"]
-                                      Group By Operator [GBY_497] (rows=19646398 width=220)
+                                      Group By Operator [GBY_503] (rows=19646398 width=220)
                                         Output:["_col0","_col1","_col2","_col3"],aggregations:["count(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
-                                      <-Reducer 17 [SIMPLE_EDGE]
+                                      <-Reducer 10 [SIMPLE_EDGE]
                                         SHUFFLE [RS_23]
                                           PartitionCols:_col0, _col1, _col2
                                           Group By Operator [GBY_22] (rows=19646398 width=220)
                                             Output:["_col0","_col1","_col2","_col3"],aggregations:["count()"],keys:_col4, _col3, _col5
                                             Merge Join Operator [MERGEJOIN_442] (rows=19646398 width=212)
-                                              Conds:RS_18._col1=RS_496._col0(Inner),Output:["_col3","_col4","_col5"]
-                                            <-Map 22 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_496]
+                                              Conds:RS_18._col1=RS_502._col0(Inner),Output:["_col3","_col4","_col5"]
+                                            <-Map 28 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_502]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_495] (rows=462000 width=118)
+                                                Select Operator [SEL_501] (rows=462000 width=118)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_494] (rows=462000 width=188)
+                                                  Filter Operator [FIL_500] (rows=462000 width=188)
                                                     predicate:i_item_sk is not null
                                                     TableScan [TS_12] (rows=462000 width=188)
                                                       default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_desc"]
-                                            <-Reducer 16 [SIMPLE_EDGE]
+                                            <-Reducer 9 [SIMPLE_EDGE]
                                               SHUFFLE [RS_18]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_441] (rows=19646398 width=98)
-                                                  Conds:RS_493._col0=RS_485._col0(Inner),Output:["_col1","_col3"]
-                                                <-Map 20 [SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_485]
+                                                  Conds:RS_499._col0=RS_474._col0(Inner),Output:["_col1","_col3"]
+                                                <-Map 16 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_474]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_484] (rows=2609 width=98)
+                                                    Select Operator [SEL_471] (rows=2609 width=98)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_483] (rows=2609 width=102)
+                                                      Filter Operator [FIL_468] (rows=2609 width=102)
                                                         predicate:((d_year) IN (1999, 2000, 2001, 2002) and d_date_sk is not null)
                                                         TableScan [TS_9] (rows=73049 width=102)
-                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_year"]
-                                                <-Map 15 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_493]
+                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_year","d_moy"]
+                                                <-Map 8 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_499]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_492] (rows=550076554 width=7)
+                                                    Select Operator [SEL_498] (rows=550076554 width=7)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_491] (rows=550076554 width=7)
+                                                      Filter Operator [FIL_497] (rows=550076554 width=7)
                                                         predicate:(ss_sold_date_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_16_date_dim_d_date_sk_min) AND DynamicValue(RS_16_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_16_date_dim_d_date_sk_bloom_filter)))
                                                         TableScan [TS_6] (rows=575995635 width=7)
                                                           default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk"]
-                                                        <-Reducer 21 [BROADCAST_EDGE] vectorized
-                                                          BROADCAST [RS_490]
-                                                            Group By Operator [GBY_489] (rows=1 width=12)
+                                                        <-Reducer 17 [BROADCAST_EDGE] vectorized
+                                                          BROADCAST [RS_496]
+                                                            Group By Operator [GBY_495] (rows=1 width=12)
                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                            <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                              PARTITION_ONLY_SHUFFLE [RS_488]
-                                                                Group By Operator [GBY_487] (rows=1 width=12)
+                                                            <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_486]
+                                                                Group By Operator [GBY_482] (rows=1 width=12)
                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                  Select Operator [SEL_486] (rows=2609 width=4)
+                                                                  Select Operator [SEL_475] (rows=2609 width=4)
                                                                     Output:["_col0"]
-                                                                     Please refer to the previous Select Operator [SEL_484]
-                      <-Reducer 10 [SIMPLE_EDGE]
+                                                                     Please refer to the previous Select Operator [SEL_471]
+                      <-Reducer 19 [SIMPLE_EDGE]
                         SHUFFLE [RS_173]
                           PartitionCols:_col1
                           Merge Join Operator [MERGEJOIN_446] (rows=3941102 width=122)
-                            Conds:RS_545._col0=RS_472._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                          <-Map 8 [SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_472]
+                            Conds:RS_545._col0=RS_478._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                          <-Map 16 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_478]
                               PartitionCols:_col0
-                              Select Operator [SEL_469] (rows=50 width=4)
+                              Select Operator [SEL_472] (rows=50 width=4)
                                 Output:["_col0"]
-                                Filter Operator [FIL_468] (rows=50 width=12)
+                                Filter Operator [FIL_469] (rows=50 width=12)
                                   predicate:((d_year = 1999) and (d_moy = 1) and d_date_sk is not null)
-                                  TableScan [TS_3] (rows=73049 width=12)
-                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                          <-Map 38 [SIMPLE_EDGE] vectorized
+                                   Please refer to the previous TableScan [TS_9]
+                          <-Map 36 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_545]
                               PartitionCols:_col0
                               Select Operator [SEL_544] (rows=143930993 width=127)
@@ -266,18 +265,18 @@ Stage-0
                                   predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_171_date_dim_d_date_sk_min) AND DynamicValue(RS_171_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_171_date_dim_d_date_sk_bloom_filter)))
                                   TableScan [TS_91] (rows=144002668 width=127)
                                     default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk","ws_quantity","ws_list_price"]
-                                  <-Reducer 14 [BROADCAST_EDGE] vectorized
+                                  <-Reducer 20 [BROADCAST_EDGE] vectorized
                                     BROADCAST [RS_542]
                                       Group By Operator [GBY_541] (rows=1 width=12)
                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                      <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_477]
-                                          Group By Operator [GBY_475] (rows=1 width=12)
+                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        SHUFFLE [RS_488]
+                                          Group By Operator [GBY_484] (rows=1 width=12)
                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                            Select Operator [SEL_473] (rows=50 width=4)
+                                            Select Operator [SEL_479] (rows=50 width=4)
                                               Output:["_col0"]
-                                               Please refer to the previous Select Operator [SEL_469]
-                  <-Reducer 31 [SIMPLE_EDGE]
+                                               Please refer to the previous Select Operator [SEL_472]
+                  <-Reducer 26 [SIMPLE_EDGE]
                     SHUFFLE [RS_179]
                       PartitionCols:_col0
                       Group By Operator [GBY_177] (rows=235937 width=4)
@@ -288,90 +287,89 @@ Stage-0
                             predicate:(_col1 > _col2)
                             Merge Join Operator [MERGEJOIN_456] (rows=1415625 width=228)
                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-                            <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_538]
-                                Select Operator [SEL_536] (rows=1 width=112)
+                            <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
+                              PARTITION_ONLY_SHUFFLE [RS_530]
+                                Select Operator [SEL_528] (rows=1 width=112)
                                   Output:["_col0"]
-                                  Filter Operator [FIL_535] (rows=1 width=112)
+                                  Filter Operator [FIL_527] (rows=1 width=112)
                                     predicate:_col0 is not null
-                                    Group By Operator [GBY_534] (rows=1 width=112)
+                                    Group By Operator [GBY_526] (rows=1 width=112)
                                       Output:["_col0"],aggregations:["max(VALUE._col0)"]
-                                    <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_533]
-                                        Group By Operator [GBY_532] (rows=1 width=112)
+                                    <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      PARTITION_ONLY_SHUFFLE [RS_525]
+                                        Group By Operator [GBY_524] (rows=1 width=112)
                                           Output:["_col0"],aggregations:["max(_col1)"]
-                                          Select Operator [SEL_531] (rows=11859 width=116)
+                                          Select Operator [SEL_523] (rows=11859 width=116)
                                             Output:["_col1"]
-                                            Group By Operator [GBY_530] (rows=11859 width=116)
+                                            Group By Operator [GBY_522] (rows=11859 width=116)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                            <-Reducer 28 [SIMPLE_EDGE]
+                                            <-Reducer 22 [SIMPLE_EDGE]
                                               SHUFFLE [RS_64]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_63] (rows=106731 width=116)
                                                   Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col4
                                                   Merge Join Operator [MERGEJOIN_445] (rows=18762463 width=116)
-                                                    Conds:RS_59._col1=RS_514._col0(Inner),Output:["_col2","_col4"]
-                                                  <-Map 27 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_514]
+                                                    Conds:RS_59._col1=RS_520._col0(Inner),Output:["_col2","_col4"]
+                                                  <-Map 32 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_520]
                                                       PartitionCols:_col0
-                                                      Select Operator [SEL_512] (rows=80000000 width=4)
+                                                      Select Operator [SEL_518] (rows=80000000 width=4)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_511] (rows=80000000 width=4)
+                                                        Filter Operator [FIL_517] (rows=80000000 width=4)
                                                           predicate:c_customer_sk is not null
                                                           TableScan [TS_35] (rows=80000000 width=4)
                                                             default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk"]
-                                                  <-Reducer 35 [SIMPLE_EDGE]
+                                                  <-Reducer 21 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_59]
                                                       PartitionCols:_col1
                                                       Merge Join Operator [MERGEJOIN_444] (rows=18762463 width=112)
-                                                        Conds:RS_529._col0=RS_521._col0(Inner),Output:["_col1","_col2"]
-                                                      <-Map 36 [SIMPLE_EDGE] vectorized
-                                                        PARTITION_ONLY_SHUFFLE [RS_521]
+                                                        Conds:RS_516._col0=RS_480._col0(Inner),Output:["_col1","_col2"]
+                                                      <-Map 16 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_480]
                                                           PartitionCols:_col0
-                                                          Select Operator [SEL_520] (rows=2609 width=4)
+                                                          Select Operator [SEL_473] (rows=2609 width=4)
                                                             Output:["_col0"]
-                                                            Filter Operator [FIL_519] (rows=2609 width=8)
+                                                            Filter Operator [FIL_470] (rows=2609 width=8)
                                                               predicate:((d_year) IN (1999, 2000, 2001, 2002) and d_date_sk is not null)
-                                                              TableScan [TS_50] (rows=73049 width=8)
-                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                      <-Map 34 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_529]
+                                                               Please refer to the previous TableScan [TS_9]
+                                                      <-Map 35 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_516]
                                                           PartitionCols:_col0
-                                                          Select Operator [SEL_528] (rows=525327388 width=119)
+                                                          Select Operator [SEL_515] (rows=525327388 width=119)
                                                             Output:["_col0","_col1","_col2"]
-                                                            Filter Operator [FIL_527] (rows=525327388 width=118)
+                                                            Filter Operator [FIL_514] (rows=525327388 width=118)
                                                               predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                               TableScan [TS_47] (rows=575995635 width=118)
                                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_quantity","ss_sales_price"]
-                                                              <-Reducer 37 [BROADCAST_EDGE] vectorized
-                                                                BROADCAST [RS_526]
-                                                                  Group By Operator [GBY_525] (rows=1 width=12)
+                                                              <-Reducer 27 [BROADCAST_EDGE] vectorized
+                                                                BROADCAST [RS_513]
+                                                                  Group By Operator [GBY_512] (rows=1 width=12)
                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                  <-Map 36 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                    PARTITION_ONLY_SHUFFLE [RS_524]
-                                                                      Group By Operator [GBY_523] (rows=1 width=12)
+                                                                  <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                    SHUFFLE [RS_489]
+                                                                      Group By Operator [GBY_485] (rows=1 width=12)
                                                                         Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                        Select Operator [SEL_522] (rows=2609 width=4)
+                                                                        Select Operator [SEL_481] (rows=2609 width=4)
                                                                           Output:["_col0"]
-                                                                           Please refer to the previous Select Operator [SEL_520]
-                            <-Reducer 33 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                           Please refer to the previous Select Operator [SEL_473]
+                            <-Reducer 34 [CUSTOM_SIMPLE_EDGE] vectorized
                               PARTITION_ONLY_SHUFFLE [RS_553]
                                 Filter Operator [FIL_552] (rows=1415625 width=116)
                                   predicate:_col1 is not null
                                   Group By Operator [GBY_551] (rows=1415625 width=116)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                  <-Reducer 32 [SIMPLE_EDGE]
+                                  <-Reducer 33 [SIMPLE_EDGE]
                                     SHUFFLE [RS_134]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_133] (rows=80000000 width=116)
                                         Output:["_col0","_col1"],aggregations:["sum(_col1)"],keys:_col2
                                         Merge Join Operator [MERGEJOIN_449] (rows=550080312 width=116)
-                                          Conds:RS_550._col0=RS_515._col0(Inner),Output:["_col1","_col2"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_515]
+                                          Conds:RS_550._col0=RS_521._col0(Inner),Output:["_col1","_col2"]
+                                        <-Map 32 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_521]
                                             PartitionCols:_col0
-                                             Please refer to the previous Select Operator [SEL_512]
-                                        <-Map 39 [SIMPLE_EDGE] vectorized
+                                             Please refer to the previous Select Operator [SEL_518]
+                                        <-Map 37 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_550]
                                             PartitionCols:_col0
                                             Select Operator [SEL_549] (rows=550080312 width=115)
@@ -380,11 +378,11 @@ Stage-0
                                                 predicate:(ss_customer_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS_178_web_sales_ws_bill_customer_sk_min) AND DynamicValue(RS_178_web_sales_ws_bill_customer_sk_max) and in_bloom_filter(ss_customer_sk, DynamicValue(RS_178_web_sales_ws_bill_customer_sk_bloom_filter)))
                                                 TableScan [TS_123] (rows=575995635 width=114)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_customer_sk","ss_quantity","ss_sales_price"]
-                                                <-Reducer 13 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 15 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_547]
                                                     Group By Operator [GBY_546] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Reducer 11 [CUSTOM_SIMPLE_EDGE]
+                                                    <-Reducer 13 [CUSTOM_SIMPLE_EDGE]
                                                       PARTITION_ONLY_SHUFFLE [RS_415]
                                                         Group By Operator [GBY_414] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -403,41 +401,41 @@ Stage-0
                     PARTITION_ONLY_SHUFFLE [RS_87]
                       PartitionCols:_col1
                       Merge Join Operator [MERGEJOIN_452] (rows=7751875 width=97)
-                        Conds:RS_82._col2=RS_504._col0(Inner),Output:["_col1","_col3","_col4"]
-                      <-Reducer 19 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_504]
+                        Conds:RS_82._col2=RS_510._col0(Inner),Output:["_col1","_col3","_col4"]
+                      <-Reducer 12 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_510]
                           PartitionCols:_col0
-                           Please refer to the previous Group By Operator [GBY_503]
+                           Please refer to the previous Group By Operator [GBY_509]
                       <-Reducer 2 [SIMPLE_EDGE]
                         SHUFFLE [RS_82]
                           PartitionCols:_col2
                           Merge Join Operator [MERGEJOIN_440] (rows=7751875 width=101)
-                            Conds:RS_482._col0=RS_470._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                          <-Map 8 [SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_470]
+                            Conds:RS_494._col0=RS_476._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                          <-Map 16 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_476]
                               PartitionCols:_col0
-                               Please refer to the previous Select Operator [SEL_469]
+                               Please refer to the previous Select Operator [SEL_472]
                           <-Map 1 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_482]
+                            SHUFFLE [RS_494]
                               PartitionCols:_col0
-                              Select Operator [SEL_481] (rows=285117831 width=127)
+                              Select Operator [SEL_493] (rows=285117831 width=127)
                                 Output:["_col0","_col1","_col2","_col3","_col4"]
-                                Filter Operator [FIL_480] (rows=285117831 width=127)
+                                Filter Operator [FIL_492] (rows=285117831 width=127)
                                   predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_80_date_dim_d_date_sk_min) AND DynamicValue(RS_80_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_80_date_dim_d_date_sk_bloom_filter)))
                                   TableScan [TS_0] (rows=287989836 width=127)
                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk","cs_quantity","cs_list_price"]
-                                  <-Reducer 9 [BROADCAST_EDGE] vectorized
-                                    BROADCAST [RS_479]
-                                      Group By Operator [GBY_478] (rows=1 width=12)
+                                  <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                    BROADCAST [RS_491]
+                                      Group By Operator [GBY_490] (rows=1 width=12)
                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                      <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_476]
-                                          Group By Operator [GBY_474] (rows=1 width=12)
+                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        SHUFFLE [RS_487]
+                                          Group By Operator [GBY_483] (rows=1 width=12)
                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                            Select Operator [SEL_471] (rows=50 width=4)
+                                            Select Operator [SEL_477] (rows=50 width=4)
                                               Output:["_col0"]
-                                               Please refer to the previous Select Operator [SEL_469]
-                  <-Reducer 26 [SIMPLE_EDGE]
+                                               Please refer to the previous Select Operator [SEL_472]
+                  <-Reducer 25 [SIMPLE_EDGE]
                     SHUFFLE [RS_88]
                       PartitionCols:_col0
                       Group By Operator [GBY_86] (rows=235937 width=4)
@@ -448,38 +446,38 @@ Stage-0
                             predicate:(_col1 > _col2)
                             Merge Join Operator [MERGEJOIN_454] (rows=1415625 width=228)
                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-                            <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_537]
-                                 Please refer to the previous Select Operator [SEL_536]
-                            <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_518]
-                                Filter Operator [FIL_517] (rows=1415625 width=116)
+                            <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
+                              PARTITION_ONLY_SHUFFLE [RS_529]
+                                 Please refer to the previous Select Operator [SEL_528]
+                            <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
+                              PARTITION_ONLY_SHUFFLE [RS_538]
+                                Filter Operator [FIL_537] (rows=1415625 width=116)
                                   predicate:_col1 is not null
-                                  Group By Operator [GBY_516] (rows=1415625 width=116)
+                                  Group By Operator [GBY_536] (rows=1415625 width=116)
                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
-                                  <-Reducer 24 [SIMPLE_EDGE]
+                                  <-Reducer 30 [SIMPLE_EDGE]
                                     SHUFFLE [RS_43]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_42] (rows=80000000 width=116)
                                         Output:["_col0","_col1"],aggregations:["sum(_col1)"],keys:_col2
                                         Merge Join Operator [MERGEJOIN_443] (rows=550080312 width=116)
-                                          Conds:RS_510._col0=RS_513._col0(Inner),Output:["_col1","_col2"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_513]
+                                          Conds:RS_535._col0=RS_519._col0(Inner),Output:["_col1","_col2"]
+                                        <-Map 32 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_519]
                                             PartitionCols:_col0
-                                             Please refer to the previous Select Operator [SEL_512]
-                                        <-Map 23 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_510]
+                                             Please refer to the previous Select Operator [SEL_518]
+                                        <-Map 29 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_535]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_509] (rows=550080312 width=115)
+                                            Select Operator [SEL_534] (rows=550080312 width=115)
                                               Output:["_col0","_col1"]
-                                              Filter Operator [FIL_508] (rows=550080312 width=114)
+                                              Filter Operator [FIL_533] (rows=550080312 width=114)
                                                 predicate:(ss_customer_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS_87_catalog_sales_cs_bill_customer_sk_min) AND DynamicValue(RS_87_catalog_sales_cs_bill_customer_sk_max) and in_bloom_filter(ss_customer_sk, DynamicValue(RS_87_catalog_sales_cs_bill_customer_sk_bloom_filter)))
                                                 TableScan [TS_32] (rows=575995635 width=114)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_customer_sk","ss_quantity","ss_sales_price"]
                                                 <-Reducer 7 [BROADCAST_EDGE] vectorized
-                                                  BROADCAST [RS_507]
-                                                    Group By Operator [GBY_506] (rows=1 width=12)
+                                                  BROADCAST [RS_532]
+                                                    Group By Operator [GBY_531] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                     <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                                                       PARTITION_ONLY_SHUFFLE [RS_329]

--- a/ql/src/test/results/clientpositive/perf/tez/query29.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query29.q.out
@@ -108,18 +108,18 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 7 (BROADCAST_EDGE)
-Map 8 <- Reducer 14 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 15 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Map 14 <- Reducer 12 (BROADCAST_EDGE)
+Reducer 10 <- Map 16 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Map 17 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 18 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 14 <- Map 13 (CUSTOM_SIMPLE_EDGE)
-Reducer 15 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 12 <- Map 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Map 15 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 11 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 7 <- Map 6 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Map 13 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 8 <- Map 14 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+Reducer 9 <- Reducer 13 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -144,14 +144,14 @@ Stage-0
                       keys:_col6, _col7, _col22, _col23,top n:100
                       Merge Join Operator [MERGEJOIN_210] (rows=4156223234 width=483)
                         Conds:RS_44._col2, _col1=RS_45._col11, _col12(Inner),Output:["_col3","_col6","_col7","_col13","_col19","_col22","_col23"]
-                      <-Reducer 12 [SIMPLE_EDGE]
+                      <-Reducer 11 [SIMPLE_EDGE]
                         SHUFFLE [RS_45]
                           PartitionCols:_col11, _col12
                           Select Operator [SEL_40] (rows=21091879 width=484)
                             Output:["_col1","_col2","_col8","_col11","_col12","_col14","_col17","_col18"]
                             Merge Join Operator [MERGEJOIN_209] (rows=21091879 width=484)
                               Conds:RS_37._col3=RS_244._col0(Inner),Output:["_col5","_col8","_col9","_col11","_col14","_col15","_col17","_col18"]
-                            <-Map 18 [SIMPLE_EDGE] vectorized
+                            <-Map 17 [SIMPLE_EDGE] vectorized
                               SHUFFLE [RS_244]
                                 PartitionCols:_col0
                                 Select Operator [SEL_243] (rows=1704 width=192)
@@ -160,12 +160,12 @@ Stage-0
                                     predicate:s_store_sk is not null
                                     TableScan [TS_25] (rows=1704 width=192)
                                       default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_id","s_store_name"]
-                            <-Reducer 11 [SIMPLE_EDGE]
+                            <-Reducer 10 [SIMPLE_EDGE]
                               SHUFFLE [RS_37]
                                 PartitionCols:_col3
                                 Merge Join Operator [MERGEJOIN_208] (rows=21091879 width=298)
                                   Conds:RS_34._col1=RS_241._col0(Inner),Output:["_col3","_col5","_col8","_col9","_col11","_col14","_col15"]
-                                <-Map 17 [SIMPLE_EDGE] vectorized
+                                <-Map 16 [SIMPLE_EDGE] vectorized
                                   SHUFFLE [RS_241]
                                     PartitionCols:_col0
                                     Select Operator [SEL_240] (rows=462000 width=288)
@@ -174,26 +174,26 @@ Stage-0
                                         predicate:i_item_sk is not null
                                         TableScan [TS_22] (rows=462000 width=288)
                                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id","i_item_desc"]
-                                <-Reducer 10 [SIMPLE_EDGE]
+                                <-Reducer 9 [SIMPLE_EDGE]
                                   SHUFFLE [RS_34]
                                     PartitionCols:_col1
                                     Merge Join Operator [MERGEJOIN_207] (rows=21091879 width=18)
                                       Conds:RS_31._col1, _col2, _col4=RS_32._col1, _col2, _col3(Inner),Output:["_col1","_col3","_col5","_col8","_col9","_col11"]
-                                    <-Reducer 15 [SIMPLE_EDGE]
+                                    <-Reducer 13 [SIMPLE_EDGE]
                                       SHUFFLE [RS_32]
                                         PartitionCols:_col1, _col2, _col3
                                         Merge Join Operator [MERGEJOIN_206] (rows=5384572 width=13)
-                                          Conds:RS_238._col0=RS_228._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                                        <-Map 13 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_228]
+                                          Conds:RS_238._col0=RS_221._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                                        <-Map 6 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_221]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_225] (rows=201 width=4)
+                                            Select Operator [SEL_216] (rows=201 width=4)
                                               Output:["_col0"]
-                                              Filter Operator [FIL_223] (rows=201 width=12)
+                                              Filter Operator [FIL_213] (rows=201 width=12)
                                                 predicate:((d_year = 1999) and d_moy BETWEEN 4 AND 7 and d_date_sk is not null)
-                                                TableScan [TS_9] (rows=73049 width=12)
-                                                  default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                        <-Map 16 [SIMPLE_EDGE] vectorized
+                                                TableScan [TS_3] (rows=73049 width=8)
+                                                  default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
+                                        <-Map 15 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_238]
                                             PartitionCols:_col0
                                             Select Operator [SEL_237] (rows=53632139 width=19)
@@ -202,20 +202,20 @@ Stage-0
                                                 predicate:(sr_customer_sk is not null and sr_returned_date_sk is not null and sr_item_sk is not null and sr_ticket_number is not null)
                                                 TableScan [TS_12] (rows=57591150 width=19)
                                                   default@store_returns,store_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["sr_returned_date_sk","sr_item_sk","sr_customer_sk","sr_ticket_number","sr_return_quantity"]
-                                    <-Reducer 9 [SIMPLE_EDGE]
+                                    <-Reducer 8 [SIMPLE_EDGE]
                                       SHUFFLE [RS_31]
                                         PartitionCols:_col1, _col2, _col4
                                         Merge Join Operator [MERGEJOIN_205] (rows=13737330 width=8)
-                                          Conds:RS_235._col0=RS_226._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                        <-Map 13 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_226]
+                                          Conds:RS_235._col0=RS_219._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
+                                        <-Map 6 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_219]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_224] (rows=50 width=4)
+                                            Select Operator [SEL_215] (rows=50 width=4)
                                               Output:["_col0"]
-                                              Filter Operator [FIL_222] (rows=50 width=12)
+                                              Filter Operator [FIL_212] (rows=50 width=12)
                                                 predicate:((d_year = 1999) and (d_moy = 4) and d_date_sk is not null)
-                                                 Please refer to the previous TableScan [TS_9]
-                                        <-Map 8 [SIMPLE_EDGE] vectorized
+                                                 Please refer to the previous TableScan [TS_3]
+                                        <-Map 14 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_235]
                                             PartitionCols:_col0
                                             Select Operator [SEL_234] (rows=501694138 width=23)
@@ -224,49 +224,48 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk is not null and ss_ticket_number is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_29_d1_d_date_sk_min) AND DynamicValue(RS_29_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_29_d1_d_date_sk_bloom_filter)))
                                                 TableScan [TS_6] (rows=575995635 width=23)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_ticket_number","ss_quantity"]
-                                                <-Reducer 14 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 12 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_232]
                                                     Group By Operator [GBY_231] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 13 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_230]
-                                                        Group By Operator [GBY_229] (rows=1 width=12)
+                                                    <-Map 6 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_225]
+                                                        Group By Operator [GBY_223] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                          Select Operator [SEL_227] (rows=50 width=4)
+                                                          Select Operator [SEL_220] (rows=50 width=4)
                                                             Output:["_col0"]
-                                                             Please refer to the previous Select Operator [SEL_224]
+                                                             Please refer to the previous Select Operator [SEL_215]
                       <-Reducer 2 [SIMPLE_EDGE]
                         SHUFFLE [RS_44]
                           PartitionCols:_col2, _col1
                           Merge Join Operator [MERGEJOIN_204] (rows=7638375 width=10)
-                            Conds:RS_221._col0=RS_213._col0(Inner),Output:["_col1","_col2","_col3"]
+                            Conds:RS_230._col0=RS_217._col0(Inner),Output:["_col1","_col2","_col3"]
                           <-Map 6 [SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_213]
+                            SHUFFLE [RS_217]
                               PartitionCols:_col0
-                              Select Operator [SEL_212] (rows=1957 width=4)
+                              Select Operator [SEL_214] (rows=1957 width=4)
                                 Output:["_col0"]
                                 Filter Operator [FIL_211] (rows=1957 width=8)
                                   predicate:((d_year) IN (1999, 2000, 2001) and d_date_sk is not null)
-                                  TableScan [TS_3] (rows=73049 width=8)
-                                    default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
+                                   Please refer to the previous TableScan [TS_3]
                           <-Map 1 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_221]
+                            SHUFFLE [RS_230]
                               PartitionCols:_col0
-                              Select Operator [SEL_220] (rows=285117831 width=15)
+                              Select Operator [SEL_229] (rows=285117831 width=15)
                                 Output:["_col0","_col1","_col2","_col3"]
-                                Filter Operator [FIL_219] (rows=285117831 width=15)
+                                Filter Operator [FIL_228] (rows=285117831 width=15)
                                   predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_42_d3_d_date_sk_min) AND DynamicValue(RS_42_d3_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_42_d3_d_date_sk_bloom_filter)))
                                   TableScan [TS_0] (rows=287989836 width=15)
                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk","cs_quantity"]
                                   <-Reducer 7 [BROADCAST_EDGE] vectorized
-                                    BROADCAST [RS_218]
-                                      Group By Operator [GBY_217] (rows=1 width=12)
+                                    BROADCAST [RS_227]
+                                      Group By Operator [GBY_226] (rows=1 width=12)
                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                       <-Map 6 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_216]
-                                          Group By Operator [GBY_215] (rows=1 width=12)
+                                        SHUFFLE [RS_224]
+                                          Group By Operator [GBY_222] (rows=1 width=12)
                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                            Select Operator [SEL_214] (rows=1957 width=4)
+                                            Select Operator [SEL_218] (rows=1957 width=4)
                                               Output:["_col0"]
-                                               Please refer to the previous Select Operator [SEL_212]
+                                               Please refer to the previous Select Operator [SEL_214]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query33.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query33.q.out
@@ -163,27 +163,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -221,40 +221,39 @@ Stage-0
                                 SHUFFLE [RS_104]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_294] (rows=461514 width=7)
-                                    Conds:RS_320._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
+                                    Conds:RS_322._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
                                   <-Map 1 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_320]
+                                    SHUFFLE [RS_322]
                                       PartitionCols:_col1
-                                      Select Operator [SEL_319] (rows=460848 width=7)
+                                      Select Operator [SEL_320] (rows=460848 width=7)
                                         Output:["_col0","_col1"]
                                         Filter Operator [FIL_318] (rows=460848 width=7)
                                           predicate:(i_manufact_id is not null and i_item_sk is not null)
                                           TableScan [TS_0] (rows=462000 width=7)
-                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_manufact_id"]
-                                  <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_manufact_id","i_category"]
+                                  <-Reducer 12 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_326]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_325] (rows=692 width=3)
                                         Output:["_col0"],keys:KEY._col0
-                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                      <-Map 1 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_324]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_323] (rows=692 width=3)
                                             Output:["_col0"],keys:i_manufact_id
-                                            Select Operator [SEL_322] (rows=46085 width=93)
+                                            Select Operator [SEL_321] (rows=46085 width=93)
                                               Output:["i_manufact_id"]
-                                              Filter Operator [FIL_321] (rows=46085 width=93)
+                                              Filter Operator [FIL_319] (rows=46085 width=93)
                                                 predicate:((i_category = 'Books') and i_manufact_id is not null)
-                                                TableScan [TS_3] (rows=462000 width=93)
-                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_category","i_manufact_id"]
-                              <-Reducer 23 [SIMPLE_EDGE]
+                                                 Please refer to the previous TableScan [TS_0]
+                              <-Reducer 22 [SIMPLE_EDGE]
                                 SHUFFLE [RS_105]
                                   PartitionCols:_col2
                                   Select Operator [SEL_100] (rows=788222 width=110)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_302] (rows=788222 width=110)
                                       Conds:RS_97._col2=RS_350._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_350]
                                         PartitionCols:_col0
                                         Select Operator [SEL_347] (rows=8000000 width=4)
@@ -263,12 +262,12 @@ Stage-0
                                             predicate:((ca_gmt_offset = -6) and ca_address_sk is not null)
                                             TableScan [TS_16] (rows=40000000 width=112)
                                               default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                    <-Reducer 22 [SIMPLE_EDGE]
+                                    <-Reducer 21 [SIMPLE_EDGE]
                                       SHUFFLE [RS_97]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_301] (rows=3941109 width=118)
                                           Conds:RS_372._col0=RS_333._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_333]
                                             PartitionCols:_col0
                                             Select Operator [SEL_328] (rows=50 width=4)
@@ -277,7 +276,7 @@ Stage-0
                                                 predicate:((d_year = 1999) and (d_moy = 3) and d_date_sk is not null)
                                                 TableScan [TS_13] (rows=73049 width=12)
                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
+                                        <-Map 26 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_372]
                                             PartitionCols:_col0
                                             Select Operator [SEL_371] (rows=143931246 width=123)
@@ -286,11 +285,11 @@ Stage-0
                                                 predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_95_date_dim_d_date_sk_min) AND DynamicValue(RS_95_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_95_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_85] (rows=144002668 width=123)
                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_369]
                                                     Group By Operator [GBY_368] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_340]
                                                         Group By Operator [GBY_337] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -315,27 +314,27 @@ Stage-0
                                 SHUFFLE [RS_29]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 16 [SIMPLE_EDGE]
+                              <-Reducer 15 [SIMPLE_EDGE]
                                 SHUFFLE [RS_30]
                                   PartitionCols:_col2
                                   Select Operator [SEL_25] (rows=2876890 width=4)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_296] (rows=2876890 width=4)
                                       Conds:RS_22._col2=RS_348._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_348]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 15 [SIMPLE_EDGE]
+                                    <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_22]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_295] (rows=14384447 width=4)
                                           Conds:RS_345._col0=RS_329._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_329]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 14 [SIMPLE_EDGE] vectorized
+                                        <-Map 13 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_345]
                                             PartitionCols:_col0
                                             Select Operator [SEL_344] (rows=525327191 width=118)
@@ -344,11 +343,11 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_20_date_dim_d_date_sk_min) AND DynamicValue(RS_20_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_20_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_10] (rows=575995635 width=118)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_342]
                                                     Group By Operator [GBY_341] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_338]
                                                         Group By Operator [GBY_335] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -373,27 +372,27 @@ Stage-0
                                 SHUFFLE [RS_66]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 20 [SIMPLE_EDGE]
+                              <-Reducer 19 [SIMPLE_EDGE]
                                 SHUFFLE [RS_67]
                                   PartitionCols:_col3
                                   Select Operator [SEL_62] (rows=1550375 width=13)
                                     Output:["_col3","_col4"]
                                     Merge Join Operator [MERGEJOIN_299] (rows=1550375 width=13)
                                       Conds:RS_59._col1=RS_349._col0(Inner),Output:["_col2","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_349]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 19 [SIMPLE_EDGE]
+                                    <-Reducer 18 [SIMPLE_EDGE]
                                       SHUFFLE [RS_59]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_298] (rows=7751872 width=98)
                                           Conds:RS_364._col0=RS_331._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_331]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
+                                        <-Map 25 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_364]
                                             PartitionCols:_col0
                                             Select Operator [SEL_363] (rows=285117733 width=123)
@@ -402,11 +401,11 @@ Stage-0
                                                 predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_47] (rows=287989836 width=123)
                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_361]
                                                     Group By Operator [GBY_360] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_339]
                                                         Group By Operator [GBY_336] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/query41.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query41.q.out
@@ -107,10 +107,10 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 6 <- Map 5 (SIMPLE_EDGE)
+Reducer 5 <- Map 1 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -134,17 +134,17 @@ Stage-0
                     Top N Key Operator [TNK_30] (rows=752 width=107)
                       keys:_col1,top n:100
                       Merge Join Operator [MERGEJOIN_43] (rows=752 width=107)
-                        Conds:RS_46._col0=RS_54._col0(Inner),Output:["_col1"]
+                        Conds:RS_48._col0=RS_54._col0(Inner),Output:["_col1"]
                       <-Map 1 [SIMPLE_EDGE] vectorized
-                        SHUFFLE [RS_46]
+                        SHUFFLE [RS_48]
                           PartitionCols:_col0
-                          Select Operator [SEL_45] (rows=20726 width=202)
+                          Select Operator [SEL_46] (rows=20726 width=202)
                             Output:["_col0","_col1"]
                             Filter Operator [FIL_44] (rows=20726 width=205)
                               predicate:(i_manufact_id BETWEEN 970 AND 1010 and i_manufact is not null)
                               TableScan [TS_0] (rows=462000 width=205)
-                                default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_manufact_id","i_manufact","i_product_name"]
-                      <-Reducer 6 [SIMPLE_EDGE] vectorized
+                                default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_manufact_id","i_manufact","i_product_name","i_category","i_size","i_color","i_units"]
+                      <-Reducer 5 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_54]
                           PartitionCols:_col0
                           Select Operator [SEL_53] (rows=46 width=95)
@@ -153,15 +153,14 @@ Stage-0
                               predicate:(_col1 > 0L)
                               Group By Operator [GBY_51] (rows=140 width=103)
                                 Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                              <-Map 5 [SIMPLE_EDGE] vectorized
+                              <-Map 1 [SIMPLE_EDGE] vectorized
                                 SHUFFLE [RS_50]
                                   PartitionCols:_col0
                                   Group By Operator [GBY_49] (rows=140 width=103)
                                     Output:["_col0","_col1"],aggregations:["count()"],keys:i_manufact
-                                    Select Operator [SEL_48] (rows=280 width=450)
+                                    Select Operator [SEL_47] (rows=280 width=450)
                                       Output:["i_manufact"]
-                                      Filter Operator [FIL_47] (rows=280 width=450)
+                                      Filter Operator [FIL_45] (rows=280 width=450)
                                         predicate:((((i_category = 'Women') and (i_color) IN ('frosted', 'rose') and (i_units) IN ('Lb', 'Gross') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('chocolate', 'black') and (i_units) IN ('Box', 'Dram') and (i_size) IN ('economy', 'petite')) or ((i_category = 'Men') and (i_color) IN ('slate', 'magenta') and (i_units) IN ('Carton', 'Bundle') and (i_size) IN ('N/A', 'small')) or ((i_category = 'Men') and (i_color) IN ('cornflower', 'firebrick') and (i_units) IN ('Pound', 'Oz') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('almond', 'steel') and (i_units) IN ('Tsp', 'Case') and (i_size) IN ('medium', 'large')) or ((i_category = 'Women') and (i_color) IN ('purple', 'aquamarine') and (i_units) IN ('Bunch', 'Gram') and (i_size) IN ('economy', 'petite')) or ((i_category = 'Men') and (i_color) IN ('lavender', 'papaya') and (i_units) IN ('Pallet', 'Cup') and (i_size) IN ('N/A', 'small')) or ((i_category = 'Men') and (i_color) IN ('maroon', 'cyan') and (i_units) IN ('Each', 'N/A') and (i_size) IN ('medium', 'large'))) and i_manufact is not null)
-                                        TableScan [TS_3] (rows=462000 width=450)
-                                          default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_category","i_manufact","i_size","i_color","i_units"]
+                                         Please refer to the previous TableScan [TS_0]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query44.q.out
@@ -77,13 +77,13 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 10 <- Reducer 8 (SIMPLE_EDGE)
-Reducer 12 <- Map 11 (SIMPLE_EDGE)
+Reducer 11 <- Map 6 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Map 1 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
 Reducer 7 <- Map 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+Reducer 8 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -138,7 +138,7 @@ Stage-0
                                         predicate:(_col1 > (0.9 * _col2))
                                         Merge Join Operator [MERGEJOIN_112] (rows=62562 width=228)
                                           Conds:(Inner),Output:["_col0","_col1","_col2"]
-                                        <-Reducer 12 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_137]
                                             Select Operator [SEL_136] (rows=1 width=112)
                                               Output:["_col0"]
@@ -148,36 +148,35 @@ Stage-0
                                                   Output:["_col1","_col2"]
                                                   Group By Operator [GBY_133] (rows=1 width=124)
                                                     Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                                  <-Map 11 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_132]
+                                                  <-Map 6 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_128]
                                                       PartitionCols:_col0
-                                                      Group By Operator [GBY_131] (rows=258 width=124)
+                                                      Group By Operator [GBY_126] (rows=258 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                        Select Operator [SEL_130] (rows=287946 width=114)
+                                                        Select Operator [SEL_124] (rows=287946 width=114)
                                                           Output:["_col1"]
-                                                          Filter Operator [FIL_129] (rows=287946 width=114)
+                                                          Filter Operator [FIL_122] (rows=287946 width=114)
                                                             predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
-                                                            TableScan [TS_11] (rows=575995635 width=114)
-                                                              default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_hdemo_sk","ss_store_sk","ss_net_profit"]
+                                                            TableScan [TS_3] (rows=575995635 width=114)
+                                                              default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                         <-Reducer 7 [CUSTOM_SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_128]
-                                            Select Operator [SEL_127] (rows=62562 width=116)
+                                          PARTITION_ONLY_SHUFFLE [RS_132]
+                                            Select Operator [SEL_131] (rows=62562 width=116)
                                               Output:["_col0","_col1"]
-                                              Filter Operator [FIL_126] (rows=62562 width=124)
+                                              Filter Operator [FIL_130] (rows=62562 width=124)
                                                 predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                Group By Operator [GBY_125] (rows=62562 width=124)
+                                                Group By Operator [GBY_129] (rows=62562 width=124)
                                                   Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
                                                 <-Map 6 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_124]
+                                                  SHUFFLE [RS_127]
                                                     PartitionCols:_col0
-                                                    Group By Operator [GBY_123] (rows=3199976 width=124)
+                                                    Group By Operator [GBY_125] (rows=3199976 width=124)
                                                       Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                      Select Operator [SEL_122] (rows=6399952 width=114)
+                                                      Select Operator [SEL_123] (rows=6399952 width=114)
                                                         Output:["ss_item_sk","ss_net_profit"]
                                                         Filter Operator [FIL_121] (rows=6399952 width=114)
                                                           predicate:(ss_store_sk = 410)
-                                                          TableScan [TS_3] (rows=575995635 width=114)
-                                                            default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit"]
+                                                           Please refer to the previous TableScan [TS_3]
                   <-Reducer 5 [SIMPLE_EDGE]
                     SHUFFLE [RS_70]
                       PartitionCols:_col3

--- a/ql/src/test/results/clientpositive/perf/tez/query45.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query45.q.out
@@ -52,15 +52,15 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 12 <- Reducer 15 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 13 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
+Map 13 <- Reducer 16 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 14 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Map 8 (SIMPLE_EDGE)
-Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 14 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (CUSTOM_SIMPLE_EDGE)
-Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 12 <- Map 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 16 <- Map 15 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Reducer 17 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+Reducer 4 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 9 <- Map 8 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
@@ -94,19 +94,19 @@ Stage-0
                             Output:["_col3","_col7","_col8","_col14","_col16"]
                             Merge Join Operator [MERGEJOIN_138] (rows=10246864 width=310)
                               Conds:(Inner),Output:["_col3","_col4","_col8","_col12","_col16"]
-                            <-Reducer 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                            <-Reducer 12 [CUSTOM_SIMPLE_EDGE] vectorized
                               PARTITION_ONLY_SHUFFLE [RS_171]
                                 Group By Operator [GBY_170] (rows=1 width=8)
                                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_169]
-                                    Group By Operator [GBY_168] (rows=1 width=8)
+                                <-Map 8 [CUSTOM_SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_155]
+                                    Group By Operator [GBY_153] (rows=1 width=8)
                                       Output:["_col0"],aggregations:["count()"]
-                                      Select Operator [SEL_167] (rows=11 width=4)
-                                        Filter Operator [FIL_166] (rows=11 width=4)
+                                      Select Operator [SEL_150] (rows=11 width=4)
+                                        Filter Operator [FIL_147] (rows=11 width=4)
                                           predicate:(i_item_sk) IN (2, 3, 5, 7, 11, 13, 17, 19, 23, 29)
-                                          TableScan [TS_33] (rows=462000 width=4)
-                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk"]
+                                          TableScan [TS_6] (rows=462000 width=104)
+                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
                             <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                               PARTITION_ONLY_SHUFFLE [RS_46]
                                 Merge Join Operator [MERGEJOIN_137] (rows=10246864 width=302)
@@ -116,67 +116,66 @@ Stage-0
                                     PartitionCols:_col6
                                     Merge Join Operator [MERGEJOIN_136] (rows=10246864 width=119)
                                       Conds:RS_29._col0=RS_30._col1(Inner),Output:["_col3","_col6","_col7"]
-                                    <-Reducer 13 [SIMPLE_EDGE]
+                                    <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_30]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_135] (rows=10246864 width=119)
-                                          Conds:RS_165._col0=RS_157._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 14 [SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_157]
+                                          Conds:RS_169._col0=RS_161._col0(Inner),Output:["_col1","_col2","_col3"]
+                                        <-Map 15 [SIMPLE_EDGE] vectorized
+                                          PARTITION_ONLY_SHUFFLE [RS_161]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_156] (rows=130 width=12)
+                                            Select Operator [SEL_160] (rows=130 width=12)
                                               Output:["_col0"]
-                                              Filter Operator [FIL_155] (rows=130 width=12)
+                                              Filter Operator [FIL_159] (rows=130 width=12)
                                                 predicate:((d_year = 2000) and (d_qoy = 2) and d_date_sk is not null)
                                                 TableScan [TS_19] (rows=73049 width=12)
                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_qoy"]
-                                        <-Map 12 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_165]
+                                        <-Map 13 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_169]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_164] (rows=143930993 width=123)
+                                            Select Operator [SEL_168] (rows=143930993 width=123)
                                               Output:["_col0","_col1","_col2","_col3"]
-                                              Filter Operator [FIL_163] (rows=143930993 width=123)
+                                              Filter Operator [FIL_167] (rows=143930993 width=123)
                                                 predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_23_date_dim_d_date_sk_min) AND DynamicValue(RS_23_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_23_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_16] (rows=144002668 width=123)
                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk","ws_sales_price"]
-                                                <-Reducer 15 [BROADCAST_EDGE] vectorized
-                                                  BROADCAST [RS_162]
-                                                    Group By Operator [GBY_161] (rows=1 width=12)
+                                                <-Reducer 16 [BROADCAST_EDGE] vectorized
+                                                  BROADCAST [RS_166]
+                                                    Group By Operator [GBY_165] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_160]
-                                                        Group By Operator [GBY_159] (rows=1 width=12)
+                                                    <-Map 15 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      PARTITION_ONLY_SHUFFLE [RS_164]
+                                                        Group By Operator [GBY_163] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                          Select Operator [SEL_158] (rows=130 width=4)
+                                                          Select Operator [SEL_162] (rows=130 width=4)
                                                             Output:["_col0"]
-                                                             Please refer to the previous Select Operator [SEL_156]
+                                                             Please refer to the previous Select Operator [SEL_160]
                                     <-Reducer 9 [SIMPLE_EDGE]
                                       SHUFFLE [RS_29]
                                         PartitionCols:_col0
                                         Merge Join Operator [MERGEJOIN_134] (rows=462007 width=4)
-                                          Conds:RS_149._col1=RS_154._col0(Left Outer),Output:["_col0","_col3"]
+                                          Conds:RS_151._col1=RS_158._col0(Left Outer),Output:["_col0","_col3"]
                                         <-Map 8 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_149]
+                                          SHUFFLE [RS_151]
                                             PartitionCols:_col1
-                                            Select Operator [SEL_147] (rows=462000 width=104)
+                                            Select Operator [SEL_148] (rows=462000 width=104)
                                               Output:["_col0","_col1"]
                                               Filter Operator [FIL_145] (rows=462000 width=104)
                                                 predicate:i_item_sk is not null
-                                                TableScan [TS_6] (rows=462000 width=104)
-                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
+                                                 Please refer to the previous TableScan [TS_6]
                                         <-Reducer 11 [SIMPLE_EDGE] vectorized
-                                          SHUFFLE [RS_154]
+                                          SHUFFLE [RS_158]
                                             PartitionCols:_col0
-                                            Select Operator [SEL_153] (rows=5 width=104)
+                                            Select Operator [SEL_157] (rows=5 width=104)
                                               Output:["_col0","_col1"]
-                                              Group By Operator [GBY_152] (rows=5 width=100)
+                                              Group By Operator [GBY_156] (rows=5 width=100)
                                                 Output:["_col0"],keys:KEY._col0
                                               <-Map 8 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_151]
+                                                SHUFFLE [RS_154]
                                                   PartitionCols:_col0
-                                                  Group By Operator [GBY_150] (rows=5 width=100)
+                                                  Group By Operator [GBY_152] (rows=5 width=100)
                                                     Output:["_col0"],keys:i_item_id
-                                                    Select Operator [SEL_148] (rows=11 width=104)
+                                                    Select Operator [SEL_149] (rows=11 width=104)
                                                       Output:["i_item_id"]
                                                       Filter Operator [FIL_146] (rows=11 width=104)
                                                         predicate:((i_item_sk) IN (2, 3, 5, 7, 11, 13, 17, 19, 23, 29) and i_item_id is not null)

--- a/ql/src/test/results/clientpositive/perf/tez/query50.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query50.q.out
@@ -130,8 +130,8 @@ Vertex dependency in root stage
 Map 10 <- Reducer 8 (BROADCAST_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
 Reducer 3 <- Map 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 11 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 12 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 4 <- Map 9 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 5 <- Map 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
@@ -161,7 +161,7 @@ Stage-0
                         keys:_col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21,top n:100
                         Merge Join Operator [MERGEJOIN_125] (rows=11945216 width=821)
                           Conds:RS_24._col8=RS_142._col0(Inner),Output:["_col0","_col5","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20","_col21"]
-                        <-Map 12 [SIMPLE_EDGE] vectorized
+                        <-Map 11 [SIMPLE_EDGE] vectorized
                           SHUFFLE [RS_142]
                             PartitionCols:_col0
                             Select Operator [SEL_141] (rows=1704 width=821)
@@ -174,26 +174,34 @@ Stage-0
                           SHUFFLE [RS_24]
                             PartitionCols:_col8
                             Merge Join Operator [MERGEJOIN_124] (rows=11945216 width=3)
-                              Conds:RS_21._col5=RS_139._col0(Inner),Output:["_col0","_col5","_col8"]
-                            <-Map 11 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_139]
+                              Conds:RS_21._col5=RS_134._col0(Inner),Output:["_col0","_col5","_col8"]
+                            <-Map 9 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_134]
                                 PartitionCols:_col0
-                                Select Operator [SEL_138] (rows=73049 width=4)
+                                Select Operator [SEL_132] (rows=73049 width=4)
                                   Output:["_col0"]
-                                  Filter Operator [FIL_137] (rows=73049 width=4)
+                                  Filter Operator [FIL_130] (rows=73049 width=4)
                                     predicate:d_date_sk is not null
-                                    TableScan [TS_9] (rows=73049 width=4)
-                                      default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk"]
+                                    TableScan [TS_3] (rows=73049 width=12)
+                                      default@date_dim,d2,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
                             <-Reducer 3 [SIMPLE_EDGE]
                               SHUFFLE [RS_21]
                                 PartitionCols:_col5
                                 Merge Join Operator [MERGEJOIN_123] (rows=11945216 width=3)
-                                  Conds:RS_18._col1, _col2, _col3=RS_136._col1, _col2, _col4(Inner),Output:["_col0","_col5","_col8"]
+                                  Conds:RS_18._col1, _col2, _col3=RS_139._col1, _col2, _col4(Inner),Output:["_col0","_col5","_col8"]
                                 <-Reducer 2 [SIMPLE_EDGE]
                                   PARTITION_ONLY_SHUFFLE [RS_18]
                                     PartitionCols:_col1, _col2, _col3
                                     Merge Join Operator [MERGEJOIN_122] (rows=1339446 width=8)
-                                      Conds:RS_128._col0=RS_131._col0(Inner),Output:["_col0","_col1","_col2","_col3"]
+                                      Conds:RS_128._col0=RS_133._col0(Inner),Output:["_col0","_col1","_col2","_col3"]
+                                    <-Map 9 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_133]
+                                        PartitionCols:_col0
+                                        Select Operator [SEL_131] (rows=50 width=4)
+                                          Output:["_col0"]
+                                          Filter Operator [FIL_129] (rows=50 width=12)
+                                            predicate:((d_year = 2000) and (d_moy = 9) and d_date_sk is not null)
+                                             Please refer to the previous TableScan [TS_3]
                                     <-Map 1 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_128]
                                         PartitionCols:_col0
@@ -203,27 +211,18 @@ Stage-0
                                             predicate:(sr_customer_sk is not null and sr_returned_date_sk is not null and sr_ticket_number is not null and sr_item_sk is not null)
                                             TableScan [TS_0] (rows=57591150 width=15)
                                               default@store_returns,store_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["sr_returned_date_sk","sr_item_sk","sr_customer_sk","sr_ticket_number"]
-                                    <-Map 9 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_131]
-                                        PartitionCols:_col0
-                                        Select Operator [SEL_130] (rows=50 width=4)
-                                          Output:["_col0"]
-                                          Filter Operator [FIL_129] (rows=50 width=12)
-                                            predicate:((d_year = 2000) and (d_moy = 9) and d_date_sk is not null)
-                                            TableScan [TS_3] (rows=73049 width=12)
-                                              default@date_dim,d2,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
                                 <-Map 10 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_136]
+                                  SHUFFLE [RS_139]
                                     PartitionCols:_col1, _col2, _col4
-                                    Select Operator [SEL_135] (rows=501694138 width=19)
+                                    Select Operator [SEL_138] (rows=501694138 width=19)
                                       Output:["_col0","_col1","_col2","_col3","_col4"]
-                                      Filter Operator [FIL_134] (rows=501694138 width=19)
+                                      Filter Operator [FIL_137] (rows=501694138 width=19)
                                         predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_ticket_number is not null and ss_item_sk is not null and ss_ticket_number BETWEEN DynamicValue(RS_18_store_returns_sr_ticket_number_min) AND DynamicValue(RS_18_store_returns_sr_ticket_number_max) and in_bloom_filter(ss_ticket_number, DynamicValue(RS_18_store_returns_sr_ticket_number_bloom_filter)))
                                         TableScan [TS_6] (rows=575995635 width=19)
                                           default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_ticket_number"]
                                         <-Reducer 8 [BROADCAST_EDGE] vectorized
-                                          BROADCAST [RS_133]
-                                            Group By Operator [GBY_132] (rows=1 width=12)
+                                          BROADCAST [RS_136]
+                                            Group By Operator [GBY_135] (rows=1 width=12)
                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE]
                                               PARTITION_ONLY_SHUFFLE [RS_99]

--- a/ql/src/test/results/clientpositive/perf/tez/query54.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query54.q.out
@@ -133,28 +133,28 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 16 <- Reducer 24 (BROADCAST_EDGE), Union 17 (CONTAINS)
-Map 22 <- Reducer 24 (BROADCAST_EDGE), Union 17 (CONTAINS)
+Map 27 <- Reducer 17 (BROADCAST_EDGE), Union 28 (CONTAINS)
+Map 29 <- Reducer 17 (BROADCAST_EDGE), Union 28 (CONTAINS)
 Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
-Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
-Reducer 14 <- Reducer 13 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
-Reducer 18 <- Map 23 (SIMPLE_EDGE), Union 17 (SIMPLE_EDGE)
-Reducer 19 <- Map 25 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 12 <- Map 11 (SIMPLE_EDGE), Union 28 (SIMPLE_EDGE)
+Reducer 13 <- Map 30 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 14 <- Map 31 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (SIMPLE_EDGE), Reducer 25 (SIMPLE_EDGE)
+Reducer 17 <- Map 11 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 11 (SIMPLE_EDGE)
+Reducer 19 <- Reducer 18 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 11 (SIMPLE_EDGE)
-Reducer 20 <- Map 26 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Reducer 20 (SIMPLE_EDGE)
-Reducer 24 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 27 (SIMPLE_EDGE)
-Reducer 29 <- Reducer 28 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Map 27 (SIMPLE_EDGE)
-Reducer 31 <- Reducer 30 (CUSTOM_SIMPLE_EDGE)
-Reducer 32 <- Map 27 (SIMPLE_EDGE)
-Reducer 33 <- Map 27 (SIMPLE_EDGE)
-Reducer 4 <- Reducer 29 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
-Reducer 5 <- Reducer 31 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 32 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-Reducer 7 <- Reducer 33 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 20 <- Map 11 (SIMPLE_EDGE)
+Reducer 21 <- Reducer 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 22 <- Map 11 (SIMPLE_EDGE)
+Reducer 23 <- Map 11 (SIMPLE_EDGE)
+Reducer 25 <- Map 24 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 4 <- Reducer 19 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+Reducer 6 <- Reducer 22 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 7 <- Reducer 23 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
@@ -198,180 +198,156 @@ Stage-0
                                       predicate:(_col4 <= _col15)
                                       Merge Join Operator [MERGEJOIN_276] (rows=109443205825 width=123)
                                         Conds:(Inner),Output:["_col2","_col4","_col10","_col15"]
-                                      <-Reducer 33 [CUSTOM_SIMPLE_EDGE] vectorized
+                                      <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
                                         PARTITION_ONLY_SHUFFLE [RS_348]
                                           Group By Operator [GBY_347] (rows=25 width=4)
                                             Output:["_col0"],keys:KEY._col0
-                                          <-Map 27 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_328]
+                                          <-Map 11 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_312]
                                               PartitionCols:_col0
-                                              Group By Operator [GBY_324] (rows=25 width=4)
+                                              Group By Operator [GBY_307] (rows=25 width=4)
                                                 Output:["_col0"],keys:_col0
-                                                Select Operator [SEL_320] (rows=50 width=12)
+                                                Select Operator [SEL_300] (rows=50 width=12)
                                                   Output:["_col0"]
-                                                  Filter Operator [FIL_316] (rows=50 width=12)
+                                                  Filter Operator [FIL_294] (rows=50 width=12)
                                                     predicate:((d_year = 1999) and (d_moy = 3) and d_month_seq is not null)
-                                                    TableScan [TS_50] (rows=73049 width=12)
-                                                      default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_month_seq","d_year","d_moy"]
+                                                    TableScan [TS_3] (rows=73049 width=8)
+                                                      default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq","d_year","d_moy"]
                                       <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                                         PARTITION_ONLY_SHUFFLE [RS_112]
                                           Filter Operator [FIL_111] (rows=4377728233 width=123)
                                             predicate:(_col14 <= _col4)
                                             Merge Join Operator [MERGEJOIN_275] (rows=13133184700 width=123)
                                               Conds:(Inner),Output:["_col2","_col4","_col10","_col14"]
-                                            <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
+                                            <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_346]
                                                 Group By Operator [GBY_345] (rows=25 width=4)
                                                   Output:["_col0"],keys:KEY._col0
-                                                <-Map 27 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_327]
+                                                <-Map 11 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_311]
                                                     PartitionCols:_col0
-                                                    Group By Operator [GBY_323] (rows=25 width=4)
+                                                    Group By Operator [GBY_306] (rows=25 width=4)
                                                       Output:["_col0"],keys:_col0
-                                                      Select Operator [SEL_319] (rows=50 width=12)
+                                                      Select Operator [SEL_299] (rows=50 width=12)
                                                         Output:["_col0"]
-                                                        Filter Operator [FIL_315] (rows=50 width=12)
+                                                        Filter Operator [FIL_293] (rows=50 width=12)
                                                           predicate:((d_year = 1999) and (d_moy = 3) and d_month_seq is not null)
-                                                           Please refer to the previous TableScan [TS_50]
+                                                           Please refer to the previous TableScan [TS_3]
                                             <-Reducer 5 [CUSTOM_SIMPLE_EDGE]
                                               PARTITION_ONLY_SHUFFLE [RS_108]
                                                 Merge Join Operator [MERGEJOIN_274] (rows=525327388 width=114)
                                                   Conds:(Inner),Output:["_col2","_col4","_col10"]
-                                                <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
                                                   PARTITION_ONLY_SHUFFLE [RS_344]
                                                     Select Operator [SEL_343] (rows=1 width=8)
                                                       Filter Operator [FIL_342] (rows=1 width=8)
                                                         predicate:(sq_count_check(_col0) <= 1)
                                                         Group By Operator [GBY_341] (rows=1 width=8)
                                                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                                        <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                        <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
                                                           PARTITION_ONLY_SHUFFLE [RS_340]
                                                             Group By Operator [GBY_339] (rows=1 width=8)
                                                               Output:["_col0"],aggregations:["count()"]
                                                               Select Operator [SEL_338] (rows=25 width=4)
                                                                 Group By Operator [GBY_337] (rows=25 width=4)
                                                                   Output:["_col0"],keys:KEY._col0
-                                                                <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_326]
+                                                                <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_310]
                                                                     PartitionCols:_col0
-                                                                    Group By Operator [GBY_322] (rows=25 width=4)
+                                                                    Group By Operator [GBY_305] (rows=25 width=4)
                                                                       Output:["_col0"],keys:_col0
-                                                                      Select Operator [SEL_318] (rows=50 width=12)
+                                                                      Select Operator [SEL_298] (rows=50 width=12)
                                                                         Output:["_col0"]
-                                                                        Filter Operator [FIL_314] (rows=50 width=12)
+                                                                        Filter Operator [FIL_292] (rows=50 width=12)
                                                                           predicate:((d_year = 1999) and (d_moy = 3))
-                                                                           Please refer to the previous TableScan [TS_50]
+                                                                           Please refer to the previous TableScan [TS_3]
                                                 <-Reducer 4 [CUSTOM_SIMPLE_EDGE]
                                                   PARTITION_ONLY_SHUFFLE [RS_105]
                                                     Merge Join Operator [MERGEJOIN_273] (rows=525327388 width=114)
                                                       Conds:(Inner),Output:["_col2","_col4","_col10"]
-                                                    <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_336]
                                                         Select Operator [SEL_335] (rows=1 width=8)
                                                           Filter Operator [FIL_334] (rows=1 width=8)
                                                             predicate:(sq_count_check(_col0) <= 1)
                                                             Group By Operator [GBY_333] (rows=1 width=8)
                                                               Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                                            <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            <-Reducer 18 [CUSTOM_SIMPLE_EDGE] vectorized
                                                               PARTITION_ONLY_SHUFFLE [RS_332]
                                                                 Group By Operator [GBY_331] (rows=1 width=8)
                                                                   Output:["_col0"],aggregations:["count()"]
                                                                   Select Operator [SEL_330] (rows=25 width=4)
                                                                     Group By Operator [GBY_329] (rows=25 width=4)
                                                                       Output:["_col0"],keys:KEY._col0
-                                                                    <-Map 27 [SIMPLE_EDGE] vectorized
-                                                                      SHUFFLE [RS_325]
+                                                                    <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                      SHUFFLE [RS_309]
                                                                         PartitionCols:_col0
-                                                                        Group By Operator [GBY_321] (rows=25 width=4)
+                                                                        Group By Operator [GBY_304] (rows=25 width=4)
                                                                           Output:["_col0"],keys:_col0
-                                                                          Select Operator [SEL_317] (rows=50 width=12)
+                                                                          Select Operator [SEL_297] (rows=50 width=12)
                                                                             Output:["_col0"]
-                                                                             Please refer to the previous Filter Operator [FIL_314]
+                                                                             Please refer to the previous Filter Operator [FIL_292]
                                                     <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                                                       PARTITION_ONLY_SHUFFLE [RS_102]
                                                         Merge Join Operator [MERGEJOIN_272] (rows=525327388 width=114)
                                                           Conds:RS_99._col1=RS_100._col5(Inner),Output:["_col2","_col4","_col10"]
-                                                        <-Reducer 14 [SIMPLE_EDGE]
+                                                        <-Reducer 16 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_100]
                                                             PartitionCols:_col5
                                                             Merge Join Operator [MERGEJOIN_271] (rows=55046 width=4)
-                                                              Conds:RS_46._col0=RS_313._col1(Inner),Output:["_col5"]
-                                                            <-Reducer 13 [SIMPLE_EDGE]
-                                                              SHUFFLE [RS_46]
-                                                                PartitionCols:_col0
-                                                                Merge Join Operator [MERGEJOIN_267] (rows=39720279 width=4)
-                                                                  Conds:RS_295._col1, _col2=RS_298._col0, _col1(Inner),Output:["_col0"]
-                                                                <-Map 12 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_295]
-                                                                    PartitionCols:_col1, _col2
-                                                                    Select Operator [SEL_294] (rows=40000000 width=188)
-                                                                      Output:["_col0","_col1","_col2"]
-                                                                      Filter Operator [FIL_293] (rows=40000000 width=188)
-                                                                        predicate:(ca_address_sk is not null and ca_county is not null and ca_state is not null)
-                                                                        TableScan [TS_6] (rows=40000000 width=188)
-                                                                          default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_state"]
-                                                                <-Map 15 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_298]
-                                                                    PartitionCols:_col0, _col1
-                                                                    Select Operator [SEL_297] (rows=1704 width=184)
-                                                                      Output:["_col0","_col1"]
-                                                                      Filter Operator [FIL_296] (rows=1704 width=184)
-                                                                        predicate:(s_county is not null and s_state is not null)
-                                                                        TableScan [TS_9] (rows=1704 width=184)
-                                                                          default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_county","s_state"]
-                                                            <-Reducer 21 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_313]
+                                                              Conds:RS_46._col0=RS_322._col1(Inner),Output:["_col5"]
+                                                            <-Reducer 15 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_322]
                                                                 PartitionCols:_col1
-                                                                Select Operator [SEL_312] (rows=55046 width=8)
+                                                                Select Operator [SEL_321] (rows=55046 width=8)
                                                                   Output:["_col0","_col1"]
-                                                                  Group By Operator [GBY_311] (rows=55046 width=8)
+                                                                  Group By Operator [GBY_320] (rows=55046 width=8)
                                                                     Output:["_col0","_col1"],keys:KEY._col0, KEY._col1
-                                                                  <-Reducer 20 [SIMPLE_EDGE]
+                                                                  <-Reducer 14 [SIMPLE_EDGE]
                                                                     SHUFFLE [RS_40]
                                                                       PartitionCols:_col0, _col1
                                                                       Group By Operator [GBY_39] (rows=55046 width=8)
                                                                         Output:["_col0","_col1"],keys:_col6, _col5
                                                                         Merge Join Operator [MERGEJOIN_270] (rows=110092 width=8)
-                                                                          Conds:RS_35._col1=RS_310._col0(Inner),Output:["_col5","_col6"]
-                                                                        <-Map 26 [SIMPLE_EDGE] vectorized
-                                                                          SHUFFLE [RS_310]
+                                                                          Conds:RS_35._col1=RS_319._col0(Inner),Output:["_col5","_col6"]
+                                                                        <-Map 31 [SIMPLE_EDGE] vectorized
+                                                                          SHUFFLE [RS_319]
                                                                             PartitionCols:_col0
-                                                                            Select Operator [SEL_309] (rows=80000000 width=8)
+                                                                            Select Operator [SEL_318] (rows=80000000 width=8)
                                                                               Output:["_col0","_col1"]
-                                                                              Filter Operator [FIL_308] (rows=80000000 width=8)
+                                                                              Filter Operator [FIL_317] (rows=80000000 width=8)
                                                                                 predicate:(c_customer_sk is not null and c_current_addr_sk is not null)
                                                                                 TableScan [TS_26] (rows=80000000 width=8)
                                                                                   default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_current_addr_sk"]
-                                                                        <-Reducer 19 [SIMPLE_EDGE]
+                                                                        <-Reducer 13 [SIMPLE_EDGE]
                                                                           SHUFFLE [RS_35]
                                                                             PartitionCols:_col1
                                                                             Merge Join Operator [MERGEJOIN_269] (rows=110092 width=0)
-                                                                              Conds:RS_32._col2=RS_307._col0(Inner),Output:["_col1"]
-                                                                            <-Map 25 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_307]
+                                                                              Conds:RS_32._col2=RS_316._col0(Inner),Output:["_col1"]
+                                                                            <-Map 30 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_316]
                                                                                 PartitionCols:_col0
-                                                                                Select Operator [SEL_306] (rows=453 width=4)
+                                                                                Select Operator [SEL_315] (rows=453 width=4)
                                                                                   Output:["_col0"]
-                                                                                  Filter Operator [FIL_305] (rows=453 width=186)
+                                                                                  Filter Operator [FIL_314] (rows=453 width=186)
                                                                                     predicate:((i_class = 'consignment') and (i_category = 'Jewelry') and i_item_sk is not null)
                                                                                     TableScan [TS_23] (rows=462000 width=186)
                                                                                       default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_class","i_category"]
-                                                                            <-Reducer 18 [SIMPLE_EDGE]
+                                                                            <-Reducer 12 [SIMPLE_EDGE]
                                                                               SHUFFLE [RS_32]
                                                                                 PartitionCols:_col2
                                                                                 Merge Join Operator [MERGEJOIN_268] (rows=11665117 width=7)
-                                                                                  Conds:Union 17._col0=RS_301._col0(Inner),Output:["_col1","_col2"]
-                                                                                <-Map 23 [SIMPLE_EDGE] vectorized
-                                                                                  PARTITION_ONLY_SHUFFLE [RS_301]
+                                                                                  Conds:Union 28._col0=RS_302._col0(Inner),Output:["_col1","_col2"]
+                                                                                <-Map 11 [SIMPLE_EDGE] vectorized
+                                                                                  SHUFFLE [RS_302]
                                                                                     PartitionCols:_col0
-                                                                                    Select Operator [SEL_300] (rows=50 width=4)
+                                                                                    Select Operator [SEL_296] (rows=50 width=4)
                                                                                       Output:["_col0"]
-                                                                                      Filter Operator [FIL_299] (rows=50 width=12)
+                                                                                      Filter Operator [FIL_291] (rows=50 width=12)
                                                                                         predicate:((d_year = 1999) and (d_moy = 3) and d_date_sk is not null)
-                                                                                        TableScan [TS_20] (rows=73049 width=12)
-                                                                                          default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                                                                <-Union 17 [SIMPLE_EDGE]
-                                                                                  <-Map 16 [CONTAINS] vectorized
+                                                                                         Please refer to the previous TableScan [TS_3]
+                                                                                <-Union 28 [SIMPLE_EDGE]
+                                                                                  <-Map 27 [CONTAINS] vectorized
                                                                                     Reduce Output Operator [RS_366]
                                                                                       PartitionCols:_col0
                                                                                       Select Operator [SEL_365] (rows=285117831 width=11)
@@ -380,18 +356,18 @@ Stage-0
                                                                                           predicate:(cs_sold_date_sk is not null and cs_bill_customer_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_30_date_dim_d_date_sk_min) AND DynamicValue(RS_30_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_30_date_dim_d_date_sk_bloom_filter)))
                                                                                           TableScan [TS_277] (rows=287989836 width=11)
                                                                                             Output:["cs_sold_date_sk","cs_bill_customer_sk","cs_item_sk"]
-                                                                                          <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                                                          <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                                                             BROADCAST [RS_362]
                                                                                               Group By Operator [GBY_361] (rows=1 width=12)
                                                                                                 Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                              <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                                PARTITION_ONLY_SHUFFLE [RS_304]
-                                                                                                  Group By Operator [GBY_303] (rows=1 width=12)
+                                                                                              <-Map 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                                                SHUFFLE [RS_313]
+                                                                                                  Group By Operator [GBY_308] (rows=1 width=12)
                                                                                                     Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                                    Select Operator [SEL_302] (rows=50 width=4)
+                                                                                                    Select Operator [SEL_303] (rows=50 width=4)
                                                                                                       Output:["_col0"]
-                                                                                                       Please refer to the previous Select Operator [SEL_300]
-                                                                                  <-Map 22 [CONTAINS] vectorized
+                                                                                                       Please refer to the previous Select Operator [SEL_296]
+                                                                                  <-Map 29 [CONTAINS] vectorized
                                                                                     Reduce Output Operator [RS_369]
                                                                                       PartitionCols:_col0
                                                                                       Select Operator [SEL_368] (rows=143930993 width=11)
@@ -400,14 +376,45 @@ Stage-0
                                                                                           predicate:(ws_bill_customer_sk is not null and ws_sold_date_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_30_date_dim_d_date_sk_min) AND DynamicValue(RS_30_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_30_date_dim_d_date_sk_bloom_filter)))
                                                                                           TableScan [TS_282] (rows=144002668 width=11)
                                                                                             Output:["ws_sold_date_sk","ws_item_sk","ws_bill_customer_sk"]
-                                                                                          <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                                                          <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                                                             BROADCAST [RS_363]
                                                                                                Please refer to the previous Group By Operator [GBY_361]
+                                                            <-Reducer 25 [SIMPLE_EDGE]
+                                                              SHUFFLE [RS_46]
+                                                                PartitionCols:_col0
+                                                                Merge Join Operator [MERGEJOIN_267] (rows=39720279 width=4)
+                                                                  Conds:RS_325._col1, _col2=RS_328._col0, _col1(Inner),Output:["_col0"]
+                                                                <-Map 24 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_325]
+                                                                    PartitionCols:_col1, _col2
+                                                                    Select Operator [SEL_324] (rows=40000000 width=188)
+                                                                      Output:["_col0","_col1","_col2"]
+                                                                      Filter Operator [FIL_323] (rows=40000000 width=188)
+                                                                        predicate:(ca_address_sk is not null and ca_county is not null and ca_state is not null)
+                                                                        TableScan [TS_6] (rows=40000000 width=188)
+                                                                          default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_county","ca_state"]
+                                                                <-Map 26 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_328]
+                                                                    PartitionCols:_col0, _col1
+                                                                    Select Operator [SEL_327] (rows=1704 width=184)
+                                                                      Output:["_col0","_col1"]
+                                                                      Filter Operator [FIL_326] (rows=1704 width=184)
+                                                                        predicate:(s_county is not null and s_state is not null)
+                                                                        TableScan [TS_9] (rows=1704 width=184)
+                                                                          default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_county","s_state"]
                                                         <-Reducer 2 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_99]
                                                             PartitionCols:_col1
                                                             Merge Join Operator [MERGEJOIN_266] (rows=525327388 width=114)
-                                                              Conds:RS_289._col0=RS_292._col0(Inner),Output:["_col1","_col2","_col4"]
+                                                              Conds:RS_289._col0=RS_301._col0(Inner),Output:["_col1","_col2","_col4"]
+                                                            <-Map 11 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_301]
+                                                                PartitionCols:_col0
+                                                                Select Operator [SEL_295] (rows=73049 width=8)
+                                                                  Output:["_col0","_col1"]
+                                                                  Filter Operator [FIL_290] (rows=73049 width=8)
+                                                                    predicate:(d_date_sk is not null and d_month_seq is not null)
+                                                                     Please refer to the previous TableScan [TS_3]
                                                             <-Map 1 [SIMPLE_EDGE] vectorized
                                                               SHUFFLE [RS_289]
                                                                 PartitionCols:_col0
@@ -417,13 +424,4 @@ Stage-0
                                                                     predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null)
                                                                     TableScan [TS_0] (rows=575995635 width=114)
                                                                       default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_customer_sk","ss_ext_sales_price"]
-                                                            <-Map 11 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_292]
-                                                                PartitionCols:_col0
-                                                                Select Operator [SEL_291] (rows=73049 width=8)
-                                                                  Output:["_col0","_col1"]
-                                                                  Filter Operator [FIL_290] (rows=73049 width=8)
-                                                                    predicate:(d_date_sk is not null and d_month_seq is not null)
-                                                                    TableScan [TS_3] (rows=73049 width=8)
-                                                                      default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query56.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query56.q.out
@@ -149,27 +149,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -207,40 +207,39 @@ Stage-0
                                 SHUFFLE [RS_104]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_294] (rows=15609 width=104)
-                                    Conds:RS_320._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
+                                    Conds:RS_322._col1=RS_326._col0(Inner),Output:["_col0","_col1"]
                                   <-Map 1 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_320]
+                                    SHUFFLE [RS_322]
                                       PartitionCols:_col1
-                                      Select Operator [SEL_319] (rows=462000 width=104)
+                                      Select Operator [SEL_320] (rows=462000 width=104)
                                         Output:["_col0","_col1"]
                                         Filter Operator [FIL_318] (rows=462000 width=104)
                                           predicate:(i_item_id is not null and i_item_sk is not null)
                                           TableScan [TS_0] (rows=462000 width=104)
-                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                  <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                            default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id","i_color"]
+                                  <-Reducer 12 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_326]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_325] (rows=10500 width=100)
                                         Output:["_col0"],keys:KEY._col0
-                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                      <-Map 1 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_324]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_323] (rows=10500 width=100)
                                             Output:["_col0"],keys:i_item_id
-                                            Select Operator [SEL_322] (rows=21000 width=189)
+                                            Select Operator [SEL_321] (rows=21000 width=189)
                                               Output:["i_item_id"]
-                                              Filter Operator [FIL_321] (rows=21000 width=189)
+                                              Filter Operator [FIL_319] (rows=21000 width=189)
                                                 predicate:((i_color) IN ('orchid', 'chiffon', 'lace') and i_item_id is not null)
-                                                TableScan [TS_3] (rows=462000 width=189)
-                                                  default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_id","i_color"]
-                              <-Reducer 23 [SIMPLE_EDGE]
+                                                 Please refer to the previous TableScan [TS_0]
+                              <-Reducer 22 [SIMPLE_EDGE]
                                 SHUFFLE [RS_105]
                                   PartitionCols:_col2
                                   Select Operator [SEL_100] (rows=788222 width=110)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_302] (rows=788222 width=110)
                                       Conds:RS_97._col2=RS_350._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_350]
                                         PartitionCols:_col0
                                         Select Operator [SEL_347] (rows=8000000 width=4)
@@ -249,12 +248,12 @@ Stage-0
                                             predicate:((ca_gmt_offset = -8) and ca_address_sk is not null)
                                             TableScan [TS_16] (rows=40000000 width=112)
                                               default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                    <-Reducer 22 [SIMPLE_EDGE]
+                                    <-Reducer 21 [SIMPLE_EDGE]
                                       SHUFFLE [RS_97]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_301] (rows=3941109 width=118)
                                           Conds:RS_372._col0=RS_333._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_333]
                                             PartitionCols:_col0
                                             Select Operator [SEL_328] (rows=50 width=4)
@@ -263,7 +262,7 @@ Stage-0
                                                 predicate:((d_year = 2000) and (d_moy = 1) and d_date_sk is not null)
                                                 TableScan [TS_13] (rows=73049 width=12)
                                                   default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                        <-Map 27 [SIMPLE_EDGE] vectorized
+                                        <-Map 26 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_372]
                                             PartitionCols:_col0
                                             Select Operator [SEL_371] (rows=143931246 width=123)
@@ -272,11 +271,11 @@ Stage-0
                                                 predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_95_date_dim_d_date_sk_min) AND DynamicValue(RS_95_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_95_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_85] (rows=144002668 width=123)
                                                   default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_369]
                                                     Group By Operator [GBY_368] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_340]
                                                         Group By Operator [GBY_337] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -301,27 +300,27 @@ Stage-0
                                 SHUFFLE [RS_29]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 16 [SIMPLE_EDGE]
+                              <-Reducer 15 [SIMPLE_EDGE]
                                 SHUFFLE [RS_30]
                                   PartitionCols:_col2
                                   Select Operator [SEL_25] (rows=2876890 width=4)
                                     Output:["_col2","_col4"]
                                     Merge Join Operator [MERGEJOIN_296] (rows=2876890 width=4)
                                       Conds:RS_22._col2=RS_348._col0(Inner),Output:["_col1","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_348]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 15 [SIMPLE_EDGE]
+                                    <-Reducer 14 [SIMPLE_EDGE]
                                       SHUFFLE [RS_22]
                                         PartitionCols:_col2
                                         Merge Join Operator [MERGEJOIN_295] (rows=14384447 width=4)
                                           Conds:RS_345._col0=RS_329._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_329]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 14 [SIMPLE_EDGE] vectorized
+                                        <-Map 13 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_345]
                                             PartitionCols:_col0
                                             Select Operator [SEL_344] (rows=525327191 width=118)
@@ -330,11 +329,11 @@ Stage-0
                                                 predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_20_date_dim_d_date_sk_min) AND DynamicValue(RS_20_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_20_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_10] (rows=575995635 width=118)
                                                   default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_342]
                                                     Group By Operator [GBY_341] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_338]
                                                         Group By Operator [GBY_335] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -359,27 +358,27 @@ Stage-0
                                 SHUFFLE [RS_66]
                                   PartitionCols:_col0
                                    Please refer to the previous Merge Join Operator [MERGEJOIN_294]
-                              <-Reducer 20 [SIMPLE_EDGE]
+                              <-Reducer 19 [SIMPLE_EDGE]
                                 SHUFFLE [RS_67]
                                   PartitionCols:_col3
                                   Select Operator [SEL_62] (rows=1550375 width=13)
                                     Output:["_col3","_col4"]
                                     Merge Join Operator [MERGEJOIN_299] (rows=1550375 width=13)
                                       Conds:RS_59._col1=RS_349._col0(Inner),Output:["_col2","_col3"]
-                                    <-Map 25 [SIMPLE_EDGE] vectorized
+                                    <-Map 24 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_349]
                                         PartitionCols:_col0
                                          Please refer to the previous Select Operator [SEL_347]
-                                    <-Reducer 19 [SIMPLE_EDGE]
+                                    <-Reducer 18 [SIMPLE_EDGE]
                                       SHUFFLE [RS_59]
                                         PartitionCols:_col1
                                         Merge Join Operator [MERGEJOIN_298] (rows=7751872 width=98)
                                           Conds:RS_364._col0=RS_331._col0(Inner),Output:["_col1","_col2","_col3"]
-                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                        <-Map 16 [SIMPLE_EDGE] vectorized
                                           PARTITION_ONLY_SHUFFLE [RS_331]
                                             PartitionCols:_col0
                                              Please refer to the previous Select Operator [SEL_328]
-                                        <-Map 26 [SIMPLE_EDGE] vectorized
+                                        <-Map 25 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_364]
                                             PartitionCols:_col0
                                             Select Operator [SEL_363] (rows=285117733 width=123)
@@ -388,11 +387,11 @@ Stage-0
                                                 predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                 TableScan [TS_47] (rows=287989836 width=123)
                                                   default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                   BROADCAST [RS_361]
                                                     Group By Operator [GBY_360] (rows=1 width=12)
                                                       Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                       PARTITION_ONLY_SHUFFLE [RS_339]
                                                         Group By Operator [GBY_336] (rows=1 width=12)
                                                           Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/query58.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query58.q.out
@@ -143,28 +143,28 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 1 <- Reducer 17 (BROADCAST_EDGE)
-Map 26 <- Reducer 18 (BROADCAST_EDGE)
-Map 27 <- Reducer 19 (BROADCAST_EDGE)
+Map 24 <- Reducer 18 (BROADCAST_EDGE)
+Map 25 <- Reducer 19 (BROADCAST_EDGE)
 Reducer 10 <- Reducer 16 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 27 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 12 <- Map 25 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 13 <- Reducer 12 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
-Reducer 16 <- Map 15 (SIMPLE_EDGE), Reducer 24 (SIMPLE_EDGE)
+Reducer 16 <- Map 15 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
 Reducer 17 <- Reducer 16 (CUSTOM_SIMPLE_EDGE)
 Reducer 18 <- Reducer 16 (CUSTOM_SIMPLE_EDGE)
 Reducer 19 <- Reducer 16 (CUSTOM_SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-Reducer 21 <- Map 20 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 25 (CUSTOM_SIMPLE_EDGE), Reducer 21 (CUSTOM_SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Reducer 23 (SIMPLE_EDGE)
+Reducer 20 <- Map 15 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
+Reducer 21 <- Reducer 20 (SIMPLE_EDGE)
+Reducer 22 <- Map 15 (CUSTOM_SIMPLE_EDGE), Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 23 <- Map 15 (CUSTOM_SIMPLE_EDGE)
 Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 14 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 9 <- Map 26 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 9 <- Map 24 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -204,65 +204,63 @@ Stage-0
                                   SHUFFLE [RS_143]
                                     PartitionCols:_col0
                                     Merge Join Operator [MERGEJOIN_407] (rows=2 width=4)
-                                      Conds:RS_423._col1=RS_439._col0(Inner),Output:["_col0"]
+                                      Conds:RS_429._col1=RS_439._col0(Inner),Output:["_col0"]
                                     <-Map 15 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_423]
+                                      PARTITION_ONLY_SHUFFLE [RS_429]
                                         PartitionCols:_col1
-                                        Select Operator [SEL_422] (rows=73049 width=98)
+                                        Select Operator [SEL_425] (rows=73049 width=98)
                                           Output:["_col0","_col1"]
                                           Filter Operator [FIL_421] (rows=73049 width=98)
                                             predicate:(d_date is not null and d_date_sk is not null)
                                             TableScan [TS_6] (rows=73049 width=98)
-                                              default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
-                                    <-Reducer 24 [SIMPLE_EDGE] vectorized
+                                              default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq"]
+                                    <-Reducer 21 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_439]
                                         PartitionCols:_col0
                                         Group By Operator [GBY_438] (rows=2 width=94)
                                           Output:["_col0"],keys:KEY._col0
-                                        <-Reducer 23 [SIMPLE_EDGE]
+                                        <-Reducer 20 [SIMPLE_EDGE]
                                           SHUFFLE [RS_32]
                                             PartitionCols:_col0
                                             Group By Operator [GBY_31] (rows=2 width=94)
                                               Output:["_col0"],keys:_col2
                                               Merge Join Operator [MERGEJOIN_406] (rows=5 width=94)
-                                                Conds:RS_27._col1=RS_436._col1(Inner),Output:["_col2"]
-                                              <-Map 25 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_436]
+                                                Conds:RS_27._col1=RS_430._col1(Inner),Output:["_col2"]
+                                              <-Map 15 [SIMPLE_EDGE] vectorized
+                                                PARTITION_ONLY_SHUFFLE [RS_430]
                                                   PartitionCols:_col1
-                                                  Select Operator [SEL_434] (rows=73049 width=98)
+                                                  Select Operator [SEL_426] (rows=73049 width=98)
                                                     Output:["_col0","_col1"]
-                                                    Filter Operator [FIL_432] (rows=73049 width=98)
+                                                    Filter Operator [FIL_422] (rows=73049 width=98)
                                                       predicate:(d_week_seq is not null and d_date is not null)
-                                                      TableScan [TS_21] (rows=73049 width=98)
-                                                        default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date","d_week_seq"]
+                                                       Please refer to the previous TableScan [TS_6]
                                               <-Reducer 22 [SIMPLE_EDGE]
                                                 SHUFFLE [RS_27]
                                                   PartitionCols:_col1
                                                   Merge Join Operator [MERGEJOIN_405] (rows=1 width=4)
                                                     Conds:(Inner),Output:["_col1"]
-                                                  <-Map 25 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_437]
-                                                      Select Operator [SEL_435] (rows=1 width=4)
-                                                        Output:["_col0"]
-                                                        Filter Operator [FIL_433] (rows=1 width=98)
-                                                          predicate:((d_date = '1998-02-19') and d_week_seq is not null)
-                                                           Please refer to the previous TableScan [TS_21]
-                                                  <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                  <-Map 15 [CUSTOM_SIMPLE_EDGE] vectorized
                                                     PARTITION_ONLY_SHUFFLE [RS_431]
-                                                      Select Operator [SEL_430] (rows=1 width=8)
-                                                        Filter Operator [FIL_429] (rows=1 width=8)
+                                                      Select Operator [SEL_427] (rows=1 width=4)
+                                                        Output:["_col0"]
+                                                        Filter Operator [FIL_423] (rows=1 width=98)
+                                                          predicate:((d_date = '1998-02-19') and d_week_seq is not null)
+                                                           Please refer to the previous TableScan [TS_6]
+                                                  <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_437]
+                                                      Select Operator [SEL_436] (rows=1 width=8)
+                                                        Filter Operator [FIL_435] (rows=1 width=8)
                                                           predicate:(sq_count_check(_col0) <= 1)
-                                                          Group By Operator [GBY_428] (rows=1 width=8)
+                                                          Group By Operator [GBY_434] (rows=1 width=8)
                                                             Output:["_col0"],aggregations:["count(VALUE._col0)"]
-                                                          <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                            PARTITION_ONLY_SHUFFLE [RS_427]
-                                                              Group By Operator [GBY_426] (rows=1 width=8)
+                                                          <-Map 15 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            PARTITION_ONLY_SHUFFLE [RS_433]
+                                                              Group By Operator [GBY_432] (rows=1 width=8)
                                                                 Output:["_col0"],aggregations:["count()"]
-                                                                Select Operator [SEL_425] (rows=1 width=94)
+                                                                Select Operator [SEL_428] (rows=1 width=94)
                                                                   Filter Operator [FIL_424] (rows=1 width=94)
                                                                     predicate:(d_date = '1998-02-19')
-                                                                    TableScan [TS_9] (rows=73049 width=94)
-                                                                      default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date"]
+                                                                     Please refer to the previous TableScan [TS_6]
                                 <-Reducer 12 [SIMPLE_EDGE]
                                   SHUFFLE [RS_142]
                                     PartitionCols:_col0
@@ -277,7 +275,7 @@ Stage-0
                                             predicate:(i_item_sk is not null and i_item_id is not null)
                                             TableScan [TS_3] (rows=462000 width=104)
                                               default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                    <-Map 27 [SIMPLE_EDGE] vectorized
+                                    <-Map 25 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_465]
                                         PartitionCols:_col1
                                         Select Operator [SEL_464] (rows=143966864 width=119)
@@ -331,7 +329,7 @@ Stage-0
                                             SHUFFLE [RS_448]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_446]
-                                          <-Map 26 [SIMPLE_EDGE] vectorized
+                                          <-Map 24 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_457]
                                               PartitionCols:_col1
                                               Select Operator [SEL_456] (rows=550076554 width=114)

--- a/ql/src/test/results/clientpositive/perf/tez/query59.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query59.q.out
@@ -96,13 +96,13 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 13 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Reducer 11 <- Map 12 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 13 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 14 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 4 <- Map 12 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 5 <- Map 13 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 11 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
-Reducer 7 <- Map 15 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+Reducer 7 <- Map 13 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
 Reducer 8 <- Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Map 1 (SIMPLE_EDGE), Map 12 (SIMPLE_EDGE)
 
@@ -111,10 +111,10 @@ Stage-0
     limit:100
     Stage-1
       Reducer 8 vectorized
-      File Output Operator [FS_215]
-        Limit [LIM_214] (rows=100 width=976)
+      File Output Operator [FS_214]
+        Limit [LIM_213] (rows=100 width=976)
           Number of rows:100
-          Select Operator [SEL_213] (rows=117616339 width=976)
+          Select Operator [SEL_212] (rows=117616339 width=976)
             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9"]
           <-Reducer 7 [SIMPLE_EDGE]
             SHUFFLE [RS_59]
@@ -123,16 +123,16 @@ Stage-0
                 Top N Key Operator [TNK_100] (rows=117616339 width=1648)
                   keys:_col12, _col11, _col0,top n:100
                   Merge Join Operator [MERGEJOIN_187] (rows=117616339 width=1648)
-                    Conds:RS_55._col11, _col14=RS_212._col1, _col0(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col20"]
-                  <-Map 15 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_212]
+                    Conds:RS_55._col11, _col14=RS_208._col1, _col0(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col11","_col12","_col15","_col16","_col17","_col18","_col19","_col20"]
+                  <-Map 13 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_208]
                       PartitionCols:_col1, _col0
-                      Select Operator [SEL_211] (rows=1704 width=104)
+                      Select Operator [SEL_206] (rows=1704 width=104)
                         Output:["_col0","_col1"]
-                        Filter Operator [FIL_210] (rows=1704 width=104)
+                        Filter Operator [FIL_205] (rows=1704 width=104)
                           predicate:(s_store_sk is not null and s_store_id is not null)
                           TableScan [TS_43] (rows=1704 width=104)
-                            default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_id"]
+                            default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_id","s_store_name"]
                   <-Reducer 6 [SIMPLE_EDGE]
                     SHUFFLE [RS_55]
                       PartitionCols:_col11, _col14
@@ -142,20 +142,20 @@ Stage-0
                         SHUFFLE [RS_53]
                           PartitionCols:(_col0 - 52)
                           Merge Join Operator [MERGEJOIN_185] (rows=28847 width=676)
-                            Conds:RS_209._col0=RS_204._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                          <-Map 13 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_204]
+                            Conds:RS_211._col0=RS_202._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
+                          <-Map 12 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_202]
                               PartitionCols:_col0
-                              Select Operator [SEL_202] (rows=317 width=4)
+                              Select Operator [SEL_198] (rows=317 width=4)
                                 Output:["_col0"]
-                                Filter Operator [FIL_200] (rows=317 width=8)
+                                Filter Operator [FIL_194] (rows=317 width=8)
                                   predicate:(d_month_seq BETWEEN 1197 AND 1208 and d_week_seq is not null)
-                                  TableScan [TS_15] (rows=73049 width=8)
-                                    default@date_dim,d,Tbl:COMPLETE,Col:COMPLETE,Output:["d_month_seq","d_week_seq"]
+                                  TableScan [TS_3] (rows=73049 width=99)
+                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name","d_month_seq"]
                           <-Reducer 10 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_209]
+                            SHUFFLE [RS_211]
                               PartitionCols:_col0
-                              Group By Operator [GBY_208] (rows=1196832 width=679)
+                              Group By Operator [GBY_210] (rows=1196832 width=679)
                                 Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)","sum(VALUE._col5)"],keys:KEY._col0, KEY._col1
                               <-Reducer 9 [SIMPLE_EDGE]
                                 SHUFFLE [RS_33]
@@ -165,7 +165,15 @@ Stage-0
                                     Select Operator [SEL_30] (rows=525329897 width=138)
                                       Output:["_col0","_col1","_col2","_col3","_col5","_col6","_col7","_col8"]
                                       Merge Join Operator [MERGEJOIN_184] (rows=525329897 width=138)
-                                        Conds:RS_191._col0=RS_196._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col8","_col9","_col10","_col11"]
+                                        Conds:RS_191._col0=RS_200._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col8","_col9","_col10","_col11"]
+                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                        SHUFFLE [RS_200]
+                                          PartitionCols:_col0
+                                          Select Operator [SEL_196] (rows=73049 width=36)
+                                            Output:["_col0","_col1","_col2","_col3","_col5","_col6","_col7","_col8"]
+                                            Filter Operator [FIL_192] (rows=73049 width=99)
+                                              predicate:(d_date_sk is not null and d_week_seq is not null)
+                                               Please refer to the previous TableScan [TS_3]
                                       <-Map 1 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_191]
                                           PartitionCols:_col0
@@ -175,46 +183,34 @@ Stage-0
                                               predicate:(ss_sold_date_sk is not null and ss_store_sk is not null)
                                               TableScan [TS_0] (rows=575995635 width=114)
                                                 default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_store_sk","ss_sales_price"]
-                                      <-Map 12 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_196]
-                                          PartitionCols:_col0
-                                          Select Operator [SEL_194] (rows=73049 width=36)
-                                            Output:["_col0","_col1","_col2","_col3","_col5","_col6","_col7","_col8"]
-                                            Filter Operator [FIL_192] (rows=73049 width=99)
-                                              predicate:(d_date_sk is not null and d_week_seq is not null)
-                                              TableScan [TS_3] (rows=73049 width=99)
-                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq","d_day_name"]
                       <-Reducer 5 [SIMPLE_EDGE]
                         SHUFFLE [RS_52]
                           PartitionCols:_col0
                           Merge Join Operator [MERGEJOIN_183] (rows=28847 width=976)
-                            Conds:RS_49._col1=RS_207._col0(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col11","_col12"]
-                          <-Map 14 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_207]
+                            Conds:RS_49._col1=RS_209._col0(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col11","_col12"]
+                          <-Map 13 [SIMPLE_EDGE] vectorized
+                            SHUFFLE [RS_209]
                               PartitionCols:_col0
-                              Select Operator [SEL_206] (rows=1704 width=192)
+                              Select Operator [SEL_207] (rows=1704 width=192)
                                 Output:["_col0","_col1","_col2"]
-                                Filter Operator [FIL_205] (rows=1704 width=192)
-                                  predicate:(s_store_sk is not null and s_store_id is not null)
-                                  TableScan [TS_18] (rows=1704 width=192)
-                                    default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_id","s_store_name"]
+                                 Please refer to the previous Filter Operator [FIL_205]
                           <-Reducer 4 [SIMPLE_EDGE]
                             SHUFFLE [RS_49]
                               PartitionCols:_col1
                               Merge Join Operator [MERGEJOIN_182] (rows=28847 width=788)
-                                Conds:RS_198._col0=RS_203._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                              <-Map 13 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_203]
+                                Conds:RS_204._col0=RS_201._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                              <-Map 12 [SIMPLE_EDGE] vectorized
+                                SHUFFLE [RS_201]
                                   PartitionCols:_col0
-                                  Select Operator [SEL_201] (rows=317 width=4)
+                                  Select Operator [SEL_197] (rows=317 width=4)
                                     Output:["_col0"]
-                                    Filter Operator [FIL_199] (rows=317 width=8)
+                                    Filter Operator [FIL_193] (rows=317 width=8)
                                       predicate:(d_month_seq BETWEEN 1185 AND 1196 and d_week_seq is not null)
-                                       Please refer to the previous TableScan [TS_15]
+                                       Please refer to the previous TableScan [TS_3]
                               <-Reducer 3 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_198]
+                                SHUFFLE [RS_204]
                                   PartitionCols:_col0
-                                  Group By Operator [GBY_197] (rows=1196832 width=791)
+                                  Group By Operator [GBY_203] (rows=1196832 width=791)
                                     Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)","sum(VALUE._col5)","sum(VALUE._col6)"],keys:KEY._col0, KEY._col1
                                   <-Reducer 2 [SIMPLE_EDGE]
                                     SHUFFLE [RS_12]
@@ -224,15 +220,15 @@ Stage-0
                                         Select Operator [SEL_9] (rows=525329897 width=142)
                                           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
                                           Merge Join Operator [MERGEJOIN_181] (rows=525329897 width=142)
-                                            Conds:RS_190._col0=RS_195._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
+                                            Conds:RS_190._col0=RS_199._col0(Inner),Output:["_col1","_col2","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
+                                          <-Map 12 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_199]
+                                              PartitionCols:_col0
+                                              Select Operator [SEL_195] (rows=73049 width=36)
+                                                Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                                                 Please refer to the previous Filter Operator [FIL_192]
                                           <-Map 1 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_190]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_189]
-                                          <-Map 12 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_195]
-                                              PartitionCols:_col0
-                                              Select Operator [SEL_193] (rows=73049 width=36)
-                                                Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                                 Please refer to the previous Filter Operator [FIL_192]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query60.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query60.q.out
@@ -169,27 +169,27 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 14 <- Reducer 18 (BROADCAST_EDGE)
-Map 26 <- Reducer 21 (BROADCAST_EDGE)
-Map 27 <- Reducer 24 (BROADCAST_EDGE)
-Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Map 13 <- Reducer 17 (BROADCAST_EDGE)
+Map 25 <- Reducer 20 (BROADCAST_EDGE)
+Map 26 <- Reducer 23 (BROADCAST_EDGE)
+Reducer 10 <- Reducer 2 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Union 5 (CONTAINS)
-Reducer 13 <- Map 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 16 <- Map 25 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 19 <- Map 17 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
-Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 20 <- Map 25 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 22 <- Map 17 (SIMPLE_EDGE), Map 27 (SIMPLE_EDGE)
-Reducer 23 <- Map 25 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 12 <- Map 1 (SIMPLE_EDGE)
+Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 16 (SIMPLE_EDGE)
+Reducer 15 <- Map 24 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 18 <- Map 16 (SIMPLE_EDGE), Map 25 (SIMPLE_EDGE)
+Reducer 19 <- Map 24 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 20 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 21 <- Map 16 (SIMPLE_EDGE), Map 26 (SIMPLE_EDGE)
+Reducer 22 <- Map 24 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 23 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Union 5 (CONTAINS)
 Reducer 6 <- Union 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Reducer 2 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 19 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE), Union 5 (CONTAINS)
 
 Stage-0
@@ -229,40 +229,39 @@ Stage-0
                                   SHUFFLE [RS_104]
                                     PartitionCols:_col0
                                     Merge Join Operator [MERGEJOIN_299] (rows=34340 width=104)
-                                      Conds:RS_328._col1=RS_334._col0(Inner),Output:["_col0","_col1"]
+                                      Conds:RS_330._col1=RS_334._col0(Inner),Output:["_col0","_col1"]
                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_328]
+                                      SHUFFLE [RS_330]
                                         PartitionCols:_col1
-                                        Select Operator [SEL_327] (rows=462000 width=104)
+                                        Select Operator [SEL_328] (rows=462000 width=104)
                                           Output:["_col0","_col1"]
                                           Filter Operator [FIL_326] (rows=462000 width=104)
                                             predicate:(i_item_id is not null and i_item_sk is not null)
                                             TableScan [TS_0] (rows=462000 width=104)
-                                              default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                    <-Reducer 13 [SIMPLE_EDGE] vectorized
+                                              default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id","i_category"]
+                                    <-Reducer 12 [SIMPLE_EDGE] vectorized
                                       SHUFFLE [RS_334]
                                         PartitionCols:_col0
                                         Group By Operator [GBY_333] (rows=23100 width=100)
                                           Output:["_col0"],keys:KEY._col0
-                                        <-Map 12 [SIMPLE_EDGE] vectorized
+                                        <-Map 1 [SIMPLE_EDGE] vectorized
                                           SHUFFLE [RS_332]
                                             PartitionCols:_col0
                                             Group By Operator [GBY_331] (rows=23100 width=100)
                                               Output:["_col0"],keys:i_item_id
-                                              Select Operator [SEL_330] (rows=46200 width=190)
+                                              Select Operator [SEL_329] (rows=46200 width=190)
                                                 Output:["i_item_id"]
-                                                Filter Operator [FIL_329] (rows=46200 width=190)
+                                                Filter Operator [FIL_327] (rows=46200 width=190)
                                                   predicate:((i_category = 'Children') and i_item_id is not null)
-                                                  TableScan [TS_3] (rows=462000 width=190)
-                                                    default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_id","i_category"]
-                                <-Reducer 23 [SIMPLE_EDGE]
+                                                   Please refer to the previous TableScan [TS_0]
+                                <-Reducer 22 [SIMPLE_EDGE]
                                   SHUFFLE [RS_105]
                                     PartitionCols:_col2
                                     Select Operator [SEL_100] (rows=788222 width=110)
                                       Output:["_col2","_col4"]
                                       Merge Join Operator [MERGEJOIN_307] (rows=788222 width=110)
                                         Conds:RS_97._col2=RS_358._col0(Inner),Output:["_col1","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_358]
                                           PartitionCols:_col0
                                           Select Operator [SEL_355] (rows=8000000 width=4)
@@ -271,12 +270,12 @@ Stage-0
                                               predicate:((ca_gmt_offset = -6) and ca_address_sk is not null)
                                               TableScan [TS_16] (rows=40000000 width=112)
                                                 default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_gmt_offset"]
-                                      <-Reducer 22 [SIMPLE_EDGE]
+                                      <-Reducer 21 [SIMPLE_EDGE]
                                         SHUFFLE [RS_97]
                                           PartitionCols:_col2
                                           Merge Join Operator [MERGEJOIN_306] (rows=3941109 width=118)
                                             Conds:RS_382._col0=RS_341._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_341]
                                               PartitionCols:_col0
                                               Select Operator [SEL_336] (rows=50 width=4)
@@ -285,7 +284,7 @@ Stage-0
                                                   predicate:((d_year = 1999) and (d_moy = 9) and d_date_sk is not null)
                                                   TableScan [TS_13] (rows=73049 width=12)
                                                     default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
-                                          <-Map 27 [SIMPLE_EDGE] vectorized
+                                          <-Map 26 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_382]
                                               PartitionCols:_col0
                                               Select Operator [SEL_381] (rows=143931246 width=123)
@@ -294,11 +293,11 @@ Stage-0
                                                   predicate:(ws_sold_date_sk is not null and ws_bill_addr_sk is not null and ws_item_sk is not null and ws_sold_date_sk BETWEEN DynamicValue(RS_95_date_dim_d_date_sk_min) AND DynamicValue(RS_95_date_dim_d_date_sk_max) and in_bloom_filter(ws_sold_date_sk, DynamicValue(RS_95_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_85] (rows=144002668 width=123)
                                                     default@web_sales,web_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ws_sold_date_sk","ws_item_sk","ws_bill_addr_sk","ws_ext_sales_price"]
-                                                  <-Reducer 24 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 23 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_379]
                                                       Group By Operator [GBY_378] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_348]
                                                           Group By Operator [GBY_345] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -325,27 +324,27 @@ Stage-0
                                   SHUFFLE [RS_29]
                                     PartitionCols:_col0
                                      Please refer to the previous Merge Join Operator [MERGEJOIN_299]
-                                <-Reducer 16 [SIMPLE_EDGE]
+                                <-Reducer 15 [SIMPLE_EDGE]
                                   SHUFFLE [RS_30]
                                     PartitionCols:_col2
                                     Select Operator [SEL_25] (rows=2876890 width=4)
                                       Output:["_col2","_col4"]
                                       Merge Join Operator [MERGEJOIN_301] (rows=2876890 width=4)
                                         Conds:RS_22._col2=RS_356._col0(Inner),Output:["_col1","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_356]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_355]
-                                      <-Reducer 15 [SIMPLE_EDGE]
+                                      <-Reducer 14 [SIMPLE_EDGE]
                                         SHUFFLE [RS_22]
                                           PartitionCols:_col2
                                           Merge Join Operator [MERGEJOIN_300] (rows=14384447 width=4)
                                             Conds:RS_353._col0=RS_337._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_337]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_336]
-                                          <-Map 14 [SIMPLE_EDGE] vectorized
+                                          <-Map 13 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_353]
                                               PartitionCols:_col0
                                               Select Operator [SEL_352] (rows=525327191 width=118)
@@ -354,11 +353,11 @@ Stage-0
                                                   predicate:(ss_sold_date_sk is not null and ss_addr_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_20_date_dim_d_date_sk_min) AND DynamicValue(RS_20_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_20_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_10] (rows=575995635 width=118)
                                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_addr_sk","ss_ext_sales_price"]
-                                                  <-Reducer 18 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 17 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_350]
                                                       Group By Operator [GBY_349] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_346]
                                                           Group By Operator [GBY_343] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
@@ -385,27 +384,27 @@ Stage-0
                                   SHUFFLE [RS_66]
                                     PartitionCols:_col0
                                      Please refer to the previous Merge Join Operator [MERGEJOIN_299]
-                                <-Reducer 20 [SIMPLE_EDGE]
+                                <-Reducer 19 [SIMPLE_EDGE]
                                   SHUFFLE [RS_67]
                                     PartitionCols:_col3
                                     Select Operator [SEL_62] (rows=1550375 width=13)
                                       Output:["_col3","_col4"]
                                       Merge Join Operator [MERGEJOIN_304] (rows=1550375 width=13)
                                         Conds:RS_59._col1=RS_357._col0(Inner),Output:["_col2","_col3"]
-                                      <-Map 25 [SIMPLE_EDGE] vectorized
+                                      <-Map 24 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_357]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_355]
-                                      <-Reducer 19 [SIMPLE_EDGE]
+                                      <-Reducer 18 [SIMPLE_EDGE]
                                         SHUFFLE [RS_59]
                                           PartitionCols:_col1
                                           Merge Join Operator [MERGEJOIN_303] (rows=7751872 width=98)
                                             Conds:RS_373._col0=RS_339._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                             PARTITION_ONLY_SHUFFLE [RS_339]
                                               PartitionCols:_col0
                                                Please refer to the previous Select Operator [SEL_336]
-                                          <-Map 26 [SIMPLE_EDGE] vectorized
+                                          <-Map 25 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_373]
                                               PartitionCols:_col0
                                               Select Operator [SEL_372] (rows=285117733 width=123)
@@ -414,11 +413,11 @@ Stage-0
                                                   predicate:(cs_sold_date_sk is not null and cs_bill_addr_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_57_date_dim_d_date_sk_min) AND DynamicValue(RS_57_date_dim_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_57_date_dim_d_date_sk_bloom_filter)))
                                                   TableScan [TS_47] (rows=287989836 width=123)
                                                     default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_bill_addr_sk","cs_item_sk","cs_ext_sales_price"]
-                                                  <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                  <-Reducer 20 [BROADCAST_EDGE] vectorized
                                                     BROADCAST [RS_370]
                                                       Group By Operator [GBY_369] (rows=1 width=12)
                                                         Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
                                                         PARTITION_ONLY_SHUFFLE [RS_347]
                                                           Group By Operator [GBY_344] (rows=1 width=12)
                                                             Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]

--- a/ql/src/test/results/clientpositive/perf/tez/query61.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query61.q.out
@@ -104,22 +104,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 23 <- Reducer 19 (BROADCAST_EDGE)
-Map 9 <- Reducer 15 (BROADCAST_EDGE)
-Reducer 10 <- Map 14 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 20 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 21 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Map 22 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
-Reducer 15 <- Map 14 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Map 14 (SIMPLE_EDGE), Map 23 (SIMPLE_EDGE)
-Reducer 17 <- Map 20 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
-Reducer 18 <- Map 21 (SIMPLE_EDGE), Reducer 17 (SIMPLE_EDGE)
-Reducer 19 <- Map 14 (CUSTOM_SIMPLE_EDGE)
+Reducer 10 <- Map 17 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 11 <- Map 18 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Reducer 12 <- Map 19 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 20 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 14 <- Map 17 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 15 <- Map 18 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
+Reducer 16 <- Map 19 (SIMPLE_EDGE), Reducer 15 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 18 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 6 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
@@ -133,8 +129,8 @@ Stage-0
           Merge Join Operator [MERGEJOIN_263] (rows=1 width=224)
             Conds:(Inner),Output:["_col0","_col1"]
           <-Reducer 4 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_297]
-              Group By Operator [GBY_296] (rows=1 width=112)
+            PARTITION_ONLY_SHUFFLE [RS_292]
+              Group By Operator [GBY_291] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(VALUE._col0)"]
               <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                 PARTITION_ONLY_SHUFFLE [RS_42]
@@ -169,13 +165,13 @@ Stage-0
                       SHUFFLE [RS_38]
                         PartitionCols:_col2
                         Merge Join Operator [MERGEJOIN_256] (rows=2526982 width=0)
-                          Conds:RS_30._col4=RS_295._col0(Inner),Output:["_col2","_col5"]
-                        <-Map 22 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_295]
+                          Conds:RS_30._col4=RS_290._col0(Inner),Output:["_col2","_col5"]
+                        <-Map 20 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_290]
                             PartitionCols:_col0
-                            Select Operator [SEL_294] (rows=2300 width=4)
+                            Select Operator [SEL_289] (rows=2300 width=4)
                               Output:["_col0"]
-                              Filter Operator [FIL_293] (rows=2300 width=259)
+                              Filter Operator [FIL_288] (rows=2300 width=259)
                                 predicate:(((p_channel_dmail = 'Y') or (p_channel_email = 'Y') or (p_channel_tv = 'Y')) and p_promo_sk is not null)
                                 TableScan [TS_18] (rows=2300 width=259)
                                   default@promotion,promotion,Tbl:COMPLETE,Col:COMPLETE,Output:["p_promo_sk","p_channel_dmail","p_channel_email","p_channel_tv"]
@@ -183,13 +179,13 @@ Stage-0
                           SHUFFLE [RS_30]
                             PartitionCols:_col4
                             Merge Join Operator [MERGEJOIN_255] (rows=2526982 width=0)
-                              Conds:RS_27._col3=RS_291._col0(Inner),Output:["_col2","_col4","_col5"]
-                            <-Map 21 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_291]
+                              Conds:RS_27._col3=RS_286._col0(Inner),Output:["_col2","_col4","_col5"]
+                            <-Map 19 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_286]
                                 PartitionCols:_col0
-                                Select Operator [SEL_290] (rows=341 width=4)
+                                Select Operator [SEL_285] (rows=341 width=4)
                                   Output:["_col0"]
-                                  Filter Operator [FIL_289] (rows=341 width=115)
+                                  Filter Operator [FIL_284] (rows=341 width=115)
                                     predicate:((s_gmt_offset = -7) and s_store_sk is not null)
                                     TableScan [TS_15] (rows=1704 width=115)
                                       default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_gmt_offset"]
@@ -197,13 +193,13 @@ Stage-0
                               SHUFFLE [RS_27]
                                 PartitionCols:_col3
                                 Merge Join Operator [MERGEJOIN_254] (rows=12627499 width=0)
-                                  Conds:RS_24._col1=RS_287._col0(Inner),Output:["_col2","_col3","_col4","_col5"]
-                                <-Map 20 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_287]
+                                  Conds:RS_24._col1=RS_282._col0(Inner),Output:["_col2","_col3","_col4","_col5"]
+                                <-Map 18 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_282]
                                     PartitionCols:_col0
-                                    Select Operator [SEL_286] (rows=46200 width=4)
+                                    Select Operator [SEL_281] (rows=46200 width=4)
                                       Output:["_col0"]
-                                      Filter Operator [FIL_285] (rows=46200 width=94)
+                                      Filter Operator [FIL_280] (rows=46200 width=94)
                                         predicate:((i_category = 'Electronics') and i_item_sk is not null)
                                         TableScan [TS_12] (rows=462000 width=94)
                                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_category"]
@@ -211,39 +207,28 @@ Stage-0
                                   SHUFFLE [RS_24]
                                     PartitionCols:_col1
                                     Merge Join Operator [MERGEJOIN_253] (rows=13119234 width=4)
-                                      Conds:RS_284._col0=RS_272._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                    <-Map 14 [SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_272]
+                                      Conds:RS_274._col0=RS_278._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5"]
+                                    <-Map 17 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_278]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_271] (rows=50 width=4)
+                                        Select Operator [SEL_277] (rows=50 width=4)
                                           Output:["_col0"]
-                                          Filter Operator [FIL_270] (rows=50 width=12)
+                                          Filter Operator [FIL_276] (rows=50 width=12)
                                             predicate:((d_year = 1999) and (d_moy = 11) and d_date_sk is not null)
                                             TableScan [TS_9] (rows=73049 width=12)
                                               default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year","d_moy"]
                                     <-Map 9 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_284]
+                                      SHUFFLE [RS_274]
                                         PartitionCols:_col0
-                                        Select Operator [SEL_283] (rows=479120969 width=126)
+                                        Select Operator [SEL_272] (rows=479120969 width=126)
                                           Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                                          Filter Operator [FIL_282] (rows=479120969 width=126)
-                                            predicate:(ss_sold_date_sk is not null and ss_promo_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_22_date_dim_d_date_sk_min) AND DynamicValue(RS_22_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_22_date_dim_d_date_sk_bloom_filter)))
+                                          Filter Operator [FIL_270] (rows=479120969 width=126)
+                                            predicate:(ss_sold_date_sk is not null and ss_promo_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk is not null)
                                             TableScan [TS_6] (rows=575995635 width=126)
                                               default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_promo_sk","ss_ext_sales_price"]
-                                            <-Reducer 15 [BROADCAST_EDGE] vectorized
-                                              BROADCAST [RS_281]
-                                                Group By Operator [GBY_280] (rows=1 width=12)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                <-Map 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_278]
-                                                    Group By Operator [GBY_276] (rows=1 width=12)
-                                                      Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                      Select Operator [SEL_273] (rows=50 width=4)
-                                                        Output:["_col0"]
-                                                         Please refer to the previous Select Operator [SEL_271]
           <-Reducer 7 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_304]
-              Group By Operator [GBY_303] (rows=1 width=112)
+            PARTITION_ONLY_SHUFFLE [RS_294]
+              Group By Operator [GBY_293] (rows=1 width=112)
                 Output:["_col0"],aggregations:["sum(VALUE._col0)"]
               <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                 PARTITION_ONLY_SHUFFLE [RS_81]
@@ -255,51 +240,39 @@ Stage-0
                       SHUFFLE [RS_76]
                         PartitionCols:_col0
                          Please refer to the previous Merge Join Operator [MERGEJOIN_252]
-                    <-Reducer 18 [SIMPLE_EDGE]
+                    <-Reducer 16 [SIMPLE_EDGE]
                       SHUFFLE [RS_77]
                         PartitionCols:_col2
                         Merge Join Operator [MERGEJOIN_260] (rows=2646038 width=0)
-                          Conds:RS_69._col3=RS_292._col0(Inner),Output:["_col2","_col4"]
-                        <-Map 21 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_292]
+                          Conds:RS_69._col3=RS_287._col0(Inner),Output:["_col2","_col4"]
+                        <-Map 19 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_287]
                             PartitionCols:_col0
-                             Please refer to the previous Select Operator [SEL_290]
-                        <-Reducer 17 [SIMPLE_EDGE]
+                             Please refer to the previous Select Operator [SEL_285]
+                        <-Reducer 15 [SIMPLE_EDGE]
                           SHUFFLE [RS_69]
                             PartitionCols:_col3
                             Merge Join Operator [MERGEJOIN_259] (rows=13222427 width=0)
-                              Conds:RS_66._col1=RS_288._col0(Inner),Output:["_col2","_col3","_col4"]
-                            <-Map 20 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_288]
+                              Conds:RS_66._col1=RS_283._col0(Inner),Output:["_col2","_col3","_col4"]
+                            <-Map 18 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_283]
                                 PartitionCols:_col0
-                                 Please refer to the previous Select Operator [SEL_286]
-                            <-Reducer 16 [SIMPLE_EDGE]
+                                 Please refer to the previous Select Operator [SEL_281]
+                            <-Reducer 14 [SIMPLE_EDGE]
                               SHUFFLE [RS_66]
                                 PartitionCols:_col1
                                 Merge Join Operator [MERGEJOIN_258] (rows=13737330 width=4)
-                                  Conds:RS_302._col0=RS_274._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
-                                <-Map 14 [SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_274]
+                                  Conds:RS_275._col0=RS_279._col0(Inner),Output:["_col1","_col2","_col3","_col4"]
+                                <-Map 17 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_279]
                                     PartitionCols:_col0
-                                     Please refer to the previous Select Operator [SEL_271]
-                                <-Map 23 [SIMPLE_EDGE] vectorized
-                                  SHUFFLE [RS_302]
+                                     Please refer to the previous Select Operator [SEL_277]
+                                <-Map 9 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_275]
                                     PartitionCols:_col0
-                                    Select Operator [SEL_301] (rows=501694138 width=122)
+                                    Select Operator [SEL_273] (rows=501694138 width=122)
                                       Output:["_col0","_col1","_col2","_col3","_col4"]
-                                      Filter Operator [FIL_300] (rows=501694138 width=122)
-                                        predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_64_date_dim_d_date_sk_min) AND DynamicValue(RS_64_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_64_date_dim_d_date_sk_bloom_filter)))
-                                        TableScan [TS_51] (rows=575995635 width=122)
-                                          default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_store_sk","ss_ext_sales_price"]
-                                        <-Reducer 19 [BROADCAST_EDGE] vectorized
-                                          BROADCAST [RS_299]
-                                            Group By Operator [GBY_298] (rows=1 width=12)
-                                              Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                            <-Map 14 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_279]
-                                                Group By Operator [GBY_277] (rows=1 width=12)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                  Select Operator [SEL_275] (rows=50 width=4)
-                                                    Output:["_col0"]
-                                                     Please refer to the previous Select Operator [SEL_271]
+                                      Filter Operator [FIL_271] (rows=501694138 width=122)
+                                        predicate:(ss_sold_date_sk is not null and ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk is not null)
+                                         Please refer to the previous TableScan [TS_6]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query64.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query64.q.out
@@ -266,48 +266,44 @@ Plan optimized by CBO.
 
 Vertex dependency in root stage
 Map 38 <- Reducer 25 (BROADCAST_EDGE)
-Map 44 <- Reducer 41 (BROADCAST_EDGE)
-Map 54 <- Reducer 33 (BROADCAST_EDGE)
-Map 55 <- Reducer 43 (BROADCAST_EDGE)
+Map 52 <- Reducer 33 (BROADCAST_EDGE)
 Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
 Reducer 12 <- Reducer 11 (SIMPLE_EDGE)
 Reducer 13 <- Reducer 32 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 14 <- Map 53 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 14 <- Map 51 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
 Reducer 15 <- Map 36 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 Reducer 16 <- Reducer 15 (SIMPLE_EDGE)
 Reducer 18 <- Map 17 (SIMPLE_EDGE), Reducer 39 (SIMPLE_EDGE)
-Reducer 19 <- Reducer 18 (SIMPLE_EDGE), Reducer 46 (SIMPLE_EDGE)
+Reducer 19 <- Reducer 18 (SIMPLE_EDGE), Reducer 44 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 20 <- Map 50 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
+Reducer 20 <- Map 48 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
 Reducer 21 <- Map 34 (SIMPLE_EDGE), Reducer 20 (SIMPLE_EDGE)
-Reducer 22 <- Map 51 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
+Reducer 22 <- Map 49 (SIMPLE_EDGE), Reducer 21 (SIMPLE_EDGE)
 Reducer 23 <- Map 37 (SIMPLE_EDGE), Reducer 22 (SIMPLE_EDGE)
-Reducer 24 <- Map 52 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
+Reducer 24 <- Map 50 (SIMPLE_EDGE), Reducer 23 (SIMPLE_EDGE)
 Reducer 25 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 26 <- Map 17 (SIMPLE_EDGE), Reducer 42 (SIMPLE_EDGE)
-Reducer 27 <- Reducer 26 (SIMPLE_EDGE), Reducer 49 (SIMPLE_EDGE)
-Reducer 28 <- Map 50 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
+Reducer 26 <- Map 17 (SIMPLE_EDGE), Reducer 41 (SIMPLE_EDGE)
+Reducer 27 <- Reducer 26 (SIMPLE_EDGE), Reducer 46 (SIMPLE_EDGE)
+Reducer 28 <- Map 48 (SIMPLE_EDGE), Reducer 27 (SIMPLE_EDGE)
 Reducer 29 <- Map 34 (SIMPLE_EDGE), Reducer 28 (SIMPLE_EDGE)
 Reducer 3 <- Map 17 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 30 <- Map 51 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE)
+Reducer 30 <- Map 49 (SIMPLE_EDGE), Reducer 29 (SIMPLE_EDGE)
 Reducer 31 <- Map 37 (SIMPLE_EDGE), Reducer 30 (SIMPLE_EDGE)
-Reducer 32 <- Map 52 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE)
+Reducer 32 <- Map 50 (SIMPLE_EDGE), Reducer 31 (SIMPLE_EDGE)
 Reducer 33 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 35 <- Map 34 (SIMPLE_EDGE), Map 36 (SIMPLE_EDGE)
 Reducer 39 <- Map 38 (SIMPLE_EDGE), Map 40 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE), Reducer 35 (SIMPLE_EDGE)
-Reducer 41 <- Map 40 (CUSTOM_SIMPLE_EDGE)
-Reducer 42 <- Map 40 (SIMPLE_EDGE), Map 54 (SIMPLE_EDGE)
-Reducer 43 <- Map 40 (CUSTOM_SIMPLE_EDGE)
-Reducer 45 <- Map 44 (SIMPLE_EDGE), Map 47 (SIMPLE_EDGE)
+Reducer 41 <- Map 40 (SIMPLE_EDGE), Map 52 (SIMPLE_EDGE)
+Reducer 43 <- Map 42 (SIMPLE_EDGE), Map 47 (SIMPLE_EDGE)
+Reducer 44 <- Reducer 43 (SIMPLE_EDGE)
+Reducer 45 <- Map 42 (SIMPLE_EDGE), Map 47 (SIMPLE_EDGE)
 Reducer 46 <- Reducer 45 (SIMPLE_EDGE)
-Reducer 48 <- Map 47 (SIMPLE_EDGE), Map 55 (SIMPLE_EDGE)
-Reducer 49 <- Reducer 48 (SIMPLE_EDGE)
 Reducer 5 <- Map 37 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
-Reducer 6 <- Map 53 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
+Reducer 6 <- Map 51 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 24 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 53 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 8 <- Map 51 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
 Reducer 9 <- Map 36 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -315,8 +311,8 @@ Stage-0
     limit:-1
     Stage-1
       Reducer 12 vectorized
-      File Output Operator [FS_1216]
-        Select Operator [SEL_1215] (rows=114089652126 width=1702)
+      File Output Operator [FS_1204]
+        Select Operator [SEL_1203] (rows=114089652126 width=1702)
           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17","_col18","_col19","_col20"]
         <-Reducer 11 [SIMPLE_EDGE]
           SHUFFLE [RS_259]
@@ -325,17 +321,17 @@ Stage-0
               Filter Operator [FIL_257] (rows=114089652126 width=1694)
                 predicate:(_col19 <= _col12)
                 Merge Join Operator [MERGEJOIN_1111] (rows=342268956379 width=1694)
-                  Conds:RS_1195._col2, _col1, _col3=RS_1214._col1, _col0, _col2(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col19","_col20","_col21","_col22"]
+                  Conds:RS_1188._col2, _col1, _col3=RS_1202._col1, _col0, _col2(Inner),Output:["_col0","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col19","_col20","_col21","_col22"]
                 <-Reducer 10 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_1195]
+                  SHUFFLE [RS_1188]
                     PartitionCols:_col2, _col1, _col3
-                    Select Operator [SEL_1194] (rows=23886447 width=1354)
+                    Select Operator [SEL_1187] (rows=23886447 width=1354)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15"]
-                      Filter Operator [FIL_1193] (rows=23886447 width=1362)
+                      Filter Operator [FIL_1186] (rows=23886447 width=1362)
                         predicate:_col14 is not null
-                        Select Operator [SEL_1192] (rows=23886447 width=1362)
+                        Select Operator [SEL_1185] (rows=23886447 width=1362)
                           Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col14","_col15","_col16","_col17"]
-                          Group By Operator [GBY_1191] (rows=23886447 width=1362)
+                          Group By Operator [GBY_1184] (rows=23886447 width=1362)
                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"],aggregations:["count(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4, KEY._col5, KEY._col6, KEY._col7, KEY._col8, KEY._col9, KEY._col10, KEY._col11, KEY._col12, KEY._col13
                           <-Reducer 9 [SIMPLE_EDGE]
                             SHUFFLE [RS_122]
@@ -360,7 +356,7 @@ Stage-0
                                       predicate:(_col50 <> _col19)
                                       Merge Join Operator [MERGEJOIN_1091] (rows=24224230 width=1327)
                                         Conds:RS_113._col36=RS_1148._col0(Inner),Output:["_col7","_col9","_col14","_col15","_col16","_col17","_col19","_col23","_col24","_col25","_col26","_col28","_col29","_col31","_col42","_col43","_col44","_col45","_col46","_col50"]
-                                      <-Map 53 [SIMPLE_EDGE] vectorized
+                                      <-Map 51 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_1148]
                                           PartitionCols:_col0
                                           Select Operator [SEL_1147] (rows=1861800 width=89)
@@ -379,7 +375,7 @@ Stage-0
                                               PartitionCols:_col0
                                               Merge Join Operator [MERGEJOIN_1080] (rows=70357394 width=458)
                                                 Conds:RS_107._col1=RS_1149._col0(Inner),Output:["_col0","_col7","_col9","_col14","_col15","_col16","_col17","_col19"]
-                                              <-Map 53 [SIMPLE_EDGE] vectorized
+                                              <-Map 51 [SIMPLE_EDGE] vectorized
                                                 SHUFFLE [RS_1149]
                                                   PartitionCols:_col0
                                                    Please refer to the previous Select Operator [SEL_1147]
@@ -458,13 +454,13 @@ Stage-0
                                               Select Operator [SEL_88] (rows=23886447 width=788)
                                                 Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col11","_col15","_col16","_col22","_col23","_col24","_col25","_col26"]
                                                 Merge Join Operator [MERGEJOIN_1089] (rows=23886447 width=788)
-                                                  Conds:RS_85._col1, _col8=RS_1189._col0, _col1(Inner),Output:["_col2","_col3","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21","_col23","_col24","_col25","_col26"]
-                                                <-Map 52 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1189]
+                                                  Conds:RS_85._col1, _col8=RS_1182._col0, _col1(Inner),Output:["_col2","_col3","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21","_col23","_col24","_col25","_col26"]
+                                                <-Map 50 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1182]
                                                     PartitionCols:_col0, _col1
-                                                    Select Operator [SEL_1188] (rows=57591150 width=8)
+                                                    Select Operator [SEL_1181] (rows=57591150 width=8)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_1187] (rows=57591150 width=8)
+                                                      Filter Operator [FIL_1180] (rows=57591150 width=8)
                                                         predicate:(sr_item_sk is not null and sr_ticket_number is not null)
                                                         TableScan [TS_61] (rows=57591150 width=8)
                                                           default@store_returns,store_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["sr_item_sk","sr_ticket_number"]
@@ -481,13 +477,13 @@ Stage-0
                                                       SHUFFLE [RS_82]
                                                         PartitionCols:_col5
                                                         Merge Join Operator [MERGEJOIN_1087] (rows=14487982 width=300)
-                                                          Conds:RS_79._col6=RS_1185._col0(Inner),Output:["_col1","_col2","_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21"]
-                                                        <-Map 51 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_1185]
+                                                          Conds:RS_79._col6=RS_1178._col0(Inner),Output:["_col1","_col2","_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21"]
+                                                        <-Map 49 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_1178]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_1184] (rows=1704 width=181)
+                                                            Select Operator [SEL_1177] (rows=1704 width=181)
                                                               Output:["_col0","_col1","_col2"]
-                                                              Filter Operator [FIL_1183] (rows=1704 width=181)
+                                                              Filter Operator [FIL_1176] (rows=1704 width=181)
                                                                 predicate:(s_store_sk is not null and s_store_name is not null and s_zip is not null)
                                                                 TableScan [TS_55] (rows=1704 width=181)
                                                                   default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_name","s_zip"]
@@ -504,13 +500,13 @@ Stage-0
                                                               SHUFFLE [RS_76]
                                                                 PartitionCols:_col4
                                                                 Merge Join Operator [MERGEJOIN_1085] (rows=14487982 width=119)
-                                                                  Conds:RS_73._col7=RS_1181._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col13"]
-                                                                <-Map 50 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_1181]
+                                                                  Conds:RS_73._col7=RS_1174._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col13"]
+                                                                <-Map 48 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_1174]
                                                                     PartitionCols:_col0
-                                                                    Select Operator [SEL_1180] (rows=2300 width=4)
+                                                                    Select Operator [SEL_1173] (rows=2300 width=4)
                                                                       Output:["_col0"]
-                                                                      Filter Operator [FIL_1179] (rows=2300 width=4)
+                                                                      Filter Operator [FIL_1172] (rows=2300 width=4)
                                                                         predicate:p_promo_sk is not null
                                                                         TableScan [TS_49] (rows=2300 width=4)
                                                                           default@promotion,promotion,Tbl:COMPLETE,Col:COMPLETE,Output:["p_promo_sk"]
@@ -518,7 +514,7 @@ Stage-0
                                                                   SHUFFLE [RS_73]
                                                                     PartitionCols:_col7
                                                                     Merge Join Operator [MERGEJOIN_1084] (rows=14487982 width=119)
-                                                                      Conds:RS_70._col1=RS_1178._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
+                                                                      Conds:RS_70._col1=RS_1171._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
                                                                     <-Reducer 18 [SIMPLE_EDGE]
                                                                       SHUFFLE [RS_70]
                                                                         PartitionCols:_col1
@@ -538,7 +534,7 @@ Stage-0
                                                                             Merge Join Operator [MERGEJOIN_1081] (rows=40575792 width=314)
                                                                               Conds:RS_1155._col1=RS_1158._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
                                                                             <-Map 40 [SIMPLE_EDGE] vectorized
-                                                                              PARTITION_ONLY_SHUFFLE [RS_1158]
+                                                                              SHUFFLE [RS_1158]
                                                                                 PartitionCols:_col0
                                                                                 Select Operator [SEL_1157] (rows=4667 width=111)
                                                                                   Output:["_col0","_col1"]
@@ -566,61 +562,50 @@ Stage-0
                                                                                               Select Operator [SEL_1124] (rows=652 width=4)
                                                                                                 Output:["_col0"]
                                                                                                  Please refer to the previous Select Operator [SEL_1119]
-                                                                    <-Reducer 46 [SIMPLE_EDGE] vectorized
-                                                                      SHUFFLE [RS_1178]
+                                                                    <-Reducer 44 [SIMPLE_EDGE] vectorized
+                                                                      SHUFFLE [RS_1171]
                                                                         PartitionCols:_col0
-                                                                        Select Operator [SEL_1177] (rows=13257 width=4)
+                                                                        Select Operator [SEL_1170] (rows=13257 width=4)
                                                                           Output:["_col0"]
-                                                                          Filter Operator [FIL_1176] (rows=13257 width=228)
+                                                                          Filter Operator [FIL_1169] (rows=13257 width=228)
                                                                             predicate:(_col1 > (2 * _col2))
-                                                                            Group By Operator [GBY_1175] (rows=39773 width=228)
+                                                                            Group By Operator [GBY_1168] (rows=39773 width=228)
                                                                               Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0
-                                                                            <-Reducer 45 [SIMPLE_EDGE]
+                                                                            <-Reducer 43 [SIMPLE_EDGE]
                                                                               SHUFFLE [RS_45]
                                                                                 PartitionCols:_col0
                                                                                 Group By Operator [GBY_44] (rows=6482999 width=228)
                                                                                   Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","sum(_col5)"],keys:_col0
                                                                                   Merge Join Operator [MERGEJOIN_1083] (rows=183085709 width=227)
-                                                                                    Conds:RS_1170._col0, _col1=RS_1173._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
-                                                                                  <-Map 47 [SIMPLE_EDGE] vectorized
-                                                                                    SHUFFLE [RS_1173]
+                                                                                    Conds:RS_1162._col0, _col1=RS_1166._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
+                                                                                  <-Map 42 [SIMPLE_EDGE] vectorized
+                                                                                    SHUFFLE [RS_1162]
                                                                                       PartitionCols:_col0, _col1
-                                                                                      Select Operator [SEL_1172] (rows=28798881 width=120)
+                                                                                      Select Operator [SEL_1161] (rows=287989836 width=119)
                                                                                         Output:["_col0","_col1","_col2"]
-                                                                                        Filter Operator [FIL_1171] (rows=28798881 width=337)
+                                                                                        Filter Operator [FIL_1160] (rows=287989836 width=119)
+                                                                                          predicate:(cs_item_sk is not null and cs_order_number is not null)
+                                                                                          TableScan [TS_34] (rows=287989836 width=119)
+                                                                                            default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
+                                                                                  <-Map 47 [SIMPLE_EDGE] vectorized
+                                                                                    SHUFFLE [RS_1166]
+                                                                                      PartitionCols:_col0, _col1
+                                                                                      Select Operator [SEL_1165] (rows=28798881 width=120)
+                                                                                        Output:["_col0","_col1","_col2"]
+                                                                                        Filter Operator [FIL_1164] (rows=28798881 width=337)
                                                                                           predicate:(cr_item_sk is not null and cr_order_number is not null)
                                                                                           TableScan [TS_37] (rows=28798881 width=337)
                                                                                             default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_item_sk","cr_order_number","cr_refunded_cash","cr_reversed_charge","cr_store_credit"]
-                                                                                  <-Map 44 [SIMPLE_EDGE] vectorized
-                                                                                    SHUFFLE [RS_1170]
-                                                                                      PartitionCols:_col0, _col1
-                                                                                      Select Operator [SEL_1169] (rows=287989836 width=119)
-                                                                                        Output:["_col0","_col1","_col2"]
-                                                                                        Filter Operator [FIL_1168] (rows=287989836 width=119)
-                                                                                          predicate:(cs_item_sk is not null and cs_order_number is not null and cs_item_sk BETWEEN DynamicValue(RS_65_item_i_item_sk_min) AND DynamicValue(RS_65_item_i_item_sk_max) and in_bloom_filter(cs_item_sk, DynamicValue(RS_65_item_i_item_sk_bloom_filter)))
-                                                                                          TableScan [TS_34] (rows=287989836 width=119)
-                                                                                            default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
-                                                                                          <-Reducer 41 [BROADCAST_EDGE] vectorized
-                                                                                            BROADCAST [RS_1167]
-                                                                                              Group By Operator [GBY_1166] (rows=1 width=12)
-                                                                                                Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                              <-Map 40 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                                PARTITION_ONLY_SHUFFLE [RS_1164]
-                                                                                                  Group By Operator [GBY_1162] (rows=1 width=12)
-                                                                                                    Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                                    Select Operator [SEL_1159] (rows=4667 width=4)
-                                                                                                      Output:["_col0"]
-                                                                                                       Please refer to the previous Select Operator [SEL_1157]
                 <-Reducer 16 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_1214]
+                  SHUFFLE [RS_1202]
                     PartitionCols:_col1, _col0, _col2
-                    Select Operator [SEL_1213] (rows=23886447 width=525)
+                    Select Operator [SEL_1201] (rows=23886447 width=525)
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6"]
-                      Filter Operator [FIL_1212] (rows=23886447 width=1362)
+                      Filter Operator [FIL_1200] (rows=23886447 width=1362)
                         predicate:_col14 is not null
-                        Select Operator [SEL_1211] (rows=23886447 width=1362)
+                        Select Operator [SEL_1199] (rows=23886447 width=1362)
                           Output:["_col1","_col2","_col3","_col14","_col15","_col16","_col17"]
-                          Group By Operator [GBY_1210] (rows=23886447 width=1362)
+                          Group By Operator [GBY_1198] (rows=23886447 width=1362)
                             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col17"],aggregations:["count(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)"],keys:KEY._col0, KEY._col1, KEY._col2, KEY._col3, KEY._col4, KEY._col5, KEY._col6, KEY._col7, KEY._col8, KEY._col9, KEY._col10, KEY._col11, KEY._col12, KEY._col13
                           <-Reducer 15 [SIMPLE_EDGE]
                             SHUFFLE [RS_249]
@@ -640,7 +625,7 @@ Stage-0
                                       predicate:(_col50 <> _col19)
                                       Merge Join Operator [MERGEJOIN_1109] (rows=24224230 width=1327)
                                         Conds:RS_240._col36=RS_1150._col0(Inner),Output:["_col7","_col9","_col14","_col15","_col16","_col17","_col19","_col23","_col24","_col25","_col26","_col28","_col29","_col31","_col42","_col43","_col44","_col45","_col46","_col50"]
-                                      <-Map 53 [SIMPLE_EDGE] vectorized
+                                      <-Map 51 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_1150]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_1147]
@@ -659,11 +644,11 @@ Stage-0
                                               Select Operator [SEL_215] (rows=23886447 width=788)
                                                 Output:["_col3","_col4","_col5","_col6","_col8","_col9","_col11","_col15","_col16","_col22","_col23","_col24","_col25","_col26"]
                                                 Merge Join Operator [MERGEJOIN_1107] (rows=23886447 width=788)
-                                                  Conds:RS_212._col1, _col8=RS_1190._col0, _col1(Inner),Output:["_col2","_col3","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21","_col23","_col24","_col25","_col26"]
-                                                <-Map 52 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_1190]
+                                                  Conds:RS_212._col1, _col8=RS_1183._col0, _col1(Inner),Output:["_col2","_col3","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21","_col23","_col24","_col25","_col26"]
+                                                <-Map 50 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_1183]
                                                     PartitionCols:_col0, _col1
-                                                     Please refer to the previous Select Operator [SEL_1188]
+                                                     Please refer to the previous Select Operator [SEL_1181]
                                                 <-Reducer 31 [SIMPLE_EDGE]
                                                   SHUFFLE [RS_212]
                                                     PartitionCols:_col1, _col8
@@ -677,11 +662,11 @@ Stage-0
                                                       SHUFFLE [RS_209]
                                                         PartitionCols:_col5
                                                         Merge Join Operator [MERGEJOIN_1105] (rows=14487982 width=300)
-                                                          Conds:RS_206._col6=RS_1186._col0(Inner),Output:["_col1","_col2","_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21"]
-                                                        <-Map 51 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_1186]
+                                                          Conds:RS_206._col6=RS_1179._col0(Inner),Output:["_col1","_col2","_col3","_col5","_col8","_col9","_col10","_col11","_col12","_col13","_col18","_col20","_col21"]
+                                                        <-Map 49 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_1179]
                                                             PartitionCols:_col0
-                                                             Please refer to the previous Select Operator [SEL_1184]
+                                                             Please refer to the previous Select Operator [SEL_1177]
                                                         <-Reducer 29 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_206]
                                                             PartitionCols:_col6
@@ -695,16 +680,16 @@ Stage-0
                                                               SHUFFLE [RS_203]
                                                                 PartitionCols:_col4
                                                                 Merge Join Operator [MERGEJOIN_1103] (rows=14487982 width=119)
-                                                                  Conds:RS_200._col7=RS_1182._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col13"]
-                                                                <-Map 50 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_1182]
+                                                                  Conds:RS_200._col7=RS_1175._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col8","_col9","_col10","_col11","_col12","_col13"]
+                                                                <-Map 48 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_1175]
                                                                     PartitionCols:_col0
-                                                                     Please refer to the previous Select Operator [SEL_1180]
+                                                                     Please refer to the previous Select Operator [SEL_1173]
                                                                 <-Reducer 27 [SIMPLE_EDGE]
                                                                   SHUFFLE [RS_200]
                                                                     PartitionCols:_col7
                                                                     Merge Join Operator [MERGEJOIN_1102] (rows=14487982 width=119)
-                                                                      Conds:RS_197._col1=RS_1209._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
+                                                                      Conds:RS_197._col1=RS_1197._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
                                                                     <-Reducer 26 [SIMPLE_EDGE]
                                                                       SHUFFLE [RS_197]
                                                                         PartitionCols:_col1
@@ -718,27 +703,27 @@ Stage-0
                                                                               Filter Operator [FIL_1117] (rows=652 width=8)
                                                                                 predicate:((d_year = 2001) and d_date_sk is not null)
                                                                                  Please refer to the previous TableScan [TS_3]
-                                                                        <-Reducer 42 [SIMPLE_EDGE]
+                                                                        <-Reducer 41 [SIMPLE_EDGE]
                                                                           SHUFFLE [RS_194]
                                                                             PartitionCols:_col0
                                                                             Merge Join Operator [MERGEJOIN_1099] (rows=40575792 width=314)
-                                                                              Conds:RS_1200._col1=RS_1160._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
+                                                                              Conds:RS_1193._col1=RS_1159._col0(Inner),Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11","_col12","_col13"]
                                                                             <-Map 40 [SIMPLE_EDGE] vectorized
-                                                                              PARTITION_ONLY_SHUFFLE [RS_1160]
+                                                                              SHUFFLE [RS_1159]
                                                                                 PartitionCols:_col0
                                                                                  Please refer to the previous Select Operator [SEL_1157]
-                                                                            <-Map 54 [SIMPLE_EDGE] vectorized
-                                                                              SHUFFLE [RS_1200]
+                                                                            <-Map 52 [SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_1193]
                                                                                 PartitionCols:_col1
-                                                                                Select Operator [SEL_1199] (rows=417313408 width=355)
+                                                                                Select Operator [SEL_1192] (rows=417313408 width=355)
                                                                                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10","_col11"]
-                                                                                  Filter Operator [FIL_1198] (rows=417313408 width=355)
+                                                                                  Filter Operator [FIL_1191] (rows=417313408 width=355)
                                                                                     predicate:(ss_cdemo_sk is not null and ss_sold_date_sk is not null and ss_promo_sk is not null and ss_addr_sk is not null and ss_customer_sk is not null and ss_hdemo_sk is not null and ss_store_sk is not null and ss_item_sk is not null and ss_ticket_number is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_195_d1_d_date_sk_min) AND DynamicValue(RS_195_d1_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_195_d1_d_date_sk_bloom_filter)))
                                                                                     TableScan [TS_152] (rows=575995635 width=355)
                                                                                       default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_customer_sk","ss_cdemo_sk","ss_hdemo_sk","ss_addr_sk","ss_store_sk","ss_promo_sk","ss_ticket_number","ss_wholesale_cost","ss_list_price","ss_coupon_amt"]
                                                                                     <-Reducer 33 [BROADCAST_EDGE] vectorized
-                                                                                      BROADCAST [RS_1197]
-                                                                                        Group By Operator [GBY_1196] (rows=1 width=12)
+                                                                                      BROADCAST [RS_1190]
+                                                                                        Group By Operator [GBY_1189] (rows=1 width=12)
                                                                                           Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
                                                                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
                                                                                           PARTITION_ONLY_SHUFFLE [RS_1130]
@@ -747,44 +732,28 @@ Stage-0
                                                                                               Select Operator [SEL_1126] (rows=652 width=4)
                                                                                                 Output:["_col0"]
                                                                                                  Please refer to the previous Select Operator [SEL_1120]
-                                                                    <-Reducer 49 [SIMPLE_EDGE] vectorized
-                                                                      SHUFFLE [RS_1209]
+                                                                    <-Reducer 46 [SIMPLE_EDGE] vectorized
+                                                                      SHUFFLE [RS_1197]
                                                                         PartitionCols:_col0
-                                                                        Select Operator [SEL_1208] (rows=13257 width=4)
+                                                                        Select Operator [SEL_1196] (rows=13257 width=4)
                                                                           Output:["_col0"]
-                                                                          Filter Operator [FIL_1207] (rows=13257 width=228)
+                                                                          Filter Operator [FIL_1195] (rows=13257 width=228)
                                                                             predicate:(_col1 > (2 * _col2))
-                                                                            Group By Operator [GBY_1206] (rows=39773 width=228)
+                                                                            Group By Operator [GBY_1194] (rows=39773 width=228)
                                                                               Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)"],keys:KEY._col0
-                                                                            <-Reducer 48 [SIMPLE_EDGE]
+                                                                            <-Reducer 45 [SIMPLE_EDGE]
                                                                               SHUFFLE [RS_172]
                                                                                 PartitionCols:_col0
                                                                                 Group By Operator [GBY_171] (rows=6482999 width=228)
                                                                                   Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","sum(_col5)"],keys:_col0
                                                                                   Merge Join Operator [MERGEJOIN_1101] (rows=183085709 width=227)
-                                                                                    Conds:RS_1205._col0, _col1=RS_1174._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
+                                                                                    Conds:RS_1163._col0, _col1=RS_1167._col0, _col1(Inner),Output:["_col0","_col2","_col5"]
+                                                                                  <-Map 42 [SIMPLE_EDGE] vectorized
+                                                                                    SHUFFLE [RS_1163]
+                                                                                      PartitionCols:_col0, _col1
+                                                                                       Please refer to the previous Select Operator [SEL_1161]
                                                                                   <-Map 47 [SIMPLE_EDGE] vectorized
-                                                                                    SHUFFLE [RS_1174]
+                                                                                    SHUFFLE [RS_1167]
                                                                                       PartitionCols:_col0, _col1
-                                                                                       Please refer to the previous Select Operator [SEL_1172]
-                                                                                  <-Map 55 [SIMPLE_EDGE] vectorized
-                                                                                    SHUFFLE [RS_1205]
-                                                                                      PartitionCols:_col0, _col1
-                                                                                      Select Operator [SEL_1204] (rows=287989836 width=119)
-                                                                                        Output:["_col0","_col1","_col2"]
-                                                                                        Filter Operator [FIL_1203] (rows=287989836 width=119)
-                                                                                          predicate:(cs_item_sk is not null and cs_order_number is not null and cs_item_sk BETWEEN DynamicValue(RS_192_item_i_item_sk_min) AND DynamicValue(RS_192_item_i_item_sk_max) and in_bloom_filter(cs_item_sk, DynamicValue(RS_192_item_i_item_sk_bloom_filter)))
-                                                                                          TableScan [TS_161] (rows=287989836 width=119)
-                                                                                            default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_item_sk","cs_order_number","cs_ext_list_price"]
-                                                                                          <-Reducer 43 [BROADCAST_EDGE] vectorized
-                                                                                            BROADCAST [RS_1202]
-                                                                                              Group By Operator [GBY_1201] (rows=1 width=12)
-                                                                                                Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                                              <-Map 40 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                                                PARTITION_ONLY_SHUFFLE [RS_1165]
-                                                                                                  Group By Operator [GBY_1163] (rows=1 width=12)
-                                                                                                    Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                                    Select Operator [SEL_1161] (rows=4667 width=4)
-                                                                                                      Output:["_col0"]
-                                                                                                       Please refer to the previous Select Operator [SEL_1157]
+                                                                                       Please refer to the previous Select Operator [SEL_1165]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query70.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query70.q.out
@@ -92,7 +92,7 @@ Reducer 4 <- Reducer 10 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 8 <- Map 13 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
 
 Stage-0
@@ -100,27 +100,27 @@ Stage-0
     limit:-1
     Stage-1
       Reducer 7 vectorized
-      File Output Operator [FS_171]
-        Limit [LIM_170] (rows=100 width=492)
+      File Output Operator [FS_170]
+        Limit [LIM_169] (rows=100 width=492)
           Number of rows:100
-          Select Operator [SEL_169] (rows=720 width=492)
+          Select Operator [SEL_168] (rows=720 width=492)
             Output:["_col0","_col1","_col2","_col3","_col4"]
           <-Reducer 6 [SIMPLE_EDGE] vectorized
-            SHUFFLE [RS_168]
-              Select Operator [SEL_167] (rows=720 width=492)
+            SHUFFLE [RS_167]
+              Select Operator [SEL_166] (rows=720 width=492)
                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
-                Top N Key Operator [TNK_166] (rows=720 width=304)
+                Top N Key Operator [TNK_165] (rows=720 width=304)
                   keys:(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN (((grouping(_col3, 1L) + grouping(_col3, 0L)) = 0L)) THEN (_col0) ELSE (null) END, rank_window_0,top n:100
-                  PTF Operator [PTF_165] (rows=720 width=304)
+                  PTF Operator [PTF_164] (rows=720 width=304)
                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col2 DESC NULLS FIRST","partition by:":"(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN ((grouping(_col3, 0L) = UDFToLong(0))) THEN (_col0) ELSE (CAST( null AS STRING)) END"}]
-                    Select Operator [SEL_164] (rows=720 width=304)
+                    Select Operator [SEL_163] (rows=720 width=304)
                       Output:["_col0","_col1","_col2","_col3"]
                     <-Reducer 5 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_163]
+                      SHUFFLE [RS_162]
                         PartitionCols:(grouping(_col3, 1L) + grouping(_col3, 0L)), CASE WHEN ((grouping(_col3, 0L) = UDFToLong(0))) THEN (_col0) ELSE (CAST( null AS STRING)) END
-                        Select Operator [SEL_162] (rows=720 width=304)
+                        Select Operator [SEL_161] (rows=720 width=304)
                           Output:["_col0","_col1","_col2","_col3"]
-                          Group By Operator [GBY_161] (rows=720 width=304)
+                          Group By Operator [GBY_160] (rows=720 width=304)
                             Output:["_col0","_col1","_col2","_col3"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1, KEY._col2
                           <-Reducer 4 [SIMPLE_EDGE]
                             SHUFFLE [RS_48]
@@ -130,24 +130,24 @@ Stage-0
                                 Select Operator [SEL_45] (rows=29778893 width=207)
                                   Output:["_col0","_col1","_col2"]
                                   Merge Join Operator [MERGEJOIN_135] (rows=29778893 width=207)
-                                    Conds:RS_42._col7=RS_160._col0(Inner),Output:["_col2","_col6","_col7"]
+                                    Conds:RS_42._col7=RS_159._col0(Inner),Output:["_col2","_col6","_col7"]
                                   <-Reducer 10 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_160]
+                                    SHUFFLE [RS_159]
                                       PartitionCols:_col0
-                                      Select Operator [SEL_159] (rows=16 width=86)
+                                      Select Operator [SEL_158] (rows=16 width=86)
                                         Output:["_col0"]
-                                        Filter Operator [FIL_158] (rows=16 width=198)
+                                        Filter Operator [FIL_157] (rows=16 width=198)
                                           predicate:(rank_window_0 <= 5)
-                                          PTF Operator [PTF_157] (rows=49 width=198)
+                                          PTF Operator [PTF_156] (rows=49 width=198)
                                             Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 DESC NULLS FIRST","partition by:":"_col0"}]
-                                            Select Operator [SEL_156] (rows=49 width=198)
+                                            Select Operator [SEL_155] (rows=49 width=198)
                                               Output:["_col0","_col1"]
                                             <-Reducer 9 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_155]
+                                              SHUFFLE [RS_154]
                                                 PartitionCols:_col0
-                                                Top N Key Operator [TNK_154] (rows=49 width=198)
+                                                Top N Key Operator [TNK_153] (rows=49 width=198)
                                                   PartitionCols:_col0,keys:_col0, _col1,top n:6
-                                                  Group By Operator [GBY_153] (rows=49 width=198)
+                                                  Group By Operator [GBY_152] (rows=49 width=198)
                                                     Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0
                                                   <-Reducer 8 [SIMPLE_EDGE]
                                                     SHUFFLE [RS_26]
@@ -155,7 +155,16 @@ Stage-0
                                                       Group By Operator [GBY_25] (rows=2989 width=198)
                                                         Output:["_col0","_col1"],aggregations:["sum(_col2)"],keys:_col5
                                                         Merge Join Operator [MERGEJOIN_134] (rows=91197860 width=168)
-                                                          Conds:RS_21._col1=RS_152._col0(Inner),Output:["_col2","_col5"]
+                                                          Conds:RS_21._col1=RS_151._col0(Inner),Output:["_col2","_col5"]
+                                                        <-Map 13 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_151]
+                                                            PartitionCols:_col0
+                                                            Select Operator [SEL_149] (rows=1704 width=90)
+                                                              Output:["_col0","_col1"]
+                                                              Filter Operator [FIL_147] (rows=1704 width=188)
+                                                                predicate:(s_state is not null and s_store_sk is not null)
+                                                                TableScan [TS_6] (rows=1704 width=188)
+                                                                  default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_county","s_state"]
                                                         <-Reducer 2 [SIMPLE_EDGE]
                                                           SHUFFLE [RS_21]
                                                             PartitionCols:_col1
@@ -190,31 +199,19 @@ Stage-0
                                                                               Select Operator [SEL_139] (rows=317 width=4)
                                                                                 Output:["_col0"]
                                                                                  Please refer to the previous Select Operator [SEL_137]
-                                                        <-Map 14 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_152]
-                                                            PartitionCols:_col0
-                                                            Select Operator [SEL_151] (rows=1704 width=90)
-                                                              Output:["_col0","_col1"]
-                                                              Filter Operator [FIL_150] (rows=1704 width=90)
-                                                                predicate:(s_store_sk is not null and s_state is not null)
-                                                                TableScan [TS_15] (rows=1704 width=90)
-                                                                  default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_state"]
                                   <-Reducer 3 [SIMPLE_EDGE]
                                     SHUFFLE [RS_42]
                                       PartitionCols:_col7
                                       Merge Join Operator [MERGEJOIN_132] (rows=91197860 width=266)
-                                        Conds:RS_39._col1=RS_149._col0(Inner),Output:["_col2","_col6","_col7"]
+                                        Conds:RS_39._col1=RS_150._col0(Inner),Output:["_col2","_col6","_col7"]
+                                      <-Map 13 [SIMPLE_EDGE] vectorized
+                                        SHUFFLE [RS_150]
+                                          PartitionCols:_col0
+                                          Select Operator [SEL_148] (rows=1704 width=188)
+                                            Output:["_col0","_col1","_col2"]
+                                             Please refer to the previous Filter Operator [FIL_147]
                                       <-Reducer 2 [SIMPLE_EDGE]
                                         SHUFFLE [RS_39]
                                           PartitionCols:_col1
                                            Please refer to the previous Merge Join Operator [MERGEJOIN_131]
-                                      <-Map 13 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_149]
-                                          PartitionCols:_col0
-                                          Select Operator [SEL_148] (rows=1704 width=188)
-                                            Output:["_col0","_col1","_col2"]
-                                            Filter Operator [FIL_147] (rows=1704 width=188)
-                                              predicate:(s_state is not null and s_store_sk is not null)
-                                              TableScan [TS_6] (rows=1704 width=188)
-                                                default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_county","s_state"]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query72.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query72.q.out
@@ -81,18 +81,18 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Map 9 <- Reducer 17 (BROADCAST_EDGE)
-Reducer 10 <- Map 16 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 18 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 19 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Map 20 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
-Reducer 14 <- Map 21 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
-Reducer 15 <- Map 22 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
-Reducer 17 <- Map 16 (CUSTOM_SIMPLE_EDGE)
+Map 9 <- Reducer 21 (BROADCAST_EDGE)
+Reducer 10 <- Map 20 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+Reducer 11 <- Map 16 (SIMPLE_EDGE), Reducer 10 (SIMPLE_EDGE)
+Reducer 12 <- Map 17 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 18 (SIMPLE_EDGE), Reducer 12 (SIMPLE_EDGE)
+Reducer 14 <- Map 19 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Map 20 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 21 <- Map 20 (CUSTOM_SIMPLE_EDGE)
 Reducer 3 <- Reducer 15 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-Reducer 4 <- Map 23 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
-Reducer 5 <- Map 24 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
+Reducer 4 <- Map 20 (SIMPLE_EDGE), Reducer 3 (SIMPLE_EDGE)
+Reducer 5 <- Map 22 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 
@@ -121,7 +121,7 @@ Stage-0
                         Output:["_col0","_col1","_col2","_col3","_col4"]
                         Merge Join Operator [MERGEJOIN_253] (rows=1488051228 width=292)
                           Conds:RS_64._col4, _col6=RS_291._col0, _col1(Left Outer),Output:["_col13","_col15","_col19","_col25"]
-                        <-Map 24 [SIMPLE_EDGE] vectorized
+                        <-Map 22 [SIMPLE_EDGE] vectorized
                           SHUFFLE [RS_291]
                             PartitionCols:_col0, _col1
                             Select Operator [SEL_290] (rows=28798881 width=8)
@@ -136,16 +136,16 @@ Stage-0
                             Select Operator [SEL_60] (rows=576990095 width=300)
                               Output:["_col4","_col6","_col13","_col15","_col19","_col25"]
                               Merge Join Operator [MERGEJOIN_252] (rows=576990095 width=300)
-                                Conds:RS_57._col0, _col19=RS_288._col0, _col1(Inner),Output:["_col5","_col9","_col14","_col16","_col19","_col23"]
-                              <-Map 23 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_288]
+                                Conds:RS_57._col0, _col19=RS_269._col0, _col1(Inner),Output:["_col5","_col9","_col14","_col16","_col19","_col23"]
+                              <-Map 20 [SIMPLE_EDGE] vectorized
+                                SHUFFLE [RS_269]
                                   PartitionCols:_col0, _col1
-                                  Select Operator [SEL_287] (rows=73049 width=8)
+                                  Select Operator [SEL_265] (rows=73049 width=8)
                                     Output:["_col0","_col1"]
-                                    Filter Operator [FIL_286] (rows=73049 width=8)
+                                    Filter Operator [FIL_262] (rows=73049 width=8)
                                       predicate:(d_date_sk is not null and d_week_seq is not null)
-                                      TableScan [TS_47] (rows=73049 width=8)
-                                        default@date_dim,d2,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_week_seq"]
+                                      TableScan [TS_24] (rows=73049 width=98)
+                                        default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq","d_year"]
                               <-Reducer 3 [SIMPLE_EDGE]
                                 SHUFFLE [RS_57]
                                   PartitionCols:_col0, _col19
@@ -161,27 +161,26 @@ Stage-0
                                           Filter Operator [FIL_45] (rows=2712713 width=219)
                                             predicate:(_col17 > _col10)
                                             Merge Join Operator [MERGEJOIN_250] (rows=8138139 width=219)
-                                              Conds:RS_42._col1=RS_285._col0(Inner),Output:["_col4","_col6","_col7","_col9","_col10","_col13","_col15","_col17"]
-                                            <-Map 22 [SIMPLE_EDGE] vectorized
-                                              SHUFFLE [RS_285]
+                                              Conds:RS_42._col1=RS_266._col0(Inner),Output:["_col4","_col6","_col7","_col9","_col10","_col13","_col15","_col17"]
+                                            <-Map 20 [SIMPLE_EDGE] vectorized
+                                              SHUFFLE [RS_266]
                                                 PartitionCols:_col0
-                                                Select Operator [SEL_284] (rows=73049 width=12)
+                                                Select Operator [SEL_263] (rows=73049 width=12)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_283] (rows=73049 width=98)
+                                                  Filter Operator [FIL_260] (rows=73049 width=98)
                                                     predicate:(d_date_sk is not null and UDFToDouble(d_date) is not null)
-                                                    TableScan [TS_24] (rows=73049 width=98)
-                                                      default@date_dim,d3,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
+                                                     Please refer to the previous TableScan [TS_24]
                                             <-Reducer 14 [SIMPLE_EDGE]
                                               SHUFFLE [RS_42]
                                                 PartitionCols:_col1
                                                 Merge Join Operator [MERGEJOIN_249] (rows=8138139 width=214)
-                                                  Conds:RS_39._col4=RS_282._col0(Inner),Output:["_col1","_col4","_col6","_col7","_col9","_col10","_col13","_col15"]
-                                                <-Map 21 [SIMPLE_EDGE] vectorized
-                                                  SHUFFLE [RS_282]
+                                                  Conds:RS_39._col4=RS_288._col0(Inner),Output:["_col1","_col4","_col6","_col7","_col9","_col10","_col13","_col15"]
+                                                <-Map 19 [SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_288]
                                                     PartitionCols:_col0
-                                                    Select Operator [SEL_281] (rows=462000 width=188)
+                                                    Select Operator [SEL_287] (rows=462000 width=188)
                                                       Output:["_col0","_col1"]
-                                                      Filter Operator [FIL_280] (rows=462000 width=188)
+                                                      Filter Operator [FIL_286] (rows=462000 width=188)
                                                         predicate:i_item_sk is not null
                                                         TableScan [TS_21] (rows=462000 width=188)
                                                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_desc"]
@@ -189,13 +188,13 @@ Stage-0
                                                   SHUFFLE [RS_39]
                                                     PartitionCols:_col4
                                                     Merge Join Operator [MERGEJOIN_248] (rows=8138139 width=30)
-                                                      Conds:RS_36._col5=RS_279._col0(Left Outer),Output:["_col1","_col4","_col6","_col7","_col9","_col10","_col13"]
-                                                    <-Map 20 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_279]
+                                                      Conds:RS_36._col5=RS_285._col0(Left Outer),Output:["_col1","_col4","_col6","_col7","_col9","_col10","_col13"]
+                                                    <-Map 18 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_285]
                                                         PartitionCols:_col0
-                                                        Select Operator [SEL_278] (rows=2300 width=4)
+                                                        Select Operator [SEL_284] (rows=2300 width=4)
                                                           Output:["_col0"]
-                                                          Filter Operator [FIL_277] (rows=2300 width=4)
+                                                          Filter Operator [FIL_283] (rows=2300 width=4)
                                                             predicate:p_promo_sk is not null
                                                             TableScan [TS_18] (rows=2300 width=4)
                                                               default@promotion,promotion,Tbl:COMPLETE,Col:COMPLETE,Output:["p_promo_sk"]
@@ -203,13 +202,13 @@ Stage-0
                                                       SHUFFLE [RS_36]
                                                         PartitionCols:_col5
                                                         Merge Join Operator [MERGEJOIN_247] (rows=8138139 width=29)
-                                                          Conds:RS_33._col3=RS_276._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col9","_col10"]
-                                                        <-Map 19 [SIMPLE_EDGE] vectorized
-                                                          SHUFFLE [RS_276]
+                                                          Conds:RS_33._col3=RS_282._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col9","_col10"]
+                                                        <-Map 17 [SIMPLE_EDGE] vectorized
+                                                          SHUFFLE [RS_282]
                                                             PartitionCols:_col0
-                                                            Select Operator [SEL_275] (rows=1440 width=4)
+                                                            Select Operator [SEL_281] (rows=1440 width=4)
                                                               Output:["_col0"]
-                                                              Filter Operator [FIL_274] (rows=1440 width=96)
+                                                              Filter Operator [FIL_280] (rows=1440 width=96)
                                                                 predicate:((hd_buy_potential = '1001-5000') and hd_demo_sk is not null)
                                                                 TableScan [TS_15] (rows=7200 width=96)
                                                                   default@household_demographics,household_demographics,Tbl:COMPLETE,Col:COMPLETE,Output:["hd_demo_sk","hd_buy_potential"]
@@ -217,13 +216,13 @@ Stage-0
                                                           SHUFFLE [RS_33]
                                                             PartitionCols:_col3
                                                             Merge Join Operator [MERGEJOIN_246] (rows=40690691 width=35)
-                                                              Conds:RS_30._col2=RS_273._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col9","_col10"]
-                                                            <-Map 18 [SIMPLE_EDGE] vectorized
-                                                              SHUFFLE [RS_273]
+                                                              Conds:RS_30._col2=RS_279._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col9","_col10"]
+                                                            <-Map 16 [SIMPLE_EDGE] vectorized
+                                                              SHUFFLE [RS_279]
                                                                 PartitionCols:_col0
-                                                                Select Operator [SEL_272] (rows=265971 width=4)
+                                                                Select Operator [SEL_278] (rows=265971 width=4)
                                                                   Output:["_col0"]
-                                                                  Filter Operator [FIL_271] (rows=265971 width=89)
+                                                                  Filter Operator [FIL_277] (rows=265971 width=89)
                                                                     predicate:((cd_marital_status = 'M') and cd_demo_sk is not null)
                                                                     TableScan [TS_12] (rows=1861800 width=89)
                                                                       default@customer_demographics,customer_demographics,Tbl:COMPLETE,Col:COMPLETE,Output:["cd_demo_sk","cd_marital_status"]
@@ -231,36 +230,35 @@ Stage-0
                                                               SHUFFLE [RS_30]
                                                                 PartitionCols:_col2
                                                                 Merge Join Operator [MERGEJOIN_245] (rows=99576237 width=39)
-                                                                  Conds:RS_270._col0=RS_262._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col9","_col10"]
-                                                                <-Map 16 [SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_262]
+                                                                  Conds:RS_276._col0=RS_267._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col9","_col10"]
+                                                                <-Map 20 [SIMPLE_EDGE] vectorized
+                                                                  SHUFFLE [RS_267]
                                                                     PartitionCols:_col0
-                                                                    Select Operator [SEL_261] (rows=652 width=16)
+                                                                    Select Operator [SEL_264] (rows=652 width=16)
                                                                       Output:["_col0","_col1","_col2"]
-                                                                      Filter Operator [FIL_260] (rows=652 width=106)
+                                                                      Filter Operator [FIL_261] (rows=652 width=106)
                                                                         predicate:((d_year = 2001) and d_date_sk is not null and d_week_seq is not null and UDFToDouble(d_date) is not null)
-                                                                        TableScan [TS_9] (rows=73049 width=106)
-                                                                          default@date_dim,d1,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq","d_year"]
+                                                                         Please refer to the previous TableScan [TS_24]
                                                                 <-Map 9 [SIMPLE_EDGE] vectorized
-                                                                  SHUFFLE [RS_270]
+                                                                  SHUFFLE [RS_276]
                                                                     PartitionCols:_col0
-                                                                    Select Operator [SEL_269] (rows=280863798 width=31)
+                                                                    Select Operator [SEL_275] (rows=280863798 width=31)
                                                                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                                                                      Filter Operator [FIL_268] (rows=280863798 width=31)
+                                                                      Filter Operator [FIL_274] (rows=280863798 width=31)
                                                                         predicate:(cs_sold_date_sk is not null and cs_bill_cdemo_sk is not null and cs_ship_date_sk is not null and cs_quantity is not null and cs_bill_hdemo_sk is not null and cs_item_sk is not null and cs_sold_date_sk BETWEEN DynamicValue(RS_28_d1_d_date_sk_min) AND DynamicValue(RS_28_d1_d_date_sk_max) and in_bloom_filter(cs_sold_date_sk, DynamicValue(RS_28_d1_d_date_sk_bloom_filter)))
                                                                         TableScan [TS_6] (rows=287989836 width=31)
                                                                           default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_ship_date_sk","cs_bill_cdemo_sk","cs_bill_hdemo_sk","cs_item_sk","cs_promo_sk","cs_order_number","cs_quantity"]
-                                                                        <-Reducer 17 [BROADCAST_EDGE] vectorized
-                                                                          BROADCAST [RS_267]
-                                                                            Group By Operator [GBY_266] (rows=1 width=12)
+                                                                        <-Reducer 21 [BROADCAST_EDGE] vectorized
+                                                                          BROADCAST [RS_273]
+                                                                            Group By Operator [GBY_272] (rows=1 width=12)
                                                                               Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                                            <-Map 16 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                              PARTITION_ONLY_SHUFFLE [RS_265]
-                                                                                Group By Operator [GBY_264] (rows=1 width=12)
+                                                                            <-Map 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                              SHUFFLE [RS_271]
+                                                                                Group By Operator [GBY_270] (rows=1 width=12)
                                                                                   Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                                                  Select Operator [SEL_263] (rows=652 width=4)
+                                                                                  Select Operator [SEL_268] (rows=652 width=4)
                                                                                     Output:["_col0"]
-                                                                                     Please refer to the previous Select Operator [SEL_261]
+                                                                                     Please refer to the previous Select Operator [SEL_264]
                                     <-Reducer 2 [SIMPLE_EDGE]
                                       SHUFFLE [RS_53]
                                         PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/query8.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query8.q.out
@@ -229,10 +229,10 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Map 1 <- Reducer 7 (BROADCAST_EDGE)
 Reducer 11 <- Union 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 18 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 14 <- Map 13 (SIMPLE_EDGE), Map 17 (SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (SIMPLE_EDGE), Union 10 (CONTAINS)
+Reducer 12 <- Map 17 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
+Reducer 13 <- Map 16 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (SIMPLE_EDGE), Union 10 (CONTAINS)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 12 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
@@ -268,7 +268,7 @@ Stage-0
                           PartitionCols:_col1
                           Merge Join Operator [MERGEJOIN_122] (rows=1 width=92)
                             Conds:RS_146._col0=RS_149._col2(Inner),Output:["_col1","_col2"]
-                          <-Map 18 [SIMPLE_EDGE] vectorized
+                          <-Map 17 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_149]
                               PartitionCols:_col2
                               Select Operator [SEL_148] (rows=1704 width=178)
@@ -287,14 +287,14 @@ Stage-0
                                   Group By Operator [GBY_143] (rows=5633 width=96)
                                     Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
                                   <-Union 10 [SIMPLE_EDGE]
-                                    <-Reducer 16 [CONTAINS] vectorized
+                                    <-Reducer 15 [CONTAINS] vectorized
                                       Reduce Output Operator [RS_175]
                                         PartitionCols:_col0
                                         Group By Operator [GBY_174] (rows=5633 width=96)
                                           Output:["_col0","_col1"],aggregations:["count(_col1)"],keys:_col0
                                           Group By Operator [GBY_173] (rows=1126 width=96)
                                             Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                                          <-Reducer 15 [SIMPLE_EDGE] vectorized
+                                          <-Reducer 14 [SIMPLE_EDGE] vectorized
                                             SHUFFLE [RS_172]
                                               PartitionCols:_col0
                                               Group By Operator [GBY_171] (rows=1126 width=96)
@@ -305,23 +305,23 @@ Stage-0
                                                     predicate:(_col1 > 10L)
                                                     Group By Operator [GBY_168] (rows=6761 width=97)
                                                       Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
-                                                    <-Reducer 14 [SIMPLE_EDGE]
+                                                    <-Reducer 13 [SIMPLE_EDGE]
                                                       SHUFFLE [RS_25]
                                                         PartitionCols:_col0
                                                         Group By Operator [GBY_24] (rows=67610 width=97)
                                                           Output:["_col0","_col1"],aggregations:["count()"],keys:_col1
                                                           Merge Join Operator [MERGEJOIN_121] (rows=26666667 width=89)
-                                                            Conds:RS_164._col0=RS_167._col0(Inner),Output:["_col1"]
-                                                          <-Map 13 [SIMPLE_EDGE] vectorized
-                                                            SHUFFLE [RS_164]
+                                                            Conds:RS_160._col0=RS_167._col0(Inner),Output:["_col1"]
+                                                          <-Map 8 [SIMPLE_EDGE] vectorized
+                                                            SHUFFLE [RS_160]
                                                               PartitionCols:_col0
-                                                              Select Operator [SEL_163] (rows=40000000 width=93)
+                                                              Select Operator [SEL_158] (rows=40000000 width=93)
                                                                 Output:["_col0","_col1"]
-                                                                Filter Operator [FIL_162] (rows=40000000 width=93)
+                                                                Filter Operator [FIL_156] (rows=40000000 width=93)
                                                                   predicate:(ca_address_sk is not null and substr(substr(ca_zip, 1, 5), 1, 2) is not null)
-                                                                  TableScan [TS_14] (rows=40000000 width=93)
-                                                                    default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_zip"]
-                                                          <-Map 17 [SIMPLE_EDGE] vectorized
+                                                                  TableScan [TS_6] (rows=40000000 width=89)
+                                                                    default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_zip","ca_address_sk"]
+                                                          <-Map 16 [SIMPLE_EDGE] vectorized
                                                             SHUFFLE [RS_167]
                                                               PartitionCols:_col0
                                                               Select Operator [SEL_166] (rows=26666667 width=4)
@@ -331,23 +331,22 @@ Stage-0
                                                                   TableScan [TS_17] (rows=80000000 width=89)
                                                                     default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_current_addr_sk","c_preferred_cust_flag"]
                                     <-Reducer 9 [CONTAINS] vectorized
-                                      Reduce Output Operator [RS_161]
+                                      Reduce Output Operator [RS_164]
                                         PartitionCols:_col0
-                                        Group By Operator [GBY_160] (rows=5633 width=96)
+                                        Group By Operator [GBY_163] (rows=5633 width=96)
                                           Output:["_col0","_col1"],aggregations:["count(_col1)"],keys:_col0
-                                          Group By Operator [GBY_159] (rows=10141 width=96)
+                                          Group By Operator [GBY_162] (rows=10141 width=96)
                                             Output:["_col0","_col1"],aggregations:["count(VALUE._col0)"],keys:KEY._col0
                                           <-Map 8 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_158]
+                                            SHUFFLE [RS_161]
                                               PartitionCols:_col0
-                                              Group By Operator [GBY_157] (rows=141974 width=96)
+                                              Group By Operator [GBY_159] (rows=141974 width=96)
                                                 Output:["_col0","_col1"],aggregations:["count()"],keys:_col0
-                                                Select Operator [SEL_156] (rows=20000000 width=89)
+                                                Select Operator [SEL_157] (rows=20000000 width=89)
                                                   Output:["_col0"]
                                                   Filter Operator [FIL_155] (rows=20000000 width=89)
                                                     predicate:((substr(ca_zip, 1, 5)) IN ('89436', '30868', '65085', '22977', '83927', '77557', '58429', '40697', '80614', '10502', '32779', '91137', '61265', '98294', '17921', '18427', '21203', '59362', '87291', '84093', '21505', '17184', '10866', '67898', '25797', '28055', '18377', '80332', '74535', '21757', '29742', '90885', '29898', '17819', '40811', '25990', '47513', '89531', '91068', '10391', '18846', '99223', '82637', '41368', '83658', '86199', '81625', '26696', '89338', '88425', '32200', '81427', '19053', '77471', '36610', '99823', '43276', '41249', '48584', '83550', '82276', '18842', '78890', '14090', '38123', '40936', '34425', '19850', '43286', '80072', '79188', '54191', '11395', '50497', '84861', '90733', '21068', '57666', '37119', '25004', '57835', '70067', '62878', '95806', '19303', '18840', '19124', '29785', '16737', '16022', '49613', '89977', '68310', '60069', '98360', '48649', '39050', '41793', '25002', '27413', '39736', '47208', '16515', '94808', '57648', '15009', '80015', '42961', '63982', '21744', '71853', '81087', '67468', '34175', '64008', '20261', '11201', '51799', '48043', '45645', '61163', '48375', '36447', '57042', '21218', '41100', '89951', '22745', '35851', '83326', '61125', '78298', '80752', '49858', '52940', '96976', '63792', '11376', '53582', '18717', '90226', '50530', '94203', '99447', '27670', '96577', '57856', '56372', '16165', '23427', '54561', '28806', '44439', '22926', '30123', '61451', '92397', '56979', '92309', '70873', '13355', '21801', '46346', '37562', '56458', '28286', '47306', '99555', '69399', '26234', '47546', '49661', '88601', '35943', '39936', '25632', '24611', '44166', '56648', '30379', '59785', '11110', '14329', '93815', '52226', '71381', '13842', '25612', '63294', '14664', '21077', '82626', '18799', '60915', '81020', '56447', '76619', '11433', '13414', '42548', '92713', '70467', '30884', '47484', '16072', '38936', '13036', '88376', '45539', '35901', '19506', '65690', '73957', '71850', '49231', '14276', '20005', '18384', '76615', '11635', '38177', '55607', '41369', '95447', '58581', '58149', '91946', '33790', '76232', '75692', '95464', '22246', '51061', '56692', '53121', '77209', '15482', '10688', '14868', '45907', '73520', '72666', '25734', '17959', '24677', '66446', '94627', '53535', '15560', '41967', '69297', '11929', '59403', '33283', '52232', '57350', '43933', '40921', '36635', '10827', '71286', '19736', '80619', '25251', '95042', '15526', '36496', '55854', '49124', '81980', '35375', '49157', '63512', '28944', '14946', '36503', '54010', '18767', '23969', '43905', '66979', '33113', '21286', '58471', '59080', '13395', '79144', '70373', '67031', '38360', '26705', '50906', '52406', '26066', '73146', '15884', '31897', '30045', '61068', '45550', '92454', '13376', '14354', '19770', '22928', '97790', '50723', '46081', '30202', '14410', '20223', '88500', '67298', '13261', '14172', '81410', '93578', '83583', '46047', '94167', '82564', '21156', '15799', '86709', '37931', '74703', '83103', '23054', '70470', '72008', '49247', '91911', '69998', '20961', '70070', '63197', '54853', '88191', '91830', '49521', '19454', '81450', '89091', '62378', '25683', '61869', '51744', '36580', '85778', '36871', '48121', '28810', '83712', '45486', '67393', '26935', '42393', '20132', '55349', '86057', '21309', '80218', '10094', '11357', '48819', '39734', '40758', '30432', '21204', '29467', '30214', '61024', '55307', '74621', '11622', '68908', '33032', '52868', '99194', '99900', '84936', '69036', '99149', '45013', '32895', '59004', '32322', '14933', '32936', '33562', '72550', '27385', '58049', '58200', '16808', '21360', '32961', '18586', '79307', '15492') and substr(substr(ca_zip, 1, 5), 1, 2) is not null)
-                                                    TableScan [TS_6] (rows=40000000 width=89)
-                                                      default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_zip"]
+                                                     Please refer to the previous TableScan [TS_6]
                       <-Reducer 2 [SIMPLE_EDGE]
                         SHUFFLE [RS_52]
                           PartitionCols:_col1

--- a/ql/src/test/results/clientpositive/perf/tez/query81.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query81.q.out
@@ -71,17 +71,17 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Reducer 14 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
-Reducer 11 <- Map 15 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-Reducer 12 <- Map 16 (SIMPLE_EDGE), Reducer 11 (SIMPLE_EDGE)
-Reducer 13 <- Reducer 12 (SIMPLE_EDGE)
-Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
+Reducer 10 <- Reducer 9 (SIMPLE_EDGE)
+Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
+Reducer 13 <- Map 12 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
+Reducer 14 <- Map 12 (SIMPLE_EDGE), Map 15 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 5 (SIMPLE_EDGE)
-Reducer 3 <- Reducer 10 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (SIMPLE_EDGE), Reducer 8 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-Reducer 7 <- Map 15 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
-Reducer 8 <- Map 16 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
-Reducer 9 <- Reducer 8 (SIMPLE_EDGE)
+Reducer 6 <- Map 5 (SIMPLE_EDGE), Reducer 13 (SIMPLE_EDGE)
+Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
+Reducer 8 <- Reducer 11 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE)
+Reducer 9 <- Map 5 (SIMPLE_EDGE), Reducer 14 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -103,114 +103,20 @@ Stage-0
                     keys:_col1, _col3, _col4, _col5, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col19,top n:100
                     Merge Join Operator [MERGEJOIN_182] (rows=1609248 width=1418)
                       Conds:RS_62._col0=RS_63._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16","_col19"]
-                    <-Reducer 10 [SIMPLE_EDGE]
-                      SHUFFLE [RS_63]
-                        PartitionCols:_col0
-                        Select Operator [SEL_58] (rows=1609248 width=227)
-                          Output:["_col0","_col2"]
-                          Filter Operator [FIL_57] (rows=1609248 width=227)
-                            predicate:(_col2 > _col3)
-                            Merge Join Operator [MERGEJOIN_181] (rows=4827746 width=227)
-                              Conds:RS_206._col1=RS_214._col1(Inner),Output:["_col0","_col2","_col3"]
-                            <-Reducer 14 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_214]
-                                PartitionCols:_col1
-                                Select Operator [SEL_213] (rows=12 width=198)
-                                  Output:["_col0","_col1"]
-                                  Filter Operator [FIL_212] (rows=12 width=206)
-                                    predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
-                                    Group By Operator [GBY_211] (rows=12 width=206)
-                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                    <-Reducer 13 [SIMPLE_EDGE] vectorized
-                                      SHUFFLE [RS_210]
-                                        PartitionCols:_col0
-                                        Group By Operator [GBY_209] (rows=60 width=206)
-                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col0
-                                          Select Operator [SEL_208] (rows=5266632 width=201)
-                                            Output:["_col0","_col2"]
-                                            Group By Operator [GBY_207] (rows=5266632 width=201)
-                                              Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                                            <-Reducer 12 [SIMPLE_EDGE]
-                                              SHUFFLE [RS_45]
-                                                PartitionCols:_col0, _col1
-                                                Group By Operator [GBY_44] (rows=8749496 width=201)
-                                                  Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
-                                                  Merge Join Operator [MERGEJOIN_180] (rows=8749496 width=194)
-                                                    Conds:RS_40._col2=RS_202._col0(Inner),Output:["_col1","_col3","_col6"]
-                                                  <-Map 16 [SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_202]
-                                                      PartitionCols:_col0
-                                                      Select Operator [SEL_200] (rows=40000000 width=90)
-                                                        Output:["_col0","_col1"]
-                                                        Filter Operator [FIL_199] (rows=40000000 width=90)
-                                                          predicate:(ca_address_sk is not null and ca_state is not null)
-                                                          TableScan [TS_12] (rows=40000000 width=90)
-                                                            default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_state"]
-                                                  <-Reducer 11 [SIMPLE_EDGE]
-                                                    SHUFFLE [RS_40]
-                                                      PartitionCols:_col2
-                                                      Merge Join Operator [MERGEJOIN_179] (rows=8749496 width=112)
-                                                        Conds:RS_194._col0=RS_198._col0(Inner),Output:["_col1","_col2","_col3"]
-                                                      <-Map 15 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_198]
-                                                          PartitionCols:_col0
-                                                          Select Operator [SEL_196] (rows=652 width=4)
-                                                            Output:["_col0"]
-                                                            Filter Operator [FIL_195] (rows=652 width=8)
-                                                              predicate:((d_year = 1998) and d_date_sk is not null)
-                                                              TableScan [TS_9] (rows=73049 width=8)
-                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
-                                                      <-Map 6 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_194]
-                                                          PartitionCols:_col0
-                                                          Select Operator [SEL_192] (rows=28221532 width=121)
-                                                            Output:["_col0","_col1","_col2","_col3"]
-                                                            Filter Operator [FIL_190] (rows=28221532 width=121)
-                                                              predicate:(cr_returning_addr_sk is not null and cr_returned_date_sk is not null)
-                                                              TableScan [TS_6] (rows=28798881 width=121)
-                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_returned_date_sk","cr_returning_customer_sk","cr_returning_addr_sk","cr_return_amt_inc_tax"]
-                            <-Reducer 9 [SIMPLE_EDGE] vectorized
-                              SHUFFLE [RS_206]
-                                PartitionCols:_col1
-                                Filter Operator [FIL_205] (rows=4827746 width=201)
-                                  predicate:_col2 is not null
-                                  Select Operator [SEL_204] (rows=4827746 width=201)
-                                    Output:["_col0","_col1","_col2"]
-                                    Group By Operator [GBY_203] (rows=4827746 width=201)
-                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                                    <-Reducer 8 [SIMPLE_EDGE]
-                                      SHUFFLE [RS_23]
-                                        PartitionCols:_col0, _col1
-                                        Group By Operator [GBY_22] (rows=8574602 width=201)
-                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
-                                          Merge Join Operator [MERGEJOIN_178] (rows=8574602 width=194)
-                                            Conds:RS_18._col2=RS_201._col0(Inner),Output:["_col1","_col3","_col6"]
-                                          <-Map 16 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_201]
-                                              PartitionCols:_col0
-                                               Please refer to the previous Select Operator [SEL_200]
-                                          <-Reducer 7 [SIMPLE_EDGE]
-                                            SHUFFLE [RS_18]
-                                              PartitionCols:_col2
-                                              Merge Join Operator [MERGEJOIN_177] (rows=8574602 width=112)
-                                                Conds:RS_193._col0=RS_197._col0(Inner),Output:["_col1","_col2","_col3"]
-                                              <-Map 15 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_197]
-                                                  PartitionCols:_col0
-                                                   Please refer to the previous Select Operator [SEL_196]
-                                              <-Map 6 [SIMPLE_EDGE] vectorized
-                                                SHUFFLE [RS_193]
-                                                  PartitionCols:_col0
-                                                  Select Operator [SEL_191] (rows=27657410 width=121)
-                                                    Output:["_col0","_col1","_col2","_col3"]
-                                                    Filter Operator [FIL_189] (rows=27657410 width=121)
-                                                      predicate:(cr_returning_addr_sk is not null and cr_returning_customer_sk is not null and cr_returned_date_sk is not null)
-                                                       Please refer to the previous TableScan [TS_6]
                     <-Reducer 2 [SIMPLE_EDGE]
                       SHUFFLE [RS_62]
                         PartitionCols:_col0
                         Merge Join Operator [MERGEJOIN_176] (rows=1568628 width=1310)
-                          Conds:RS_185._col2=RS_188._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"]
+                          Conds:RS_185._col2=RS_190._col0(Inner),Output:["_col0","_col1","_col3","_col4","_col5","_col7","_col8","_col9","_col10","_col11","_col12","_col13","_col14","_col15","_col16"]
+                        <-Map 5 [SIMPLE_EDGE] vectorized
+                          SHUFFLE [RS_190]
+                            PartitionCols:_col0
+                            Select Operator [SEL_188] (rows=784314 width=941)
+                              Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
+                              Filter Operator [FIL_186] (rows=784314 width=1027)
+                                predicate:((ca_state = 'IL') and ca_address_sk is not null)
+                                TableScan [TS_3] (rows=40000000 width=1027)
+                                  default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_street_number","ca_street_name","ca_street_type","ca_suite_number","ca_city","ca_county","ca_state","ca_zip","ca_country","ca_gmt_offset","ca_location_type"]
                         <-Map 1 [SIMPLE_EDGE] vectorized
                           SHUFFLE [RS_185]
                             PartitionCols:_col2
@@ -220,13 +126,106 @@ Stage-0
                                 predicate:(c_current_addr_sk is not null and c_customer_sk is not null)
                                 TableScan [TS_0] (rows=80000000 width=375)
                                   default@customer,customer,Tbl:COMPLETE,Col:COMPLETE,Output:["c_customer_sk","c_customer_id","c_current_addr_sk","c_salutation","c_first_name","c_last_name"]
-                        <-Map 5 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_188]
-                            PartitionCols:_col0
-                            Select Operator [SEL_187] (rows=784314 width=941)
-                              Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9","_col10"]
-                              Filter Operator [FIL_186] (rows=784314 width=1027)
-                                predicate:((ca_state = 'IL') and ca_address_sk is not null)
-                                TableScan [TS_3] (rows=40000000 width=1027)
-                                  default@customer_address,customer_address,Tbl:COMPLETE,Col:COMPLETE,Output:["ca_address_sk","ca_street_number","ca_street_name","ca_street_type","ca_suite_number","ca_city","ca_county","ca_state","ca_zip","ca_country","ca_gmt_offset","ca_location_type"]
+                    <-Reducer 8 [SIMPLE_EDGE]
+                      SHUFFLE [RS_63]
+                        PartitionCols:_col0
+                        Select Operator [SEL_58] (rows=1609248 width=227)
+                          Output:["_col0","_col2"]
+                          Filter Operator [FIL_57] (rows=1609248 width=227)
+                            predicate:(_col2 > _col3)
+                            Merge Join Operator [MERGEJOIN_181] (rows=4827746 width=227)
+                              Conds:RS_206._col1=RS_214._col1(Inner),Output:["_col0","_col2","_col3"]
+                            <-Reducer 11 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_214]
+                                PartitionCols:_col1
+                                Select Operator [SEL_213] (rows=12 width=198)
+                                  Output:["_col0","_col1"]
+                                  Filter Operator [FIL_212] (rows=12 width=206)
+                                    predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
+                                    Group By Operator [GBY_211] (rows=12 width=206)
+                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+                                    <-Reducer 10 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_210]
+                                        PartitionCols:_col0
+                                        Group By Operator [GBY_209] (rows=60 width=206)
+                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col0
+                                          Select Operator [SEL_208] (rows=5266632 width=201)
+                                            Output:["_col0","_col2"]
+                                            Group By Operator [GBY_207] (rows=5266632 width=201)
+                                              Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
+                                            <-Reducer 9 [SIMPLE_EDGE]
+                                              SHUFFLE [RS_45]
+                                                PartitionCols:_col0, _col1
+                                                Group By Operator [GBY_44] (rows=8749496 width=201)
+                                                  Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
+                                                  Merge Join Operator [MERGEJOIN_180] (rows=8749496 width=194)
+                                                    Conds:RS_40._col2=RS_192._col0(Inner),Output:["_col1","_col3","_col6"]
+                                                  <-Map 5 [SIMPLE_EDGE] vectorized
+                                                    SHUFFLE [RS_192]
+                                                      PartitionCols:_col0
+                                                      Select Operator [SEL_189] (rows=40000000 width=90)
+                                                        Output:["_col0","_col1"]
+                                                        Filter Operator [FIL_187] (rows=40000000 width=90)
+                                                          predicate:(ca_address_sk is not null and ca_state is not null)
+                                                           Please refer to the previous TableScan [TS_3]
+                                                  <-Reducer 14 [SIMPLE_EDGE]
+                                                    SHUFFLE [RS_40]
+                                                      PartitionCols:_col2
+                                                      Merge Join Operator [MERGEJOIN_179] (rows=8749496 width=112)
+                                                        Conds:RS_198._col0=RS_202._col0(Inner),Output:["_col1","_col2","_col3"]
+                                                      <-Map 12 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_198]
+                                                          PartitionCols:_col0
+                                                          Select Operator [SEL_196] (rows=28221532 width=121)
+                                                            Output:["_col0","_col1","_col2","_col3"]
+                                                            Filter Operator [FIL_194] (rows=28221532 width=121)
+                                                              predicate:(cr_returning_addr_sk is not null and cr_returned_date_sk is not null)
+                                                              TableScan [TS_6] (rows=28798881 width=121)
+                                                                default@catalog_returns,catalog_returns,Tbl:COMPLETE,Col:COMPLETE,Output:["cr_returned_date_sk","cr_returning_customer_sk","cr_returning_addr_sk","cr_return_amt_inc_tax"]
+                                                      <-Map 15 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_202]
+                                                          PartitionCols:_col0
+                                                          Select Operator [SEL_200] (rows=652 width=4)
+                                                            Output:["_col0"]
+                                                            Filter Operator [FIL_199] (rows=652 width=8)
+                                                              predicate:((d_year = 1998) and d_date_sk is not null)
+                                                              TableScan [TS_9] (rows=73049 width=8)
+                                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_year"]
+                            <-Reducer 7 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_206]
+                                PartitionCols:_col1
+                                Filter Operator [FIL_205] (rows=4827746 width=201)
+                                  predicate:_col2 is not null
+                                  Select Operator [SEL_204] (rows=4827746 width=201)
+                                    Output:["_col0","_col1","_col2"]
+                                    Group By Operator [GBY_203] (rows=4827746 width=201)
+                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
+                                    <-Reducer 6 [SIMPLE_EDGE]
+                                      SHUFFLE [RS_23]
+                                        PartitionCols:_col0, _col1
+                                        Group By Operator [GBY_22] (rows=8574602 width=201)
+                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col6, _col1
+                                          Merge Join Operator [MERGEJOIN_178] (rows=8574602 width=194)
+                                            Conds:RS_18._col2=RS_191._col0(Inner),Output:["_col1","_col3","_col6"]
+                                          <-Map 5 [SIMPLE_EDGE] vectorized
+                                            SHUFFLE [RS_191]
+                                              PartitionCols:_col0
+                                               Please refer to the previous Select Operator [SEL_189]
+                                          <-Reducer 13 [SIMPLE_EDGE]
+                                            SHUFFLE [RS_18]
+                                              PartitionCols:_col2
+                                              Merge Join Operator [MERGEJOIN_177] (rows=8574602 width=112)
+                                                Conds:RS_197._col0=RS_201._col0(Inner),Output:["_col1","_col2","_col3"]
+                                              <-Map 12 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_197]
+                                                  PartitionCols:_col0
+                                                  Select Operator [SEL_195] (rows=27657410 width=121)
+                                                    Output:["_col0","_col1","_col2","_col3"]
+                                                    Filter Operator [FIL_193] (rows=27657410 width=121)
+                                                      predicate:(cr_returning_addr_sk is not null and cr_returning_customer_sk is not null and cr_returned_date_sk is not null)
+                                                       Please refer to the previous TableScan [TS_6]
+                                              <-Map 15 [SIMPLE_EDGE] vectorized
+                                                SHUFFLE [RS_201]
+                                                  PartitionCols:_col0
+                                                   Please refer to the previous Select Operator [SEL_200]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query83.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query83.q.out
@@ -147,19 +147,19 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Reducer 10 <- Reducer 16 (SIMPLE_EDGE), Reducer 9 (SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (SIMPLE_EDGE)
-Reducer 12 <- Map 22 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 12 <- Map 21 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 13 <- Reducer 12 (SIMPLE_EDGE), Reducer 16 (SIMPLE_EDGE)
 Reducer 14 <- Reducer 13 (SIMPLE_EDGE)
-Reducer 16 <- Map 15 (SIMPLE_EDGE), Reducer 19 (SIMPLE_EDGE)
-Reducer 18 <- Map 17 (SIMPLE_EDGE), Map 20 (SIMPLE_EDGE)
-Reducer 19 <- Reducer 18 (SIMPLE_EDGE)
+Reducer 16 <- Map 15 (SIMPLE_EDGE), Reducer 18 (SIMPLE_EDGE)
+Reducer 17 <- Map 15 (SIMPLE_EDGE), Map 19 (SIMPLE_EDGE)
+Reducer 18 <- Reducer 17 (SIMPLE_EDGE)
 Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
 Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
 Reducer 5 <- Reducer 11 (SIMPLE_EDGE), Reducer 4 (SIMPLE_EDGE)
 Reducer 6 <- Reducer 14 (SIMPLE_EDGE), Reducer 5 (SIMPLE_EDGE)
 Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-Reducer 9 <- Map 21 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+Reducer 9 <- Map 20 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -197,38 +197,37 @@ Stage-0
                                 SHUFFLE [RS_113]
                                   PartitionCols:_col0
                                   Merge Join Operator [MERGEJOIN_353] (rows=2 width=4)
-                                    Conds:RS_375._col1=RS_384._col0(Inner),Output:["_col0"]
+                                    Conds:RS_377._col1=RS_384._col0(Inner),Output:["_col0"]
                                   <-Map 15 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_375]
+                                    SHUFFLE [RS_377]
                                       PartitionCols:_col1
-                                      Select Operator [SEL_374] (rows=73049 width=98)
+                                      Select Operator [SEL_375] (rows=73049 width=98)
                                         Output:["_col0","_col1"]
                                         Filter Operator [FIL_373] (rows=73049 width=98)
                                           predicate:(d_date is not null and d_date_sk is not null)
                                           TableScan [TS_6] (rows=73049 width=98)
-                                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date"]
-                                  <-Reducer 19 [SIMPLE_EDGE] vectorized
+                                            default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_date","d_week_seq"]
+                                  <-Reducer 18 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_384]
                                       PartitionCols:_col0
                                       Group By Operator [GBY_383] (rows=2 width=94)
                                         Output:["_col0"],keys:KEY._col0
-                                      <-Reducer 18 [SIMPLE_EDGE]
+                                      <-Reducer 17 [SIMPLE_EDGE]
                                         SHUFFLE [RS_22]
                                           PartitionCols:_col0
                                           Group By Operator [GBY_21] (rows=2 width=94)
                                             Output:["_col0"],keys:_col0
                                             Merge Join Operator [MERGEJOIN_352] (rows=5 width=94)
                                               Conds:RS_378._col1=RS_382._col0(Left Semi),Output:["_col0"]
-                                            <-Map 17 [SIMPLE_EDGE] vectorized
+                                            <-Map 15 [SIMPLE_EDGE] vectorized
                                               SHUFFLE [RS_378]
                                                 PartitionCols:_col1
-                                                Select Operator [SEL_377] (rows=73049 width=98)
+                                                Select Operator [SEL_376] (rows=73049 width=98)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_376] (rows=73049 width=98)
+                                                  Filter Operator [FIL_374] (rows=73049 width=98)
                                                     predicate:(d_week_seq is not null and d_date is not null)
-                                                    TableScan [TS_9] (rows=73049 width=98)
-                                                      default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date","d_week_seq"]
-                                            <-Map 20 [SIMPLE_EDGE] vectorized
+                                                     Please refer to the previous TableScan [TS_6]
+                                            <-Map 19 [SIMPLE_EDGE] vectorized
                                               SHUFFLE [RS_382]
                                                 PartitionCols:_col0
                                                 Group By Operator [GBY_381] (rows=1 width=4)
@@ -253,7 +252,7 @@ Stage-0
                                           predicate:(i_item_sk is not null and i_item_id is not null)
                                           TableScan [TS_3] (rows=462000 width=104)
                                             default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_id"]
-                                  <-Map 22 [SIMPLE_EDGE] vectorized
+                                  <-Map 21 [SIMPLE_EDGE] vectorized
                                     SHUFFLE [RS_396]
                                       PartitionCols:_col1
                                       Select Operator [SEL_395] (rows=13749816 width=11)
@@ -294,7 +293,7 @@ Stage-0
                                         SHUFFLE [RS_371]
                                           PartitionCols:_col0
                                            Please refer to the previous Select Operator [SEL_369]
-                                      <-Map 21 [SIMPLE_EDGE] vectorized
+                                      <-Map 20 [SIMPLE_EDGE] vectorized
                                         SHUFFLE [RS_390]
                                           PartitionCols:_col1
                                           Select Operator [SEL_389] (rows=55578005 width=11)

--- a/ql/src/test/results/clientpositive/perf/tez/query9.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query9.q.out
@@ -122,14 +122,14 @@ Plan optimized by CBO.
 Vertex dependency in root stage
 Reducer 10 <- Reducer 32 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 18 (CUSTOM_SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
-Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 20 (CUSTOM_SIMPLE_EDGE)
-Reducer 14 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 21 (CUSTOM_SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 22 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 23 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 28 (CUSTOM_SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 29 (CUSTOM_SIMPLE_EDGE)
 Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 19 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 20 (CUSTOM_SIMPLE_EDGE)
 Reducer 20 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 22 <- Map 17 (CUSTOM_SIMPLE_EDGE)
@@ -144,12 +144,12 @@ Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 25 (CUSTOM_SIMPLE_EDGE)
 Reducer 30 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 31 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 32 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 4 <- Reducer 26 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
-Reducer 5 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 28 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-Reducer 7 <- Reducer 29 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-Reducer 8 <- Reducer 30 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Reducer 31 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 30 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+Reducer 6 <- Reducer 26 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 7 <- Reducer 31 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 8 <- Reducer 22 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+Reducer 9 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -186,18 +186,18 @@ Stage-0
                                   Merge Join Operator [MERGEJOIN_179] (rows=2 width=684)
                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9"]
                                   <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
-                                    PARTITION_ONLY_SHUFFLE [RS_273]
-                                      Select Operator [SEL_272] (rows=1 width=112)
+                                    PARTITION_ONLY_SHUFFLE [RS_275]
+                                      Select Operator [SEL_274] (rows=1 width=112)
                                         Output:["_col0"]
-                                        Group By Operator [GBY_271] (rows=1 width=120)
+                                        Group By Operator [GBY_273] (rows=1 width=120)
                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_246]
-                                            Group By Operator [GBY_231] (rows=1 width=120)
+                                          PARTITION_ONLY_SHUFFLE [RS_248]
+                                            Group By Operator [GBY_233] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                              Select Operator [SEL_216] (rows=182855757 width=110)
+                                              Select Operator [SEL_218] (rows=182855757 width=110)
                                                 Output:["ss_net_paid_inc_tax"]
-                                                Filter Operator [FIL_201] (rows=182855757 width=110)
+                                                Filter Operator [FIL_203] (rows=182855757 width=110)
                                                   predicate:ss_quantity BETWEEN 41 AND 60
                                                   TableScan [TS_66] (rows=575995635 width=3)
                                                     default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_ext_list_price","ss_net_paid_inc_tax"]
@@ -205,67 +205,67 @@ Stage-0
                                     PARTITION_ONLY_SHUFFLE [RS_132]
                                       Merge Join Operator [MERGEJOIN_178] (rows=2 width=572)
                                         Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                      <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_270]
-                                          Select Operator [SEL_269] (rows=1 width=112)
+                                      <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_272]
+                                          Select Operator [SEL_271] (rows=1 width=112)
                                             Output:["_col0"]
-                                            Group By Operator [GBY_268] (rows=1 width=120)
+                                            Group By Operator [GBY_270] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                             <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_245]
-                                                Group By Operator [GBY_230] (rows=1 width=120)
+                                              PARTITION_ONLY_SHUFFLE [RS_243]
+                                                Group By Operator [GBY_228] (rows=1 width=120)
                                                   Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                  Select Operator [SEL_215] (rows=182855757 width=110)
+                                                  Select Operator [SEL_213] (rows=182855757 width=110)
                                                     Output:["ss_ext_list_price"]
-                                                    Filter Operator [FIL_200] (rows=182855757 width=110)
+                                                    Filter Operator [FIL_198] (rows=182855757 width=110)
                                                       predicate:ss_quantity BETWEEN 41 AND 60
                                                        Please refer to the previous TableScan [TS_66]
                                       <-Reducer 8 [CUSTOM_SIMPLE_EDGE]
                                         PARTITION_ONLY_SHUFFLE [RS_129]
                                           Merge Join Operator [MERGEJOIN_177] (rows=2 width=460)
                                             Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                                          <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
-                                            PARTITION_ONLY_SHUFFLE [RS_267]
-                                              Select Operator [SEL_266] (rows=1 width=4)
+                                          <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
+                                            PARTITION_ONLY_SHUFFLE [RS_269]
+                                              Select Operator [SEL_268] (rows=1 width=4)
                                                 Output:["_col0"]
-                                                Group By Operator [GBY_265] (rows=1 width=8)
+                                                Group By Operator [GBY_267] (rows=1 width=8)
                                                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                 <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_244]
-                                                    Group By Operator [GBY_229] (rows=1 width=8)
+                                                  PARTITION_ONLY_SHUFFLE [RS_238]
+                                                    Group By Operator [GBY_223] (rows=1 width=8)
                                                       Output:["_col0"],aggregations:["count()"]
-                                                      Select Operator [SEL_214] (rows=182855757 width=3)
-                                                        Filter Operator [FIL_199] (rows=182855757 width=3)
+                                                      Select Operator [SEL_208] (rows=182855757 width=3)
+                                                        Filter Operator [FIL_193] (rows=182855757 width=3)
                                                           predicate:ss_quantity BETWEEN 41 AND 60
                                                            Please refer to the previous TableScan [TS_66]
                                           <-Reducer 7 [CUSTOM_SIMPLE_EDGE]
                                             PARTITION_ONLY_SHUFFLE [RS_126]
                                               Merge Join Operator [MERGEJOIN_176] (rows=2 width=456)
                                                 Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6"]
-                                              <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                PARTITION_ONLY_SHUFFLE [RS_264]
-                                                  Select Operator [SEL_263] (rows=1 width=112)
+                                              <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                PARTITION_ONLY_SHUFFLE [RS_266]
+                                                  Select Operator [SEL_265] (rows=1 width=112)
                                                     Output:["_col0"]
-                                                    Group By Operator [GBY_262] (rows=1 width=120)
+                                                    Group By Operator [GBY_264] (rows=1 width=120)
                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_243]
-                                                        Group By Operator [GBY_228] (rows=1 width=120)
+                                                      PARTITION_ONLY_SHUFFLE [RS_247]
+                                                        Group By Operator [GBY_232] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                          Select Operator [SEL_213] (rows=182855757 width=110)
+                                                          Select Operator [SEL_217] (rows=182855757 width=110)
                                                             Output:["ss_net_paid_inc_tax"]
-                                                            Filter Operator [FIL_198] (rows=182855757 width=110)
+                                                            Filter Operator [FIL_202] (rows=182855757 width=110)
                                                               predicate:ss_quantity BETWEEN 21 AND 40
                                                                Please refer to the previous TableScan [TS_66]
                                               <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                                                 PARTITION_ONLY_SHUFFLE [RS_123]
                                                   Merge Join Operator [MERGEJOIN_175] (rows=2 width=344)
                                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                                  <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_261]
-                                                      Select Operator [SEL_260] (rows=1 width=112)
+                                                  <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_263]
+                                                      Select Operator [SEL_262] (rows=1 width=112)
                                                         Output:["_col0"]
-                                                        Group By Operator [GBY_259] (rows=1 width=120)
+                                                        Group By Operator [GBY_261] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
                                                           PARTITION_ONLY_SHUFFLE [RS_242]
@@ -280,39 +280,24 @@ Stage-0
                                                     PARTITION_ONLY_SHUFFLE [RS_120]
                                                       Merge Join Operator [MERGEJOIN_174] (rows=2 width=232)
                                                         Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4"]
-                                                      <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                        PARTITION_ONLY_SHUFFLE [RS_258]
-                                                          Select Operator [SEL_257] (rows=1 width=4)
+                                                      <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                        PARTITION_ONLY_SHUFFLE [RS_260]
+                                                          Select Operator [SEL_259] (rows=1 width=4)
                                                             Output:["_col0"]
-                                                            Group By Operator [GBY_256] (rows=1 width=8)
+                                                            Group By Operator [GBY_258] (rows=1 width=8)
                                                               Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                             <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                              PARTITION_ONLY_SHUFFLE [RS_241]
-                                                                Group By Operator [GBY_226] (rows=1 width=8)
+                                                              PARTITION_ONLY_SHUFFLE [RS_237]
+                                                                Group By Operator [GBY_222] (rows=1 width=8)
                                                                   Output:["_col0"],aggregations:["count()"]
-                                                                  Select Operator [SEL_211] (rows=182855757 width=3)
-                                                                    Filter Operator [FIL_196] (rows=182855757 width=3)
+                                                                  Select Operator [SEL_207] (rows=182855757 width=3)
+                                                                    Filter Operator [FIL_192] (rows=182855757 width=3)
                                                                       predicate:ss_quantity BETWEEN 21 AND 40
                                                                        Please refer to the previous TableScan [TS_66]
                                                       <-Reducer 4 [CUSTOM_SIMPLE_EDGE]
                                                         PARTITION_ONLY_SHUFFLE [RS_117]
                                                           Merge Join Operator [MERGEJOIN_173] (rows=2 width=228)
                                                             Conds:(Left Outer),Output:["_col1","_col2","_col3"]
-                                                          <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                            PARTITION_ONLY_SHUFFLE [RS_255]
-                                                              Select Operator [SEL_254] (rows=1 width=112)
-                                                                Output:["_col0"]
-                                                                Group By Operator [GBY_253] (rows=1 width=120)
-                                                                  Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_240]
-                                                                    Group By Operator [GBY_225] (rows=1 width=120)
-                                                                      Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                                      Select Operator [SEL_210] (rows=182855757 width=110)
-                                                                        Output:["ss_net_paid_inc_tax"]
-                                                                        Filter Operator [FIL_195] (rows=182855757 width=110)
-                                                                          predicate:ss_quantity BETWEEN 1 AND 20
-                                                                           Please refer to the previous TableScan [TS_66]
                                                           <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                                                             PARTITION_ONLY_SHUFFLE [RS_114]
                                                               Merge Join Operator [MERGEJOIN_172] (rows=2 width=116)
@@ -328,80 +313,99 @@ Stage-0
                                                                           predicate:(r_reason_sk = 1)
                                                                           TableScan [TS_0] (rows=72 width=4)
                                                                             default@reason,reason,Tbl:COMPLETE,Col:COMPLETE,Output:["r_reason_sk"]
-                                                                  <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                    PARTITION_ONLY_SHUFFLE [RS_249]
-                                                                      Select Operator [SEL_248] (rows=1 width=4)
+                                                                  <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                    PARTITION_ONLY_SHUFFLE [RS_251]
+                                                                      Select Operator [SEL_250] (rows=1 width=4)
                                                                         Output:["_col0"]
-                                                                        Group By Operator [GBY_247] (rows=1 width=8)
+                                                                        Group By Operator [GBY_249] (rows=1 width=8)
                                                                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                          PARTITION_ONLY_SHUFFLE [RS_238]
-                                                                            Group By Operator [GBY_223] (rows=1 width=8)
+                                                                          PARTITION_ONLY_SHUFFLE [RS_236]
+                                                                            Group By Operator [GBY_221] (rows=1 width=8)
                                                                               Output:["_col0"],aggregations:["count()"]
-                                                                              Select Operator [SEL_208] (rows=182855757 width=3)
-                                                                                Filter Operator [FIL_193] (rows=182855757 width=3)
+                                                                              Select Operator [SEL_206] (rows=182855757 width=3)
+                                                                                Filter Operator [FIL_191] (rows=182855757 width=3)
                                                                                   predicate:ss_quantity BETWEEN 1 AND 20
                                                                                    Please refer to the previous TableScan [TS_66]
                                                               <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_252]
-                                                                  Select Operator [SEL_251] (rows=1 width=112)
+                                                                PARTITION_ONLY_SHUFFLE [RS_254]
+                                                                  Select Operator [SEL_253] (rows=1 width=112)
                                                                     Output:["_col0"]
-                                                                    Group By Operator [GBY_250] (rows=1 width=120)
+                                                                    Group By Operator [GBY_252] (rows=1 width=120)
                                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                                                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_239]
-                                                                        Group By Operator [GBY_224] (rows=1 width=120)
+                                                                      PARTITION_ONLY_SHUFFLE [RS_241]
+                                                                        Group By Operator [GBY_226] (rows=1 width=120)
                                                                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                                          Select Operator [SEL_209] (rows=182855757 width=110)
+                                                                          Select Operator [SEL_211] (rows=182855757 width=110)
                                                                             Output:["ss_ext_list_price"]
-                                                                            Filter Operator [FIL_194] (rows=182855757 width=110)
+                                                                            Filter Operator [FIL_196] (rows=182855757 width=110)
                                                                               predicate:ss_quantity BETWEEN 1 AND 20
                                                                                Please refer to the previous TableScan [TS_66]
+                                                          <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            PARTITION_ONLY_SHUFFLE [RS_257]
+                                                              Select Operator [SEL_256] (rows=1 width=112)
+                                                                Output:["_col0"]
+                                                                Group By Operator [GBY_255] (rows=1 width=120)
+                                                                  Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
+                                                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                  PARTITION_ONLY_SHUFFLE [RS_246]
+                                                                    Group By Operator [GBY_231] (rows=1 width=120)
+                                                                      Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
+                                                                      Select Operator [SEL_216] (rows=182855757 width=110)
+                                                                        Output:["ss_net_paid_inc_tax"]
+                                                                        Filter Operator [FIL_201] (rows=182855757 width=110)
+                                                                          predicate:ss_quantity BETWEEN 1 AND 20
+                                                                           Please refer to the previous TableScan [TS_66]
                               <-Reducer 18 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_276]
-                                  Select Operator [SEL_275] (rows=1 width=4)
+                                PARTITION_ONLY_SHUFFLE [RS_278]
+                                  Select Operator [SEL_277] (rows=1 width=4)
                                     Output:["_col0"]
-                                    Group By Operator [GBY_274] (rows=1 width=8)
+                                    Group By Operator [GBY_276] (rows=1 width=8)
                                       Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_232]
-                                        Group By Operator [GBY_217] (rows=1 width=8)
+                                      PARTITION_ONLY_SHUFFLE [RS_234]
+                                        Group By Operator [GBY_219] (rows=1 width=8)
                                           Output:["_col0"],aggregations:["count()"]
-                                          Select Operator [SEL_202] (rows=182855757 width=3)
+                                          Select Operator [SEL_204] (rows=182855757 width=3)
                                             Filter Operator [FIL_189] (rows=182855757 width=3)
                                               predicate:ss_quantity BETWEEN 61 AND 80
                                                Please refer to the previous TableScan [TS_66]
-                          <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_279]
-                              Select Operator [SEL_278] (rows=1 width=112)
+                          <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
+                            PARTITION_ONLY_SHUFFLE [RS_281]
+                              Select Operator [SEL_280] (rows=1 width=112)
                                 Output:["_col0"]
-                                Group By Operator [GBY_277] (rows=1 width=120)
+                                Group By Operator [GBY_279] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                                 <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_233]
-                                    Group By Operator [GBY_218] (rows=1 width=120)
+                                  PARTITION_ONLY_SHUFFLE [RS_239]
+                                    Group By Operator [GBY_224] (rows=1 width=120)
                                       Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                      Select Operator [SEL_203] (rows=182855757 width=110)
+                                      Select Operator [SEL_209] (rows=182855757 width=110)
                                         Output:["ss_ext_list_price"]
-                                         Please refer to the previous Filter Operator [FIL_189]
-                      <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
-                        PARTITION_ONLY_SHUFFLE [RS_282]
-                          Select Operator [SEL_281] (rows=1 width=112)
+                                        Filter Operator [FIL_194] (rows=182855757 width=110)
+                                          predicate:ss_quantity BETWEEN 61 AND 80
+                                           Please refer to the previous TableScan [TS_66]
+                      <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
+                        PARTITION_ONLY_SHUFFLE [RS_284]
+                          Select Operator [SEL_283] (rows=1 width=112)
                             Output:["_col0"]
-                            Group By Operator [GBY_280] (rows=1 width=120)
+                            Group By Operator [GBY_282] (rows=1 width=120)
                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                             <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_234]
-                                Group By Operator [GBY_219] (rows=1 width=120)
+                              PARTITION_ONLY_SHUFFLE [RS_244]
+                                Group By Operator [GBY_229] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                  Select Operator [SEL_204] (rows=182855757 width=110)
+                                  Select Operator [SEL_214] (rows=182855757 width=110)
                                     Output:["ss_net_paid_inc_tax"]
-                                     Please refer to the previous Filter Operator [FIL_189]
-                  <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
-                    PARTITION_ONLY_SHUFFLE [RS_285]
-                      Select Operator [SEL_284] (rows=1 width=4)
+                                    Filter Operator [FIL_199] (rows=182855757 width=110)
+                                      predicate:ss_quantity BETWEEN 61 AND 80
+                                       Please refer to the previous TableScan [TS_66]
+                  <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
+                    PARTITION_ONLY_SHUFFLE [RS_287]
+                      Select Operator [SEL_286] (rows=1 width=4)
                         Output:["_col0"]
-                        Group By Operator [GBY_283] (rows=1 width=8)
+                        Group By Operator [GBY_285] (rows=1 width=8)
                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
                           PARTITION_ONLY_SHUFFLE [RS_235]
@@ -411,34 +415,34 @@ Stage-0
                                 Filter Operator [FIL_190] (rows=182855757 width=3)
                                   predicate:ss_quantity BETWEEN 81 AND 100
                                    Please refer to the previous TableScan [TS_66]
-              <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
-                PARTITION_ONLY_SHUFFLE [RS_288]
-                  Select Operator [SEL_287] (rows=1 width=112)
+              <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
+                PARTITION_ONLY_SHUFFLE [RS_290]
+                  Select Operator [SEL_289] (rows=1 width=112)
                     Output:["_col0"]
-                    Group By Operator [GBY_286] (rows=1 width=120)
+                    Group By Operator [GBY_288] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                      PARTITION_ONLY_SHUFFLE [RS_236]
-                        Group By Operator [GBY_221] (rows=1 width=120)
+                      PARTITION_ONLY_SHUFFLE [RS_240]
+                        Group By Operator [GBY_225] (rows=1 width=120)
                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                          Select Operator [SEL_206] (rows=182855757 width=110)
+                          Select Operator [SEL_210] (rows=182855757 width=110)
                             Output:["ss_ext_list_price"]
-                            Filter Operator [FIL_191] (rows=182855757 width=110)
+                            Filter Operator [FIL_195] (rows=182855757 width=110)
                               predicate:ss_quantity BETWEEN 81 AND 100
                                Please refer to the previous TableScan [TS_66]
-          <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_291]
-              Select Operator [SEL_290] (rows=1 width=112)
+          <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
+            PARTITION_ONLY_SHUFFLE [RS_293]
+              Select Operator [SEL_292] (rows=1 width=112)
                 Output:["_col0"]
-                Group By Operator [GBY_289] (rows=1 width=120)
+                Group By Operator [GBY_291] (rows=1 width=120)
                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
                 <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                  PARTITION_ONLY_SHUFFLE [RS_237]
-                    Group By Operator [GBY_222] (rows=1 width=120)
+                  PARTITION_ONLY_SHUFFLE [RS_245]
+                    Group By Operator [GBY_230] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                      Select Operator [SEL_207] (rows=182855757 width=110)
+                      Select Operator [SEL_215] (rows=182855757 width=110)
                         Output:["ss_net_paid_inc_tax"]
-                        Filter Operator [FIL_192] (rows=182855757 width=110)
+                        Filter Operator [FIL_200] (rows=182855757 width=110)
                           predicate:ss_quantity BETWEEN 81 AND 100
                            Please refer to the previous TableScan [TS_66]
 

--- a/ql/src/test/results/clientpositive/perf/tez/query9.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/query9.q.out
@@ -120,36 +120,36 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 Plan optimized by CBO.
 
 Vertex dependency in root stage
-Reducer 10 <- Reducer 34 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
+Reducer 10 <- Reducer 32 (CUSTOM_SIMPLE_EDGE), Reducer 9 (CUSTOM_SIMPLE_EDGE)
 Reducer 11 <- Reducer 10 (CUSTOM_SIMPLE_EDGE), Reducer 18 (CUSTOM_SIMPLE_EDGE)
-Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
-Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 30 (CUSTOM_SIMPLE_EDGE)
-Reducer 14 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
-Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 25 (CUSTOM_SIMPLE_EDGE)
-Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 31 (CUSTOM_SIMPLE_EDGE)
+Reducer 12 <- Reducer 11 (CUSTOM_SIMPLE_EDGE), Reducer 19 (CUSTOM_SIMPLE_EDGE)
+Reducer 13 <- Reducer 12 (CUSTOM_SIMPLE_EDGE), Reducer 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 14 <- Reducer 13 (CUSTOM_SIMPLE_EDGE), Reducer 21 (CUSTOM_SIMPLE_EDGE)
+Reducer 15 <- Reducer 14 (CUSTOM_SIMPLE_EDGE), Reducer 22 (CUSTOM_SIMPLE_EDGE)
+Reducer 16 <- Reducer 15 (CUSTOM_SIMPLE_EDGE), Reducer 23 (CUSTOM_SIMPLE_EDGE)
 Reducer 18 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 19 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 20 (CUSTOM_SIMPLE_EDGE)
+Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 24 (CUSTOM_SIMPLE_EDGE)
 Reducer 20 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 21 <- Map 17 (CUSTOM_SIMPLE_EDGE)
 Reducer 22 <- Map 17 (CUSTOM_SIMPLE_EDGE)
-Reducer 24 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 25 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 26 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 27 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 28 <- Map 23 (CUSTOM_SIMPLE_EDGE)
-Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 26 (CUSTOM_SIMPLE_EDGE)
-Reducer 30 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 31 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 32 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 33 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 34 <- Map 29 (CUSTOM_SIMPLE_EDGE)
-Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE), Reducer 32 (CUSTOM_SIMPLE_EDGE)
-Reducer 5 <- Reducer 21 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
-Reducer 6 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
-Reducer 7 <- Reducer 33 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
-Reducer 8 <- Reducer 22 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-Reducer 9 <- Reducer 28 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
+Reducer 23 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 24 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 25 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 26 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 27 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 28 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 29 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE), Reducer 25 (CUSTOM_SIMPLE_EDGE)
+Reducer 30 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 31 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 32 <- Map 17 (CUSTOM_SIMPLE_EDGE)
+Reducer 4 <- Reducer 26 (CUSTOM_SIMPLE_EDGE), Reducer 3 (CUSTOM_SIMPLE_EDGE)
+Reducer 5 <- Reducer 27 (CUSTOM_SIMPLE_EDGE), Reducer 4 (CUSTOM_SIMPLE_EDGE)
+Reducer 6 <- Reducer 28 (CUSTOM_SIMPLE_EDGE), Reducer 5 (CUSTOM_SIMPLE_EDGE)
+Reducer 7 <- Reducer 29 (CUSTOM_SIMPLE_EDGE), Reducer 6 (CUSTOM_SIMPLE_EDGE)
+Reducer 8 <- Reducer 30 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+Reducer 9 <- Reducer 31 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
 
 Stage-0
   Fetch Operator
@@ -185,121 +185,134 @@ Stage-0
                                 PARTITION_ONLY_SHUFFLE [RS_135]
                                   Merge Join Operator [MERGEJOIN_179] (rows=2 width=684)
                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8","_col9"]
-                                  <-Reducer 34 [CUSTOM_SIMPLE_EDGE] vectorized
-                                    PARTITION_ONLY_SHUFFLE [RS_275]
-                                      Select Operator [SEL_274] (rows=1 width=112)
+                                  <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
+                                    PARTITION_ONLY_SHUFFLE [RS_273]
+                                      Select Operator [SEL_272] (rows=1 width=112)
                                         Output:["_col0"]
-                                        Group By Operator [GBY_273] (rows=1 width=120)
+                                        Group By Operator [GBY_271] (rows=1 width=120)
                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                        <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                          PARTITION_ONLY_SHUFFLE [RS_254]
-                                            Group By Operator [GBY_249] (rows=1 width=120)
+                                        <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                          PARTITION_ONLY_SHUFFLE [RS_246]
+                                            Group By Operator [GBY_231] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                              Select Operator [SEL_244] (rows=182855757 width=110)
+                                              Select Operator [SEL_216] (rows=182855757 width=110)
                                                 Output:["ss_net_paid_inc_tax"]
-                                                Filter Operator [FIL_239] (rows=182855757 width=110)
+                                                Filter Operator [FIL_201] (rows=182855757 width=110)
                                                   predicate:ss_quantity BETWEEN 41 AND 60
-                                                  TableScan [TS_80] (rows=575995635 width=110)
-                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_net_paid_inc_tax"]
+                                                  TableScan [TS_66] (rows=575995635 width=3)
+                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_ext_list_price","ss_net_paid_inc_tax"]
                                   <-Reducer 9 [CUSTOM_SIMPLE_EDGE]
                                     PARTITION_ONLY_SHUFFLE [RS_132]
                                       Merge Join Operator [MERGEJOIN_178] (rows=2 width=572)
                                         Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                      <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
-                                        PARTITION_ONLY_SHUFFLE [RS_272]
-                                          Select Operator [SEL_271] (rows=1 width=112)
+                                      <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
+                                        PARTITION_ONLY_SHUFFLE [RS_270]
+                                          Select Operator [SEL_269] (rows=1 width=112)
                                             Output:["_col0"]
-                                            Group By Operator [GBY_270] (rows=1 width=120)
+                                            Group By Operator [GBY_268] (rows=1 width=120)
                                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                            <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_231]
-                                                Group By Operator [GBY_226] (rows=1 width=120)
+                                            <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              PARTITION_ONLY_SHUFFLE [RS_245]
+                                                Group By Operator [GBY_230] (rows=1 width=120)
                                                   Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                  Select Operator [SEL_221] (rows=182855757 width=110)
+                                                  Select Operator [SEL_215] (rows=182855757 width=110)
                                                     Output:["ss_ext_list_price"]
-                                                    Filter Operator [FIL_216] (rows=182855757 width=110)
+                                                    Filter Operator [FIL_200] (rows=182855757 width=110)
                                                       predicate:ss_quantity BETWEEN 41 AND 60
-                                                      TableScan [TS_73] (rows=575995635 width=110)
-                                                        default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity","ss_ext_list_price"]
+                                                       Please refer to the previous TableScan [TS_66]
                                       <-Reducer 8 [CUSTOM_SIMPLE_EDGE]
                                         PARTITION_ONLY_SHUFFLE [RS_129]
                                           Merge Join Operator [MERGEJOIN_177] (rows=2 width=460)
                                             Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
-                                          <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
-                                            PARTITION_ONLY_SHUFFLE [RS_269]
-                                              Select Operator [SEL_268] (rows=1 width=4)
+                                          <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
+                                            PARTITION_ONLY_SHUFFLE [RS_267]
+                                              Select Operator [SEL_266] (rows=1 width=4)
                                                 Output:["_col0"]
-                                                Group By Operator [GBY_267] (rows=1 width=8)
+                                                Group By Operator [GBY_265] (rows=1 width=8)
                                                   Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                 <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                  PARTITION_ONLY_SHUFFLE [RS_208]
-                                                    Group By Operator [GBY_203] (rows=1 width=8)
+                                                  PARTITION_ONLY_SHUFFLE [RS_244]
+                                                    Group By Operator [GBY_229] (rows=1 width=8)
                                                       Output:["_col0"],aggregations:["count()"]
-                                                      Select Operator [SEL_198] (rows=182855757 width=3)
-                                                        Filter Operator [FIL_193] (rows=182855757 width=3)
+                                                      Select Operator [SEL_214] (rows=182855757 width=3)
+                                                        Filter Operator [FIL_199] (rows=182855757 width=3)
                                                           predicate:ss_quantity BETWEEN 41 AND 60
-                                                          TableScan [TS_66] (rows=575995635 width=3)
-                                                            default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_quantity"]
+                                                           Please refer to the previous TableScan [TS_66]
                                           <-Reducer 7 [CUSTOM_SIMPLE_EDGE]
                                             PARTITION_ONLY_SHUFFLE [RS_126]
                                               Merge Join Operator [MERGEJOIN_176] (rows=2 width=456)
                                                 Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5","_col6"]
-                                              <-Reducer 33 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                PARTITION_ONLY_SHUFFLE [RS_266]
-                                                  Select Operator [SEL_265] (rows=1 width=112)
+                                              <-Reducer 29 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                PARTITION_ONLY_SHUFFLE [RS_264]
+                                                  Select Operator [SEL_263] (rows=1 width=112)
                                                     Output:["_col0"]
-                                                    Group By Operator [GBY_264] (rows=1 width=120)
+                                                    Group By Operator [GBY_262] (rows=1 width=120)
                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                    <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                      PARTITION_ONLY_SHUFFLE [RS_253]
-                                                        Group By Operator [GBY_248] (rows=1 width=120)
+                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      PARTITION_ONLY_SHUFFLE [RS_243]
+                                                        Group By Operator [GBY_228] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                          Select Operator [SEL_243] (rows=182855757 width=110)
+                                                          Select Operator [SEL_213] (rows=182855757 width=110)
                                                             Output:["ss_net_paid_inc_tax"]
-                                                            Filter Operator [FIL_238] (rows=182855757 width=110)
+                                                            Filter Operator [FIL_198] (rows=182855757 width=110)
                                                               predicate:ss_quantity BETWEEN 21 AND 40
-                                                               Please refer to the previous TableScan [TS_80]
+                                                               Please refer to the previous TableScan [TS_66]
                                               <-Reducer 6 [CUSTOM_SIMPLE_EDGE]
                                                 PARTITION_ONLY_SHUFFLE [RS_123]
                                                   Merge Join Operator [MERGEJOIN_175] (rows=2 width=344)
                                                     Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4","_col5"]
-                                                  <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    PARTITION_ONLY_SHUFFLE [RS_263]
-                                                      Select Operator [SEL_262] (rows=1 width=112)
+                                                  <-Reducer 28 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                    PARTITION_ONLY_SHUFFLE [RS_261]
+                                                      Select Operator [SEL_260] (rows=1 width=112)
                                                         Output:["_col0"]
-                                                        Group By Operator [GBY_261] (rows=1 width=120)
+                                                        Group By Operator [GBY_259] (rows=1 width=120)
                                                           Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                        <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                          PARTITION_ONLY_SHUFFLE [RS_230]
-                                                            Group By Operator [GBY_225] (rows=1 width=120)
+                                                        <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                          PARTITION_ONLY_SHUFFLE [RS_242]
+                                                            Group By Operator [GBY_227] (rows=1 width=120)
                                                               Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                              Select Operator [SEL_220] (rows=182855757 width=110)
+                                                              Select Operator [SEL_212] (rows=182855757 width=110)
                                                                 Output:["ss_ext_list_price"]
-                                                                Filter Operator [FIL_215] (rows=182855757 width=110)
+                                                                Filter Operator [FIL_197] (rows=182855757 width=110)
                                                                   predicate:ss_quantity BETWEEN 21 AND 40
-                                                                   Please refer to the previous TableScan [TS_73]
+                                                                   Please refer to the previous TableScan [TS_66]
                                                   <-Reducer 5 [CUSTOM_SIMPLE_EDGE]
                                                     PARTITION_ONLY_SHUFFLE [RS_120]
                                                       Merge Join Operator [MERGEJOIN_174] (rows=2 width=232)
                                                         Conds:(Left Outer),Output:["_col1","_col2","_col3","_col4"]
-                                                      <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                        PARTITION_ONLY_SHUFFLE [RS_260]
-                                                          Select Operator [SEL_259] (rows=1 width=4)
+                                                      <-Reducer 27 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                        PARTITION_ONLY_SHUFFLE [RS_258]
+                                                          Select Operator [SEL_257] (rows=1 width=4)
                                                             Output:["_col0"]
-                                                            Group By Operator [GBY_258] (rows=1 width=8)
+                                                            Group By Operator [GBY_256] (rows=1 width=8)
                                                               Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                             <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                              PARTITION_ONLY_SHUFFLE [RS_207]
-                                                                Group By Operator [GBY_202] (rows=1 width=8)
+                                                              PARTITION_ONLY_SHUFFLE [RS_241]
+                                                                Group By Operator [GBY_226] (rows=1 width=8)
                                                                   Output:["_col0"],aggregations:["count()"]
-                                                                  Select Operator [SEL_197] (rows=182855757 width=3)
-                                                                    Filter Operator [FIL_192] (rows=182855757 width=3)
+                                                                  Select Operator [SEL_211] (rows=182855757 width=3)
+                                                                    Filter Operator [FIL_196] (rows=182855757 width=3)
                                                                       predicate:ss_quantity BETWEEN 21 AND 40
                                                                        Please refer to the previous TableScan [TS_66]
                                                       <-Reducer 4 [CUSTOM_SIMPLE_EDGE]
                                                         PARTITION_ONLY_SHUFFLE [RS_117]
                                                           Merge Join Operator [MERGEJOIN_173] (rows=2 width=228)
                                                             Conds:(Left Outer),Output:["_col1","_col2","_col3"]
+                                                          <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                            PARTITION_ONLY_SHUFFLE [RS_255]
+                                                              Select Operator [SEL_254] (rows=1 width=112)
+                                                                Output:["_col0"]
+                                                                Group By Operator [GBY_253] (rows=1 width=120)
+                                                                  Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
+                                                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                  PARTITION_ONLY_SHUFFLE [RS_240]
+                                                                    Group By Operator [GBY_225] (rows=1 width=120)
+                                                                      Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
+                                                                      Select Operator [SEL_210] (rows=182855757 width=110)
+                                                                        Output:["ss_net_paid_inc_tax"]
+                                                                        Filter Operator [FIL_195] (rows=182855757 width=110)
+                                                                          predicate:ss_quantity BETWEEN 1 AND 20
+                                                                           Please refer to the previous TableScan [TS_66]
                                                           <-Reducer 3 [CUSTOM_SIMPLE_EDGE]
                                                             PARTITION_ONLY_SHUFFLE [RS_114]
                                                               Merge Join Operator [MERGEJOIN_172] (rows=2 width=116)
@@ -315,136 +328,117 @@ Stage-0
                                                                           predicate:(r_reason_sk = 1)
                                                                           TableScan [TS_0] (rows=72 width=4)
                                                                             default@reason,reason,Tbl:COMPLETE,Col:COMPLETE,Output:["r_reason_sk"]
-                                                                  <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                    PARTITION_ONLY_SHUFFLE [RS_211]
-                                                                      Select Operator [SEL_210] (rows=1 width=4)
+                                                                  <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                    PARTITION_ONLY_SHUFFLE [RS_249]
+                                                                      Select Operator [SEL_248] (rows=1 width=4)
                                                                         Output:["_col0"]
-                                                                        Group By Operator [GBY_209] (rows=1 width=8)
+                                                                        Group By Operator [GBY_247] (rows=1 width=8)
                                                                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                                                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                          PARTITION_ONLY_SHUFFLE [RS_206]
-                                                                            Group By Operator [GBY_201] (rows=1 width=8)
+                                                                          PARTITION_ONLY_SHUFFLE [RS_238]
+                                                                            Group By Operator [GBY_223] (rows=1 width=8)
                                                                               Output:["_col0"],aggregations:["count()"]
-                                                                              Select Operator [SEL_196] (rows=182855757 width=3)
-                                                                                Filter Operator [FIL_191] (rows=182855757 width=3)
+                                                                              Select Operator [SEL_208] (rows=182855757 width=3)
+                                                                                Filter Operator [FIL_193] (rows=182855757 width=3)
                                                                                   predicate:ss_quantity BETWEEN 1 AND 20
                                                                                    Please refer to the previous TableScan [TS_66]
-                                                              <-Reducer 26 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                PARTITION_ONLY_SHUFFLE [RS_234]
-                                                                  Select Operator [SEL_233] (rows=1 width=112)
+                                                              <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                PARTITION_ONLY_SHUFFLE [RS_252]
+                                                                  Select Operator [SEL_251] (rows=1 width=112)
                                                                     Output:["_col0"]
-                                                                    Group By Operator [GBY_232] (rows=1 width=120)
+                                                                    Group By Operator [GBY_250] (rows=1 width=120)
                                                                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                                    <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                      PARTITION_ONLY_SHUFFLE [RS_229]
+                                                                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                                      PARTITION_ONLY_SHUFFLE [RS_239]
                                                                         Group By Operator [GBY_224] (rows=1 width=120)
                                                                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                                                          Select Operator [SEL_219] (rows=182855757 width=110)
+                                                                          Select Operator [SEL_209] (rows=182855757 width=110)
                                                                             Output:["ss_ext_list_price"]
-                                                                            Filter Operator [FIL_214] (rows=182855757 width=110)
+                                                                            Filter Operator [FIL_194] (rows=182855757 width=110)
                                                                               predicate:ss_quantity BETWEEN 1 AND 20
-                                                                               Please refer to the previous TableScan [TS_73]
-                                                          <-Reducer 32 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                            PARTITION_ONLY_SHUFFLE [RS_257]
-                                                              Select Operator [SEL_256] (rows=1 width=112)
-                                                                Output:["_col0"]
-                                                                Group By Operator [GBY_255] (rows=1 width=120)
-                                                                  Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                                                <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                                  PARTITION_ONLY_SHUFFLE [RS_252]
-                                                                    Group By Operator [GBY_247] (rows=1 width=120)
-                                                                      Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                                                      Select Operator [SEL_242] (rows=182855757 width=110)
-                                                                        Output:["ss_net_paid_inc_tax"]
-                                                                        Filter Operator [FIL_237] (rows=182855757 width=110)
-                                                                          predicate:ss_quantity BETWEEN 1 AND 20
-                                                                           Please refer to the previous TableScan [TS_80]
+                                                                               Please refer to the previous TableScan [TS_66]
                               <-Reducer 18 [CUSTOM_SIMPLE_EDGE] vectorized
-                                PARTITION_ONLY_SHUFFLE [RS_278]
-                                  Select Operator [SEL_277] (rows=1 width=4)
+                                PARTITION_ONLY_SHUFFLE [RS_276]
+                                  Select Operator [SEL_275] (rows=1 width=4)
                                     Output:["_col0"]
-                                    Group By Operator [GBY_276] (rows=1 width=8)
+                                    Group By Operator [GBY_274] (rows=1 width=8)
                                       Output:["_col0"],aggregations:["count(VALUE._col0)"]
                                     <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                                      PARTITION_ONLY_SHUFFLE [RS_204]
-                                        Group By Operator [GBY_199] (rows=1 width=8)
+                                      PARTITION_ONLY_SHUFFLE [RS_232]
+                                        Group By Operator [GBY_217] (rows=1 width=8)
                                           Output:["_col0"],aggregations:["count()"]
-                                          Select Operator [SEL_194] (rows=182855757 width=3)
+                                          Select Operator [SEL_202] (rows=182855757 width=3)
                                             Filter Operator [FIL_189] (rows=182855757 width=3)
                                               predicate:ss_quantity BETWEEN 61 AND 80
                                                Please refer to the previous TableScan [TS_66]
-                          <-Reducer 24 [CUSTOM_SIMPLE_EDGE] vectorized
-                            PARTITION_ONLY_SHUFFLE [RS_281]
-                              Select Operator [SEL_280] (rows=1 width=112)
+                          <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
+                            PARTITION_ONLY_SHUFFLE [RS_279]
+                              Select Operator [SEL_278] (rows=1 width=112)
                                 Output:["_col0"]
-                                Group By Operator [GBY_279] (rows=1 width=120)
+                                Group By Operator [GBY_277] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                                <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                                  PARTITION_ONLY_SHUFFLE [RS_227]
-                                    Group By Operator [GBY_222] (rows=1 width=120)
+                                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                                  PARTITION_ONLY_SHUFFLE [RS_233]
+                                    Group By Operator [GBY_218] (rows=1 width=120)
                                       Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                                      Select Operator [SEL_217] (rows=182855757 width=110)
+                                      Select Operator [SEL_203] (rows=182855757 width=110)
                                         Output:["ss_ext_list_price"]
-                                        Filter Operator [FIL_212] (rows=182855757 width=110)
-                                          predicate:ss_quantity BETWEEN 61 AND 80
-                                           Please refer to the previous TableScan [TS_73]
-                      <-Reducer 30 [CUSTOM_SIMPLE_EDGE] vectorized
-                        PARTITION_ONLY_SHUFFLE [RS_284]
-                          Select Operator [SEL_283] (rows=1 width=112)
+                                         Please refer to the previous Filter Operator [FIL_189]
+                      <-Reducer 20 [CUSTOM_SIMPLE_EDGE] vectorized
+                        PARTITION_ONLY_SHUFFLE [RS_282]
+                          Select Operator [SEL_281] (rows=1 width=112)
                             Output:["_col0"]
-                            Group By Operator [GBY_282] (rows=1 width=120)
+                            Group By Operator [GBY_280] (rows=1 width=120)
                               Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                            <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                              PARTITION_ONLY_SHUFFLE [RS_250]
-                                Group By Operator [GBY_245] (rows=1 width=120)
+                            <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                              PARTITION_ONLY_SHUFFLE [RS_234]
+                                Group By Operator [GBY_219] (rows=1 width=120)
                                   Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                                  Select Operator [SEL_240] (rows=182855757 width=110)
+                                  Select Operator [SEL_204] (rows=182855757 width=110)
                                     Output:["ss_net_paid_inc_tax"]
-                                    Filter Operator [FIL_235] (rows=182855757 width=110)
-                                      predicate:ss_quantity BETWEEN 61 AND 80
-                                       Please refer to the previous TableScan [TS_80]
-                  <-Reducer 19 [CUSTOM_SIMPLE_EDGE] vectorized
-                    PARTITION_ONLY_SHUFFLE [RS_287]
-                      Select Operator [SEL_286] (rows=1 width=4)
+                                     Please refer to the previous Filter Operator [FIL_189]
+                  <-Reducer 21 [CUSTOM_SIMPLE_EDGE] vectorized
+                    PARTITION_ONLY_SHUFFLE [RS_285]
+                      Select Operator [SEL_284] (rows=1 width=4)
                         Output:["_col0"]
-                        Group By Operator [GBY_285] (rows=1 width=8)
+                        Group By Operator [GBY_283] (rows=1 width=8)
                           Output:["_col0"],aggregations:["count(VALUE._col0)"]
                         <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
-                          PARTITION_ONLY_SHUFFLE [RS_205]
-                            Group By Operator [GBY_200] (rows=1 width=8)
+                          PARTITION_ONLY_SHUFFLE [RS_235]
+                            Group By Operator [GBY_220] (rows=1 width=8)
                               Output:["_col0"],aggregations:["count()"]
-                              Select Operator [SEL_195] (rows=182855757 width=3)
+                              Select Operator [SEL_205] (rows=182855757 width=3)
                                 Filter Operator [FIL_190] (rows=182855757 width=3)
                                   predicate:ss_quantity BETWEEN 81 AND 100
                                    Please refer to the previous TableScan [TS_66]
-              <-Reducer 25 [CUSTOM_SIMPLE_EDGE] vectorized
-                PARTITION_ONLY_SHUFFLE [RS_290]
-                  Select Operator [SEL_289] (rows=1 width=112)
+              <-Reducer 22 [CUSTOM_SIMPLE_EDGE] vectorized
+                PARTITION_ONLY_SHUFFLE [RS_288]
+                  Select Operator [SEL_287] (rows=1 width=112)
                     Output:["_col0"]
-                    Group By Operator [GBY_288] (rows=1 width=120)
+                    Group By Operator [GBY_286] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                    <-Map 23 [CUSTOM_SIMPLE_EDGE] vectorized
-                      PARTITION_ONLY_SHUFFLE [RS_228]
-                        Group By Operator [GBY_223] (rows=1 width=120)
+                    <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                      PARTITION_ONLY_SHUFFLE [RS_236]
+                        Group By Operator [GBY_221] (rows=1 width=120)
                           Output:["_col0","_col1"],aggregations:["sum(ss_ext_list_price)","count(ss_ext_list_price)"]
-                          Select Operator [SEL_218] (rows=182855757 width=110)
+                          Select Operator [SEL_206] (rows=182855757 width=110)
                             Output:["ss_ext_list_price"]
-                            Filter Operator [FIL_213] (rows=182855757 width=110)
+                            Filter Operator [FIL_191] (rows=182855757 width=110)
                               predicate:ss_quantity BETWEEN 81 AND 100
-                               Please refer to the previous TableScan [TS_73]
-          <-Reducer 31 [CUSTOM_SIMPLE_EDGE] vectorized
-            PARTITION_ONLY_SHUFFLE [RS_293]
-              Select Operator [SEL_292] (rows=1 width=112)
+                               Please refer to the previous TableScan [TS_66]
+          <-Reducer 23 [CUSTOM_SIMPLE_EDGE] vectorized
+            PARTITION_ONLY_SHUFFLE [RS_291]
+              Select Operator [SEL_290] (rows=1 width=112)
                 Output:["_col0"]
-                Group By Operator [GBY_291] (rows=1 width=120)
+                Group By Operator [GBY_289] (rows=1 width=120)
                   Output:["_col0","_col1"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"]
-                <-Map 29 [CUSTOM_SIMPLE_EDGE] vectorized
-                  PARTITION_ONLY_SHUFFLE [RS_251]
-                    Group By Operator [GBY_246] (rows=1 width=120)
+                <-Map 17 [CUSTOM_SIMPLE_EDGE] vectorized
+                  PARTITION_ONLY_SHUFFLE [RS_237]
+                    Group By Operator [GBY_222] (rows=1 width=120)
                       Output:["_col0","_col1"],aggregations:["sum(ss_net_paid_inc_tax)","count(ss_net_paid_inc_tax)"]
-                      Select Operator [SEL_241] (rows=182855757 width=110)
+                      Select Operator [SEL_207] (rows=182855757 width=110)
                         Output:["ss_net_paid_inc_tax"]
-                        Filter Operator [FIL_236] (rows=182855757 width=110)
+                        Filter Operator [FIL_192] (rows=182855757 width=110)
                           predicate:ss_quantity BETWEEN 81 AND 100
-                           Please refer to the previous TableScan [TS_80]
+                           Please refer to the previous TableScan [TS_66]
 

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
@@ -966,17 +966,17 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 2 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
-        Map 8 <- Map 10 (BROADCAST_EDGE), Map 7 (BROADCAST_EDGE)
+        Map 7 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
         Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -987,22 +987,15 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: y
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Map 2 
             Map Operator Tree:
@@ -1048,7 +1041,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1059,24 +1052,17 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: z
@@ -1093,7 +1079,7 @@ STAGE PLANS:
                         1 value (type: string)
                       outputColumnNames: _col1
                       input vertices:
-                        0 Map 7
+                        0 Map 1
                       Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
                       Map Join Operator
                         condition map:
@@ -1102,7 +1088,7 @@ STAGE PLANS:
                           0 _col1 (type: string)
                           1 value (type: string)
                         input vertices:
-                          1 Map 10
+                          1 Map 6
                         Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: count()
@@ -1151,7 +1137,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator
@@ -1258,17 +1244,17 @@ STAGE PLANS:
 #### A masked pattern was here ####
       Edges:
         Map 2 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
-        Map 8 <- Map 10 (BROADCAST_EDGE), Map 7 (BROADCAST_EDGE)
+        Map 7 <- Map 1 (BROADCAST_EDGE), Map 6 (BROADCAST_EDGE)
         Reducer 3 <- Map 2 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
         Reducer 5 <- Union 4 (SIMPLE_EDGE)
-        Reducer 9 <- Map 8 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
+        Reducer 8 <- Map 7 (CUSTOM_SIMPLE_EDGE), Union 4 (CONTAINS)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1279,22 +1265,15 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 25 Data size: 2150 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: y
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
         Map 2 
             Map Operator Tree:
@@ -1342,7 +1321,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y
-                  filterExpr: key is not null (type: boolean)
+                  filterExpr: (key is not null or value is not null) (type: boolean)
                   Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: key is not null (type: boolean)
@@ -1353,24 +1332,17 @@ STAGE PLANS:
                       sort order: +
                       Map-reduce partition columns: key (type: string)
                       Statistics: Num rows: 500 Data size: 43500 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 7 
-            Map Operator Tree:
-                TableScan
-                  alias: x
-                  filterExpr: value is not null (type: boolean)
-                  Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: value is not null (type: boolean)
-                    Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: value (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: value (type: string)
-                      Statistics: Num rows: 25 Data size: 2225 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 500 Data size: 45500 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: z
@@ -1387,7 +1359,7 @@ STAGE PLANS:
                         1 value (type: string)
                       outputColumnNames: _col1
                       input vertices:
-                        0 Map 7
+                        0 Map 1
                       Statistics: Num rows: 162 Data size: 14418 Basic stats: COMPLETE Column stats: COMPLETE
                       HybridGraceHashJoin: true
                       Map Join Operator
@@ -1397,7 +1369,7 @@ STAGE PLANS:
                           0 _col1 (type: string)
                           1 value (type: string)
                         input vertices:
-                          1 Map 10
+                          1 Map 6
                         Statistics: Num rows: 263 Data size: 2104 Basic stats: COMPLETE Column stats: COMPLETE
                         HybridGraceHashJoin: true
                         Group By Operator
@@ -1447,7 +1419,7 @@ STAGE PLANS:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                       serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
-        Reducer 9 
+        Reducer 8 
             Execution mode: vectorized
             Reduce Operator Tree:
               Group By Operator


### PR DESCRIPTION
Testing done:
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestTezPerfCliDriver -Dqfile=query9.q -pl itests/qtest -Pitests
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestTezPerfConstraintsCliDriver -Dqfile=query9.q -pl itests/qtest -Pitests
```