### PR TITLE
HIVE-23941: Refactor TypeCheckProcFactory to be database agnostic

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionInfo.java
@@ -50,9 +50,9 @@ public class FunctionInfo {
 
   private String className;
 
-  private GenericUDF genericUDF;
+  protected GenericUDF genericUDF;
 
-  private GenericUDTF genericUDTF;
+  protected GenericUDTF genericUDTF;
 
   private GenericUDAFResolver genericUDAFResolver;
 
@@ -111,6 +111,24 @@ public class FunctionInfo {
     this.resources = resources;
   }
 
+  public FunctionInfo(FunctionType functionType, String displayName, Class<? extends TableFunctionResolver> tFnCls,
+      GenericUDF genericUDF, GenericUDTF genericUDTF, GenericUDAFResolver genericUDAFResolver,
+      String className, FunctionResource... resources) {
+    this.functionType = functionType;
+    this.displayName = displayName;
+    this.tableFunctionResolver = tFnCls;
+    PartitionTableFunctionDescription def =
+        (tableFunctionResolver != null)
+	    ? AnnotationUtils.getAnnotation(
+                tableFunctionResolver, PartitionTableFunctionDescription.class)
+            : null;
+    this.genericUDF = genericUDF;
+    this.genericUDTF = genericUDTF;
+    this.genericUDAFResolver = genericUDAFResolver;
+    this.className = className;
+    this.isInternalTableFunction = def != null && def.isInternal();
+    this.resources = resources;
+  }
   /**
    * Get a new GenericUDF object for the function.
    */
@@ -214,6 +232,10 @@ public class FunctionInfo {
     return null != genericUDTF;
   }
 
+  public Class<? extends TableFunctionResolver>  getTableFunctionResolver() {
+    return tableFunctionResolver;
+  }
+
   /**
    * @return TRUE if the function is a Table Function
    */
@@ -239,6 +261,10 @@ public class FunctionInfo {
 
   public String getClassName() {
     return className;
+  }
+
+  public void setClassName(String className) {
+    this.className = className;
   }
 
   public FunctionResource[] getResources() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/HiveFunctionInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/HiveFunctionInfo.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDTF;
+import org.apache.hadoop.hive.ql.udf.ptf.TableFunctionResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * FunctionInfo implementation for Hive.
+ *
+ */
+public class HiveFunctionInfo extends FunctionInfo {
+
+  static final Logger LOG = LoggerFactory.getLogger(
+      HiveFunctionInfo.class.getName());
+
+  public HiveFunctionInfo(FunctionInfo functionInfo) {
+    super(functionInfo.getFunctionType(), functionInfo.getDisplayName(),
+        functionInfo.getTableFunctionResolver(), functionInfo.getGenericUDF(),
+	functionInfo.getGenericUDTF(), functionInfo.getGenericUDAFResolver(),
+	functionInfo.getClassName(), functionInfo.getResources());
+  }
+
+  @Override
+  public GenericUDF getGenericUDF() {
+    return genericUDF;
+  }
+
+  @Override
+  public GenericUDTF getGenericUDTF() {
+    return genericUDTF;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/ExprFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/ExprFactory.java
@@ -21,6 +21,7 @@ import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.util.List;
 import org.apache.hadoop.hive.ql.exec.ColumnInfo;
+import org.apache.hadoop.hive.ql.exec.FunctionInfo;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.RowResolver;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -293,13 +294,7 @@ public abstract class ExprFactory<T> {
   /**
    * Creates function call expression.
    */
-  protected abstract T createFuncCallExpr(TypeInfo typeInfo, GenericUDF genericUDF,
-      List<T> inputs) throws SemanticException;
-
-  /**
-   * Creates function call expression.
-   */
-  protected abstract T createFuncCallExpr(GenericUDF genericUDF, String funcText,
+  protected abstract T createFuncCallExpr(TypeInfo typeInfo, FunctionInfo fi, String funcText,
       List<T> inputs) throws SemanticException;
 
   /**
@@ -327,10 +322,23 @@ public abstract class ExprFactory<T> {
    */
   protected abstract boolean isSTRUCTFuncCallExpr(T expr);
 
+  protected abstract boolean isAndFunction(FunctionInfo fi);
+
+  protected abstract boolean isOrFunction(FunctionInfo fi);
+
+  protected abstract boolean isInFunction(FunctionInfo fi);
+
+  protected abstract boolean isCompareFunction(FunctionInfo fi);
+
+  protected abstract boolean isEqualFunction(FunctionInfo fi);
+
+  protected abstract boolean isConsistentWithinQuery(FunctionInfo fi);
+
+  protected abstract boolean isStateful(FunctionInfo fi);
   /**
    * Returns true if a CASE expression can be converted into a COALESCE function call.
    */
-  protected abstract boolean convertCASEIntoCOALESCEFuncCallExpr(GenericUDF genericUDF, List<T> inputs);
+  protected abstract boolean convertCASEIntoCOALESCEFuncCallExpr(FunctionInfo fi, List<T> inputs);
 
   /* SUBQUERIES */
   /**
@@ -392,5 +400,10 @@ public abstract class ExprFactory<T> {
    * Returns the list of names in the input struct expression.
    */
   protected abstract List<String> getStructNameList(T expr);
+
+  /**
+   * Returns the FunctionInfo given the name
+   */
+  protected abstract FunctionInfo getFunctionInfo(String funcName) throws SemanticException;
 
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/FunctionHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/FunctionHelper.java
@@ -83,6 +83,43 @@ public interface FunctionHelper {
   }
 
   /**
+   * returns true if FunctionInfo is an And function.
+   */
+  boolean isAndFunction(FunctionInfo fi);
+
+  /**
+   * returns true if FunctionInfo is an Or function.
+   */
+  boolean isOrFunction(FunctionInfo fi);
+
+  /**
+   * returns true if FunctionInfo is an In function.
+   */
+  boolean isInFunction(FunctionInfo fi);
+
+  /**
+   * returns true if FunctionInfo is a compare function (e.g. '<=')
+   */
+  boolean isCompareFunction(FunctionInfo fi);
+
+  /**
+   * returns true if FunctionInfo is an == function.
+   */
+  boolean isEqualFunction(FunctionInfo fi);
+
+  /**
+   * Returns whether the expression, for a single query, returns the same result given
+   * the same arguments/children. This includes deterministic functions as well as runtime
+   * constants (which may not be deterministic across queries).
+   */
+  boolean isConsistentWithinQuery(FunctionInfo fi);
+
+  /**
+   * returns true if FunctionInfo is a stateful function.
+   */
+  boolean isStateful(FunctionInfo fi);
+
+  /**
    * Class to store aggregate function related information.
    */
   class AggregateInfo {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/RexNodeExprFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/RexNodeExprFactory.java
@@ -621,28 +621,12 @@ public class RexNodeExprFactory extends ExprFactory<RexNode> {
    * {@inheritDoc}
    */
   @Override
-  protected RexNode createFuncCallExpr(TypeInfo returnType, GenericUDF genericUDF,
+  protected RexNode createFuncCallExpr(TypeInfo typeInfo, FunctionInfo functionInfo, String funcText,
       List<RexNode> inputs) throws SemanticException {
-    final String funcText = genericUDF.getClass().getAnnotation(Description.class).name();
-    final FunctionInfo functionInfo = functionHelper.getFunctionInfo(funcText);
-    return functionHelper.getExpression(
-        funcText, functionInfo, inputs,
-        TypeConverter.convert(returnType, rexBuilder.getTypeFactory()));
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  protected RexNode createFuncCallExpr(GenericUDF genericUDF, String funcText,
-      List<RexNode> inputs) throws SemanticException {
-    // 1) Function resolution
-    final FunctionInfo functionInfo = functionHelper.getFunctionInfo(funcText);
     // 2) Compute return type
     RelDataType returnType;
-    if (genericUDF instanceof SettableUDF) {
-      returnType = TypeConverter.convert(
-          ((SettableUDF) genericUDF).getTypeInfo(), rexBuilder.getTypeFactory());
+    if (typeInfo != null) {
+      returnType = TypeConverter.convert(typeInfo, rexBuilder.getTypeFactory());
     } else {
       returnType = functionHelper.getReturnType(functionInfo, inputs);
     }
@@ -796,6 +780,22 @@ public class RexNodeExprFactory extends ExprFactory<RexNode> {
    * {@inheritDoc}
    */
   @Override
+  protected boolean isConsistentWithinQuery(FunctionInfo fi) {
+    return functionHelper.isConsistentWithinQuery(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isStateful(FunctionInfo fi) {
+    return functionHelper.isStateful(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
   protected boolean isPOSITIVEFuncCallExpr(RexNode expr) {
     return expr.isA(SqlKind.PLUS_PREFIX);
   }
@@ -832,7 +832,7 @@ public class RexNodeExprFactory extends ExprFactory<RexNode> {
    * {@inheritDoc}
    */
   @Override
-  protected boolean convertCASEIntoCOALESCEFuncCallExpr(GenericUDF genericUDF, List<RexNode> inputs) {
+  protected boolean convertCASEIntoCOALESCEFuncCallExpr(FunctionInfo fi, List<RexNode> inputs) {
     return false;
   }
 
@@ -851,6 +851,46 @@ public class RexNodeExprFactory extends ExprFactory<RexNode> {
   protected boolean isSTRUCTFuncCallExpr(RexNode expr) {
     return expr instanceof RexCall &&
         ((RexCall) expr).getOperator() == SqlStdOperatorTable.ROW;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isAndFunction(FunctionInfo fi) {
+    return functionHelper.isAndFunction(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isOrFunction(FunctionInfo fi) {
+    return functionHelper.isOrFunction(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isInFunction(FunctionInfo fi) {
+    return functionHelper.isInFunction(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isCompareFunction(FunctionInfo fi) {
+    return functionHelper.isCompareFunction(fi);
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected boolean isEqualFunction(FunctionInfo fi) {
+    return functionHelper.isEqualFunction(fi);
   }
 
   /**
@@ -925,6 +965,14 @@ public class RexNodeExprFactory extends ExprFactory<RexNode> {
       default:
         return null;
     }
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  protected FunctionInfo getFunctionInfo(String funcName) throws SemanticException {
+    return functionHelper.getFunctionInfo(funcName);
   }
 
   private static void throwInvalidSubqueryError(final ASTNode comparisonOp) throws SemanticException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -65,15 +65,6 @@ import org.apache.hadoop.hive.ql.plan.SubqueryType;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.hive.ql.udf.SettableUDF;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBaseCompare;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFCoalesce;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqual;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPEqualNS;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPNot;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPOr;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector.Category;
@@ -119,7 +110,6 @@ public class TypeCheckProcFactory<T> {
     SPECIAL_UNARY_OPERATOR_TEXT_MAP = new HashMap<>();
     SPECIAL_UNARY_OPERATOR_TEXT_MAP.put(HiveParser.PLUS, "positive");
     SPECIAL_UNARY_OPERATOR_TEXT_MAP.put(HiveParser.MINUS, "negative");
-
     CONVERSION_FUNCTION_TEXT_MAP = new HashMap<Integer, String>();
     CONVERSION_FUNCTION_TEXT_MAP.put(HiveParser.TOK_BOOLEAN,
         serdeConstants.BOOLEAN_TYPE_NAME);
@@ -174,7 +164,6 @@ public class TypeCheckProcFactory<T> {
     WINDOWING_TOKENS.add(HiveParser.TOK_NULLS_FIRST);
     WINDOWING_TOKENS.add(HiveParser.TOK_NULLS_LAST);
   }
-
 
   /**
    * Factory that will be used to create the different expressions.
@@ -698,7 +687,7 @@ public class TypeCheckProcFactory<T> {
    */
   public class DefaultExprProcessor implements SemanticNodeProcessor {
 
-    protected boolean isRedundantConversionFunction(ASTNode expr,
+    private boolean isRedundantConversionFunction(ASTNode expr,
         boolean isFunction, List<T> children) {
       if (!isFunction) {
         return false;
@@ -730,7 +719,7 @@ public class TypeCheckProcFactory<T> {
 
       FunctionInfo fi;
       try {
-        fi = FunctionRegistry.getFunctionInfo(udfName);
+        fi = exprFactory.getFunctionInfo(udfName);
       } catch (SemanticException e) {
         throw new UDFArgumentException(e);
       }
@@ -738,23 +727,15 @@ public class TypeCheckProcFactory<T> {
         throw new UDFArgumentException(udfName + " not found.");
       }
 
-      GenericUDF genericUDF = fi.getGenericUDF();
-      if (genericUDF == null) {
+      if (!fi.isGenericUDF()) {
         throw new UDFArgumentException(udfName
             + " is an aggregation function or a table function.");
-      }
-
-      // Add udfData to UDF if necessary
-      if (typeInfo != null) {
-        if (genericUDF instanceof SettableUDF) {
-          ((SettableUDF) genericUDF).setTypeInfo(typeInfo);
-        }
       }
 
       List<T> childrenList = new ArrayList<>(children.length);
 
       childrenList.addAll(Arrays.asList(children));
-      return exprFactory.createFuncCallExpr(genericUDF, udfName, childrenList);
+      return exprFactory.createFuncCallExpr(typeInfo, fi, udfName, childrenList);
     }
 
     public T getFuncExprNodeDesc(String udfName, T... children) throws SemanticException {
@@ -793,10 +774,10 @@ public class TypeCheckProcFactory<T> {
     }
 
     protected void validateUDF(ASTNode expr, boolean isFunction, TypeCheckCtx ctx, FunctionInfo fi,
-        List<T> children, GenericUDF genericUDF) throws SemanticException {
+        List<T> children) throws SemanticException {
       // Check if a bigint is implicitely cast to a double as part of a comparison
       // Perform the check here instead of in GenericUDFBaseCompare to guarantee it is only run once per operator
-      if (genericUDF instanceof GenericUDFBaseCompare && children.size() == 2) {
+      if (exprFactory.isCompareFunction(fi) && children.size() == 2) {
         TypeInfo oiTypeInfo0 = exprFactory.getTypeInfo(children.get(0));
         TypeInfo oiTypeInfo1 = exprFactory.getTypeInfo(children.get(1));
 
@@ -838,14 +819,14 @@ public class TypeCheckProcFactory<T> {
               ErrorMsg.UDAF_INVALID_LOCATION.getMsg(), expr));
         }
       }
-      if (!ctx.getAllowStatefulFunctions() && (genericUDF != null)) {
-        if (FunctionRegistry.isStateful(genericUDF)) {
+      if (!ctx.getAllowStatefulFunctions()) {
+        if (exprFactory.isStateful(fi)) {
           throw new SemanticException(ErrorMsg.UDF_STATEFUL_INVALID_LOCATION.getMsg());
         }
       }
     }
 
-    protected void insertCast(String funcText, List<T> children) throws SemanticException {
+    private void insertCast(String funcText, List<T> children) throws SemanticException {
       // substring, concat UDFs expect first argument as string. Therefore this method inserts explicit cast
       // to cast the first operand to string
       if (funcText.equals("substring") || funcText.equals("concat")) {
@@ -868,8 +849,6 @@ public class TypeCheckProcFactory<T> {
       String funcText = getFunctionText(node, isFunction);
       T expr;
       if (funcText.equals(".")) {
-        // "." : FIELD Expression
-
         assert (children.size() == 2);
         // Only allow constant field name for now
         assert (exprFactory.isConstantExpr(children.get(1)));
@@ -895,6 +874,9 @@ public class TypeCheckProcFactory<T> {
 
         expr = exprFactory.createNestedColumnRefExpr(t, children.get(0), fieldNameString, isList);
       } else if (funcText.equals("[")) {
+        funcText = "index";
+        FunctionInfo fi = exprFactory.getFunctionInfo(funcText);
+
         // "[]" : LSQUARE/INDEX Expression
         if (!ctx.getallowIndexExpr()) {
           throw new SemanticException(ASTErrorUtils.getMsg(
@@ -916,7 +898,7 @@ public class TypeCheckProcFactory<T> {
 
           // Calculate TypeInfo
           TypeInfo t = ((ListTypeInfo) myt).getListElementTypeInfo();
-          expr = exprFactory.createFuncCallExpr(t, FunctionRegistry.getGenericUDFForIndex(), children);
+          expr = exprFactory.createFuncCallExpr(t, fi, funcText, children);
         } else if (myt.getCategory() == Category.MAP) {
           if (!TypeInfoUtils.implicitConvertible(exprFactory.getTypeInfo(children.get(1)),
               ((MapTypeInfo) myt).getMapKeyTypeInfo())) {
@@ -925,14 +907,14 @@ public class TypeCheckProcFactory<T> {
           }
           // Calculate TypeInfo
           TypeInfo t = ((MapTypeInfo) myt).getMapValueTypeInfo();
-          expr = exprFactory.createFuncCallExpr(t, FunctionRegistry.getGenericUDFForIndex(), children);
+          expr = exprFactory.createFuncCallExpr(t, fi, funcText, children);
         } else {
           throw new SemanticException(ASTErrorUtils.getMsg(
               ErrorMsg.NON_COLLECTION_TYPE.getMsg(), node, myt.getTypeName()));
         }
       } else {
         // other operators or functions
-        FunctionInfo fi = FunctionRegistry.getFunctionInfo(funcText);
+        FunctionInfo fi = exprFactory.getFunctionInfo(funcText);
 
         if (fi == null) {
           if (isFunction) {
@@ -944,63 +926,21 @@ public class TypeCheckProcFactory<T> {
           }
         }
 
-        // getGenericUDF() actually clones the UDF. Just call it once and reuse.
-        GenericUDF genericUDF = fi.getGenericUDF();
-
         if (!fi.isNative()) {
           ctx.getUnparseTranslator().addIdentifierTranslation(
               (ASTNode) node.getChild(0));
         }
 
         // Handle type casts that may contain type parameters
-        if (isFunction) {
-          ASTNode funcNameNode = (ASTNode) node.getChild(0);
-          switch (funcNameNode.getType()) {
-            case HiveParser.TOK_CHAR:
-              // Add type params
-              CharTypeInfo charTypeInfo = ParseUtils.getCharTypeInfo(funcNameNode);
-              if (genericUDF != null) {
-                ((SettableUDF) genericUDF).setTypeInfo(charTypeInfo);
-              }
-              break;
-            case HiveParser.TOK_VARCHAR:
-              VarcharTypeInfo varcharTypeInfo = ParseUtils.getVarcharTypeInfo(funcNameNode);
-              if (genericUDF != null) {
-                ((SettableUDF) genericUDF).setTypeInfo(varcharTypeInfo);
-              }
-              break;
-            case HiveParser.TOK_TIMESTAMPLOCALTZ:
-              TimestampLocalTZTypeInfo timestampLocalTZTypeInfo = new TimestampLocalTZTypeInfo();
-              HiveConf conf;
-              try {
-                conf = Hive.get().getConf();
-              } catch (HiveException e) {
-                throw new SemanticException(e);
-              }
-              timestampLocalTZTypeInfo.setTimeZone(conf.getLocalTimeZone());
-              if (genericUDF != null) {
-                ((SettableUDF) genericUDF).setTypeInfo(timestampLocalTZTypeInfo);
-              }
-              break;
-            case HiveParser.TOK_DECIMAL:
-              DecimalTypeInfo decTypeInfo = ParseUtils.getDecimalTypeTypeInfo(funcNameNode);
-              if (genericUDF != null) {
-                ((SettableUDF) genericUDF).setTypeInfo(decTypeInfo);
-              }
-              break;
-            default:
-              // Do nothing
-              break;
-          }
-        }
+        TypeInfo typeInfo = isFunction ? getTypeInfo((ASTNode) node.getChild(0)) : null;
 
         insertCast(funcText, children);
 
-        validateUDF(node, isFunction, ctx, fi, children, genericUDF);
+        validateUDF(node, isFunction, ctx, fi, children);
 
         // Try to infer the type of the constant only if there are two
         // nodes, one of them is column and the other is numeric const
-        if (genericUDF instanceof GenericUDFBaseCompare
+        if (exprFactory.isCompareFunction(fi)
             && children.size() == 2
             && ((exprFactory.isConstantExpr(children.get(0))
             && exprFactory.isColumnRefExpr(children.get(1)))
@@ -1018,15 +958,19 @@ public class TypeCheckProcFactory<T> {
           if (newChild == null) {
             // non-interpretable as target type...
             // TODO: all comparisons with null should result in null
-            if (genericUDF instanceof GenericUDFOPEqual
-                && !(genericUDF instanceof GenericUDFOPEqualNS)) {
+            if (exprFactory.isEqualFunction(fi)) {
               return exprFactory.createBooleanConstantExpr(null);
             }
           } else {
             children.set(constIdx, newChild);
           }
         }
-        if (genericUDF instanceof GenericUDFIn) {
+        // The "in" function is sometimes changed to an "or".  Later on, the "or"
+        // function is processed a little differently.  We don't want to process this
+        // new "or" function differently, so we track it with this variable.
+        // TODO: Test to see if this can be removed.
+        boolean functionInfoChangedFromIn = false;
+        if (exprFactory.isInFunction(fi)) {
           // We will split the IN clause into different IN clauses, one for each
           // different value type. The reason is that Hive and Calcite treat
           // types in IN clauses differently and it is practically impossible
@@ -1063,19 +1007,20 @@ public class TypeCheckProcFactory<T> {
           if (numEntries == 1) {
             children.addAll(expressions.asMap().values().iterator().next());
             funcText = "in";
-            genericUDF = new GenericUDFIn();
+            fi = exprFactory.getFunctionInfo("in");
           } else {
+            FunctionInfo inFunctionInfo  = exprFactory.getFunctionInfo("in");
             for (Collection<T> c : expressions.asMap().values()) {
-              newExprs.add(
-                  exprFactory.createFuncCallExpr(
-                      new GenericUDFIn(), "in", (List<T>) c));
+              newExprs.add(exprFactory.createFuncCallExpr(null, inFunctionInfo,
+                  "in", (List<T>) c));
             }
             children.addAll(newExprs);
             funcText = "or";
-            genericUDF = new GenericUDFOPOr();
+            fi = exprFactory.getFunctionInfo("or");
+            functionInfoChangedFromIn = true;
           }
         }
-        if (genericUDF instanceof GenericUDFOPOr) {
+        if (exprFactory.isOrFunction(fi) && !functionInfoChangedFromIn) {
           // flatten OR
           List<T> childrenList = new ArrayList<>(children.size());
           for (T child : children) {
@@ -1088,8 +1033,8 @@ public class TypeCheckProcFactory<T> {
               childrenList.add(child);
             }
           }
-          expr = exprFactory.createFuncCallExpr(genericUDF, funcText, childrenList);
-        } else if (genericUDF instanceof GenericUDFOPAnd) {
+          expr = exprFactory.createFuncCallExpr(null, fi, funcText, childrenList);
+        } else if (exprFactory.isAndFunction(fi)) {
           // flatten AND
           List<T> childrenList = new ArrayList<>(children.size());
           for (T child : children) {
@@ -1102,22 +1047,24 @@ public class TypeCheckProcFactory<T> {
               childrenList.add(child);
             }
           }
-          expr = exprFactory.createFuncCallExpr(genericUDF, funcText, childrenList);
-        } else if (ctx.isFoldExpr() && exprFactory.convertCASEIntoCOALESCEFuncCallExpr(genericUDF, children)) {
+          expr = exprFactory.createFuncCallExpr(null, fi, funcText, childrenList);
+        } else if (ctx.isFoldExpr() && exprFactory.convertCASEIntoCOALESCEFuncCallExpr(fi, children)) {
           // Rewrite CASE into COALESCE
-          expr = exprFactory.createFuncCallExpr(new GenericUDFCoalesce(), "coalesce",
+          fi = exprFactory.getFunctionInfo("coalesce");
+          expr = exprFactory.createFuncCallExpr(null, fi, "coalesce",
               Lists.newArrayList(children.get(0), exprFactory.createBooleanConstantExpr(Boolean.FALSE.toString())));
           if (Boolean.FALSE.equals(exprFactory.getConstantValue(children.get(1)))) {
-            expr = exprFactory.createFuncCallExpr(new GenericUDFOPNot(), "not", Lists.newArrayList(expr));
+            fi = exprFactory.getFunctionInfo("not");
+            expr = exprFactory.createFuncCallExpr(null, fi, "not", Lists.newArrayList(expr));
           }
         } else {
-          expr = exprFactory.createFuncCallExpr(genericUDF, funcText, children);
+          expr = exprFactory.createFuncCallExpr(typeInfo, fi, funcText, children);
         }
 
         // If the function is deterministic and the children are constants,
         // we try to fold the expression to remove e.g. cast on constant
         if (ctx.isFoldExpr() && exprFactory.isFuncCallExpr(expr) &&
-            FunctionRegistry.isConsistentWithinQuery(genericUDF) &&
+            exprFactory.isConsistentWithinQuery(fi) &&
             exprFactory.isAllConstants(children)) {
           T constantExpr = exprFactory.foldExpr(expr);
           if (constantExpr != null) {
@@ -1145,6 +1092,28 @@ public class TypeCheckProcFactory<T> {
       return expr;
     }
 
+    private TypeInfo getTypeInfo(ASTNode funcNameNode) throws SemanticException {
+      switch (funcNameNode.getType()) {
+        case HiveParser.TOK_CHAR:
+          return ParseUtils.getCharTypeInfo(funcNameNode);
+        case HiveParser.TOK_VARCHAR:
+          return ParseUtils.getVarcharTypeInfo(funcNameNode);
+        case HiveParser.TOK_TIMESTAMPLOCALTZ:
+          TimestampLocalTZTypeInfo timestampLocalTZTypeInfo = new TimestampLocalTZTypeInfo();
+          HiveConf conf;
+          try {
+            conf = Hive.get().getConf();
+          } catch (HiveException e) {
+            throw new SemanticException(e);
+          }
+          timestampLocalTZTypeInfo.setTimeZone(conf.getLocalTimeZone());
+          return timestampLocalTZTypeInfo;
+        case HiveParser.TOK_DECIMAL:
+          return ParseUtils.getDecimalTypeTypeInfo(funcNameNode);
+        default:
+          return null;
+      }
+    }
     /**
      * Interprets the given value as the input columnDesc if possible.
      * Otherwise, returns input valueDesc as is.

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestBigIntCompareValidation.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestBigIntCompareValidation.java
@@ -70,7 +70,7 @@ public class TestBigIntCompareValidation {
     try {
       TypeCheckCtx ctx = new TypeCheckCtx(null);
       processor.validateUDF(null, false, ctx, functionInfo,
-          Lists.newArrayList(constant, nodeDesc), functionInfo.getGenericUDF());
+          Lists.newArrayList(constant, nodeDesc));
       Assert.fail("Should throw exception as comparing a bigint and a " + nodeDesc.getTypeString());
     } catch (Exception e) {
       Assert.assertEquals(errorMsg, e.getMessage());


### PR DESCRIPTION
Part of the code has already been refactored to become database agnostic
(i.e. HiveFunctionHelper).

Further refactoring needs to be done on TypeCheckProcFactory which also
should be database agnostic.

The most interesting part of this code change involved the addition of
HiveFunctionInfo.  Previous to this commit, a query specific GenericUDF was
cloned out of the FunctionRegistry every time that the FunctionInfo.getGenericUDF()
was called. With this commit, a new query specific FunctionInfo (HiveFunctionInfo)
is created with the cloned GenericUDF.

## NOTICE

Please create an issue in ASF JIRA before opening a pull request,
and you need to set the title of the pull request which starts with
the corresponding JIRA issue number. (e.g. HIVE-XXXXX: Fix a typo in YYY)
For more details, please see https://cwiki.apache.org/confluence/display/Hive/HowToContribute
