### PR TITLE
HIVE-24020: Fix Automatic compaction for streaming ingest with dynamic partition

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -664,6 +664,121 @@ public class TestCompactor {
   }
 
   @Test
+  public void autoCompactOnStreamingIngestWithDynamicPartition() throws Exception {
+    String dbName = "default";
+    String tblName = "cws";
+    String columnNamesProperty = "a,b";
+    String columnTypesProperty = "string:int";
+    String agentInfo = "UT_" + Thread.currentThread().getName();
+
+    executeStatementOnDriver("drop table if exists " + tblName, driver);
+    executeStatementOnDriver("CREATE TABLE " + tblName + "(a STRING) " +
+        " PARTITIONED BY (b INT)" + //currently ACID requires table to be bucketed
+        " STORED AS ORC  TBLPROPERTIES ('transactional'='true')", driver);
+
+    StrictDelimitedInputWriter writer1 = StrictDelimitedInputWriter.newBuilder()
+        .withFieldDelimiter(',')
+        .build();
+    StrictDelimitedInputWriter writer2 = StrictDelimitedInputWriter.newBuilder()
+        .withFieldDelimiter(',')
+        .build();
+
+    StreamingConnection connection1 = HiveStreamingConnection.newBuilder()
+        .withDatabase(dbName)
+        .withTable(tblName)
+        .withAgentInfo(agentInfo)
+        .withHiveConf(conf)
+        .withRecordWriter(writer1)
+        .withStreamingOptimizations(true)
+        // Transaction size has to be one or exception should happen.
+        .withTransactionBatchSize(1)
+        .connect();
+
+    StreamingConnection connection2 = HiveStreamingConnection.newBuilder()
+        .withDatabase(dbName)
+        .withTable(tblName)
+        .withAgentInfo(agentInfo)
+        .withHiveConf(conf)
+        .withRecordWriter(writer2)
+        .withStreamingOptimizations(true)
+        // Transaction size has to be one or exception should happen.
+        .withTransactionBatchSize(1)
+        .connect();
+
+    try {
+      connection1.beginTransaction();
+      connection1.write("1,1".getBytes());
+      connection1.commitTransaction();
+
+      connection1.beginTransaction();
+      connection1.write("1,1".getBytes());
+      connection1.commitTransaction();
+      connection1.close();
+
+      conf.setIntVar(HiveConf.ConfVars.HIVE_COMPACTOR_DELTA_NUM_THRESHOLD, 1);
+      runInitiator(conf);
+
+      TxnStore txnHandler = TxnUtils.getTxnStore(conf);
+      ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+
+      List<ShowCompactResponseElement> compacts1 = rsp.getCompacts();
+      Assert.assertEquals(1, compacts1.size());
+      SortedSet<String> partNames1 = new TreeSet<String>();
+      verifyCompactions(compacts1, partNames1, tblName);
+      List<String> names1 = new ArrayList<String>(partNames1);
+      Assert.assertEquals("b=1", names1.get(0));
+
+      runWorker(conf);
+      runCleaner(conf);
+
+      connection2.beginTransaction();
+      connection2.write("1,1".getBytes());
+      connection2.commitTransaction();
+
+      connection2.beginTransaction();
+      connection2.write("1,1".getBytes());
+      connection2.commitTransaction();
+      connection2.close();
+
+      runInitiator(conf);
+
+      List<ShowCompactResponseElement> compacts2 = rsp.getCompacts();
+      Assert.assertEquals(1, compacts2.size());
+      SortedSet<String> partNames2 = new TreeSet<String>();
+      verifyCompactions(compacts2, partNames2, tblName);
+      List<String> names2 = new ArrayList<String>(partNames2);
+      Assert.assertEquals("b=1", names2.get(0));
+
+      runWorker(conf);
+      runCleaner(conf);
+
+      // Find the location of the table
+      IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
+      Table table = msClient.getTable(dbName, tblName);
+      String tablePath = table.getSd().getLocation();
+      String partName = "b=1";
+      Path partPath = new Path(tablePath, partName);
+      FileSystem fs = FileSystem.get(conf);
+      FileStatus[] stat = fs.listStatus(partPath, AcidUtils.baseFileFilter);
+      if (1 != stat.length) {
+        Assert.fail("Expecting 1 file \"base_0000004\" and found " + stat.length + " files " + Arrays.toString(stat));
+      }
+      String name = stat[0].getPath().getName();
+      Assert.assertEquals("base_0000004_v0000008", name);
+      CompactorTestUtil
+          .checkExpectedTxnsPresent(stat[0].getPath(), null, columnNamesProperty, columnTypesProperty, 0, 1L, 4L, null,
+              1);
+    } finally {
+      if (connection1 != null) {
+        connection1.close();
+      }
+      if (connection2 != null) {
+        connection2.close();
+      }
+    }
+  }
+
+  @Test
   public void minorCompactAfterAbort() throws Exception {
     String dbName = "default";
     String tblName = "cws";

--- a/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
+++ b/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
@@ -393,6 +393,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
       entry.getValue().clear();
     }
     updaters.clear();
