### PR TITLE
HIVE-23958: HiveServer2 should support additional keystore/truststore types besides JKS

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
@@ -19,13 +19,16 @@ package org.apache.hadoop.hive.common.auth;
 
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.TrustManagerFactory;
 
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TServerSocket;
@@ -57,7 +60,8 @@ public class HiveAuthUtils {
     String trustStorePath, String trustStorePassWord) throws TTransportException {
     TSSLTransportFactory.TSSLTransportParameters params =
       new TSSLTransportFactory.TSSLTransportParameters();
-    params.setTrustStore(trustStorePath, trustStorePassWord);
+    params.setTrustStore(trustStorePath, trustStorePassWord,
+        TrustManagerFactory.getDefaultAlgorithm(), KeyStore.getDefaultType());
     params.requireClientAuth(true);
     // The underlying SSLSocket object is bound to host:port with the given SO_TIMEOUT and
     // SSLContext created with the given params
@@ -92,7 +96,8 @@ public class HiveAuthUtils {
       UnknownHostException {
     TSSLTransportFactory.TSSLTransportParameters params =
         new TSSLTransportFactory.TSSLTransportParameters();
-    params.setKeyStore(keyStorePath, keyStorePassWord);
+    params.setKeyStore(keyStorePath, keyStorePassWord,
+        KeyManagerFactory.getDefaultAlgorithm(), KeyStore.getDefaultType());
     InetSocketAddress serverAddress;
     if (hiveHost == null || hiveHost.isEmpty()) {
       // Wildcard bind

--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.security.KeyStore;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -518,6 +519,7 @@ public class HttpServer {
     } else {
       SslContextFactory sslContextFactory = new SslContextFactory();
       sslContextFactory.setKeyStorePath(b.keyStorePath);
+      sslContextFactory.setKeyStoreType(KeyStore.getDefaultType());
       Set<String> excludedSSLProtocols = Sets.newHashSet(
         Splitter.on(",").trimResults().omitEmptyStrings().split(
           Strings.nullToEmpty(b.conf.getVar(ConfVars.HIVE_SSL_PROTOCOL_BLACKLIST))));

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -18,6 +18,7 @@
 
 package org.apache.hive.service.cli.thrift;
 
+import java.security.KeyStore;
 import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
@@ -143,6 +144,7 @@ public class ThriftHttpCLIService extends ThriftCLIService {
             + Arrays.toString(sslContextFactory.getExcludeProtocols()));
         sslContextFactory.setKeyStorePath(keyStorePath);
         sslContextFactory.setKeyStorePassword(keyStorePassword);
+        sslContextFactory.setKeyStoreType(KeyStore.getDefaultType());
         connector = new ServerConnector(server, sslContextFactory, http);
       } else {
         connector = new ServerConnector(server, http);


### PR DESCRIPTION
Ensures that HS2 uses the default JDK keystore/truststore type when interacting with Thrift and Jetty. It isn't possible to add a test for this since FIPS compatible keystore/truststore needs special TLS provider and isn't shipped w/ the JDK. Using JKS or PKCS12 would work in either case since the JDK supports both in JDK 8 and 11. 
