### PR TITLE
HIVE-23989: Read isMetastoreRemote flag from system var in StartMiniS2Cluster

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/StartMiniHS2Cluster.java
@@ -48,6 +48,7 @@ public class StartMiniHS2Cluster {
     MiniClusterType clusterType = MiniClusterType.valueOf(System.getProperty("miniHS2.clusterType", "MR").toUpperCase());
     String confFilesProperty = System.getProperty("miniHS2.conf", "../../data/conf/hive-site.xml");
     boolean usePortsFromConf = Boolean.parseBoolean(System.getProperty("miniHS2.usePortsFromConf", "false"));
+    boolean isMetastoreRemote = Boolean.getBoolean("miniHS2.isMetastoreRemote");
 
     // Load conf files
     String[] confFiles = confFilesProperty.split(",");
@@ -72,7 +73,7 @@ public class StartMiniHS2Cluster {
       conf.addResource(new URL("file://" + new File(confFile).toURI().getPath()));
     }
 
-    miniHS2 = new MiniHS2(conf, clusterType, usePortsFromConf);
+    miniHS2 = new MiniHS2(conf, clusterType, usePortsFromConf, isMetastoreRemote);
     Map<String, String> confOverlay = new HashMap<String, String>();
     miniHS2.start(confOverlay);
     miniHS2.getDFS().getFileSystem().mkdirs(new Path("/apps_staging_dir/anonymous"));

--- a/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
+++ b/itests/util/src/main/java/org/apache/hive/jdbc/miniHS2/MiniHS2.java
@@ -358,13 +358,13 @@ public class MiniHS2 extends AbstractHiveService {
   }
 
   public MiniHS2(HiveConf hiveConf, MiniClusterType clusterType) throws Exception {
-    this(hiveConf, clusterType, false);
+    this(hiveConf, clusterType, false, false);
   }
 
-  public MiniHS2(HiveConf hiveConf, MiniClusterType clusterType, boolean usePortsFromConf)
+  public MiniHS2(HiveConf hiveConf, MiniClusterType clusterType, boolean usePortsFromConf, boolean isMetastoreRemote)
       throws Exception {
     this(hiveConf, clusterType, false, null, null,
-        false, true, usePortsFromConf, "KERBEROS", false, true,
+        isMetastoreRemote, true, usePortsFromConf, "KERBEROS", false, true,
         false, null, null, DEFAULT_DATANODE_COUNT);
   }
 


### PR DESCRIPTION


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Read isMetastoreRemote flag from system var when running testRunCluster test in StartMiniS2Cluster.java

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
In order to access ACID tables created using MiniHS2, spark-acid requires to access the same HMS which MiniHS2 uses. 
In StartMiniHS2Cluster, while initializing MiniHS2, isMetastoreRemote is set to false. 
Hence the metastore cannot be accessed from Spark or any other application per se. 
Due to this limitation, spark-acid cannot be tested on ACID tables created using MiniHS2.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Ran the test locally with `-DminiHS2.isMetastoreRemote=true` flag. 
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
