### PR TITLE
HIVE-23998: Upgrade guava to 27 for Hive 2.3 branch

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JvmMetricsInfo.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JvmMetricsInfo.java
@@ -18,7 +18,7 @@
 
 package org.apache.hadoop.hive.common;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 import org.apache.hadoop.metrics2.MetricsInfo;
 
@@ -58,7 +58,7 @@ public enum JvmMetricsInfo implements MetricsInfo {
   @Override public String description() { return desc; }
 
   @Override public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/common/src/java/org/apache/hadoop/hive/common/JvmPauseMonitor.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JvmPauseMonitor.java
@@ -173,7 +173,7 @@ public class JvmPauseMonitor {
   private class Monitor implements Runnable {
     @Override
     public void run() {
-      Stopwatch sw = new Stopwatch();
+      Stopwatch sw = Stopwatch.createUnstarted();
       Map<String, GcTimes> gcTimesBeforeSleep = getGcTimes();
       while (shouldRun) {
         sw.reset().start();

--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandler.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandler.java
@@ -295,6 +295,11 @@ public class DruidStorageHandler extends DefaultHiveMetaHook implements HiveStor
           }
         }, new Predicate<Throwable>() {
           @Override
+          public boolean test(@Nullable Throwable input) {
+            return input instanceof IOException;
+          }
+
+          @Override
           public boolean apply(@Nullable Throwable input) {
             return input instanceof IOException;
           }
@@ -341,6 +346,18 @@ public class DruidStorageHandler extends DefaultHiveMetaHook implements HiveStor
       int numRetries = 0;
       while (numRetries++ < maxTries && !setOfUrls.isEmpty()) {
         setOfUrls = ImmutableSet.copyOf(Sets.filter(setOfUrls, new Predicate<URL>() {
+          @Override
+          public boolean test(URL input) {
+            try {
+              String result = DruidStorageHandlerUtils.getURL(httpClient, input);
+              LOG.debug(String.format("Checking segment [%s] response is [%s]", input, result));
+              return Strings.isNullOrEmpty(result);
+            } catch (IOException e) {
+              LOG.error(String.format("Error while checking URL [%s]", input), e);
+              return true;
+            }
+          }
+
           @Override
           public boolean apply(URL input) {
             try {

--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidQueryRecordReader.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidQueryRecordReader.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.druid.serde;
 
-import com.google.common.collect.Iterators;
 import com.metamx.common.lifecycle.Lifecycle;
 import com.metamx.http.client.HttpClient;
 import com.metamx.http.client.HttpClientConfig;
@@ -37,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -63,7 +63,8 @@ public abstract class DruidQueryRecordReader<T extends BaseQuery<R>, R extends C
   /**
    * Query results.
    */
-  protected Iterator<R> results = Iterators.emptyIterator();
+
+  protected Iterator<R> results = Collections.emptyIterator();
 
   @Override
   public void initialize(InputSplit split, TaskAttemptContext context) throws IOException {

--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidSelectQueryRecordReader.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidSelectQueryRecordReader.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.druid.serde;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,7 +28,6 @@ import org.apache.hadoop.hive.druid.DruidStorageHandlerUtils;
 import org.apache.hadoop.io.NullWritable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.Iterators;
 
 import io.druid.query.Result;
 import io.druid.query.select.EventHolder;
@@ -42,7 +42,7 @@ public class DruidSelectQueryRecordReader
 
   private Result<SelectResultValue> current;
 
-  private Iterator<EventHolder> values = Iterators.emptyIterator();
+  private Iterator<EventHolder> values = Collections.emptyIterator();
 
   @Override
   protected SelectQuery createQuery(String content) throws IOException {

--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidTopNQueryRecordReader.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/serde/DruidTopNQueryRecordReader.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.druid.serde;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -27,7 +28,6 @@ import org.apache.hadoop.hive.druid.DruidStorageHandlerUtils;
 import org.apache.hadoop.io.NullWritable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
-import com.google.common.collect.Iterators;
 
 import io.druid.query.Result;
 import io.druid.query.topn.DimensionAndMetricValueExtractor;
@@ -42,7 +42,7 @@ public class DruidTopNQueryRecordReader
 
   private Result<TopNResultValue> current;
 
-  private Iterator<DimensionAndMetricValueExtractor> values = Iterators.emptyIterator();
+  private Iterator<DimensionAndMetricValueExtractor> values = Collections.emptyIterator();
 
   @Override
   protected TopNQuery createQuery(String content) throws IOException {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/io/TestHadoopFileStatus.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/io/TestHadoopFileStatus.java
@@ -80,6 +80,14 @@ public class TestHadoopFileStatus {
     Assert.assertTrue(sourceStatus.getAclEntries().size() == 3);
     Iterables.removeIf(sourceStatus.getAclEntries(), new Predicate<AclEntry>() {
       @Override
+      public boolean test(AclEntry input) {
+        if (input.getName() == null) {
+          return true;
+        }
+        return false;
+      }
+
+      @Override
       public boolean apply(AclEntry input) {
         if (input.getName() == null) {
           return true;

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestServiceDiscovery.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestServiceDiscovery.java
@@ -144,6 +144,12 @@ public class TestServiceDiscovery {
     }
 
     @Override
+    public boolean test(ConnParamInfo inputParam) {
+      return inputParam.host.equals(host) && inputParam.port == port &&
+              inputParam.path.startsWith(pathPrefix);
+    }
+
+    @Override
     public boolean apply(ConnParamInfo inputParam) {
       return inputParam.host.equals(host) && inputParam.port == port &&
         inputParam.path.startsWith(pathPrefix);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -153,7 +153,7 @@ public class CoreCliDriver extends CliAdapter {
 
   @Override
   public void runTest(String tname, String fname, String fpath) throws Exception {
-    Stopwatch sw = new Stopwatch().start();
+    Stopwatch sw = Stopwatch.createStarted();
     boolean skipped = false;
     boolean failed = false;
     try {

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/security/authorization/plugin/sqlstd/SQLStdHiveAuthorizationValidatorForTest.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/security/authorization/plugin/sqlstd/SQLStdHiveAuthorizationValidatorForTest.java
@@ -80,6 +80,15 @@ public class SQLStdHiveAuthorizationValidatorForTest extends SQLStdHiveAuthoriza
     } else {
       return Lists.newArrayList(Iterables.filter(privilegeObjects,new Predicate<HivePrivilegeObject>() {
         @Override
+        public boolean test(@Nullable HivePrivilegeObject hivePrivilegeObject) {
+          // Return true to retain an item, and false to filter it out.
+          if (hivePrivilegeObject == null){
+            return true;
+          }
+          return !bypassObjectTypes.contains(hivePrivilegeObject.getType());
+        }
+
+        @Override
         public boolean apply(@Nullable HivePrivilegeObject hivePrivilegeObject) {
           // Return true to retain an item, and false to filter it out.
           if (hivePrivilegeObject == null){

--- a/itests/util/src/main/java/org/apache/hadoop/hive/util/ElapsedTimeLoggingWrapper.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/util/ElapsedTimeLoggingWrapper.java
@@ -28,7 +28,7 @@ public abstract class ElapsedTimeLoggingWrapper<T> {
   public abstract T invokeInternal() throws Exception;
 
   public T invoke(String message, Logger LOG, boolean toStdErr) throws Exception {
-    Stopwatch sw = new Stopwatch().start();
+    Stopwatch sw = Stopwatch.createStarted();
     try {
       T retVal = invokeInternal();
       return retVal;

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/tez/LlapProtocolClientProxy.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/tez/LlapProtocolClientProxy.java
@@ -131,7 +131,7 @@ public class LlapProtocolClientProxy extends AbstractService {
       public void onFailure(Throwable t) {
         LOG.warn("RequestManager shutdown with error", t);
       }
-    });
+    }, requestManagerExecutor);
   }
 
   @Override
@@ -263,7 +263,7 @@ public class LlapProtocolClientProxy extends AbstractService {
     void submitToExecutor(CallableRequest request, LlapNodeId nodeId) {
       ListenableFuture<SourceStateUpdatedResponseProto> future =
           executor.submit(request);
-      Futures.addCallback(future, new ResponseCallback(request.getCallback(), nodeId, this));
+      Futures.addCallback(future, new ResponseCallback(request.getCallback(), nodeId, this), executor);
     }
 
     @VisibleForTesting

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
@@ -176,7 +176,7 @@ public class AMReporter extends AbstractService {
           Thread.getDefaultUncaughtExceptionHandler().uncaughtException(Thread.currentThread(), t);
         }
       }
-    });
+    }, queueLookupExecutor);
     // TODO: why is this needed? we could just save the host and port?
     nodeId = LlapNodeId.getInstance(localAddress.get().getHostName(), localAddress.get().getPort());
     LOG.info("AMReporter running with DaemonId: {}, NodeId: {}", daemonId, nodeId);
@@ -271,7 +271,7 @@ public class AMReporter extends AbstractService {
         LOG.warn("Failed to send taskKilled for {}. The attempt will likely time out.",
             taskAttemptId);
       }
-    });
+    }, executor);
   }
 
   public void queryComplete(QueryIdentifier queryIdentifier) {
@@ -337,7 +337,7 @@ public class AMReporter extends AbstractService {
                     amNodeInfo.amNodeId, currentQueryIdentifier, t);
                   queryFailedHandler.queryFailed(currentQueryIdentifier);
                 }
-              });
+              }, executor);
             }
           }
         } catch (InterruptedException e) {

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapTaskReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapTaskReporter.java
@@ -123,7 +123,7 @@ public class LlapTaskReporter implements TaskReporterInterface {
     currentCallable = new HeartbeatCallable(completionListener, task, umbilical, pollInterval, sendCounterInterval,
         maxEventsToGet, requestCounter, containerIdStr, initialEvent, fragmentRequestId);
     ListenableFuture<Boolean> future = heartbeatExecutor.submit(currentCallable);
-    Futures.addCallback(future, new HeartbeatCallback(errorReporter));
+    Futures.addCallback(future, new HeartbeatCallback(errorReporter), heartbeatExecutor);
   }
 
   /**

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -168,7 +168,7 @@ public class TaskExecutorService extends AbstractService
     executionCompletionExecutorService = MoreExecutors.listeningDecorator(
         executionCompletionExecutorServiceRaw);
     ListenableFuture<?> future = waitQueueExecutorService.submit(new WaitQueueWorker());
-    Futures.addCallback(future, new WaitQueueWorkerCallback());
+    Futures.addCallback(future, new WaitQueueWorkerCallback(), waitQueueExecutorService);
   }
 
   private Comparator<TaskWrapper> createComparator(

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskRunnerCallable.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskRunnerCallable.java
@@ -113,8 +113,8 @@ public class TaskRunnerCallable extends CallableWithNdc<TaskRunner2Result> {
   private final String queryId;
   private final HadoopShim tezHadoopShim;
   private boolean shouldRunTask = true;
-  final Stopwatch runtimeWatch = new Stopwatch();
-  final Stopwatch killtimerWatch = new Stopwatch();
+  final Stopwatch runtimeWatch = Stopwatch.createUnstarted();
+  final Stopwatch killtimerWatch = Stopwatch.createUnstarted();
   private final AtomicBoolean isStarted = new AtomicBoolean(false);
   private final AtomicBoolean isCompleted = new AtomicBoolean(false);
   private final AtomicBoolean killInvoked = new AtomicBoolean(false);
@@ -275,7 +275,7 @@ public class TaskRunnerCallable extends CallableWithNdc<TaskRunner2Result> {
         } finally {
           FileSystem.closeAllForUGI(fsTaskUgi);
           LOG.info("ExecutionTime for Container: " + request.getContainerIdString() + "=" +
-                  runtimeWatch.stop().elapsedMillis());
+                  runtimeWatch.stop().elapsed(TimeUnit.MILLISECONDS));
           if (LOG.isDebugEnabled()) {
             LOG.debug(
                 "canFinish post completion: " + taskSpec.getTaskAttemptID() + ": " + canFinish());
@@ -501,14 +501,14 @@ public class TaskRunnerCallable extends CallableWithNdc<TaskRunner2Result> {
           LOG.info("Killed task {}", requestId);
           if (killtimerWatch.isRunning()) {
             killtimerWatch.stop();
-            long elapsed = killtimerWatch.elapsedMillis();
+            long elapsed = killtimerWatch.elapsed(TimeUnit.MILLISECONDS);
             LOG.info("Time to die for task {}", elapsed);
             if (metrics != null) {
               metrics.addMetricsPreemptionTimeToKill(elapsed);
             }
           }
           if (metrics != null) {
-            metrics.addMetricsPreemptionTimeLost(runtimeWatch.elapsedMillis());
+            metrics.addMetricsPreemptionTimeLost(runtimeWatch.elapsed(TimeUnit.MILLISECONDS));
             metrics.incrExecutorTotalKilled();
           }
           break;

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonCacheInfo.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonCacheInfo.java
@@ -17,9 +17,8 @@
  */
 package org.apache.hadoop.hive.llap.metrics;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.metrics2.MetricsInfo;
-
-import com.google.common.base.Objects;
 
 /**
  * Metrics information for llap cache.
@@ -50,7 +49,7 @@ public enum LlapDaemonCacheInfo implements MetricsInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorInfo.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonExecutorInfo.java
@@ -17,9 +17,8 @@
  */
 package org.apache.hadoop.hive.llap.metrics;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.metrics2.MetricsInfo;
-
-import com.google.common.base.Objects;
 
 /**
  * Metrics information for llap daemon container.
@@ -74,7 +73,7 @@ public enum LlapDaemonExecutorInfo implements MetricsInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonIOInfo.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonIOInfo.java
@@ -17,9 +17,8 @@
  */
 package org.apache.hadoop.hive.llap.metrics;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.metrics2.MetricsInfo;
-
-import com.google.common.base.Objects;
 
 /**
  * Llap daemon I/O elevator metrics
@@ -42,7 +41,7 @@ public enum LlapDaemonIOInfo implements MetricsInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonJvmInfo.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/metrics/LlapDaemonJvmInfo.java
@@ -17,9 +17,8 @@
  */
 package org.apache.hadoop.hive.llap.metrics;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.metrics2.MetricsInfo;
-
-import com.google.common.base.Objects;
 
 /**
  * Llap daemon JVM info. These are some additional metrics that are not exposed via
@@ -53,7 +52,7 @@ public enum LlapDaemonJvmInfo implements MetricsInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
       .add("name", name()).add("description", desc)
       .toString();
   }

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -317,15 +317,15 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       }, 10000L, TimeUnit.MILLISECONDS);
 
       nodeEnablerFuture = nodeEnabledExecutor.submit(nodeEnablerCallable);
-      Futures.addCallback(nodeEnablerFuture, new LoggingFutureCallback("NodeEnablerThread", LOG));
+      Futures.addCallback(nodeEnablerFuture, new LoggingFutureCallback("NodeEnablerThread", LOG), nodeEnabledExecutor);
 
       delayedTaskSchedulerFuture =
           delayedTaskSchedulerExecutor.submit(delayedTaskSchedulerCallable);
       Futures.addCallback(delayedTaskSchedulerFuture,
-          new LoggingFutureCallback("DelayedTaskSchedulerThread", LOG));
+          new LoggingFutureCallback("DelayedTaskSchedulerThread", LOG), delayedTaskSchedulerExecutor);
 
       schedulerFuture = schedulerExecutor.submit(schedulerCallable);
-      Futures.addCallback(schedulerFuture, new LoggingFutureCallback("SchedulerThread", LOG));
+      Futures.addCallback(schedulerFuture, new LoggingFutureCallback("SchedulerThread", LOG), schedulerExecutor);
 
       registry.start();
       registry.registerStateChangeListener(new NodeStateChangeListener());

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerInfo.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/metrics/LlapTaskSchedulerInfo.java
@@ -17,9 +17,8 @@
  */
 package org.apache.hadoop.hive.llap.tezplugins.metrics;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.metrics2.MetricsInfo;
-
-import com.google.common.base.Objects;
 
 /**
  * Metrics information for llap task scheduler.
@@ -52,7 +51,7 @@ public enum LlapTaskSchedulerInfo implements MetricsInfo {
 
   @Override
   public String toString() {
-    return Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("name", name()).add("description", desc)
         .toString();
   }

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/hbase/TephraHBaseConnection.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/hbase/TephraHBaseConnection.java
@@ -61,7 +61,8 @@ public class TephraHBaseConnection extends VanillaHBaseConnection {
     if (HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_IN_TEST)) {
       LOG.debug("Using an in memory client transaction system for testing");
       TransactionManager txnMgr = new TransactionManager(conf);
-      txnMgr.startAndWait();
+      txnMgr.startAsync();
+      txnMgr.awaitRunning();
       txnClient = new InMemoryTxSystemClient(txnMgr);
     } else {
       // TODO should enable use of ZKDiscoveryService if users want it

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dropwizard.version>3.1.0</dropwizard.version>
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
     <druid.version>0.9.2</druid.version>
-    <guava.version>14.0.1</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <groovy.version>2.4.4</groovy.version>
     <h2database.version>1.3.166</h2database.version>
     <hadoop.version>2.7.2</hadoop.version>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -105,7 +106,7 @@ public class FetchOperator implements Serializable {
 
   private transient Iterator<Path> iterPath;
   private transient Iterator<PartitionDesc> iterPartDesc;
-  private transient Iterator<FetchInputFormatSplit> iterSplits = Iterators.emptyIterator();
+  private transient Iterator<FetchInputFormatSplit> iterSplits = Collections.emptyIterator();
 
   private transient Path currPath;
   private transient PartitionDesc currDesc;
@@ -540,7 +541,7 @@ public class FetchOperator implements Serializable {
       this.currPath = null;
       this.iterPath = null;
       this.iterPartDesc = null;
-      this.iterSplits = Iterators.emptyIterator();
+      this.iterSplits = Collections.emptyIterator();
     } catch (Exception e) {
       throw new HiveException("Failed with exception " + e.getMessage()
           + StringUtils.stringifyException(e));

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/LineageLogger.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/LineageLogger.java
@@ -461,7 +461,7 @@ public class LineageLogger implements ExecuteWithHookContext {
    */
   private String getQueryHash(String queryStr) {
     Hasher hasher = Hashing.md5().newHasher();
-    hasher.putString(queryStr);
+    hasher.putUnencodedChars(queryStr);
     return hasher.hash().toString();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreChecker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveMetaStoreChecker.java
@@ -433,7 +433,7 @@ public class HiveMetaStoreChecker {
     ExecutorService executor;
     if (poolSize <= 1) {
       LOG.debug("Using single-threaded version of MSCK-GetPaths");
-      executor = MoreExecutors.sameThreadExecutor();
+      executor = MoreExecutors.newDirectExecutorService();
     } else {
       LOG.debug("Using multi-threaded version of MSCK-GetPaths with number of threads " + poolSize);
       ThreadFactory threadFactory =

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/SubstitutionVisitor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/SubstitutionVisitor.java
@@ -2413,6 +2413,10 @@ public class SubstitutionVisitor {
   public static class FilterOnProjectRule extends RelOptRule {
     private static final Predicate<Filter> PREDICATE =
         new Predicate<Filter>() {
+          public boolean test(Filter input) {
+            return input.getCondition() instanceof RexInputRef;
+          }
+
           public boolean apply(Filter input) {
             return input.getCondition() instanceof RexInputRef;
           }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveRelMdPredicates.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/stats/HiveRelMdPredicates.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.stats;
 
 import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -532,7 +533,7 @@ public class HiveRelMdPredicates implements MetadataHandler<BuiltInMetadata.Pred
         public Iterator<Mapping> iterator() {
           ImmutableBitSet fields = exprFields.get(predicate.toString());
           if (fields.cardinality() == 0) {
-            return Iterators.emptyIterator();
+            return Collections.emptyIterator();
           }
           return new ExprsItr(fields);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AnnotateRunTimeStatsOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/AnnotateRunTimeStatsOptimizer.java
@@ -18,13 +18,7 @@
 package org.apache.hadoop.hive.ql.optimizer.physical;
 
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.Stack;
+import java.util.*;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,16 +67,16 @@ public class AnnotateRunTimeStatsOptimizer implements PhysicalPlanResolver {
 
       if (currTask instanceof MapRedTask) {
         MapRedTask mr = (MapRedTask) currTask;
-        ops.addAll(mr.getWork().getAllOperators());
+        ops.addAll((List<Operator<? extends OperatorDesc>>) mr.getWork().getAllOperators());
       } else if (currTask instanceof TezTask) {
         TezWork work = ((TezTask) currTask).getWork();
         for (BaseWork w : work.getAllWork()) {
-          ops.addAll(w.getAllOperators());
+          ops.addAll((Set<Operator<? extends OperatorDesc>>) w.getAllOperators());
         }
       } else if (currTask instanceof SparkTask) {
         SparkWork sparkWork = (SparkWork) currTask.getWork();
         for (BaseWork w : sparkWork.getAllWork()) {
-          ops.addAll(w.getAllOperators());
+          ops.addAll((Set<Operator<? extends OperatorDesc>>) w.getAllOperators());
         }
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSpec.java
@@ -250,8 +250,16 @@ public class ReplicationSpec {
   public Predicate<Partition> allowEventReplacementInto() {
     return new Predicate<Partition>() {
       @Override
+      public boolean test(@Nullable Partition partition) {
+        if (partition == null) {
+            return false;
+        }
+        return (allowEventReplacementInto(partition));
+      }
+
+      @Override
       public boolean apply(@Nullable Partition partition) {
-        if (partition == null){
+        if (partition == null) {
           return false;
         }
         return (allowEventReplacementInto(partition));

--- a/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
+++ b/service/src/java/org/apache/hive/service/cli/session/SessionManager.java
@@ -134,6 +134,11 @@ public class SessionManager extends CompositeService {
       public Integer getValue() {
         Iterable<HiveSession> filtered = Iterables.filter(getSessions(), new Predicate<HiveSession>() {
           @Override
+          public boolean test(HiveSession hiveSession) {
+            return hiveSession.getNoOperationTime() == 0L;
+          }
+
+          @Override
           public boolean apply(HiveSession hiveSession) {
             return hiveSession.getNoOperationTime() == 0L;
           }

--- a/shims/common/src/main/java/org/apache/hadoop/hive/io/HdfsUtils.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/io/HdfsUtils.java
@@ -187,6 +187,13 @@ public class HdfsUtils {
   private static void removeBaseAclEntries(List<AclEntry> entries) {
     Iterables.removeIf(entries, new Predicate<AclEntry>() {
       @Override
+      public boolean test(AclEntry input) {
+        if (input.getName() == null) {
+          return true;
+        }
+        return false;
+      }
+      @Override
       public boolean apply(AclEntry input) {
         if (input.getName() == null) {
           return true;

--- a/spark-client/src/main/java/org/apache/hive/spark/client/MetricsCollection.java
+++ b/spark-client/src/main/java/org/apache/hive/spark/client/MetricsCollection.java
@@ -101,6 +101,10 @@ public class MetricsCollection {
   public Metrics getTaskMetrics(final int jobId, final int stageId, final long taskId) {
     Predicate<TaskInfo> filter = new Predicate<TaskInfo>() {
       @Override
+      public boolean test(TaskInfo input) {
+        return jobId == input.jobId && stageId == input.stageId && taskId == input.taskId;
+      }
+      @Override
       public boolean apply(TaskInfo input) {
         return jobId == input.jobId && stageId == input.stageId && taskId == input.taskId;
       }
@@ -258,6 +262,10 @@ public class MetricsCollection {
       return jobId == input.jobId;
     }
 
+    @Override
+    public boolean test(TaskInfo input) {
+      return jobId == input.jobId;
+    }
   }
 
   private static class StageFilter implements Predicate<TaskInfo> {
@@ -275,6 +283,10 @@ public class MetricsCollection {
       return jobId == input.jobId && stageId == input.stageId;
     }
 
+    @Override
+    public boolean test(TaskInfo input) {
+      return jobId == input.jobId && stageId == input.stageId;
+    }
   }
 
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

This PR proposes to upgrade Guava to 27 in Hive 2.3 branch.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

When trying to upgrade Guava in Spark, found the following error. A Guava method became package-private since Guava version 20. So there is incompatibility with Guava versions > 19.0.

```
sbt.ForkMain$ForkError: sbt.ForkMain$ForkError: java.lang.IllegalAccessError: tried to access method com.google.common.collect.Iterators.emptyIterator()Lcom/google/common/collect/UnmodifiableIterator; from class org.apache.hadoop.hive.ql.exec.FetchOperator
	at org.apache.hadoop.hive.ql.exec.FetchOperator.<init>(FetchOperator.java:108)
	at org.apache.hadoop.hive.ql.exec.FetchTask.initialize(FetchTask.java:87)
	at org.apache.hadoop.hive.ql.Driver.compile(Driver.java:541)
	at org.apache.hadoop.hive.ql.Driver.compileInternal(Driver.java:1317)
	at org.apache.hadoop.hive.ql.Driver.runInternal(Driver.java:1457)
	at org.apache.hadoop.hive.ql.Driver.run(Driver.java:1237)
	at org.apache.hadoop.hive.ql.Driver.run(Driver.java:1227)
```

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->

Yes. This upgrades Guava to 27.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

Built Hive locally.