### PR TITLE
HIVE-24021: Read insert-only tables truncated by Impala correctly

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -220,6 +220,10 @@ public class AcidUtils {
       if (name.startsWith(OrcAcidVersion.ACID_FORMAT)) {
         return true;
       }
+      // Don't filter out empty files
+      if (name.startsWith("_empty")) {
+        return true;
+      }
       return !name.startsWith("_") && !name.startsWith(".");
     }
   };

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -208,6 +208,7 @@ public class AcidUtils {
     }
   };
 
+  public static final String IMPALA_WROTE_EMPTY_FILE = "_empty";
   public static final PathFilter acidHiddenFileFilter = new PathFilter() {
     @Override
     public boolean accept(Path p) {
@@ -220,8 +221,8 @@ public class AcidUtils {
       if (name.startsWith(OrcAcidVersion.ACID_FORMAT)) {
         return true;
       }
-      // Don't filter out empty files
-      if (name.startsWith("_empty")) {
+      // Don't filter out empty files written by Impala
+      if (name.startsWith(IMPALA_WROTE_EMPTY_FILE)) {
         return true;
       }
       return !name.startsWith("_") && !name.startsWith(".");

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -3303,7 +3303,7 @@ public class Vectorizer implements PhysicalPlanResolver {
       smallTableIndicesSize = smallTableIndices.length;
     } else {
       smallTableIndices = null;
-      LOG.info("Vectorizer isBigTableOnlyResults smallTableIndices EMPTY");
+      LOG.info("Vectorizer isBigTableOnlyResults smallTableIndices IMPALA_WROTE_EMPTY_FILE");
       smallTableIndicesSize = 0;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -3303,7 +3303,7 @@ public class Vectorizer implements PhysicalPlanResolver {
       smallTableIndicesSize = smallTableIndices.length;
     } else {
       smallTableIndices = null;
-      LOG.info("Vectorizer isBigTableOnlyResults smallTableIndices IMPALA_WROTE_EMPTY_FILE");
+      LOG.info("Vectorizer isBigTableOnlyResults smallTableIndices EMPTY");
       smallTableIndicesSize = 0;
     }
 


### PR DESCRIPTION
This is the second PR for this change.


### Why are the changes needed?
Hive reads insert-only tables truncated by Impala as if the truncation hadn't happened.

### Does this PR introduce _any_ user-facing change?
Yes, getAcidState will not filter out files with names beginning with "_empty"


### How was this patch tested?
Unit test