### PR TITLE
HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)

### DIFF
--- a/ql/src/test/queries/clientpositive/topnkey_inner_join.q
+++ b/ql/src/test/queries/clientpositive/topnkey_inner_join.q
@@ -25,10 +25,10 @@ set hive.optimize.topnkey=true;
 set hive.optimize.limittranspose=false;
 
 select 'positive: order by columns are coming from child table';
-explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3;
+explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3;
 explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, orders.amount limit 3;
 explain select * from customer join orders on orders.customer_id = customer.id order by orders.amount, orders.customer_id limit 3;
-select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3;
+select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3;
 select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, orders.amount limit 3;
 select * from customer join orders on orders.customer_id = customer.id order by orders.amount, orders.customer_id limit 3;
 
@@ -43,10 +43,10 @@ explain select * from orders join customer on customer.id = orders.customer_id o
 select * from orders join customer on customer.id = orders.customer_id order by customer.name, orders.amount limit 3;
 
 select 'mixed/positive: 1st n order by columns are coming from child table';
-explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3;
-select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3;
+explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3;
+select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3;
 
-select 'positive: nulls first';
+select 'negative: nulls first';
 explain select * from customer join orders on orders.customer_id = customer.id order by customer_id nulls first limit 1;
 select * from customer join orders on orders.customer_id = customer.id order by customer_id nulls first limit 1;
 

--- a/ql/src/test/queries/clientpositive/topnkey_inner_join2.q
+++ b/ql/src/test/queries/clientpositive/topnkey_inner_join2.q
@@ -45,12 +45,12 @@ explain select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3;
 
 select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3;

--- a/ql/src/test/results/clientpositive/llap/topnkey_inner_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_inner_join.q.out
@@ -80,12 +80,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 positive: order by columns are coming from child table
-PREHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3
+PREHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
 PREHOOK: Input: default@orders
 #### A masked pattern was here ####
-POSTHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3
+POSTHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@customer
 POSTHOOK: Input: default@orders
@@ -114,7 +114,7 @@ STAGE PLANS:
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                     Top N Key Operator
                       sort order: +
-                      keys: amount (type: int)
+                      keys: customer_id (type: int)
                       null sort order: z
                       Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                       top n: 3
@@ -161,16 +161,16 @@ STAGE PLANS:
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
-                  key expressions: _col1 (type: int)
+                  key expressions: _col0 (type: int)
                   null sort order: z
                   sort order: +
                   Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col2 (type: int), _col3 (type: string), _col4 (type: string)
+                  value expressions: _col1 (type: int), _col2 (type: int), _col3 (type: string), _col4 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: string), VALUE._col3 (type: string)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: string), VALUE._col3 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
@@ -223,9 +223,9 @@ STAGE PLANS:
                     predicate: customer_id is not null (type: boolean)
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                     Top N Key Operator
-                      sort order: ++
-                      keys: customer_id (type: int), amount (type: int)
-                      null sort order: zz
+                      sort order: +
+                      keys: customer_id (type: int)
+                      null sort order: z
                       Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                       top n: 3
                       Select Operator
@@ -270,25 +270,31 @@ STAGE PLANS:
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col0 (type: int), _col1 (type: int)
-                  null sort order: zz
+                Top N Key Operator
                   sort order: ++
+                  keys: _col0 (type: int), _col1 (type: int)
+                  null sort order: zz
                   Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col2 (type: int), _col3 (type: string), _col4 (type: string)
+                  top n: 3
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: int), _col3 (type: string), _col4 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 1008 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 3
-                  Statistics: Num rows: 3 Data size: 612 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 608 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 3 Data size: 612 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 3 Data size: 608 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -350,23 +356,17 @@ STAGE PLANS:
                   Filter Operator
                     predicate: customer_id is not null (type: boolean)
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                    Top N Key Operator
-                      sort order: ++
-                      keys: amount (type: int), customer_id (type: int)
-                      null sort order: zz
+                    Select Operator
+                      expressions: customer_id (type: int), amount (type: int)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      top n: 3
-                      Select Operator
-                        expressions: customer_id (type: int), amount (type: int)
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 5 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: int)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: int)
-                          Statistics: Num rows: 5 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: int)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -379,13 +379,19 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col4 (type: int), _col3 (type: int)
-                  null sort order: zz
+                Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Top N Key Operator
                   sort order: ++
-                  Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
+                  keys: _col4 (type: int), _col3 (type: int)
+                  null sort order: zz
+                  Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  top n: 3
+                  Reduce Output Operator
+                    key expressions: _col4 (type: int), _col3 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -410,19 +416,19 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-PREHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3
+PREHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
 PREHOOK: Input: default@orders
 #### A masked pattern was here ####
-POSTHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.amount limit 3
+POSTHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@customer
 POSTHOOK: Input: default@orders
 #### A masked pattern was here ####
-3	30	3	Smith	smith@email.com
-3	40	3	Smith	smith@email.com
+1	100	1	Robinson	robinson@email.com
 1	50	1	Robinson	robinson@email.com
+2	200	2	Jones	jones@email.com
 PREHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, orders.amount limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
@@ -845,12 +851,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 mixed/positive: 1st n order by columns are coming from child table
-PREHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3
+PREHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
 PREHOOK: Input: default@orders
 #### A masked pattern was here ####
-POSTHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3
+POSTHOOK: query: explain select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@customer
 POSTHOOK: Input: default@orders
@@ -879,7 +885,7 @@ STAGE PLANS:
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                     Top N Key Operator
                       sort order: +
-                      keys: amount (type: int)
+                      keys: customer_id (type: int)
                       null sort order: z
                       Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
                       top n: 3
@@ -927,21 +933,21 @@ STAGE PLANS:
                 Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
                 Top N Key Operator
                   sort order: ++
-                  keys: _col1 (type: int), _col3 (type: string)
+                  keys: _col0 (type: int), _col3 (type: string)
                   null sort order: zz
                   Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
                   top n: 3
                   Reduce Output Operator
-                    key expressions: _col1 (type: int), _col3 (type: string)
+                    key expressions: _col0 (type: int), _col3 (type: string)
                     null sort order: zz
                     sort order: ++
                     Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col0 (type: int), _col2 (type: int), _col4 (type: string)
+                    value expressions: _col1 (type: int), _col2 (type: int), _col4 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: int), VALUE._col1 (type: int), KEY.reducesinkkey1 (type: string), VALUE._col2 (type: string)
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: int), KEY.reducesinkkey1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
                 Statistics: Num rows: 5 Data size: 1008 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
@@ -961,28 +967,28 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-PREHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3
+PREHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
 PREHOOK: Input: default@orders
 #### A masked pattern was here ####
-POSTHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.amount, customer.name limit 3
+POSTHOOK: query: select * from orders join customer on customer.id = orders.customer_id order by orders.customer_id, customer.name limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@customer
 POSTHOOK: Input: default@orders
 #### A masked pattern was here ####
-3	30	3	Smith	smith@email.com
-3	40	3	Smith	smith@email.com
+1	100	1	Robinson	robinson@email.com
 1	50	1	Robinson	robinson@email.com
-PREHOOK: query: select 'positive: nulls first'
+2	200	2	Jones	jones@email.com
+PREHOOK: query: select 'negative: nulls first'
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-POSTHOOK: query: select 'positive: nulls first'
+POSTHOOK: query: select 'negative: nulls first'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-positive: nulls first
+negative: nulls first
 PREHOOK: query: explain select * from customer join orders on orders.customer_id = customer.id order by customer_id nulls first limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@customer
@@ -1033,23 +1039,17 @@ STAGE PLANS:
                   Filter Operator
                     predicate: customer_id is not null (type: boolean)
                     Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                    Top N Key Operator
-                      sort order: +
-                      keys: customer_id (type: int)
-                      null sort order: a
+                    Select Operator
+                      expressions: customer_id (type: int), amount (type: int)
+                      outputColumnNames: _col0, _col1
                       Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
