### PR TITLE
HIVE-24030: Upgrade ORC to 1.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,7 +177,7 @@
     <log4j2.version>2.12.1</log4j2.version>
     <mariadb.version>2.5.0</mariadb.version>
     <opencsv.version>2.3</opencsv.version>
-    <orc.version>1.5.9</orc.version>
+    <orc.version>1.5.10</orc.version>
     <mockito-core.version>3.3.3</mockito-core.version>
     <powermock.version>2.0.2</powermock.version>
     <mina.version>2.0.0-M5</mina.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade ORC to 1.5.10.

### Why are the changes needed?

This will bring the latest bug fixes.
- [ORC-616 In Patched Base encoding, the value of headerThirdByte goes beyond the range of byte](https://issues.apache.org/jira/browse/ORC-616)
- [ORC-613 OrcMapredRecordReader mis-reuse struct object when actual children schema differs](https://issues.apache.org/jira/browse/ORC-613)

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI with the existing UTs.