### PR TITLE
HIVE-23966: Minor query-based compaction always results in delta dirs with minWriteId=1

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -1304,7 +1304,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
   public void testMinorCompactionAfterMajor() throws Exception {
     Assume.assumeTrue(runsOnTez);
     String dbName = "default";
-    String tableName = "testMinorCompaction";
+    String tableName = "testMinorCompactionAfterMajor";
     // Create test table
     TestDataProvider dataProvider = new TestDataProvider();
     dataProvider.createFullAcidTable(tableName, false, false);
@@ -1345,8 +1345,11 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
         Collections.singletonList("base_0000005_v0000009"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     Assert.assertEquals("Delta directories do not match after major compaction",
-        Collections.singletonList("delta_0000001_0000010_v0000020"),
+        Collections.singletonList("delta_0000006_0000010_v0000020"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
+    Assert.assertEquals("Delete delta directories does not match after minor compaction",
+        Collections.singletonList("delete_delta_0000006_0000010_v0000020"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
     // Verify all contents
     actualData = dataProvider.getAllData(tableName);
     Assert.assertEquals(expectedData, actualData);
@@ -1506,6 +1509,166 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   @Test public void testMinorCompactionDb() throws Exception {
     testCompactionDb(CompactionType.MINOR, "delta_0000001_0000005_v0000011");
+  }
+
+  /**
+   * Minor compaction on a table with no deletes shouldn't result in any delete deltas.
+   */
+  @Test public void testJustInserts() throws Exception {
+    String dbName = "default";
+    String tableName = "testJustInserts";
+    // Create test table
+    executeStatementOnDriver("CREATE TABLE " + tableName + " (id string, value string)"
+        + "CLUSTERED BY(id) INTO 10 BUCKETS "
+        + "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    // Find the location of the table
+    IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
+    Table table = metaStoreClient.getTable(dbName, tableName);
+    FileSystem fs = FileSystem.get(conf);
+    // Insert test data into test table
+    executeStatementOnDriver("insert into " + tableName + " values ('21', 'value21'),('84', 'value84'),"
+        + "('66', 'value66'),('54', 'value54')", driver);
+    executeStatementOnDriver("insert into " + tableName + " values ('22', 'value22'),('34', 'value34'),"
+        + "('35', 'value35')", driver);
+    executeStatementOnDriver("insert into " + tableName + " values ('75', 'value75'),('99', 'value99')", driver);
+
+    CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
+    // Clean up resources
+    CompactorTestUtil.runCleaner(conf);
+    // Only 1 compaction should be in the response queue with succeeded state
+    verifySuccessfulCompaction(1);
+
+    List<String> actualDeltasAfterComp =
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
+    Assert.assertEquals("Delta directories does not match after compaction",
+        Collections.singletonList("delta_0000001_0000003_v0000005"), actualDeltasAfterComp);
+    List<String> actualDeleteDeltasAfterComp =
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
+    Assert.assertEquals("Delete delta directories does not match after compaction",
+        Collections.emptyList(), actualDeleteDeltasAfterComp);
+  }
+
+  /**
+   * Minor compaction on a table with no insert deltas should result in just a delete delta.
+   */
+  @Test public void testJustDeletes() throws Exception {
+    String dbName = "default";
+    String tableName = "testJustDeletes";
+    // Create test table
+    executeStatementOnDriver("CREATE TABLE " + tableName + " (id string, value string)"
+        + "CLUSTERED BY(id) INTO 10 BUCKETS "
+        + "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    // Find the location of the table
+    IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
+    Table table = metaStoreClient.getTable(dbName, tableName);
+    FileSystem fs = FileSystem.get(conf);
+    // Insert test data into test table
+    executeStatementOnDriver("insert overwrite table " + tableName + " values ('1','one'),('2','two'),('3','three'),"
+        + "('4','four'),('5','five'),('6','six'),('7','seven'),('8','eight'),('9','nine'),('10','ten'),('11','eleven'),"
+        + "('12','twelve'),('13','thirteen'),('14','fourteen'),('15','fifteen'),('16','sixteen'),('17','seventeen'),"
+        + "('18','eighteen'),('19','nineteen'),('20','twenty')", driver);
+    executeStatementOnDriver("delete from " + tableName + " where id in ('2', '4', '12', '15')", driver);
+    executeStatementOnDriver("delete from " + tableName + " where id in ('11', '10', '14', '5')", driver);
+
+    CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
+    // Clean up resources
+    CompactorTestUtil.runCleaner(conf);
+    // Only 1 compaction should be in the response queue with succeeded state
+    verifySuccessfulCompaction(1);
+
+    // insert one more to verify a correct writeid (4)
+    executeStatementOnDriver("insert into " + tableName + " values ('75', 'value75'),('99', 'value99')", driver);
+
+    List<String> actualDeltasAfterComp =
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null);
+    Assert.assertEquals("Delta directories does not match after compaction",
+        Collections.singletonList("delta_0000004_0000004_0000"), actualDeltasAfterComp);
+    List<String> actualDeleteDeltasAfterComp =
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null);
+    Assert.assertEquals("Delete delta directories does not match after compaction",
+        Collections.singletonList("delete_delta_0000002_0000003_v0000005"), actualDeleteDeltasAfterComp);
+  }
+
+  /**
+   * After running insert overwrite, followed by a minor compaction, major compaction was failing because minor
+   * compaction was resulting in deltas named delta_1_y.
+   */
+  @Test public void testIowMinorMajor() throws Exception {
+    String dbName = "default";
+    String tableName = "testIowMinorMajor";
+    // Create test table
+    executeStatementOnDriver("CREATE TABLE " + tableName + " (id string, value string)"
+        + "CLUSTERED BY(id) INTO 2 BUCKETS "
+        + "STORED AS ORC TBLPROPERTIES('transactional'='true')", driver);
+    // Find the location of the table
+    IMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
+    Table table = metaStoreClient.getTable(dbName, tableName);
+    FileSystem fs = FileSystem.get(conf);
+    // Insert test data into test table
+    executeStatementOnDriver("insert overwrite table " + tableName + " values ('1','one'),('2','two'),('3','three'),"
+        + "('4','four'),('5','five'),('6','six'),('7','seven'),('8','eight'),('9','nine'),('10','ten'),('11','eleven'),"
+        + "('12','twelve'),('13','thirteen'),('14','fourteen'),('15','fifteen'),('16','sixteen'),('17','seventeen'),"
+        + "('18','eighteen'),('19','nineteen'),('20','twenty')", driver);
+    executeStatementOnDriver("delete from " + tableName + " where id in ('2', '4', '12', '15')", driver);
+    executeStatementOnDriver("delete from " + tableName + " where id in ('11', '10', '14', '5')", driver);
+    executeStatementOnDriver("insert into " + tableName + " values ('21', 'value21'),('84', 'value84'),('66', 'value66'),('54', 'value54')", driver);
+    executeStatementOnDriver("insert into " + tableName + " values ('22', 'value22'),('34', 'value34'),('35', 'value35')", driver);
+    executeStatementOnDriver("insert into " + tableName + " values ('75', 'value75'),('99', 'value99')", driver);
+
+    // Verify deltas
+    Assert.assertEquals("Delta directories does not match",
+        Arrays.asList("delta_0000004_0000004_0000", "delta_0000005_0000005_0000", "delta_0000006_0000006_0000"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
+    // Verify delete delta
+    Assert.assertEquals("Delete directories does not match",
+        Arrays.asList("delete_delta_0000002_0000002_0000", "delete_delta_0000003_0000003_0000"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
+    // Get all data before compaction is run
+    TestDataProvider dataProvider = new TestDataProvider();
+    List<String> expectedData = dataProvider.getAllData(tableName);
+
+    // Run a compaction
+    CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MINOR, true);
+    // Clean up resources
+    CompactorTestUtil.runCleaner(conf);
+    // Only 1 compaction should be in the response queue with succeeded state
+    verifySuccessfulCompaction(1);
+    // Verify deltas
+    Assert.assertEquals("Delta directories does not match",
+        Collections.singletonList("delta_0000002_0000006_v0000009"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
+    // Verify delete delta
+    Assert.assertEquals("Delete directories does not match",
+        Collections.singletonList("delete_delta_0000002_0000006_v0000009"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deleteEventDeltaDirFilter, table, null));
+    // Verify all contents
+    List<String> actualData = dataProvider.getAllData(tableName);
+    Assert.assertEquals(expectedData, actualData);
+
+    // Run a compaction
+    CompactorTestUtil.runCompaction(conf, dbName, tableName, CompactionType.MAJOR, true);
+    // Clean up resources
+    CompactorTestUtil.runCleaner(conf);
+    // 2 compactions should be in the response queue with succeeded state
+    verifySuccessfulCompaction(2);
+    // Should contain only one base directory now
+    String expectedBase = "base_0000006_v0000023";
+    Assert.assertEquals("Base directory does not match after major compaction",
+        Collections.singletonList(expectedBase),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
+    // Check base dir contents
+    List<String> expectedBucketFiles = Arrays.asList("bucket_00000", "bucket_00001");
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+        CompactorTestUtil.getBucketFileNames(fs, table, null, expectedBase));
+    // Check bucket file contents
+    checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
+    checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 1);
+    // Verify all contents
+    actualData = dataProvider.getAllData(tableName);
+    Assert.assertEquals(expectedData, actualData);
+
+    // Clean up
+    dataProvider.dropTable(tableName);
   }
 
   /**

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -503,6 +503,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   @Test
   public void testMinorCompactionWithoutBuckets() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testMinorCompaction_wobuckets_1";
     String tempTableName = "tmp_txt_table_1";
@@ -525,6 +526,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   @Test
   public void testMinorCompactionWithoutBucketsInsertOverwrite() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testMinorCompaction_wobuckets_2";
     String tempTableName = "tmp_txt_table_2";
@@ -541,7 +543,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     expectedDeleteDeltas.add("delete_delta_0000005_0000005_0000");
 
     testMinorCompactionWithoutBucketsCommon(dbName, tableName, tempTableName, true, expectedDeltas,
-        expectedDeleteDeltas, "delta_0000001_0000008_v0000025", CompactionType.MINOR);
+        expectedDeleteDeltas, "delta_0000002_0000008_v0000025", CompactionType.MINOR);
   }
 
   @Test
@@ -569,6 +571,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
       boolean insertOverWrite, List<String> expectedDeltas, List<String> expectedDeleteDeltas,
       String expectedCompactedDeltaDirName, CompactionType compactionType) throws Exception {
 
+    Assume.assumeTrue(runsOnTez);
     TestDataProvider dataProvider = new TestDataProvider();
     dataProvider.createTableWithoutBucketWithMultipleSplits(dbName, tableName, tempTableName, true, true,
         insertOverWrite);
@@ -653,6 +656,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
 
   @Test
   public void testMinorAndMajorCompactionWithoutBuckets() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testMinorCompaction_wobuckets_5";
     String tempTableName = "tmp_txt_table_5";
@@ -1508,6 +1512,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
   }
 
   @Test public void testMinorCompactionDb() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     testCompactionDb(CompactionType.MINOR, "delta_0000001_0000005_v0000011");
   }
 
@@ -1515,6 +1520,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
    * Minor compaction on a table with no deletes shouldn't result in any delete deltas.
    */
   @Test public void testJustInserts() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testJustInserts";
     // Create test table
@@ -1552,6 +1558,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
    * Minor compaction on a table with no insert deltas should result in just a delete delta.
    */
   @Test public void testJustDeletes() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testJustDeletes";
     // Create test table
@@ -1594,6 +1601,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
    * compaction was resulting in deltas named delta_1_y.
    */
   @Test public void testIowMinorMajor() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     String dbName = "default";
     String tableName = "testIowMinorMajor";
     // Create test table
@@ -1707,6 +1715,7 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
   }
 
   @Test public void testVectorizationOff() throws Exception {
+    Assume.assumeTrue(runsOnTez);
     conf.setBoolVar(HiveConf.ConfVars.HIVE_VECTORIZATION_ENABLED, false);
     testMinorCompactionAfterMajor();
   }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnTez.java
@@ -403,7 +403,7 @@ public class TestMmCompactorOnTez extends CompactorOnTezTest {
         Collections.singletonList("base_0000003_v0000007"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
     Assert.assertEquals("Delta directories does not match after minor compaction",
-        Collections.singletonList("delta_0000001_0000006_v0000016"),
+        Collections.singletonList("delta_0000004_0000006_v0000016"),
         CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
     verifyAllContents(tableName, dataProvider, expectedData);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MajorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MajorQueryCompactor.java
@@ -54,7 +54,7 @@ final class MajorQueryCompactor extends QueryCompactor {
     String tmpPrefix = table.getDbName() + "_tmp_compactor_" + table.getTableName() + "_";
     String tmpTableName = tmpPrefix + System.currentTimeMillis();
     Path tmpTablePath = QueryCompactor.Util.getCompactionResultDir(storageDescriptor, writeIds,
-        conf, true, false, false);
+        conf, true, false, false, null);
 
     List<String> createQueries = getCreateQueries(tmpTableName, table, tmpTablePath.toString());
     List<String> compactionQueries = getCompactionQueries(table, partition, tmpTableName);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MinorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MinorQueryCompactor.java
@@ -60,9 +60,9 @@ final class MinorQueryCompactor extends QueryCompactor {
         table.getDbName() + "_tmp_compactor_" + table.getTableName() + "_" + System.currentTimeMillis();
 
     Path resultDeltaDir = QueryCompactor.Util.getCompactionResultDir(storageDescriptor,
-        writeIds, conf, false, false, false);
+        writeIds, conf, false, false, false, dir);
     Path resultDeleteDeltaDir = QueryCompactor.Util.getCompactionResultDir(storageDescriptor,
-        writeIds, conf, false, true, false);
+        writeIds, conf, false, true, false, dir);
 
     List<String> createQueries = getCreateQueries(table, tmpTableName, dir, writeIds,
         resultDeltaDir, resultDeleteDeltaDir);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMajorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMajorQueryCompactor.java
@@ -58,7 +58,7 @@ final class MmMajorQueryCompactor extends QueryCompactor {
     String tmpPrefix = table.getDbName() + ".tmp_compactor_" + table.getTableName() + "_";
     String tmpTableName = tmpPrefix + System.currentTimeMillis();
     Path resultBaseDir = QueryCompactor.Util.getCompactionResultDir(
-        storageDescriptor, writeIds, driverConf, true, true, false);
+        storageDescriptor, writeIds, driverConf, true, true, false, null);
 
     List<String> createTableQueries = getCreateQueries(tmpTableName, table, storageDescriptor,
         resultBaseDir.toString());

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMinorQueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MmMinorQueryCompactor.java
@@ -59,7 +59,7 @@ final class MmMinorQueryCompactor extends QueryCompactor {
     String tmpTableName = tmpPrefix + System.currentTimeMillis();
     String resultTmpTableName = tmpTableName + "_result";
     Path resultDeltaDir = QueryCompactor.Util.getCompactionResultDir(storageDescriptor, writeIds, driverConf,
-        false, false, false);
+        false, false, false, dir);
 
     List<String> createTableQueries = getCreateQueries(tmpTableName, table, storageDescriptor, dir,
         writeIds, resultDeltaDir);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
@@ -178,16 +178,17 @@ abstract class QueryCompactor {
      * @param writingBase if true, we are creating a base directory, otherwise a delta
      * @param createDeleteDelta if true, the delta dir we are creating is a delete delta
      * @param bucket0 whether to specify 0 as the bucketid
+     * @param directory AcidUtils.Directory - only required for minor compaction result (delta) dirs
      *
      * @return Path of new base/delta/delete delta directory
      */
     static Path getCompactionResultDir(StorageDescriptor sd, ValidWriteIdList writeIds, HiveConf conf,
-        boolean writingBase, boolean createDeleteDelta, boolean bucket0) {
-      long minOpenWriteId = writeIds.getMinOpenWriteId() == null ? 1 : writeIds.getMinOpenWriteId();
+        boolean writingBase, boolean createDeleteDelta, boolean bucket0, AcidUtils.Directory directory) {
+      long minWriteID = writingBase ? 1 : getMinWriteID(directory);
       long highWatermark = writeIds.getHighWatermark();
       long compactorTxnId = CompactorMR.CompactorMap.getCompactorTxnId(conf);
       AcidOutputFormat.Options options =
-          new AcidOutputFormat.Options(conf).isCompressed(false).minimumWriteId(minOpenWriteId)
+          new AcidOutputFormat.Options(conf).isCompressed(false).minimumWriteId(minWriteID)
               .maximumWriteId(highWatermark).statementId(-1).visibilityTxnId(compactorTxnId)
               .writingBase(writingBase).writingDeleteDelta(createDeleteDelta);
       if (bucket0) {
@@ -195,6 +196,26 @@ abstract class QueryCompactor {
       }
       Path location = new Path(sd.getLocation());
       return AcidUtils.baseOrDeltaSubdirPath(location, options);
+    }
+
+    /**
+     * Get the min writeId for the new result directory. This only matters if the result directory will be a delta
+     * directory i.e. minor compaction.
+     * AcidUtils.Directory sorts delta directory names in alphabetical order: First it lists the delete deltas
+     * (delete_delta_x_y) then deltas (delta_x_y), both sorted by x, which is the min write id we're looking for.
+     * Get the the minimum value of x.
+     * @param directory holds information about the deltas we are compacting
+     * @return the smallest min write id found in deltas and delete deltas
+     */
+    private static long getMinWriteID(AcidUtils.Directory directory) {
+      long minWriteID = Long.MAX_VALUE;
+      for (AcidUtils.ParsedDelta delta : directory.getCurrentDirectories()) {
+        minWriteID = Math.min(delta.getMinWriteId(), minWriteID);
+        if (!delta.isDeleteDelta()) {
+          break;
+        }
+      }
+      return minWriteID;
     }
 
     /**


### PR DESCRIPTION
See HIVE-23966 for details.

### Does this PR introduce _any_ user-facing change?
Minor compaction results will have different file names.

### How was this patch tested?
Unit tests