-                      top n: 1
-                      Select Operator
-                        expressions: customer_id (type: int), amount (type: int)
-                        outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 5 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
-                        Reduce Output Operator
-                          key expressions: _col0 (type: int)
-                          null sort order: z
-                          sort order: +
-                          Map-reduce partition columns: _col0 (type: int)
-                          Statistics: Num rows: 5 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col1 (type: int)
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 5 Data size: 40 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Reducer 2 
@@ -1062,13 +1062,19 @@ STAGE PLANS:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                Reduce Output Operator
-                  key expressions: _col3 (type: int)
-                  null sort order: a
+                Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Top N Key Operator
                   sort order: +
-                  Statistics: Num rows: 5 Data size: 1016 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: int)
+                  keys: _col3 (type: int)
+                  null sort order: a
+                  Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  top n: 1
+                  Reduce Output Operator
+                    key expressions: _col3 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Statistics: Num rows: 5 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col0 (type: int), _col1 (type: string), _col2 (type: string), _col4 (type: int)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:

--- a/ql/src/test/results/clientpositive/llap/topnkey_inner_join2.q.out
+++ b/ql/src/test/results/clientpositive/llap/topnkey_inner_join2.q.out
@@ -243,7 +243,7 @@ PREHOOK: query: explain select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@address
@@ -253,7 +253,7 @@ POSTHOOK: query: explain select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@address
@@ -277,27 +277,27 @@ STAGE PLANS:
                 TableScan
                   alias: customer
                   filterExpr: ((name) IN ('Joe                 ', 'Robert              ', 'Heisenberg          ') and address_id is not null) (type: boolean)
-                  Statistics: Num rows: 6 Data size: 630 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 582 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((name) IN ('Joe                 ', 'Robert              ', 'Heisenberg          ') and address_id is not null) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 315 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
                     Top N Key Operator
                       sort order: +
-                      keys: id (type: bigint)
+                      keys: address_id (type: bigint)
                       null sort order: z
-                      Statistics: Num rows: 3 Data size: 315 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
                       top n: 3
                       Select Operator
-                        expressions: id (type: bigint), address_id (type: bigint), name (type: char(20))
-                        outputColumnNames: _col0, _col1, _col2
-                        Statistics: Num rows: 3 Data size: 315 Basic stats: COMPLETE Column stats: COMPLETE
+                        expressions: address_id (type: bigint), name (type: char(20))
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
-                          key expressions: _col1 (type: bigint)
+                          key expressions: _col0 (type: bigint)
                           null sort order: z
                           sort order: +
-                          Map-reduce partition columns: _col1 (type: bigint)
-                          Statistics: Num rows: 3 Data size: 315 Basic stats: COMPLETE Column stats: COMPLETE
-                          value expressions: _col0 (type: bigint), _col2 (type: char(20))
+                          Map-reduce partition columns: _col0 (type: bigint)
+                          Statistics: Num rows: 3 Data size: 291 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: char(20))
             Execution mode: vectorized, llap
             LLAP IO: no inputs
         Map 4 
@@ -325,12 +325,12 @@ STAGE PLANS:
                 condition map:
                      Inner Join 0 to 1
                 keys:
-                  0 _col1 (type: bigint)
+                  0 _col0 (type: bigint)
                   1 _col0 (type: bigint)
-                outputColumnNames: _col0, _col2, _col4
+                outputColumnNames: _col0, _col1, _col3
                 Statistics: Num rows: 3 Data size: 567 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
-                  expressions: _col2 (type: char(20)), _col4 (type: varchar(60)), _col0 (type: bigint)
+                  expressions: _col1 (type: char(20)), _col3 (type: varchar(60)), _col0 (type: bigint)
                   outputColumnNames: _col0, _col1, _col2
                   Statistics: Num rows: 3 Data size: 567 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
@@ -367,7 +367,7 @@ PREHOOK: query: select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3
 PREHOOK: type: QUERY
 PREHOOK: Input: default@address
@@ -377,7 +377,7 @@ POSTHOOK: query: select name, city
    from customer join address
    on customer.address_id = address.id
    and name in ('Joe', 'Robert','Heisenberg')
-  order by customer.id
+  order by customer.address_id
   limit 3
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@address

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
@@ -122,38 +122,11 @@ Stage-0
             SHUFFLE [RS_70]
               Select Operator [SEL_69] (rows=6951 width=218)
                 Output:["_col0","_col1","_col2"]
-<<<<<<< HEAD
-                Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
-                  Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
-                <-Map 11 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_148]
-                    PartitionCols:_col0
-                    Select Operator [SEL_146] (rows=462000 width=111)
-                      Output:["_col0","_col1"]
-                      TableScan [TS_56] (rows=462000 width=111)
-                        default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_product_name"]
-                <-Reducer 6 [SIMPLE_EDGE]
-                  SHUFFLE [RS_66]
-                    PartitionCols:_col2
-                    Merge Join Operator [MERGEJOIN_117] (rows=6951 width=115)
-                      Conds:RS_63._col0=RS_147._col0(Inner),Output:["_col1","_col2","_col5"]
-                    <-Map 11 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_147]
-                        PartitionCols:_col0
-                         Please refer to the previous Select Operator [SEL_146]
-                    <-Reducer 5 [SIMPLE_EDGE]
-                      SHUFFLE [RS_63]
-                        PartitionCols:_col0
-                        Top N Key Operator [TNK_101] (rows=6951 width=12)
-                          keys:_col1,top n:100
-                          Merge Join Operator [MERGEJOIN_116] (rows=6951 width=12)
-                            Conds:RS_140._col1=RS_145._col1(Inner),Output:["_col0","_col1","_col2"]
-=======
                 Top N Key Operator [TNK_99] (rows=6951 width=218)
                   keys:_col1,top n:100
                   Merge Join Operator [MERGEJOIN_116] (rows=6951 width=218)
                     Conds:RS_66._col2=RS_146._col0(Inner),Output:["_col1","_col5","_col7"]
-                  <-Map 12 [SIMPLE_EDGE] vectorized
+                  <-Map 11 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_146]
                       PartitionCols:_col0
                       Select Operator [SEL_144] (rows=462000 width=111)
@@ -165,7 +138,7 @@ Stage-0
                       PartitionCols:_col2
                       Merge Join Operator [MERGEJOIN_115] (rows=6951 width=115)
                         Conds:RS_63._col0=RS_145._col0(Inner),Output:["_col1","_col2","_col5"]
-                      <-Map 12 [SIMPLE_EDGE] vectorized
+                      <-Map 11 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_145]
                           PartitionCols:_col0
                            Please refer to the previous Select Operator [SEL_144]
@@ -174,7 +147,6 @@ Stage-0
                           PartitionCols:_col0
                           Merge Join Operator [MERGEJOIN_114] (rows=6951 width=12)
                             Conds:RS_138._col1=RS_143._col1(Inner),Output:["_col0","_col1","_col2"]
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                           <-Reducer 4 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_138]
                               PartitionCols:_col1
@@ -195,15 +167,9 @@ Stage-0
                                             predicate:(_col1 > (0.9 * _col2))
                                             Merge Join Operator [MERGEJOIN_112] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-<<<<<<< HEAD
                                             <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_135]
-                                                Select Operator [SEL_134] (rows=1 width=112)
-=======
-                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_133]
                                                 Select Operator [SEL_132] (rows=1 width=112)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                   Output:["_col0"]
                                                   Filter Operator [FIL_131] (rows=1 width=120)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
@@ -211,58 +177,31 @@ Stage-0
                                                       Output:["_col1","_col2"]
                                                       Group By Operator [GBY_129] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-<<<<<<< HEAD
                                                       <-Map 1 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_126]
+                                                        SHUFFLE [RS_124]
                                                           PartitionCols:_col0
-                                                          Group By Operator [GBY_124] (rows=258 width=124)
+                                                          Group By Operator [GBY_122] (rows=258 width=124)
                                                             Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_122] (rows=287946 width=114)
+                                                            Select Operator [SEL_120] (rows=287946 width=114)
                                                               Output:["_col1"]
-                                                              Filter Operator [FIL_120] (rows=287946 width=114)
-=======
-                                                      <-Map 10 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_128]
-                                                          PartitionCols:_col0
-                                                          Group By Operator [GBY_127] (rows=258 width=124)
-                                                            Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_126] (rows=287946 width=114)
-                                                              Output:["_col1"]
-                                                              Filter Operator [FIL_125] (rows=287946 width=114)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
+                                                              Filter Operator [FIL_118] (rows=287946 width=114)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
                                                                 TableScan [TS_0] (rows=575995635 width=114)
                                                                   default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
