### PR TITLE
HIVE-24004: Improve performance for filter hook for superuser path

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/plugin/metastore/HiveMetaStoreAuthorizer.java
@@ -96,9 +96,10 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
     LOG.debug("==> HiveMetaStoreAuthorizer.onEvent(): EventType=" + preEventContext.getEventType());
 
     try {
-      HiveAuthorizer hiveAuthorizer = createHiveMetaStoreAuthorizer();
-      if (!skipAuthorization()) {
-        HiveMetaStoreAuthzInfo authzContext = buildAuthzContext(preEventContext);
+      HiveMetaStoreAuthzInfo authzContext = buildAuthzContext(preEventContext);
+
+      if (!skipAuthorization(authzContext)) {
+        HiveAuthorizer hiveAuthorizer = createHiveMetaStoreAuthorizer();
         checkPrivileges(authzContext, hiveAuthorizer);
       }
     } catch (Exception e) {
@@ -516,11 +517,13 @@ public class HiveMetaStoreAuthorizer extends MetaStorePreEventListener implement
     LOG.debug("<== HiveMetaStoreAuthorizer.checkPrivileges(): authzContext=" + authzContext + ", authorizer=" + authorizer);
   }
 
-  private boolean skipAuthorization() {
+  private boolean skipAuthorization(HiveMetaStoreAuthzInfo authzContext) {
     LOG.debug("==> HiveMetaStoreAuthorizer.skipAuthorization()");
 
+    if(authzContext == null){
+      return false;
+    }
     boolean ret = false;
-
     UserGroupInformation ugi = null;
     try {
       ugi = getUGI();


### PR DESCRIPTION
This is an improvement on filter hook. For superuser if we can skip authorization, we don't need to create authorizer. This can save some CPU cycles. 