### PR TITLE
HIVE-24011: Flaky test AsyncResponseHandlerTest

### DIFF
--- a/llap-common/src/test/org/apache/hadoop/hive/llap/AsyncResponseHandlerTest.java
+++ b/llap-common/src/test/org/apache/hadoop/hive/llap/AsyncResponseHandlerTest.java
@@ -194,7 +194,7 @@ public class AsyncResponseHandlerTest {
   }
 
   private void assertTrueEventually(AssertTask assertTask) throws InterruptedException {
-    assertTrueEventually(assertTask, 10000);
+    assertTrueEventually(assertTask, 100000);
   }
 
   private void assertTrueEventually(AssertTask assertTask, int timeoutMillis) throws InterruptedException {
@@ -207,9 +207,7 @@ public class AsyncResponseHandlerTest {
         return;
       } catch (AssertionError e) {
         assertionError = e;
-        long millisUntilTimeout = endTime - System.currentTimeMillis();
-        sleep(millisUntilTimeout < 50 ? millisUntilTimeout : 50 );
-        continue;
+        sleep(50);
       }
     }
     throw assertionError;


### PR DESCRIPTION
Timeout is too low. Also retry logic could cause "java.lang.IllegalArgumentException: timeout value is negative"

Change-Id: I3b40dad06889e0e6582d61a8f031fbaba6d06cc3