-<<<<<<< HEAD
-                                              PARTITION_ONLY_SHUFFLE [RS_130]
-                                                Select Operator [SEL_129] (rows=62562 width=116)
+                                              PARTITION_ONLY_SHUFFLE [RS_128]
+                                                Select Operator [SEL_127] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_128] (rows=62562 width=124)
+                                                  Filter Operator [FIL_126] (rows=62562 width=124)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_127] (rows=62562 width=124)
+                                                    Group By Operator [GBY_125] (rows=62562 width=124)
                                                       Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
                                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_125]
+                                                      SHUFFLE [RS_123]
                                                         PartitionCols:_col0
-                                                        Group By Operator [GBY_123] (rows=3199976 width=124)
+                                                        Group By Operator [GBY_121] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_121] (rows=6399952 width=114)
-=======
-                                              PARTITION_ONLY_SHUFFLE [RS_124]
-                                                Select Operator [SEL_123] (rows=62562 width=116)
-                                                  Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_122] (rows=62562 width=124)
-                                                    predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_121] (rows=62562 width=124)
-                                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                                    <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_120]
-                                                        PartitionCols:_col0
-                                                        Group By Operator [GBY_119] (rows=3199976 width=124)
-                                                          Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_118] (rows=6399952 width=114)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
+                                                          Select Operator [SEL_119] (rows=6399952 width=114)
                                                             Output:["ss_item_sk","ss_net_profit"]
                                                             Filter Operator [FIL_117] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/mv_query44.q.out
@@ -20,7 +20,7 @@ POSTHOOK: Input: default@store_sales
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mv_store_sales_item_customer
 POSTHOOK: Output: default@mv_store_sales_item_customer
-Warning: Shuffle Join MERGEJOIN[114][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[112][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain
 select  asceding.rnk, i1.i_product_name best_performing, i2.i_product_name worst_performing
 from(select *
@@ -113,15 +113,16 @@ Stage-0
     limit:100
     Stage-1
       Reducer 8 vectorized
-      File Output Operator [FS_151]
-        Limit [LIM_150] (rows=100 width=218)
+      File Output Operator [FS_149]
+        Limit [LIM_148] (rows=100 width=218)
           Number of rows:100
-          Select Operator [SEL_149] (rows=6951 width=218)
+          Select Operator [SEL_147] (rows=6951 width=218)
             Output:["_col0","_col1","_col2"]
           <-Reducer 7 [SIMPLE_EDGE]
             SHUFFLE [RS_70]
               Select Operator [SEL_69] (rows=6951 width=218)
                 Output:["_col0","_col1","_col2"]
+<<<<<<< HEAD
                 Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
                   Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
                 <-Map 11 [SIMPLE_EDGE] vectorized
@@ -147,36 +148,70 @@ Stage-0
                           keys:_col1,top n:100
                           Merge Join Operator [MERGEJOIN_116] (rows=6951 width=12)
                             Conds:RS_140._col1=RS_145._col1(Inner),Output:["_col0","_col1","_col2"]
+=======
+                Top N Key Operator [TNK_99] (rows=6951 width=218)
+                  keys:_col1,top n:100
+                  Merge Join Operator [MERGEJOIN_116] (rows=6951 width=218)
+                    Conds:RS_66._col2=RS_146._col0(Inner),Output:["_col1","_col5","_col7"]
+                  <-Map 12 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_146]
+                      PartitionCols:_col0
+                      Select Operator [SEL_144] (rows=462000 width=111)
+                        Output:["_col0","_col1"]
+                        TableScan [TS_56] (rows=462000 width=111)
+                          default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_product_name"]
+                  <-Reducer 6 [SIMPLE_EDGE]
+                    SHUFFLE [RS_66]
+                      PartitionCols:_col2
+                      Merge Join Operator [MERGEJOIN_115] (rows=6951 width=115)
+                        Conds:RS_63._col0=RS_145._col0(Inner),Output:["_col1","_col2","_col5"]
+                      <-Map 12 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_145]
+                          PartitionCols:_col0
+                           Please refer to the previous Select Operator [SEL_144]
+                      <-Reducer 5 [SIMPLE_EDGE]
+                        SHUFFLE [RS_63]
+                          PartitionCols:_col0
+                          Merge Join Operator [MERGEJOIN_114] (rows=6951 width=12)
+                            Conds:RS_138._col1=RS_143._col1(Inner),Output:["_col0","_col1","_col2"]
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                           <-Reducer 4 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_140]
+                            SHUFFLE [RS_138]
                               PartitionCols:_col1
-                              Select Operator [SEL_139] (rows=6951 width=8)
+                              Select Operator [SEL_137] (rows=6951 width=8)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_138] (rows=6951 width=116)
+                                Filter Operator [FIL_136] (rows=6951 width=116)
                                   predicate:(rank_window_0 < 11)
-                                  PTF Operator [PTF_137] (rows=20854 width=116)
+                                  PTF Operator [PTF_135] (rows=20854 width=116)
                                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 ASC NULLS LAST","partition by:":"0"}]
-                                    Select Operator [SEL_136] (rows=20854 width=116)
+                                    Select Operator [SEL_134] (rows=20854 width=116)
                                       Output:["_col0","_col1"]
                                     <-Reducer 3 [SIMPLE_EDGE]
                                       SHUFFLE [RS_21]
                                         PartitionCols:0
-                                        Top N Key Operator [TNK_102] (rows=20854 width=228)
+                                        Top N Key Operator [TNK_100] (rows=20854 width=228)
                                           keys:_col1,top n:11
                                           Filter Operator [FIL_20] (rows=20854 width=228)
                                             predicate:(_col1 > (0.9 * _col2))
-                                            Merge Join Operator [MERGEJOIN_114] (rows=62562 width=228)
+                                            Merge Join Operator [MERGEJOIN_112] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
+<<<<<<< HEAD
                                             <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_135]
                                                 Select Operator [SEL_134] (rows=1 width=112)
+=======
+                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              PARTITION_ONLY_SHUFFLE [RS_133]
+                                                Select Operator [SEL_132] (rows=1 width=112)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                   Output:["_col0"]
-                                                  Filter Operator [FIL_133] (rows=1 width=120)
+                                                  Filter Operator [FIL_131] (rows=1 width=120)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Select Operator [SEL_132] (rows=1 width=120)
+                                                    Select Operator [SEL_130] (rows=1 width=120)
                                                       Output:["_col1","_col2"]
-                                                      Group By Operator [GBY_131] (rows=1 width=124)
+                                                      Group By Operator [GBY_129] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+<<<<<<< HEAD
                                                       <-Map 1 [SIMPLE_EDGE] vectorized
                                                         SHUFFLE [RS_126]
                                                           PartitionCols:_col0
@@ -185,10 +220,21 @@ Stage-0
                                                             Select Operator [SEL_122] (rows=287946 width=114)
                                                               Output:["_col1"]
                                                               Filter Operator [FIL_120] (rows=287946 width=114)
+=======
+                                                      <-Map 10 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_128]
+                                                          PartitionCols:_col0
+                                                          Group By Operator [GBY_127] (rows=258 width=124)
+                                                            Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
+                                                            Select Operator [SEL_126] (rows=287946 width=114)
+                                                              Output:["_col1"]
+                                                              Filter Operator [FIL_125] (rows=287946 width=114)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
                                                                 TableScan [TS_0] (rows=575995635 width=114)
                                                                   default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
+<<<<<<< HEAD
                                               PARTITION_ONLY_SHUFFLE [RS_130]
                                                 Select Operator [SEL_129] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
@@ -202,25 +248,40 @@ Stage-0
                                                         Group By Operator [GBY_123] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
                                                           Select Operator [SEL_121] (rows=6399952 width=114)
