### PR TITLE
HIVE-23946: Improve control flow and error handling in QTest dataset loading/unloading

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
@@ -216,7 +216,7 @@ public class QTestDatasetHandler implements QTestOptionHandler {
   }
 
   private Set<String> tablesToUnload() {
-    if (unloadImplicitTables) {
+    if (!unloadImplicitTables) {
       return Collections.emptySet();
     }
     Set<String> tables = new HashSet<>(getSrcTables());

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public class QTestDatasetHandler implements QTestOptionHandler {
   private static final Logger LOG = LoggerFactory.getLogger("QTestDatasetHandler");
 
-  private File datasetDir;
+  private final File datasetDir;
   /**
    * All tables already loaded in the database.
    */
@@ -58,7 +58,7 @@ public class QTestDatasetHandler implements QTestOptionHandler {
   /**
    * Tables mentioned explicitly inside a single QFile and not yet loaded to the database.
    */
-  private Set<String> explicitTables = new HashSet<>();
+  private final Set<String> explicitTables = new HashSet<>();
   /**
    * Indicates if implicit tables (srcTables MINUS explicitTables) need to be unloaded.
    */

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
@@ -122,7 +122,7 @@ public class QTestDatasetHandler implements QTestOptionHandler {
     return srcTables;
   }
 
-  public static void addSrcTable(String table) {
+  private static void addSrcTable(String table) {
     getSrcTables().add(table);
     storeSrcTables();
   }

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
@@ -97,7 +97,7 @@ public class QTestDatasetHandler implements QTestOptionHandler {
     } catch (CommandProcessorException e) {
       throw new RuntimeException("Failed while loading table " + table, e);
     }
-    // Add the talbe in sources if it is loaded sucessfully
+    // Add the table in sources if it is loaded successfully
     addSrcTable(table);
   }
 

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/dataset/QTestDatasetHandler.java
@@ -116,7 +116,8 @@ public class QTestDatasetHandler implements QTestOptionHandler {
 
   public static Set<String> getSrcTables() {
     if (srcTables == null) {
-      initSrcTables();
+      initSrcTablesFromSystemProperty();
+      storeSrcTables();
     }
     return srcTables;
   }
@@ -129,15 +130,6 @@ public class QTestDatasetHandler implements QTestOptionHandler {
   private void removeSrcTable(String table) {
     srcTables.remove(table);
     storeSrcTables();
-  }
-
-  public static Set<String> initSrcTables() {
-    if (srcTables == null) {
-      initSrcTablesFromSystemProperty();
-      storeSrcTables();
-    }
-
-    return srcTables;
   }
 
   public static boolean isSourceTable(String name) {

--- a/ql/src/test/results/clientpositive/llap/testdataset_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/testdataset_3.q.out
@@ -1,0 +1,18 @@
+PREHOOK: query: show tables
+PREHOOK: type: SHOWTABLES
+PREHOOK: Input: database:default
+POSTHOOK: query: show tables
+POSTHOOK: type: SHOWTABLES
+POSTHOOK: Input: database:default
+alltypesorc
+part
+testdataset
+PREHOOK: query: show tables
+PREHOOK: type: SHOWTABLES
+PREHOOK: Input: database:default
+POSTHOOK: query: show tables
+POSTHOOK: type: SHOWTABLES
+POSTHOOK: Input: database:default
+alltypesorc
+part
+testdataset


### PR DESCRIPTION
1. Remove redundant boolean return type from QTestDatasetHandler#initDataset and QTestDatasetHandler#unloadDataset (the method return true or fails).
2. Replace AssertionError with RuntimeException to allow callers handle failures properly (AssertionErrors are not meant to be caught).
3. Restore table to unload in src tables if unload fails
4. Reset 'missingTables' and 'tableToUnload' variables in case of failure on loading/unloading dataset, otherwise all subsequent tests using the same dataset handler will fail.
5. Turn 'missingTables' from class variable to instance variable; there is no reason to share this variable among instances; we need to have a way to know globally which tables are loaded but for this we have 'srcTables'.