+    addedPartitions.clear();
     if (LOG.isDebugEnabled()) {
       logStats("Stats after close:");
     }
@@ -581,16 +582,9 @@ public abstract class AbstractRecordWriter implements RecordWriter {
           destLocation = new Path(table.getSd().getLocation());
         } else {
           PartitionInfo partitionInfo = conn.createPartitionIfNotExists(partitionValues);
-          // collect the newly added partitions. connection.commitTransaction() will report the dynamically added
-          // partitions to TxnHandler
-          if (!partitionInfo.isExists()) {
-            addedPartitions.add(partitionInfo.getName());
-          } else {
-            if (LOG.isDebugEnabled()) {
-              LOG.debug("Partition {} already exists for table {}",
-                  partitionInfo.getName(), fullyQualifiedTableName);
-            }
-          }
+          // collect the newly added/updated partitions. connection.commitTransaction() will report the dynamically
+          // added partitions to TxnHandler
+          addedPartitions.add(partitionInfo.getName());
           destLocation = new Path(partitionInfo.getPartitionLocation());
         }
         partitionPaths.put(key, destLocation);

--- a/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
+++ b/streaming/src/java/org/apache/hive/streaming/AbstractRecordWriter.java
@@ -77,7 +77,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
   protected String fullyQualifiedTableName;
   protected Map<String, List<RecordUpdater>> updaters = new HashMap<>();
   protected Map<String, Path> partitionPaths = new HashMap<>();
-  protected Set<String> addedPartitions = new HashSet<>();
+  protected Set<String> updatedPartitions = new HashSet<>();
   // input OI includes table columns + partition columns
   protected StructObjectInspector inputRowObjectInspector;
   // output OI strips off the partition columns and retains other columns
@@ -393,7 +393,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
       entry.getValue().clear();
     }
     updaters.clear();
-    addedPartitions.clear();
+    updatedPartitions.clear();
     if (LOG.isDebugEnabled()) {
       logStats("Stats after close:");
     }
@@ -494,9 +494,12 @@ public abstract class AbstractRecordWriter implements RecordWriter {
     }
   }
 
+  /**
+   * @return the list of newly added or updated partitions.
+   */
   @Override
   public Set<String> getPartitions() {
-    return addedPartitions;
+    return updatedPartitions;
   }
 
   protected RecordUpdater createRecordUpdater(List<String> partitionValues, final Path partitionPath,
@@ -584,7 +587,7 @@ public abstract class AbstractRecordWriter implements RecordWriter {
           PartitionInfo partitionInfo = conn.createPartitionIfNotExists(partitionValues);
           // collect the newly added/updated partitions. connection.commitTransaction() will report the dynamically
           // added partitions to TxnHandler
-          addedPartitions.add(partitionInfo.getName());
+          updatedPartitions.add(partitionInfo.getName());
           destLocation = new Path(partitionInfo.getPartitionLocation());
         }
         partitionPaths.put(key, destLocation);


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
We need to keep info about the updated partition as well, and pass this to addDynamicPartitions. Here i am reusing addedParitions, as I don't see any effect on stats either. Reviewers please suggest if you think it can affect.

### Why are the changes needed?
To fix automatic compaction in case of streaming ingest with dynamic partition.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added unit-test.