+=======
+                                              PARTITION_ONLY_SHUFFLE [RS_124]
+                                                Select Operator [SEL_123] (rows=62562 width=116)
+                                                  Output:["_col0","_col1"]
+                                                  Filter Operator [FIL_122] (rows=62562 width=124)
+                                                    predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
+                                                    Group By Operator [GBY_121] (rows=62562 width=124)
+                                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+                                                    <-Map 1 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_120]
+                                                        PartitionCols:_col0
+                                                        Group By Operator [GBY_119] (rows=3199976 width=124)
+                                                          Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
+                                                          Select Operator [SEL_118] (rows=6399952 width=114)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                             Output:["ss_item_sk","ss_net_profit"]
-                                                            Filter Operator [FIL_119] (rows=6399952 width=114)
+                                                            Filter Operator [FIL_117] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)
                                                                Please refer to the previous TableScan [TS_0]
                           <-Reducer 9 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_145]
+                            SHUFFLE [RS_143]
                               PartitionCols:_col1
-                              Select Operator [SEL_144] (rows=6951 width=8)
+                              Select Operator [SEL_142] (rows=6951 width=8)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_143] (rows=6951 width=116)
+                                Filter Operator [FIL_141] (rows=6951 width=116)
                                   predicate:(rank_window_0 < 11)
-                                  PTF Operator [PTF_142] (rows=20854 width=116)
+                                  PTF Operator [PTF_140] (rows=20854 width=116)
                                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 DESC NULLS FIRST","partition by:":"0"}]
-                                    Select Operator [SEL_141] (rows=20854 width=116)
+                                    Select Operator [SEL_139] (rows=20854 width=116)
                                       Output:["_col0","_col1"]
                                     <-Reducer 3 [SIMPLE_EDGE]
                                       SHUFFLE [RS_49]
                                         PartitionCols:0
-                                        Top N Key Operator [TNK_103] (rows=20854 width=228)
+                                        Top N Key Operator [TNK_101] (rows=20854 width=228)
                                           keys:_col1,top n:11
                                            Please refer to the previous Filter Operator [FIL_20]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
@@ -100,38 +100,11 @@ Stage-0
             SHUFFLE [RS_70]
               Select Operator [SEL_69] (rows=6951 width=218)
                 Output:["_col0","_col1","_col2"]
-<<<<<<< HEAD
-                Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
-                  Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
-                <-Map 11 [SIMPLE_EDGE] vectorized
-                  SHUFFLE [RS_148]
-                    PartitionCols:_col0
-                    Select Operator [SEL_146] (rows=462000 width=111)
-                      Output:["_col0","_col1"]
-                      TableScan [TS_56] (rows=462000 width=111)
-                        default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_product_name"]
-                <-Reducer 6 [SIMPLE_EDGE]
-                  SHUFFLE [RS_66]
-                    PartitionCols:_col2
-                    Merge Join Operator [MERGEJOIN_117] (rows=6951 width=115)
-                      Conds:RS_63._col0=RS_147._col0(Inner),Output:["_col1","_col2","_col5"]
-                    <-Map 11 [SIMPLE_EDGE] vectorized
-                      SHUFFLE [RS_147]
-                        PartitionCols:_col0
-                         Please refer to the previous Select Operator [SEL_146]
-                    <-Reducer 5 [SIMPLE_EDGE]
-                      SHUFFLE [RS_63]
-                        PartitionCols:_col0
-                        Top N Key Operator [TNK_101] (rows=6951 width=12)
-                          keys:_col1,top n:100
-                          Merge Join Operator [MERGEJOIN_116] (rows=6951 width=12)
-                            Conds:RS_140._col1=RS_145._col1(Inner),Output:["_col0","_col1","_col2"]
-=======
                 Top N Key Operator [TNK_99] (rows=6951 width=218)
                   keys:_col1,top n:100
                   Merge Join Operator [MERGEJOIN_116] (rows=6951 width=218)
                     Conds:RS_66._col2=RS_146._col0(Inner),Output:["_col1","_col5","_col7"]
-                  <-Map 12 [SIMPLE_EDGE] vectorized
+                  <-Map 11 [SIMPLE_EDGE] vectorized
                     SHUFFLE [RS_146]
                       PartitionCols:_col0
                       Select Operator [SEL_144] (rows=462000 width=111)
@@ -143,7 +116,7 @@ Stage-0
                       PartitionCols:_col2
                       Merge Join Operator [MERGEJOIN_115] (rows=6951 width=115)
                         Conds:RS_63._col0=RS_145._col0(Inner),Output:["_col1","_col2","_col5"]
-                      <-Map 12 [SIMPLE_EDGE] vectorized
+                      <-Map 11 [SIMPLE_EDGE] vectorized
                         SHUFFLE [RS_145]
                           PartitionCols:_col0
                            Please refer to the previous Select Operator [SEL_144]
@@ -152,7 +125,6 @@ Stage-0
                           PartitionCols:_col0
                           Merge Join Operator [MERGEJOIN_114] (rows=6951 width=12)
                             Conds:RS_138._col1=RS_143._col1(Inner),Output:["_col0","_col1","_col2"]
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                           <-Reducer 4 [SIMPLE_EDGE] vectorized
                             SHUFFLE [RS_138]
                               PartitionCols:_col1
@@ -173,15 +145,9 @@ Stage-0
                                             predicate:(_col1 > (0.9 * _col2))
                                             Merge Join Operator [MERGEJOIN_112] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
-<<<<<<< HEAD
                                             <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
-                                              PARTITION_ONLY_SHUFFLE [RS_135]
-                                                Select Operator [SEL_134] (rows=1 width=112)
-=======
-                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_133]
                                                 Select Operator [SEL_132] (rows=1 width=112)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                   Output:["_col0"]
                                                   Filter Operator [FIL_131] (rows=1 width=120)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
@@ -189,58 +155,31 @@ Stage-0
                                                       Output:["_col1","_col2"]
                                                       Group By Operator [GBY_129] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-<<<<<<< HEAD
                                                       <-Map 1 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_126]
+                                                        SHUFFLE [RS_124]
                                                           PartitionCols:_col0
-                                                          Group By Operator [GBY_124] (rows=258 width=124)
+                                                          Group By Operator [GBY_122] (rows=258 width=124)
                                                             Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_122] (rows=287946 width=114)
+                                                            Select Operator [SEL_120] (rows=287946 width=114)
                                                               Output:["_col1"]
-                                                              Filter Operator [FIL_120] (rows=287946 width=114)
-=======
-                                                      <-Map 10 [SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_128]
-                                                          PartitionCols:_col0
-                                                          Group By Operator [GBY_127] (rows=258 width=124)
-                                                            Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
-                                                            Select Operator [SEL_126] (rows=287946 width=114)
-                                                              Output:["_col1"]
-                                                              Filter Operator [FIL_125] (rows=287946 width=114)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
+                                                              Filter Operator [FIL_118] (rows=287946 width=114)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
                                                                 TableScan [TS_0] (rows=575995635 width=114)
                                                                   default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
-<<<<<<< HEAD
-                                              PARTITION_ONLY_SHUFFLE [RS_130]
-                                                Select Operator [SEL_129] (rows=62562 width=116)
+                                              PARTITION_ONLY_SHUFFLE [RS_128]
+                                                Select Operator [SEL_127] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_128] (rows=62562 width=124)
+                                                  Filter Operator [FIL_126] (rows=62562 width=124)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_127] (rows=62562 width=124)
+                                                    Group By Operator [GBY_125] (rows=62562 width=124)
                                                       Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
                                                     <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_125]
+                                                      SHUFFLE [RS_123]
                                                         PartitionCols:_col0
-                                                        Group By Operator [GBY_123] (rows=3199976 width=124)
+                                                        Group By Operator [GBY_121] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_121] (rows=6399952 width=114)
-=======
-                                              PARTITION_ONLY_SHUFFLE [RS_124]
-                                                Select Operator [SEL_123] (rows=62562 width=116)
-                                                  Output:["_col0","_col1"]
-                                                  Filter Operator [FIL_122] (rows=62562 width=124)
-                                                    predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Group By Operator [GBY_121] (rows=62562 width=124)
-                                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                                    <-Map 1 [SIMPLE_EDGE] vectorized
-                                                      SHUFFLE [RS_120]
-                                                        PartitionCols:_col0
-                                                        Group By Operator [GBY_119] (rows=3199976 width=124)
-                                                          Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
-                                                          Select Operator [SEL_118] (rows=6399952 width=114)
->>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
+                                                          Select Operator [SEL_119] (rows=6399952 width=114)
                                                             Output:["ss_item_sk","ss_net_profit"]
                                                             Filter Operator [FIL_117] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query44.q.out
