### PR TITLE
HIVE-24043: Retain original path info in Warehouse.makeSpecFromName()'s logger

### DIFF
--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -596,6 +596,7 @@ public class Warehouse {
 
   public static boolean makeSpecFromName(Map<String, String> partSpec, Path currPath,
       Set<String> requiredKeys) {
+    Path originalCurrPath = currPath;
     List<String[]> kvs = new ArrayList<>();
     do {
       String component = currPath.getName();
@@ -620,7 +621,7 @@ public class Warehouse {
       partSpec.put(key, kvs.get(i - 1)[1]);
     }
     if (requiredKeys == null || requiredKeys.isEmpty()) return true;
-    LOG.warn("Cannot create partition spec from " + currPath + "; missing keys " + requiredKeys);
+    LOG.warn("Cannot create partition spec from " + originalCurrPath + "; missing keys " + requiredKeys);
     return false;
   }
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Retain original path info in Warehouse.makeSpecFromName()'s logger


### Why are the changes needed?
helpful to debug


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
see logger content output
