### PR TITLE
HIVE-23408: Hive on Tez : Kafka storage handler broken in secure envi…

### DIFF
--- a/kafka-handler/pom.xml
+++ b/kafka-handler/pom.xml
@@ -30,7 +30,6 @@
 
   <properties>
     <hive.path.to.root>..</hive.path.to.root>
-    <kafka.version>2.5.0</kafka.version>
   </properties>
 
   <artifactId>kafka-handler</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,7 @@
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <junit.vintage.version>5.6.2</junit.vintage.version>
+    <kafka.version>2.5.0</kafka.version>
     <kryo.version>4.0.2</kryo.version>
     <kudu.version>1.12.0</kudu.version>
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -857,6 +857,17 @@
       <artifactId>jersey-multipart</artifactId>
       <version>${jersey.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>${kafka.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.shiro</groupId>
+          <artifactId>shiro-crypto-cipher</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -300,6 +300,10 @@ public class DagUtils {
       if (kafkaBrokers != null && !kafkaBrokers.isEmpty()) {
         getKafkaDelegationTokenForBrokers(dag, conf, kafkaBrokers);
         return;
+      } else {
+        // we don't need to iterate on all partitions, and checking the same TableDesc
+        // if partitions[0].getTableDesc() doesn't show kafka table, let's return quickly
+        break;
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -504,7 +504,7 @@ public class TezTask extends Task<TezWork> {
           wx.setConf(TEZ_MEMORY_RESERVE_FRACTION, Double.toString(frac));
         } // Otherwise just leave it up to Tez to decide how much memory to allocate
         dag.addVertex(wx);
-        utils.addCredentials(workUnit, dag);
+        utils.addCredentials(workUnit, dag, conf);
         perfLogger.perfLogEnd(CLASS_NAME, PerfLogger.TEZ_CREATE_VERTEX + workUnit.getName());
         workToVertex.put(workUnit, wx);
         workToConf.put(workUnit, wxConf);

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
@@ -467,7 +467,7 @@ public class GenericUDTFGetSplits extends GenericUDTF {
           DagUtils.createTezLrMap(appJarLr, null));
       String vertexName = wx.getName();
       dag.addVertex(wx);
-      utils.addCredentials(mapWork, dag);
+      utils.addCredentials(mapWork, dag, job);
 
 
       // we have the dag now proceed to get the splits:

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDagUtils.java
@@ -57,7 +57,7 @@ public class TestDagUtils {
     testUser.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
       public Void run() throws Exception {
-        dagUtils.addCredentials(work, dag);
+        dagUtils.addCredentials(work, dag, null);
         return null;
       }
     });


### PR DESCRIPTION
…ronment

Change-Id: I486e9169279765b8a695d27264b770c8db92128f

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. collect kafka delegation token in HS2
2. propagate tokens to tez and use it in tasks


### Why are the changes needed?
tez tasks fail to connect to kafka brokers on a secure cluster

### Does this PR introduce _any_ user-facing change?
not really, except that tez tasks will able to read from kafka topics on a secure cluster


### How was this patch tested?
tested on secure cluster