@@ -1,4 +1,4 @@
-Warning: Shuffle Join MERGEJOIN[114][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+Warning: Shuffle Join MERGEJOIN[112][tables = [$hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
 PREHOOK: query: explain
 select  asceding.rnk, i1.i_product_name best_performing, i2.i_product_name worst_performing
 from(select *
@@ -91,15 +91,16 @@ Stage-0
     limit:100
     Stage-1
       Reducer 8 vectorized
-      File Output Operator [FS_151]
-        Limit [LIM_150] (rows=100 width=218)
+      File Output Operator [FS_149]
+        Limit [LIM_148] (rows=100 width=218)
           Number of rows:100
-          Select Operator [SEL_149] (rows=6951 width=218)
+          Select Operator [SEL_147] (rows=6951 width=218)
             Output:["_col0","_col1","_col2"]
           <-Reducer 7 [SIMPLE_EDGE]
             SHUFFLE [RS_70]
               Select Operator [SEL_69] (rows=6951 width=218)
                 Output:["_col0","_col1","_col2"]
+<<<<<<< HEAD
                 Merge Join Operator [MERGEJOIN_118] (rows=6951 width=218)
                   Conds:RS_66._col2=RS_148._col0(Inner),Output:["_col1","_col5","_col7"]
                 <-Map 11 [SIMPLE_EDGE] vectorized
@@ -125,36 +126,70 @@ Stage-0
                           keys:_col1,top n:100
                           Merge Join Operator [MERGEJOIN_116] (rows=6951 width=12)
                             Conds:RS_140._col1=RS_145._col1(Inner),Output:["_col0","_col1","_col2"]
+=======
+                Top N Key Operator [TNK_99] (rows=6951 width=218)
+                  keys:_col1,top n:100
+                  Merge Join Operator [MERGEJOIN_116] (rows=6951 width=218)
+                    Conds:RS_66._col2=RS_146._col0(Inner),Output:["_col1","_col5","_col7"]
+                  <-Map 12 [SIMPLE_EDGE] vectorized
+                    SHUFFLE [RS_146]
+                      PartitionCols:_col0
+                      Select Operator [SEL_144] (rows=462000 width=111)
+                        Output:["_col0","_col1"]
+                        TableScan [TS_56] (rows=462000 width=111)
+                          default@item,i1,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_product_name"]
+                  <-Reducer 6 [SIMPLE_EDGE]
+                    SHUFFLE [RS_66]
+                      PartitionCols:_col2
+                      Merge Join Operator [MERGEJOIN_115] (rows=6951 width=115)
+                        Conds:RS_63._col0=RS_145._col0(Inner),Output:["_col1","_col2","_col5"]
+                      <-Map 12 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_145]
+                          PartitionCols:_col0
+                           Please refer to the previous Select Operator [SEL_144]
+                      <-Reducer 5 [SIMPLE_EDGE]
+                        SHUFFLE [RS_63]
+                          PartitionCols:_col0
+                          Merge Join Operator [MERGEJOIN_114] (rows=6951 width=12)
+                            Conds:RS_138._col1=RS_143._col1(Inner),Output:["_col0","_col1","_col2"]
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                           <-Reducer 4 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_140]
+                            SHUFFLE [RS_138]
                               PartitionCols:_col1
-                              Select Operator [SEL_139] (rows=6951 width=8)
+                              Select Operator [SEL_137] (rows=6951 width=8)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_138] (rows=6951 width=116)
+                                Filter Operator [FIL_136] (rows=6951 width=116)
                                   predicate:(rank_window_0 < 11)
-                                  PTF Operator [PTF_137] (rows=20854 width=116)
+                                  PTF Operator [PTF_135] (rows=20854 width=116)
                                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 ASC NULLS LAST","partition by:":"0"}]
-                                    Select Operator [SEL_136] (rows=20854 width=116)
+                                    Select Operator [SEL_134] (rows=20854 width=116)
                                       Output:["_col0","_col1"]
                                     <-Reducer 3 [SIMPLE_EDGE]
                                       SHUFFLE [RS_21]
                                         PartitionCols:0
-                                        Top N Key Operator [TNK_102] (rows=20854 width=228)
+                                        Top N Key Operator [TNK_100] (rows=20854 width=228)
                                           keys:_col1,top n:11
                                           Filter Operator [FIL_20] (rows=20854 width=228)
                                             predicate:(_col1 > (0.9 * _col2))
-                                            Merge Join Operator [MERGEJOIN_114] (rows=62562 width=228)
+                                            Merge Join Operator [MERGEJOIN_112] (rows=62562 width=228)
                                               Conds:(Inner),Output:["_col0","_col1","_col2"]
+<<<<<<< HEAD
                                             <-Reducer 10 [CUSTOM_SIMPLE_EDGE] vectorized
                                               PARTITION_ONLY_SHUFFLE [RS_135]
                                                 Select Operator [SEL_134] (rows=1 width=112)
+=======
+                                            <-Reducer 11 [CUSTOM_SIMPLE_EDGE] vectorized
+                                              PARTITION_ONLY_SHUFFLE [RS_133]
+                                                Select Operator [SEL_132] (rows=1 width=112)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                   Output:["_col0"]
-                                                  Filter Operator [FIL_133] (rows=1 width=120)
+                                                  Filter Operator [FIL_131] (rows=1 width=120)
                                                     predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
-                                                    Select Operator [SEL_132] (rows=1 width=120)
+                                                    Select Operator [SEL_130] (rows=1 width=120)
                                                       Output:["_col1","_col2"]
-                                                      Group By Operator [GBY_131] (rows=1 width=124)
+                                                      Group By Operator [GBY_129] (rows=1 width=124)
                                                         Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+<<<<<<< HEAD
                                                       <-Map 1 [SIMPLE_EDGE] vectorized
                                                         SHUFFLE [RS_126]
                                                           PartitionCols:_col0
@@ -163,10 +198,21 @@ Stage-0
                                                             Select Operator [SEL_122] (rows=287946 width=114)
                                                               Output:["_col1"]
                                                               Filter Operator [FIL_120] (rows=287946 width=114)
+=======
+                                                      <-Map 10 [SIMPLE_EDGE] vectorized
+                                                        SHUFFLE [RS_128]
+                                                          PartitionCols:_col0
+                                                          Group By Operator [GBY_127] (rows=258 width=124)
+                                                            Output:["_col0","_col1","_col2"],aggregations:["sum(_col1)","count(_col1)"],keys:true
+                                                            Select Operator [SEL_126] (rows=287946 width=114)
+                                                              Output:["_col1"]
+                                                              Filter Operator [FIL_125] (rows=287946 width=114)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                                 predicate:(ss_hdemo_sk is null and (ss_store_sk = 410))
                                                                 TableScan [TS_0] (rows=575995635 width=114)
                                                                   default@store_sales,ss1,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_item_sk","ss_store_sk","ss_net_profit","ss_hdemo_sk"]
                                             <-Reducer 2 [CUSTOM_SIMPLE_EDGE] vectorized
+<<<<<<< HEAD
                                               PARTITION_ONLY_SHUFFLE [RS_130]
                                                 Select Operator [SEL_129] (rows=62562 width=116)
                                                   Output:["_col0","_col1"]
@@ -180,25 +226,40 @@ Stage-0
                                                         Group By Operator [GBY_123] (rows=3199976 width=124)
                                                           Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
                                                           Select Operator [SEL_121] (rows=6399952 width=114)
+=======
+                                              PARTITION_ONLY_SHUFFLE [RS_124]
+                                                Select Operator [SEL_123] (rows=62562 width=116)
+                                                  Output:["_col0","_col1"]
+                                                  Filter Operator [FIL_122] (rows=62562 width=124)
+                                                    predicate:CAST( (_col1 / _col2) AS decimal(11,6)) is not null
+                                                    Group By Operator [GBY_121] (rows=62562 width=124)
+                                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+                                                    <-Map 1 [SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_120]
+                                                        PartitionCols:_col0
+                                                        Group By Operator [GBY_119] (rows=3199976 width=124)
+                                                          Output:["_col0","_col1","_col2"],aggregations:["sum(ss_net_profit)","count(ss_net_profit)"],keys:ss_item_sk
+                                                          Select Operator [SEL_118] (rows=6399952 width=114)
+>>>>>>> HIVE-23937. Take null ordering into consideration when pushing TNK through inner joins (amagyar)
                                                             Output:["ss_item_sk","ss_net_profit"]
-                                                            Filter Operator [FIL_119] (rows=6399952 width=114)
+                                                            Filter Operator [FIL_117] (rows=6399952 width=114)
                                                               predicate:(ss_store_sk = 410)
                                                                Please refer to the previous TableScan [TS_0]
                           <-Reducer 9 [SIMPLE_EDGE] vectorized
-                            SHUFFLE [RS_145]
+                            SHUFFLE [RS_143]
                               PartitionCols:_col1
-                              Select Operator [SEL_144] (rows=6951 width=8)
+                              Select Operator [SEL_142] (rows=6951 width=8)
                                 Output:["_col0","_col1"]
-                                Filter Operator [FIL_143] (rows=6951 width=116)
+                                Filter Operator [FIL_141] (rows=6951 width=116)
                                   predicate:(rank_window_0 < 11)
-                                  PTF Operator [PTF_142] (rows=20854 width=116)
+                                  PTF Operator [PTF_140] (rows=20854 width=116)
                                     Function definitions:[{},{"name:":"windowingtablefunction","order by:":"_col1 DESC NULLS FIRST","partition by:":"0"}]
-                                    Select Operator [SEL_141] (rows=20854 width=116)
+                                    Select Operator [SEL_139] (rows=20854 width=116)
                                       Output:["_col0","_col1"]
                                     <-Reducer 3 [SIMPLE_EDGE]
                                       SHUFFLE [RS_49]
                                         PartitionCols:0
-                                        Top N Key Operator [TNK_103] (rows=20854 width=228)
+                                        Top N Key Operator [TNK_101] (rows=20854 width=228)
                                           keys:_col1,top n:11
                                            Please refer to the previous Filter Operator [FIL_20]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query65.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query65.q.out
@@ -82,10 +82,10 @@ Stage-0
     limit:100
     Stage-1
       Reducer 7 vectorized
-      File Output Operator [FS_167]
-        Limit [LIM_166] (rows=100 width=702)
+      File Output Operator [FS_166]
+        Limit [LIM_165] (rows=100 width=702)
           Number of rows:100
-          Select Operator [SEL_165] (rows=65392 width=700)
+          Select Operator [SEL_164] (rows=65392 width=700)
             Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
           <-Reducer 6 [SIMPLE_EDGE]
             SHUFFLE [RS_51]
@@ -93,94 +93,92 @@ Stage-0
                 Output:["_col0","_col1","_col2","_col3","_col4","_col5"]
                 Top N Key Operator [TNK_80] (rows=65392 width=704)
                   keys:_col6, _col8,top n:100
-                  Merge Join Operator [MERGEJOIN_139] (rows=65392 width=704)
-                    Conds:RS_47._col1=RS_164._col0(Inner),Output:["_col2","_col6","_col8","_col9","_col10","_col11"]
+                  Merge Join Operator [MERGEJOIN_138] (rows=65392 width=704)
+                    Conds:RS_47._col1=RS_163._col0(Inner),Output:["_col2","_col6","_col8","_col9","_col10","_col11"]
                   <-Map 12 [SIMPLE_EDGE] vectorized
-                    SHUFFLE [RS_164]
+                    SHUFFLE [RS_163]
                       PartitionCols:_col0
-                      Select Operator [SEL_163] (rows=462000 width=511)
+                      Select Operator [SEL_162] (rows=462000 width=511)
                         Output:["_col0","_col1","_col2","_col3","_col4"]
                         TableScan [TS_38] (rows=462000 width=511)
                           default@item,item,Tbl:COMPLETE,Col:COMPLETE,Output:["i_item_sk","i_item_desc","i_current_price","i_wholesale_cost","i_brand"]
                   <-Reducer 5 [SIMPLE_EDGE]
                     SHUFFLE [RS_47]
                       PartitionCols:_col1
-                      Top N Key Operator [TNK_81] (rows=65392 width=204)
-                        keys:_col6,top n:100
-                        Merge Join Operator [MERGEJOIN_138] (rows=65392 width=204)
-                          Conds:RS_44._col0=RS_162._col0(Inner),Output:["_col1","_col2","_col6"]
-                        <-Map 11 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_162]
-                            PartitionCols:_col0
-                            Select Operator [SEL_161] (rows=1704 width=92)
-                              Output:["_col0","_col1"]
-                              TableScan [TS_36] (rows=1704 width=92)
-                                default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_name"]
-                        <-Reducer 4 [SIMPLE_EDGE]
-                          SHUFFLE [RS_44]
-                            PartitionCols:_col0
-                            Filter Operator [FIL_43] (rows=65392 width=231)
-                              predicate:(_col2 <= _col4)
-                              Merge Join Operator [MERGEJOIN_137] (rows=196176 width=231)
-                                Conds:RS_154._col0=RS_160._col0(Inner),Output:["_col0","_col1","_col2","_col4"]
-                              <-Reducer 3 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_154]
-                                  PartitionCols:_col0
-                                  Filter Operator [FIL_152] (rows=184637 width=118)
-                                    predicate:_col2 is not null
-                                    Group By Operator [GBY_151] (rows=184637 width=118)
-                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
-                                    <-Reducer 2 [SIMPLE_EDGE]
-                                      SHUFFLE [RS_11]
-                                        PartitionCols:_col0, _col1
-                                        Group By Operator [GBY_10] (rows=6093021 width=118)
-                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col2, _col1
-                                          Merge Join Operator [MERGEJOIN_135] (rows=91197860 width=89)
-                                            Conds:RS_150._col0=RS_142._col0(Inner),Output:["_col1","_col2","_col3"]
-                                          <-Map 9 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_142]
-                                              PartitionCols:_col0
-                                              Select Operator [SEL_141] (rows=317 width=4)
-                                                Output:["_col0"]
-                                                Filter Operator [FIL_140] (rows=317 width=8)
-                                                  predicate:d_month_seq BETWEEN 1212 AND 1223
-                                                  TableScan [TS_3] (rows=73049 width=8)
-                                                    default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
-                                          <-Map 1 [SIMPLE_EDGE] vectorized
-                                            SHUFFLE [RS_150]
-                                              PartitionCols:_col0
-                                              Select Operator [SEL_149] (rows=525329897 width=118)
-                                                Output:["_col0","_col1","_col2","_col3"]
-                                                Filter Operator [FIL_148] (rows=525329897 width=118)
-                                                  predicate:(ss_sold_date_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_7_date_dim_d_date_sk_min) AND DynamicValue(RS_7_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_7_date_dim_d_date_sk_bloom_filter)))
-                                                  TableScan [TS_0] (rows=575995635 width=118)
-                                                    default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_store_sk","ss_sales_price"]
-                                                  <-Reducer 10 [BROADCAST_EDGE] vectorized
-                                                    BROADCAST [RS_147]
-                                                      Group By Operator [GBY_146] (rows=1 width=12)
-                                                        Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                      <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                        SHUFFLE [RS_145]
-                                                          Group By Operator [GBY_144] (rows=1 width=12)
-                                                            Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                            Select Operator [SEL_143] (rows=317 width=4)
-                                                              Output:["_col0"]
-                                                               Please refer to the previous Select Operator [SEL_141]
-                              <-Reducer 8 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_160]
-                                  PartitionCols:_col0
-                                  Select Operator [SEL_159] (rows=17 width=115)
-                                    Output:["_col0","_col1"]
-                                    Filter Operator [FIL_158] (rows=17 width=123)
-                                      predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
-                                      Group By Operator [GBY_157] (rows=17 width=123)
-                                        Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
-                                      <-Reducer 3 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_156]
-                                          PartitionCols:_col0
-                                          Group By Operator [GBY_155] (rows=17 width=123)
-                                            Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col1
-                                            Select Operator [SEL_153] (rows=184637 width=118)
-                                              Output:["_col1","_col2"]
-                                               Please refer to the previous Group By Operator [GBY_151]
+                      Merge Join Operator [MERGEJOIN_137] (rows=65392 width=204)
+                        Conds:RS_44._col0=RS_161._col0(Inner),Output:["_col1","_col2","_col6"]
+                      <-Map 11 [SIMPLE_EDGE] vectorized
+                        SHUFFLE [RS_161]
+                          PartitionCols:_col0
+                          Select Operator [SEL_160] (rows=1704 width=92)
+                            Output:["_col0","_col1"]
+                            TableScan [TS_36] (rows=1704 width=92)
+                              default@store,store,Tbl:COMPLETE,Col:COMPLETE,Output:["s_store_sk","s_store_name"]
+                      <-Reducer 4 [SIMPLE_EDGE]
+                        SHUFFLE [RS_44]
+                          PartitionCols:_col0
+                          Filter Operator [FIL_43] (rows=65392 width=231)
+                            predicate:(_col2 <= _col4)
+                            Merge Join Operator [MERGEJOIN_136] (rows=196176 width=231)
+                              Conds:RS_153._col0=RS_159._col0(Inner),Output:["_col0","_col1","_col2","_col4"]
+                            <-Reducer 3 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_153]
+                                PartitionCols:_col0
+                                Filter Operator [FIL_151] (rows=184637 width=118)
+                                  predicate:_col2 is not null
+                                  Group By Operator [GBY_150] (rows=184637 width=118)
+                                    Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)"],keys:KEY._col0, KEY._col1
+                                  <-Reducer 2 [SIMPLE_EDGE]
+                                    SHUFFLE [RS_11]
+                                      PartitionCols:_col0, _col1
+                                      Group By Operator [GBY_10] (rows=6093021 width=118)
+                                        Output:["_col0","_col1","_col2"],aggregations:["sum(_col3)"],keys:_col2, _col1
+                                        Merge Join Operator [MERGEJOIN_134] (rows=91197860 width=89)
+                                          Conds:RS_149._col0=RS_141._col0(Inner),Output:["_col1","_col2","_col3"]
+                                        <-Map 9 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_141]
+                                            PartitionCols:_col0
+                                            Select Operator [SEL_140] (rows=317 width=4)
+                                              Output:["_col0"]
+                                              Filter Operator [FIL_139] (rows=317 width=8)
+                                                predicate:d_month_seq BETWEEN 1212 AND 1223
+                                                TableScan [TS_3] (rows=73049 width=8)
+                                                  default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
+                                        <-Map 1 [SIMPLE_EDGE] vectorized
+                                          SHUFFLE [RS_149]
+                                            PartitionCols:_col0
+                                            Select Operator [SEL_148] (rows=525329897 width=118)
+                                              Output:["_col0","_col1","_col2","_col3"]
+                                              Filter Operator [FIL_147] (rows=525329897 width=118)
+                                                predicate:(ss_sold_date_sk is not null and ss_store_sk is not null and ss_sold_date_sk BETWEEN DynamicValue(RS_7_date_dim_d_date_sk_min) AND DynamicValue(RS_7_date_dim_d_date_sk_max) and in_bloom_filter(ss_sold_date_sk, DynamicValue(RS_7_date_dim_d_date_sk_bloom_filter)))
+                                                TableScan [TS_0] (rows=575995635 width=118)
+                                                  default@store_sales,store_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["ss_sold_date_sk","ss_item_sk","ss_store_sk","ss_sales_price"]
+                                                <-Reducer 10 [BROADCAST_EDGE] vectorized
+                                                  BROADCAST [RS_146]
+                                                    Group By Operator [GBY_145] (rows=1 width=12)
+                                                      Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
+                                                    <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                      SHUFFLE [RS_144]
+                                                        Group By Operator [GBY_143] (rows=1 width=12)
+                                                          Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
+                                                          Select Operator [SEL_142] (rows=317 width=4)
+                                                            Output:["_col0"]
+                                                             Please refer to the previous Select Operator [SEL_140]
+                            <-Reducer 8 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_159]
+                                PartitionCols:_col0
+                                Select Operator [SEL_158] (rows=17 width=115)
+                                  Output:["_col0","_col1"]
+                                  Filter Operator [FIL_157] (rows=17 width=123)
+                                    predicate:CAST( (_col1 / _col2) AS decimal(21,6)) is not null
+                                    Group By Operator [GBY_156] (rows=17 width=123)
+                                      Output:["_col0","_col1","_col2"],aggregations:["sum(VALUE._col0)","count(VALUE._col1)"],keys:KEY._col0
+                                    <-Reducer 3 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_155]
+                                        PartitionCols:_col0
+                                        Group By Operator [GBY_154] (rows=17 width=123)
+                                          Output:["_col0","_col1","_col2"],aggregations:["sum(_col2)","count(_col2)"],keys:_col1
+                                          Select Operator [SEL_152] (rows=184637 width=118)
+                                            Output:["_col1","_col2"]
+                                             Please refer to the previous Group By Operator [GBY_150]
 

