### PR TITLE
HIVE-18284: Fix NPE when inserting data with 'distribute by' clause with dynpart sort optimization

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -7,6 +7,7 @@ minimr.query.files=\
 # Queries ran by both MiniLlapLocal and MiniTez
 minitez.query.files.shared=\
   compressed_skip_header_footer_aggr.q,\
+  dynpart_sort_optimization_distribute_by.q,\
   hybridgrace_hashjoin_1.q,\
   hybridgrace_hashjoin_2.q
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplicationUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplicationUtils.java
@@ -17,10 +17,12 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.correlation;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 
+import com.google.common.collect.Lists;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
@@ -181,6 +183,23 @@ public class ReduceSinkDeDuplicationUtils {
         TableDesc keyTable = PlanUtils.getReduceKeyTableDesc(new ArrayList<FieldSchema>(), pRS
             .getConf().getOrder(), pRS.getConf().getNullOrder());
         pRS.getConf().setKeySerializeInfo(keyTable);
+      } else if (cRS.getConf().getKeyCols() != null && cRS.getConf().getKeyCols().size() > 0) {
+        ArrayList<String> keyColNames = Lists.newArrayList();
+        for (ExprNodeDesc keyCol : pRS.getConf().getKeyCols()) {
+          String keyColName = keyCol.getExprString();
+          keyColNames.add(keyColName);
+        }
+        List<FieldSchema> fields = PlanUtils.getFieldSchemasFromColumnList(pRS.getConf().getKeyCols(),
+            keyColNames, 0, "");
+        TableDesc keyTable = PlanUtils.getReduceKeyTableDesc(fields, pRS.getConf().getOrder(),
+            pRS.getConf().getNullOrder());
+        ArrayList<String> outputKeyCols = Lists.newArrayList();
+        for (int i = 0; i < fields.size(); i++) {
+          outputKeyCols.add(fields.get(i).getName());
+        }
+        pRS.getConf().setOutputKeyColumnNames(outputKeyCols);
+        pRS.getConf().setKeySerializeInfo(keyTable);
+        pRS.getConf().setNumDistributionKeys(cRS.getConf().getNumDistributionKeys());
       }
     }
     return true;

