### PR TITLE
HIVE-21611: Date.getTime() can be changed to System.currentTimeMillis()

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -55,7 +55,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -138,7 +137,7 @@ public class BeeLine implements Closeable {
   private Collection<Driver> drivers = null;
   private final BeeLineOpts opts = new BeeLineOpts(this, System.getProperties());
   private String lastProgress = null;
-  private final Map<SQLWarning, Date> seenWarnings = new HashMap<SQLWarning, Date>();
+  private final Map<SQLWarning, Long> seenWarnings = new HashMap<SQLWarning, Long>();
   private final Commands commands = new Commands(this);
   private OutputFile scriptOutputFile = null;
   private OutputFile recordOutputFile = null;
@@ -1798,7 +1797,7 @@ public class BeeLine implements Closeable {
 
     if (seenWarnings.get(warn) == null) {
       // don't re-display warnings we have already seen
-      seenWarnings.put(warn, new java.util.Date());
+      seenWarnings.put(warn, System.currentTimeMillis());
       handleSQLException(warn);
     }
 

--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -73,6 +73,7 @@ import java.util.SortedSet;
 import java.util.StringTokenizer;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
 
@@ -1797,7 +1798,7 @@ public class BeeLine implements Closeable {
 
     if (seenWarnings.get(warn) == null) {
       // don't re-display warnings we have already seen
-      seenWarnings.put(warn, System.currentTimeMillis());
+      seenWarnings.put(warn, System.nanoTime());
       handleSQLException(warn);
     }
 
@@ -2295,7 +2296,7 @@ public class BeeLine implements Closeable {
   }
 
   Driver[] scanDrivers(boolean knownOnly) throws IOException {
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
 
     ServiceLoader<Driver> sqlDrivers = ServiceLoader.load(Driver.class);
 
@@ -2305,7 +2306,7 @@ public class BeeLine implements Closeable {
         driverClasses.add(driver);
     }
     info("scan complete in "
-        + (System.currentTimeMillis() - start) + "ms");
+        + (TimeUnit.SECONDS.convert(System.nanoTime() - start, null)) + "ms");
     return driverClasses.toArray(new Driver[0]);
   }
 

--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -2306,7 +2306,7 @@ public class BeeLine implements Closeable {
         driverClasses.add(driver);
     }
     info("scan complete in "
-        + (TimeUnit.SECONDS.convert(System.nanoTime() - start, null)) + "ms");
+        + (TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + "ms");
     return driverClasses.toArray(new Driver[0]);
   }
 

--- a/beeline/src/java/org/apache/hive/beeline/BeeLine.java
+++ b/beeline/src/java/org/apache/hive/beeline/BeeLine.java
@@ -2306,7 +2306,7 @@ public class BeeLine implements Closeable {
         driverClasses.add(driver);
     }
     info("scan complete in "
-        + (TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + "ms");
+        + (TimeUnit.MILLISECONDS.convert(System.nanoTime() - start, TimeUnit.NANOSECONDS) + "ms"));
     return driverClasses.toArray(new Driver[0]);
   }
 

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
@@ -19,7 +19,6 @@
 package org.apache.hive.hcatalog.templeton.tool;
 
 import java.io.IOException;
-import java.util.Date;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -113,8 +112,7 @@ public class HDFSCleanup extends Thread {
         }
 
         long sleepMillis = (long) (Math.random() * interval);
-        LOG.info("Next execution: " + new Date(new Date().getTime()
-                             + sleepMillis));
+        LOG.info("Next execution: " + (System.currentTimeMillis() + sleepMillis));
         Thread.sleep(sleepMillis);
 
       } catch (Exception e) {
@@ -134,7 +132,7 @@ public class HDFSCleanup extends Thread {
    * @throws IOException
    */
   private void checkFiles(FileSystem fs) throws IOException {
-    long now = new Date().getTime();
+    long now = System.currentTimeMillis();
     for (Type type : Type.values()) {
       try {
         for (FileStatus status : fs.listStatus(new Path(

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/HDFSCleanup.java
@@ -112,7 +112,7 @@ public class HDFSCleanup extends Thread {
         }
 
         long sleepMillis = (long) (Math.random() * interval);
-        LOG.info("Next execution: " + (System.currentTimeMillis() + sleepMillis));
+        LOG.info("Next execution in {}ms", sleepMillis);
         Thread.sleep(sleepMillis);
 
       } catch (Exception e) {

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
@@ -21,7 +21,6 @@ package org.apache.hive.hcatalog.templeton.tool;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.Date;
 
 import org.apache.curator.framework.CuratorFramework;
 import org.apache.hadoop.conf.Configuration;
@@ -113,8 +112,7 @@ public class ZooKeeperCleanup extends Thread {
         }
 
         long sleepMillis = (long) (Math.random() * interval);
-        LOG.info("Next execution: " + new Date(new Date().getTime()
-          + sleepMillis));
+        LOG.info("Next execution: " + (System.currentTimeMillis() + sleepMillis));
         Thread.sleep(sleepMillis);
 
       } catch (Exception e) {
@@ -149,7 +147,7 @@ public class ZooKeeperCleanup extends Thread {
       JobStateTracker tracker = new JobStateTracker(node, zk, true,
         appConf.get(TempletonStorage.STORAGE_ROOT +
           ZooKeeperStorage.TRACKINGDIR));
-      long now = new Date().getTime();
+      long now = System.currentTimeMillis();
       state = new JobState(tracker.getJobID(), appConf);
 
       // Set the default to 0 -- if the created date is null, there was

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/tool/ZooKeeperCleanup.java
@@ -112,7 +112,7 @@ public class ZooKeeperCleanup extends Thread {
         }
 
         long sleepMillis = (long) (Math.random() * interval);
-        LOG.info("Next execution: " + (System.currentTimeMillis() + sleepMillis));
+        LOG.info("Next execution in {}ms", sleepMillis);
         Thread.sleep(sleepMillis);
 
       } catch (Exception e) {


### PR DESCRIPTION
Date.getTime() is a less performant thin wrapper of System.currentTimeMillis()