--- a/ql/src/test/results/clientpositive/perf/tez/constraints/query99.q.out
+++ b/ql/src/test/results/clientpositive/perf/tez/constraints/query99.q.out
@@ -95,16 +95,16 @@ Stage-0
     limit:-1
     Stage-1
       Reducer 7 vectorized
-      File Output Operator [FS_127]
-        Limit [LIM_126] (rows=100 width=420)
+      File Output Operator [FS_125]
+        Limit [LIM_124] (rows=100 width=420)
           Number of rows:100
-          Select Operator [SEL_125] (rows=3869553 width=420)
+          Select Operator [SEL_123] (rows=3869553 width=420)
             Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"]
           <-Reducer 6 [SIMPLE_EDGE] vectorized
-            SHUFFLE [RS_124]
-              Select Operator [SEL_123] (rows=3869553 width=420)
+            SHUFFLE [RS_122]
+              Select Operator [SEL_121] (rows=3869553 width=420)
                 Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                Group By Operator [GBY_122] (rows=3869553 width=321)
+                Group By Operator [GBY_120] (rows=3869553 width=321)
                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"],aggregations:["sum(VALUE._col0)","sum(VALUE._col1)","sum(VALUE._col2)","sum(VALUE._col3)","sum(VALUE._col4)"],keys:KEY._col0, KEY._col1, KEY._col2
                 <-Reducer 5 [SIMPLE_EDGE]
                   SHUFFLE [RS_26]