--- a/ql/src/test/queries/clientpositive/dynpart_sort_optimization_distribute_by.q
+++ b/ql/src/test/queries/clientpositive/dynpart_sort_optimization_distribute_by.q
@@ -1,0 +1,26 @@
+set hive.exec.dynamic.partition.mode=nonstrict;
+set hive.optimize.sort.dynamic.partition=true;
+set hive.vectorized.execution.enabled=false;
+
+
+create table table1 (col1 string, datekey int);
+insert into table1 values ('ROW1', 1), ('ROW2', 2), ('ROW3', 1);
+create table table2 (col1 string) partitioned by (datekey int);
+
+explain extended insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey;
+
+
+insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey;
+
+select * from table1;
+select * from table2;

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization_distribute_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization_distribute_by.q.out
@@ -1,0 +1,279 @@
+PREHOOK: query: create table table1 (col1 string, datekey int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table1
+POSTHOOK: query: create table table1 (col1 string, datekey int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table1
+PREHOOK: query: insert into table1 values ('ROW1', 1), ('ROW2', 2), ('ROW3', 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table1
+POSTHOOK: query: insert into table1 values ('ROW1', 1), ('ROW2', 2), ('ROW3', 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table1
+POSTHOOK: Lineage: table1.col1 SCRIPT []
+POSTHOOK: Lineage: table1.datekey SCRIPT []
+PREHOOK: query: create table table2 (col1 string) partitioned by (datekey int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table2
+POSTHOOK: query: create table table2 (col1 string) partitioned by (datekey int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table2
+PREHOOK: query: explain extended insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+PREHOOK: Output: default@table2
+POSTHOOK: query: explain extended insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+POSTHOOK: Output: default@table2
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: table1
+                  Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
+                  Select Operator
+                    expressions: col1 (type: string), datekey (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      bucketingVersion: 2
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      numBuckets: -1
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                      tag: -1
+                      value expressions: _col0 (type: string), _col1 (type: int)
+                      auto parallelism: true
+            Execution mode: llap
+            LLAP IO: all inputs
+            Path -> Alias:
+#### A masked pattern was here ####
+            Path -> Partition:
+#### A masked pattern was here ####
+                Partition
+                  base file name: table1
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  properties:
+                    bucket_count -1
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns col1,datekey
+                    columns.types string:int
+#### A masked pattern was here ####
+                    name default.table1
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns col1,datekey
+                      columns.comments 
+                      columns.types string:int
+#### A masked pattern was here ####
+                      name default.table1
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.table1
+                  name: default.table1
+            Truncated Path -> Alias:
+              /table1 [table1]
+        Reducer 2 
+            Execution mode: llap
+            Needs Tagging: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: string), VALUE._col1 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  bucketingVersion: 2
+                  compressed: false
+                  GlobalTableId: 1
+#### A masked pattern was here ####
+                  NumFilesPerFileSink: 1
+                  Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
+                  table:
+                      input format: org.apache.hadoop.mapred.TextInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                      properties:
+                        bucketing_version 2
+                        column.name.delimiter ,
+                        columns col1
+                        columns.comments 
+                        columns.types string
+#### A masked pattern was here ####
+                        name default.table2
+                        partition_columns datekey
+                        partition_columns.types int
+                        serialization.format 1
+                        serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                      name: default.table2
+                  TotalFiles: 1
+                  GatherStats: true
+                  MultiFileSpray: false
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: int)
+                  outputColumnNames: col1, datekey
+                  Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector(col1, 'hll')
+                    keys: datekey (type: int)
+                    mode: complete
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                    Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col1,0)) (type: bigint), COALESCE(_col2,0) (type: double), (_col3 - _col4) (type: bigint), COALESCE(ndv_compute_bit_vector(_col5),0) (type: bigint), _col5 (type: binary), _col0 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 1 Data size: 270 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        bucketingVersion: 2
+                        compressed: false
+                        GlobalTableId: 0
+#### A masked pattern was here ####
+                        NumFilesPerFileSink: 1
+                        Statistics: Num rows: 1 Data size: 270 Basic stats: COMPLETE Column stats: COMPLETE
+#### A masked pattern was here ####
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            properties:
+                              bucketing_version -1
+                              columns _col0,_col1,_col2,_col3,_col4,_col5,_col6
+                              columns.types string:bigint:double:bigint:bigint:binary:int
+                              escape.delim \
+                              hive.serialization.extend.additional.nesting.levels true
+                              serialization.escape.crlf true
+                              serialization.format 1
+                              serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        TotalFiles: 1
+                        GatherStats: false
+                        MultiFileSpray: false
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            datekey 
+          replace: false
+#### A masked pattern was here ####
+          table:
+              input format: org.apache.hadoop.mapred.TextInputFormat
+              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+              properties:
+                bucketing_version 2
+                column.name.delimiter ,
+                columns col1
+                columns.comments 
+                columns.types string
+#### A masked pattern was here ####
+                name default.table2
+                partition_columns datekey
+                partition_columns.types int
+                serialization.format 1
+                serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              name: default.table2
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+#### A masked pattern was here ####
+      Column Stats Desc:
+          Columns: col1
+          Column Types: string
+          Table: default.table2
+          Is Table Level Stats: false
+
+PREHOOK: query: insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+PREHOOK: Output: default@table2
+POSTHOOK: query: insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+POSTHOOK: Output: default@table2
+POSTHOOK: Output: default@table2@datekey=1
+POSTHOOK: Output: default@table2@datekey=2
+POSTHOOK: Lineage: table2 PARTITION(datekey=1).col1 SIMPLE [(table1)table1.FieldSchema(name:col1, type:string, comment:null), ]
+POSTHOOK: Lineage: table2 PARTITION(datekey=2).col1 SIMPLE [(table1)table1.FieldSchema(name:col1, type:string, comment:null), ]
+PREHOOK: query: select * from table1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+#### A masked pattern was here ####
+POSTHOOK: query: select * from table1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+#### A masked pattern was here ####
+ROW1	1
+ROW2	2
+ROW3	1
+PREHOOK: query: select * from table2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table2
+PREHOOK: Input: default@table2@datekey=1
+PREHOOK: Input: default@table2@datekey=2
+#### A masked pattern was here ####
+POSTHOOK: query: select * from table2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table2
+POSTHOOK: Input: default@table2@datekey=1
+POSTHOOK: Input: default@table2@datekey=2
+#### A masked pattern was here ####
+ROW1	1
+ROW3	1
+ROW2	2

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization_distribute_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization_distribute_by.q.out
@@ -157,7 +157,7 @@ STAGE PLANS:
                   outputColumnNames: col1, datekey
                   Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
-                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector(col1, 'hll')
+                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector_hll(col1)
                     keys: datekey (type: int)
                     mode: complete
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5

--- a/ql/src/test/results/clientpositive/tez/dynpart_sort_optimization_distribute_by.q.out
+++ b/ql/src/test/results/clientpositive/tez/dynpart_sort_optimization_distribute_by.q.out
@@ -1,0 +1,284 @@
+PREHOOK: query: create table table1 (col1 string, datekey int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table1
+POSTHOOK: query: create table table1 (col1 string, datekey int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table1
+PREHOOK: query: insert into table1 values ('ROW1', 1), ('ROW2', 2), ('ROW3', 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table1
+POSTHOOK: query: insert into table1 values ('ROW1', 1), ('ROW2', 2), ('ROW3', 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table1
+POSTHOOK: Lineage: table1.col1 SCRIPT []
+POSTHOOK: Lineage: table1.datekey SCRIPT []
+PREHOOK: query: create table table2 (col1 string) partitioned by (datekey int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table2
+POSTHOOK: query: create table table2 (col1 string) partitioned by (datekey int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table2
+PREHOOK: query: explain extended insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+PREHOOK: Output: default@table2
+POSTHOOK: query: explain extended insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+POSTHOOK: Output: default@table2
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: table1
+                  Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                  GatherStats: false
+                  Select Operator
+                    expressions: col1 (type: string), datekey (type: int)
+                    outputColumnNames: _col0, _col1
+                    Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      bucketingVersion: 2
+                      key expressions: _col1 (type: int)
+                      null sort order: a
+                      numBuckets: -1
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                      tag: -1
+                      value expressions: _col0 (type: string), _col1 (type: int)
+                      auto parallelism: true
+            Path -> Alias:
+              hdfs://### HDFS PATH ### [table1]
+            Path -> Partition:
+              hdfs://### HDFS PATH ### 
+                Partition
+                  base file name: table1
+                  input format: org.apache.hadoop.mapred.TextInputFormat
+                  output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                  properties:
+                    bucket_count -1
+                    bucketing_version 2
+                    column.name.delimiter ,
+                    columns col1,datekey
+                    columns.types string:int
+#### A masked pattern was here ####
+                    location hdfs://### HDFS PATH ###
+                    name default.table1
+                    serialization.format 1
+                    serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                
+                    input format: org.apache.hadoop.mapred.TextInputFormat
+                    output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                    properties:
+                      bucketing_version 2
+                      column.name.delimiter ,
+                      columns col1,datekey
+                      columns.comments 
+                      columns.types string:int
+#### A masked pattern was here ####
+                      location hdfs://### HDFS PATH ###
+                      name default.table1
+                      serialization.format 1
+                      serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    name: default.table1
+                  name: default.table1
+            Truncated Path -> Alias:
+              /table1 [table1]
+        Reducer 2 
+            Needs Tagging: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: string), VALUE._col1 (type: int)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: int)
+                  outputColumnNames: col1, datekey
+                  Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector(col1, 'hll')
+                    keys: datekey (type: int)
+                    mode: complete
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                    Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: 'STRING' (type: string), UDFToLong(COALESCE(_col1,0)) (type: bigint), COALESCE(_col2,0) (type: double), (_col3 - _col4) (type: bigint), COALESCE(ndv_compute_bit_vector(_col5),0) (type: bigint), _col5 (type: binary), _col0 (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                      Statistics: Num rows: 1 Data size: 270 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        bucketingVersion: 2
+                        compressed: false
+                        GlobalTableId: 0
+                        directory: hdfs://### HDFS PATH ###
+                        NumFilesPerFileSink: 1
+                        Statistics: Num rows: 1 Data size: 270 Basic stats: COMPLETE Column stats: COMPLETE
+                        Stats Publishing Key Prefix: hdfs://### HDFS PATH ###
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            properties:
+                              bucketing_version -1
+                              columns _col0,_col1,_col2,_col3,_col4,_col5,_col6
+                              columns.types string:bigint:double:bigint:bigint:binary:int
+                              escape.delim \
+                              hive.serialization.extend.additional.nesting.levels true
+                              serialization.escape.crlf true
+                              serialization.format 1
+                              serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        TotalFiles: 1
+                        GatherStats: false
+                        MultiFileSpray: false
+                Select Operator
+                  expressions: _col0 (type: string), _col1 (type: int)
+                  outputColumnNames: _col0, _col1
+                  File Output Operator
+                    bucketingVersion: 2
+                    compressed: false
+                    GlobalTableId: 1
+                    directory: hdfs://### HDFS PATH ###
+                    Dp Sort State: PARTITION_SORTED
+                    NumFilesPerFileSink: 1
+                    Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
+                    Stats Publishing Key Prefix: hdfs://### HDFS PATH ###
+                    table:
+                        input format: org.apache.hadoop.mapred.TextInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+                        properties:
+                          bucketing_version 2
+                          column.name.delimiter ,
+                          columns col1
+                          columns.comments 
+                          columns.types string
+#### A masked pattern was here ####
+                          location hdfs://### HDFS PATH ###
+                          name default.table2
+                          partition_columns datekey
+                          partition_columns.types int
+                          serialization.format 1
+                          serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                        name: default.table2
+                    TotalFiles: 1
+                    GatherStats: true
+                    MultiFileSpray: false
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            datekey 
+          replace: false
+          source: hdfs://### HDFS PATH ###
+          table:
+              input format: org.apache.hadoop.mapred.TextInputFormat
+              output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
+              properties:
+                bucketing_version 2
+                column.name.delimiter ,
+                columns col1
+                columns.comments 
+                columns.types string
+#### A masked pattern was here ####
+                location hdfs://### HDFS PATH ###
+                name default.table2
+                partition_columns datekey
+                partition_columns.types int
+                serialization.format 1
+                serialization.lib org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+              name: default.table2
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+          Stats Aggregation Key Prefix: hdfs://### HDFS PATH ###
+      Column Stats Desc:
+          Columns: col1
+          Column Types: string
+          Table: default.table2
+          Is Table Level Stats: false
+
+PREHOOK: query: insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+PREHOOK: Output: default@table2
+POSTHOOK: query: insert into table table2
+PARTITION(datekey)
+select col1,
+datekey
+from table1
+distribute by datekey
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+POSTHOOK: Output: default@table2
+POSTHOOK: Output: default@table2@datekey=1
+POSTHOOK: Output: default@table2@datekey=2
+POSTHOOK: Lineage: table2 PARTITION(datekey=1).col1 SIMPLE [(table1)table1.FieldSchema(name:col1, type:string, comment:null), ]
+POSTHOOK: Lineage: table2 PARTITION(datekey=2).col1 SIMPLE [(table1)table1.FieldSchema(name:col1, type:string, comment:null), ]
+PREHOOK: query: select * from table1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table1
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from table1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table1
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+ROW1	1
+ROW2	2
+ROW3	1
+PREHOOK: query: select * from table2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table2
+PREHOOK: Input: default@table2@datekey=1
+PREHOOK: Input: default@table2@datekey=2
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from table2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table2
+POSTHOOK: Input: default@table2@datekey=1
+POSTHOOK: Input: default@table2@datekey=2
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+ROW1	1
+ROW3	1
+ROW2	2

--- a/ql/src/test/results/clientpositive/tez/dynpart_sort_optimization_distribute_by.q.out
+++ b/ql/src/test/results/clientpositive/tez/dynpart_sort_optimization_distribute_by.q.out
@@ -69,7 +69,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col1 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
@@ -128,7 +128,7 @@ STAGE PLANS:
                   outputColumnNames: col1, datekey
                   Statistics: Num rows: 3 Data size: 276 Basic stats: COMPLETE Column stats: COMPLETE
                   Group By Operator
-                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector(col1, 'hll')
+                    aggregations: max(length(col1)), avg(COALESCE(length(col1),0)), count(1), count(col1), compute_bit_vector_hll(col1)
                     keys: datekey (type: int)
                     mode: complete
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5


### PR DESCRIPTION
…

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Changes are required in ReduceSinkDeduplication to merge properly the Child reduce sink operator and parent reduce sink operator

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
A Null Pointer Exception occurs when inserting data with 'distribute by' clause when hive.optimize.sort.dynamic.partition=true we expect the keys to be sorted in the reducer side so that reducers can keep only one record writer open at any time thereby reducing the memory pressure on the reducers (HIVE-6455) , But in case of non-vectorizied , non-llap execution the keys are not sorted and fails with NPE.
Refer: https://issues.apache.org/jira/browse/HIVE-18284?focusedCommentId=17173124&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17173124
Caused due to: https://issues.apache.org/jira/browse/HIVE-13260

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added a qtest