### PR TITLE
[HIVE-24025] Add getAggrColStatsFor to the HS2 local cache

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1056,7 +1056,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(writeIdList);
 
-      return client.get_aggr_stats_for(req);
+      return getAggrStatsFromLocalCache(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -1064,6 +1064,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected AggrStats getAggrStatsFromLocalCache(PartitionsStatsRequest req) throws TException {
+    return client.get_aggr_stats_for(req);
   }
 
   @Override
@@ -2255,7 +2259,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = client.get_table_req(req).getTable();
+      Table t = getTableFromLocalCache(req);
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -2271,6 +2275,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   public Table getTable(String catName, String dbName, String tableName,
       String validWriteIdList) throws TException {
     return getTable(catName, dbName, tableName, validWriteIdList, false, null);
+  }
+
+  protected Table getTableFromLocalCache(GetTableRequest req) throws TException{
+    return client.get_table_req(req).getTable();
   }
 
   @Override
@@ -2296,7 +2304,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = client.get_table_req(req).getTable();
+      Table t = getTableFromLocalCache(req);
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -4000,7 +4008,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(getValidWriteIdList(TableName.getDbTable(dbName, tblName)));
 
-      return client.get_aggr_stats_for(req);
+      return getAggrStatsFromLocalCache(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1056,7 +1056,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(writeIdList);
 
-      return getAggrStatsFromLocalCache(req);
+      return getAggrStatsFor(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -1066,7 +1066,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
   }
 
-  protected AggrStats getAggrStatsFromLocalCache(PartitionsStatsRequest req) throws TException {
+  protected AggrStats getAggrStatsFor(PartitionsStatsRequest req) throws TException {
     return client.get_aggr_stats_for(req);
   }
 
@@ -2259,7 +2259,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = getTableFromLocalCache(req);
+      Table t = client.get_table_req(req).getTable();
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -2277,9 +2277,6 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return getTable(catName, dbName, tableName, validWriteIdList, false, null);
   }
 
-  protected Table getTableFromLocalCache(GetTableRequest req) throws TException{
-    return client.get_table_req(req).getTable();
-  }
 
   @Override
   public Table getTable(String catName, String dbName, String tableName, String validWriteIdList,
@@ -2304,7 +2301,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = getTableFromLocalCache(req);
+      Table t = client.get_table_req(req).getTable();
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -4008,7 +4005,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(getValidWriteIdList(TableName.getDbTable(dbName, tblName)));
 
-      return getAggrStatsFromLocalCache(req);
+      return getAggrStatsFor(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -4421,7 +4418,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
    * @param fullTableName
    * @return
    */
-  private String getValidWriteIdList(String fullTableName) {
+  protected String getValidWriteIdList(String fullTableName) {
     if (conf.get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY) == null) {
       return null;
     }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
@@ -135,7 +135,7 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
     }
   }
 
-  class PartitionsStatsCustomRequest {
+  public static class PartitionsStatsCustomRequest {
     PartitionsStatsRequest request;
     String validWriteIdList;
     long tableId;


### PR DESCRIPTION
getAggrColStats API takes a long time to run in HMS. Adding it to the HS2 local cache can reduce the query compilation time significantly.

https://issues.apache.org/jira/browse/HIVE-24025