@@ -113,73 +113,71 @@ Stage-0
                       Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7"],aggregations:["sum(_col4)","sum(_col5)","sum(_col6)","sum(_col7)","sum(_col8)"],keys:_col13, _col11, _col15
                       Top N Key Operator [TNK_56] (rows=15478212 width=301)
                         keys:_col13, _col11, _col15,top n:100
-                        Merge Join Operator [MERGEJOIN_104] (rows=15478212 width=301)
-                          Conds:RS_21._col1=RS_121._col0(Inner),Output:["_col4","_col5","_col6","_col7","_col8","_col11","_col13","_col15"]
+                        Merge Join Operator [MERGEJOIN_102] (rows=15478212 width=301)
+                          Conds:RS_21._col1=RS_119._col0(Inner),Output:["_col4","_col5","_col6","_col7","_col8","_col11","_col13","_col15"]
                         <-Map 12 [SIMPLE_EDGE] vectorized
-                          SHUFFLE [RS_121]
+                          SHUFFLE [RS_119]
                             PartitionCols:_col0
-                            Select Operator [SEL_120] (rows=60 width=102)
+                            Select Operator [SEL_118] (rows=60 width=102)
                               Output:["_col0","_col1"]
                               TableScan [TS_10] (rows=60 width=102)
                                 default@call_center,call_center,Tbl:COMPLETE,Col:COMPLETE,Output:["cc_call_center_sk","cc_name"]
                         <-Reducer 4 [SIMPLE_EDGE]
                           SHUFFLE [RS_21]
                             PartitionCols:_col1
