### PR TITLE
HIVE-23963: UnsupportedOperationException in queries 74 and 84 while applying HiveCardinalityPreservingJoinRule

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/Bug.java
@@ -36,4 +36,9 @@ public final class Bug {
    */
   public static final boolean CALCITE_3982_FIXED = false;
 
+  /**
+   * Whether <a href="https://issues.apache.org/jira/browse/CALCITE-4166">issue
+   * CALCITE-4166</a> is fixed.
+   */
+  public static final boolean CALCITE_4166_FIXED = false;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelDistribution.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelDistribution.java
@@ -27,6 +27,7 @@ import org.apache.calcite.plan.RelTraitDef;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelDistributionTraitDef;
 import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.util.mapping.IntPair;
 import org.apache.calcite.util.mapping.Mappings.TargetMapping;
 
 import com.google.common.collect.Ordering;
@@ -82,7 +83,14 @@ public class HiveRelDistribution implements RelDistribution {
     }
     List<Integer> newKeys = new ArrayList<>(keys.size());
     for (Integer key : keys) {
-      newKeys.add(mapping.getTargetOpt(key));
+      // Instead of this inner for loop newKeys.add(mapping.getTargetOpt(key)); should be called but not all the
+      // mapping supports that. See HIVE-23963. Replace this when this is fixed in calcite.
+      for (IntPair aMapping : mapping) {
+        if (aMapping.source == key) {
+          newKeys.add(aMapping.target);
+          break;
+        }
+      }
     }
     return new HiveRelDistribution(type, newKeys);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelDistribution.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelDistribution.java
@@ -85,8 +85,11 @@ public class HiveRelDistribution implements RelDistribution {
     }
     List<Integer> newKeys = new ArrayList<>(keys.size());
 
-    // Instead of using a HashMap for lookup newKeys.add(mapping.getTargetOpt(key)); should be called but not all the
-    // mapping supports that. See HIVE-23963. Replace this when this is fixed in calcite.
+    if (Bug.CALCITE_4166_FIXED) {
+      throw new AssertionError("Remove logic in HiveRelDistribution when [CALCITE-4166] "
+          + "has been fixed and use newKeys.add(mapping.getTargetOpt(key)); instead.");
+    }
+
     Map<Integer, Integer> tmp = new HashMap<>(mapping.getSourceCount());
     for (IntPair aMapping : mapping) {
       tmp.put(aMapping.source, aMapping.target);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Avoid `UnsupportedOperationException` when calculating cost using `HiveOnTezCostModel`.
https://issues.apache.org/jira/browse/HIVE-23963?focusedCommentId=17169985&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-17169985

### Why are the changes needed?
See above section.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
Run query 74 and 84 using a 30tb metastore dump:
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestTezPerfDBCliDriver -Dqfile=query74.q,query84.q -Dtest.metastore.db=postgres.tpcds -pl itests/qtest -Pitests
```