### PR TITLE
HIVE-23997: Some logs in ConstantPropagateProcFactory are not straightforward

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/ConstantPropagateProcFactory.java
@@ -544,7 +544,8 @@ public final class ConstantPropagateProcFactory {
       ColumnInfo ci = resolveColumn(rs, c);
       if (ci != null) {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Filter " + udf + " is identified as a value assignment, propagate it.");
+          LOG.debug("Filter {} is identified as a value assignment, propagate it.",
+              udf.getDisplayString(new String[]{lOperand.getExprString(), rOperand.getExprString()}));
         }
         if (!v.getTypeInfo().equals(ci.getType())) {
           v = typeCast(v, ci.getType(), true);
@@ -557,7 +558,8 @@ public final class ConstantPropagateProcFactory {
       ExprNodeDesc operand = newExprs.get(0);
       if (operand instanceof ExprNodeColumnDesc) {
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Filter " + udf + " is identified as a value assignment, propagate it.");
+          LOG.debug("Filter {} is identified as a value assignment, propagate it.",
+              udf.getDisplayString(new String[]{operand.getExprString()}));
         }
         ExprNodeColumnDesc c = (ExprNodeColumnDesc) operand;
         ColumnInfo ci = resolveColumn(rs, c);
@@ -979,8 +981,8 @@ public final class ConstantPropagateProcFactory {
             ObjectInspectorUtils.copyToStandardJavaObject(o, coi));
       } else if (!PrimitiveObjectInspectorUtils.isPrimitiveJavaClass(clz)) {
         if (LOG.isErrorEnabled()) {
-          LOG.error("Unable to evaluate " + udf
-              + ". Return value unrecoginizable.");
+          LOG.error("Unable to evaluate {}({}). Return value unrecoginizable.",
+              udf.getClass().getName(), exprs);
         }
         return null;
       } else {
@@ -993,8 +995,8 @@ public final class ConstantPropagateProcFactory {
       }
       return new ExprNodeConstantDesc(o).setFoldedFromVal(constStr);
     } catch (HiveException e) {
-      LOG.error("Evaluation function " + udf.getClass()
-          + " failed in Constant Propagation Optimizer.");
+      LOG.error("Evaluation function {}({}) failed in Constant Propagation Optimizer.",
+          udf.getClass().getName(), exprs);
       throw new RuntimeException(e);
     }
   }
@@ -1458,7 +1460,9 @@ public final class ConstantPropagateProcFactory {
           ndRecursive = ndRecursive.getChildren().get(0);
         }
         if (ndRecursive.getChildren().get(0) instanceof ReduceSinkOperator) {
-          LOG.debug("Skip JOIN-FIL(*)-RS structure.");
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Skip JOIN-FIL(*)-RS structure.");
+          }
           return null;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -785,7 +785,8 @@ public final class OpProcFactory {
           exprs.addAll(finalCandidates);
         }
       }
-      
+
+      logExpr(nd, prunedPred);
       if (!nonFinalCandidates.isEmpty()) {
         createFilter((Operator) nd, nonFinalCandidates, owi);
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Logging in ConstantPropagateProcFactory

### Why are the changes needed?
Make the logging in ConstantPropagateProcFactory more straightforward

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No