-                            Top N Key Operator [TNK_57] (rows=15478212 width=206)
-                              keys:_col13, _col11,top n:100
-                              Merge Join Operator [MERGEJOIN_103] (rows=15478212 width=206)
-                                Conds:RS_18._col3=RS_119._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col8","_col11","_col13"]
-                              <-Map 11 [SIMPLE_EDGE] vectorized
-                                SHUFFLE [RS_119]
-                                  PartitionCols:_col0
-                                  Select Operator [SEL_118] (rows=27 width=103)
-                                    Output:["_col0","_col1"]
-                                    TableScan [TS_8] (rows=27 width=104)
-                                      default@warehouse,warehouse,Tbl:COMPLETE,Col:COMPLETE,Output:["w_warehouse_sk","w_warehouse_name"]
-                              <-Reducer 3 [SIMPLE_EDGE]
-                                SHUFFLE [RS_18]
-                                  PartitionCols:_col3
-                                  Merge Join Operator [MERGEJOIN_102] (rows=15478212 width=111)
-                                    Conds:RS_15._col2=RS_106._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
-                                  <-Map 9 [SIMPLE_EDGE] vectorized
-                                    SHUFFLE [RS_106]
-                                      PartitionCols:_col0
-                                      Select Operator [SEL_105] (rows=1 width=88)
-                                        Output:["_col0","_col1"]
-                                        TableScan [TS_6] (rows=1 width=88)
-                                          default@ship_mode,ship_mode,Tbl:COMPLETE,Col:COMPLETE,Output:["sm_ship_mode_sk","sm_type"]
-                                  <-Reducer 2 [SIMPLE_EDGE]
-                                    SHUFFLE [RS_15]
-                                      PartitionCols:_col2
-                                      Merge Join Operator [MERGEJOIN_101] (rows=46434637 width=31)
-                                        Conds:RS_114._col0=RS_117._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                      <-Map 1 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_114]
-                                          PartitionCols:_col0
-                                          Select Operator [SEL_113] (rows=282273729 width=35)
-                                            Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
-                                            Filter Operator [FIL_112] (rows=282273729 width=19)
-                                              predicate:(cs_warehouse_sk is not null and cs_ship_date_sk is not null and cs_ship_mode_sk is not null and cs_call_center_sk is not null and cs_ship_mode_sk BETWEEN DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_min) AND DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_max) and in_bloom_filter(cs_ship_mode_sk, DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_bloom_filter)))
-                                              TableScan [TS_0] (rows=287989836 width=19)
-                                                default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_ship_date_sk","cs_call_center_sk","cs_ship_mode_sk","cs_warehouse_sk"]
-                                              <-Reducer 10 [BROADCAST_EDGE] vectorized
-                                                BROADCAST [RS_111]
-                                                  Group By Operator [GBY_110] (rows=1 width=12)
-                                                    Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
-                                                  <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
-                                                    SHUFFLE [RS_109]
-                                                      Group By Operator [GBY_108] (rows=1 width=12)
-                                                        Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
-                                                        Select Operator [SEL_107] (rows=1 width=4)
-                                                          Output:["_col0"]
-                                                           Please refer to the previous Select Operator [SEL_105]
-                                      <-Map 8 [SIMPLE_EDGE] vectorized
-                                        SHUFFLE [RS_117]
-                                          PartitionCols:_col0
-                                          Select Operator [SEL_116] (rows=317 width=4)
-                                            Output:["_col0"]
-                                            Filter Operator [FIL_115] (rows=317 width=8)
-                                              predicate:d_month_seq BETWEEN 1212 AND 1223
-                                              TableScan [TS_3] (rows=73049 width=8)
-                                                default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
+                            Merge Join Operator [MERGEJOIN_101] (rows=15478212 width=206)
+                              Conds:RS_18._col3=RS_117._col0(Inner),Output:["_col1","_col4","_col5","_col6","_col7","_col8","_col11","_col13"]
+                            <-Map 11 [SIMPLE_EDGE] vectorized
+                              SHUFFLE [RS_117]
+                                PartitionCols:_col0
+                                Select Operator [SEL_116] (rows=27 width=103)
+                                  Output:["_col0","_col1"]
+                                  TableScan [TS_8] (rows=27 width=104)
+                                    default@warehouse,warehouse,Tbl:COMPLETE,Col:COMPLETE,Output:["w_warehouse_sk","w_warehouse_name"]
+                            <-Reducer 3 [SIMPLE_EDGE]
+                              SHUFFLE [RS_18]
+                                PartitionCols:_col3
+                                Merge Join Operator [MERGEJOIN_100] (rows=15478212 width=111)
+                                  Conds:RS_15._col2=RS_104._col0(Inner),Output:["_col1","_col3","_col4","_col5","_col6","_col7","_col8","_col11"]
+                                <-Map 9 [SIMPLE_EDGE] vectorized
+                                  SHUFFLE [RS_104]
+                                    PartitionCols:_col0
+                                    Select Operator [SEL_103] (rows=1 width=88)
+                                      Output:["_col0","_col1"]
+                                      TableScan [TS_6] (rows=1 width=88)
+                                        default@ship_mode,ship_mode,Tbl:COMPLETE,Col:COMPLETE,Output:["sm_ship_mode_sk","sm_type"]
+                                <-Reducer 2 [SIMPLE_EDGE]
+                                  SHUFFLE [RS_15]
+                                    PartitionCols:_col2
+                                    Merge Join Operator [MERGEJOIN_99] (rows=46434637 width=31)
+                                      Conds:RS_112._col0=RS_115._col0(Inner),Output:["_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                                    <-Map 1 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_112]
+                                        PartitionCols:_col0
+                                        Select Operator [SEL_111] (rows=282273729 width=35)
+                                          Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"]
+                                          Filter Operator [FIL_110] (rows=282273729 width=19)
+                                            predicate:(cs_warehouse_sk is not null and cs_ship_date_sk is not null and cs_ship_mode_sk is not null and cs_call_center_sk is not null and cs_ship_mode_sk BETWEEN DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_min) AND DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_max) and in_bloom_filter(cs_ship_mode_sk, DynamicValue(RS_16_ship_mode_sm_ship_mode_sk_bloom_filter)))
+                                            TableScan [TS_0] (rows=287989836 width=19)
+                                              default@catalog_sales,catalog_sales,Tbl:COMPLETE,Col:COMPLETE,Output:["cs_sold_date_sk","cs_ship_date_sk","cs_call_center_sk","cs_ship_mode_sk","cs_warehouse_sk"]
+                                            <-Reducer 10 [BROADCAST_EDGE] vectorized
+                                              BROADCAST [RS_109]
+                                                Group By Operator [GBY_108] (rows=1 width=12)
+                                                  Output:["_col0","_col1","_col2"],aggregations:["min(VALUE._col0)","max(VALUE._col1)","bloom_filter(VALUE._col2, expectedEntries=1000000)"]
+                                                <-Map 9 [CUSTOM_SIMPLE_EDGE] vectorized
+                                                  SHUFFLE [RS_107]
+                                                    Group By Operator [GBY_106] (rows=1 width=12)
+                                                      Output:["_col0","_col1","_col2"],aggregations:["min(_col0)","max(_col0)","bloom_filter(_col0, expectedEntries=1000000)"]
+                                                      Select Operator [SEL_105] (rows=1 width=4)
+                                                        Output:["_col0"]
+                                                         Please refer to the previous Select Operator [SEL_103]
+                                    <-Map 8 [SIMPLE_EDGE] vectorized
+                                      SHUFFLE [RS_115]
+                                        PartitionCols:_col0
+                                        Select Operator [SEL_114] (rows=317 width=4)
+                                          Output:["_col0"]
+                                          Filter Operator [FIL_113] (rows=317 width=8)
+                                            predicate:d_month_seq BETWEEN 1212 AND 1223
+                                            TableScan [TS_3] (rows=73049 width=8)
+                                              default@date_dim,date_dim,Tbl:COMPLETE,Col:COMPLETE,Output:["d_date_sk","d_month_seq"]
 


### PR DESCRIPTION
Followup for HIVE-23723. In HIVE-23723 we only check 1.) if join is a PK-FK join, 2.) FK side is not filtered, 3.) first n order by columns are originated from the FK side. It doesn't check if the order by columns actually match (including sort oder + null order) to columns used in the reduce output operator. This patch is intended to fix that.