### PR TITLE
HIVE-21052: Make sure transactions get cleaned if they are aborted before addPartitions is called

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1835,6 +1835,7 @@ public class HiveConf extends Configuration {
     HIVETESTCURRENTTIMESTAMP("hive.test.currenttimestamp", null, "current timestamp for test", false),
     HIVETESTMODEROLLBACKTXN("hive.test.rollbacktxn", false, "For testing only.  Will mark every ACID transaction aborted", false),
     HIVETESTMODEFAILCOMPACTION("hive.test.fail.compaction", false, "For testing only.  Will cause CompactorMR to fail.", false),
+    HIVETESTMODEFAILLOADDYNAMICPARTITION("hive.test.fail.load.dynamic.partition", false, "For testing only.  Will cause loadDynamicPartition to fail.", false),
     HIVETESTMODEFAILHEARTBEATER("hive.test.fail.heartbeater", false, "For testing only.  Will cause Heartbeater to fail.", false),
     TESTMODE_BUCKET_CODEC_VERSION("hive.test.bucketcodec.version", 1,
       "For testing only.  Will make ACID subsystem write RecordIdentifier.bucketId in specified\n" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
@@ -251,7 +251,9 @@ public class CompactorMR {
     // and discovering that in getSplits is too late as we then have no way to pass it to our
     // mapper.
 
-    AcidUtils.Directory dir = AcidUtils.getAcidState(new Path(sd.getLocation()), conf, writeIds, false, true);
+    AcidUtils.Directory dir = AcidUtils.getAcidState(
+        new Path(sd.getLocation()), conf, writeIds, false, true, t.getParameters());
+    removeAbortedDirsForAcidTable(conf, dir);
     List<AcidUtils.ParsedDelta> parsedDeltas = dir.getCurrentDirectories();
     int maxDeltastoHandle = conf.getIntVar(HiveConf.ConfVars.COMPACTOR_MAX_NUM_DELTA);
     if(parsedDeltas.size() > maxDeltastoHandle) {
@@ -328,7 +330,7 @@ public class CompactorMR {
         + t.getDbName() + "." + t.getTableName());
     AcidUtils.Directory dir = AcidUtils.getAcidState(new Path(sd.getLocation()),
         conf, writeIds, Ref.from(false), false, t.getParameters());
-    removeFilesForMmTable(conf, dir);
+    removeAbortedDirsForAcidTable(conf, dir);
 
     // Then, actually do the compaction.
     if (!ci.isMajorCompaction()) {
@@ -622,7 +624,7 @@ public class CompactorMR {
   }
 
   // Remove the directories for aborted transactions only
-  private void removeFilesForMmTable(HiveConf conf, Directory dir) throws IOException {
+  private void removeAbortedDirsForAcidTable(HiveConf conf, Directory dir) throws IOException {
     // For MM table, we only want to delete delta dirs for aborted txns.
     List<FileStatus> abortedDirs = dir.getAbortedDirectories();
     List<Path> filesToDelete = new ArrayList<>(abortedDirs.size());

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -1747,7 +1747,7 @@ public class TestDbTxnManager2 {
     Assert.assertEquals(
       "TXN_COMPONENTS mismatch(" + JavaUtils.txnIdToString(txnId1) + "): " +
         TxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"),
-      0,
+      1,
       TxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS where tc_txnid=" + txnId1));
     //complete 1st txn
     long writeId = txnMgr.getTableWriteId("default", "target");
@@ -1813,7 +1813,7 @@ public class TestDbTxnManager2 {
     Assert.assertEquals(
       "TXN_COMPONENTS mismatch(" + JavaUtils.txnIdToString(txnId2) + "): " +
         TxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"),
-      0,
+      1,
       TxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS where tc_txnid=" + txnId2));
     //complete 2nd txn
     writeId = txnMgr2.getTableWriteId("default", "target");
@@ -2040,7 +2040,8 @@ public class TestDbTxnManager2 {
     Assert.assertEquals(
       "TXN_COMPONENTS mismatch(" + JavaUtils.txnIdToString(txnid1) + "): " +
         TxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"),
-      0,
+      // We have one before addDynamicPartitions in case the txn fails before.
+      1,
       TxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS where tc_txnid=" + txnid1));
     //now actually write to table to generate some partitions
     checkCmdOnDriver(driver.run("insert into target partition(p=1,q) values (1,2,2), (3,4,2), (5,6,3), (7,8,2)"));
@@ -2135,7 +2136,7 @@ public class TestDbTxnManager2 {
     Assert.assertEquals(
       "TXN_COMPONENTS mismatch(" + JavaUtils.txnIdToString(txnId1) + "): " +
         TxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"),
-      0,//because it's using a DP write
+      1,//because it's using a DP write
       TxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS where tc_txnid=" + txnId1));
     //complete T1 transaction (simulate writing to 2 partitions)
     long writeId = txnMgr.getTableWriteId("default", "target");
@@ -2171,7 +2172,7 @@ public class TestDbTxnManager2 {
     Assert.assertEquals(
       "TXN_COMPONENTS mismatch(" + JavaUtils.txnIdToString(txnid2) + "): " +
         TxnDbUtil.queryToString(conf, "select * from TXN_COMPONENTS"),
-      0,//because it's using a DP write
+      1,//because it's using a DP write
       TxnDbUtil.countQueryAgent(conf, "select count(*) from TXN_COMPONENTS where tc_txnid=" + txnid2));
     //complete T2 txn
     //simulate Insert into 2 partitions

--- a/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
+++ b/shims/common/src/main/java/org/apache/hadoop/hive/shims/HadoopShims.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.security.AccessControlException;
 import java.security.NoSuchAlgorithmException;
 import java.util.Comparator;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeMap;
@@ -39,6 +40,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.LongWritable;
@@ -234,6 +236,18 @@ public interface HadoopShims {
   }
 
   List<HdfsFileStatusWithId> listLocatedHdfsStatus(
+      FileSystem fs, Path path, PathFilter filter) throws IOException;
+
+  /**
+   * Returns an interator of the list of files in a directory. Useful
+   * when a big number of files/directories are expected to be listed.
+   * @param fs filesystem
+   * @param path path to list
+   * @param filter filter to apply to the files and folders int the path
+   * @return iterator with the listed files
+   * @throws IOException
+   */
+  RemoteIterator<HdfsFileStatusWithId> listLocatedHdfsStatusIterator(
       FileSystem fs, Path path, PathFilter filter) throws IOException;
 
   /**

--- a/standalone-metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CompactionType.java
+++ b/standalone-metastore/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CompactionType.java
@@ -13,7 +13,8 @@ import org.apache.thrift.TEnum;
 
 public enum CompactionType implements org.apache.thrift.TEnum {
   MINOR(1),
-  MAJOR(2);
+  MAJOR(2),
+  CLEAN_ABORTED(3);
 
   private final int value;
 
@@ -38,6 +39,8 @@ public enum CompactionType implements org.apache.thrift.TEnum {
         return MINOR;
       case 2:
         return MAJOR;
+      case 3:
+        return CLEAN_ABORTED;
       default:
         return null;
     }

--- a/standalone-metastore/src/gen/thrift/gen-php/metastore/Types.php
+++ b/standalone-metastore/src/gen/thrift/gen-php/metastore/Types.php
@@ -99,9 +99,11 @@ final class LockType {
 final class CompactionType {
   const MINOR = 1;
   const MAJOR = 2;
+  const CLEAN_ABORTED = 3;
   static public $__names = array(
     1 => 'MINOR',
     2 => 'MAJOR',
+    3 => 'CLEAN_ABORTED',
   );
 }
 

--- a/standalone-metastore/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -143,15 +143,18 @@ class LockType:
 class CompactionType:
   MINOR = 1
   MAJOR = 2
+  CLEAN_ABORTED = 3
 
   _VALUES_TO_NAMES = {
     1: "MINOR",
     2: "MAJOR",
+    3: "CLEAN_ABORTED",
   }
 
   _NAMES_TO_VALUES = {
     "MINOR": 1,
     "MAJOR": 2,
+    "CLEAN_ABORTED": 3,
   }
 
 class GrantRevokeType:

--- a/standalone-metastore/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -68,8 +68,9 @@ end
 module CompactionType
   MINOR = 1
   MAJOR = 2
-  VALUE_MAP = {1 => "MINOR", 2 => "MAJOR"}
-  VALID_VALUES = Set.new([MINOR, MAJOR]).freeze
+  CLEAN_ABORTED = 3
+  VALUE_MAP = {1 => "MINOR", 2 => "MAJOR", 3 => "CLEAN_ABORTED"}
+  VALID_VALUES = Set.new([MINOR, MAJOR, CLEAN_ABORTED]).freeze
 end
 
 module GrantRevokeType

--- a/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -82,10 +82,11 @@ class CompactionTxnHandler extends TxnHandler {
         }
         rs.close();
 
-        // Check for aborted txns
+        // Check for aborted txns that are not 'p' type
         s = "select tc_database, tc_table, tc_partition " +
           "from TXNS, TXN_COMPONENTS " +
           "where txn_id = tc_txnid and txn_state = '" + TXN_ABORTED + "' " +
+          " and tc_operation_type <> '" + OperationType.ALL_PARTITIONS.getSqlConst() + "' " +
           "group by tc_database, tc_table, tc_partition " +
           "having count(*) > " + maxAborted;
 
@@ -96,6 +97,26 @@ class CompactionTxnHandler extends TxnHandler {
           info.dbname = rs.getString(1);
           info.tableName = rs.getString(2);
           info.partName = rs.getString(3);
+          info.tooManyAborts = true;
+          response.add(info);
+        }
+        rs.close();
+
+        // Check for aborted txns that are 'p' type
+        s = "select tc_database, tc_table, tc_partition, tc_operation_type " +
+            "from TXNS, TXN_COMPONENTS " +
+            "where txn_id = tc_txnid and txn_state = '" + TXN_ABORTED + "' " +
+            " and tc_operation_type = '" + OperationType.ALL_PARTITIONS.getSqlConst() + "' " +
+            "group by tc_database, tc_table, tc_partition, tc_operation_type ";
+
+        LOG.debug("Going to execute query <" + s + ">");
+        rs = stmt.executeQuery(s);
+        while (rs.next()) {
+          CompactionInfo info = new CompactionInfo();
+          info.dbname = rs.getString(1);
+          info.tableName = rs.getString(2);
+          info.partName = rs.getString(3);
+          info.type = dbCompactionType2ThriftType(rs.getString(4).charAt(0));
           info.tooManyAborts = true;
           response.add(info);
         }
@@ -298,14 +319,32 @@ class CompactionTxnHandler extends TxnHandler {
           info.tableName = rs.getString(3);
           info.partName = rs.getString(4);
           switch (rs.getString(5).charAt(0)) {
-            case MAJOR_TYPE: info.type = CompactionType.MAJOR; break;
-            case MINOR_TYPE: info.type = CompactionType.MINOR; break;
+            case TxnHandler.MAJOR_TYPE: info.type = CompactionType.MAJOR; break;
+            case TxnHandler.MINOR_TYPE: info.type = CompactionType.MINOR; break;
+            case TxnHandler.CLEAN_ABORTED: info.type = CompactionType.CLEAN_ABORTED; break;
             default: throw new MetaException("Unexpected compaction type " + rs.getString(5));
           }
           info.runAs = rs.getString(6);
           info.highestWriteId = rs.getLong(7);
           rc.add(info);
         }
+
+        for (CompactionInfo ci: rc) {
+          if (ci.type.equals(CompactionType.CLEAN_ABORTED)) {
+            String s2 = "select tc_writeid from TXN_COMPONENTS where tc_database=? AND tc_table=? AND tc_operation_type=?";
+            PreparedStatement pStmt = dbConn.prepareStatement(s2);
+            LOG.debug("Going to execute query <" + s2 + ">");
+            pStmt.setString(1, ci.dbname);
+            pStmt.setString(2, ci.tableName);
+            pStmt.setString(3, String.valueOf(OperationType.ALL_PARTITIONS.getSqlConst()));
+            rs = pStmt.executeQuery();
+            ci.writeIds = new HashSet<>();
+            while(rs.next()) {
+              ci.writeIds.add(rs.getLong(1));
+            }
+          }
+        }
+
         LOG.debug("Going to rollback");
         dbConn.rollback();
         return rc;
@@ -342,8 +381,10 @@ class CompactionTxnHandler extends TxnHandler {
         pStmt = dbConn.prepareStatement("select CQ_ID, CQ_DATABASE, CQ_TABLE, CQ_PARTITION, CQ_STATE, CQ_TYPE, CQ_TBLPROPERTIES, CQ_WORKER_ID, CQ_START, CQ_RUN_AS, CQ_HIGHEST_WRITE_ID, CQ_META_INFO, CQ_HADOOP_JOB_ID from COMPACTION_QUEUE WHERE CQ_ID = ?");
         pStmt.setLong(1, info.id);
         rs = pStmt.executeQuery();
+        Set<Long> writeIds = info.writeIds;
         if(rs.next()) {
           info = CompactionInfo.loadFullFromCompactionQueue(rs);
+          info.writeIds = writeIds;
         }
         else {
           throw new IllegalStateException("No record with CQ_ID=" + info.id + " found in COMPACTION_QUEUE");
@@ -386,15 +427,27 @@ class CompactionTxnHandler extends TxnHandler {
           pStmt.setLong(paramCount++, info.highestWriteId);
         }
         LOG.debug("Going to execute update <" + s + ">");
-        if (pStmt.executeUpdate() < 1) {
-          LOG.error("Expected to remove at least one row from completed_txn_components when " +
-            "marking compaction entry as clean!");
+        if ((updCount = pStmt.executeUpdate()) < 1) {
+          // In the case of clean abort commit hasn't happened so completed_txn_components hasn't been filled
+          if (!info.isCleanAbortedCompaction()) {
+            LOG.error(
+                "Expected to remove at least one row from completed_txn_components when "
+                    + "marking compaction entry as clean!");
+          }
         }
 
         s = "select distinct txn_id from TXNS, TXN_COMPONENTS where txn_id = tc_txnid and txn_state = '" +
           TXN_ABORTED + "' and tc_database = ? and tc_table = ?";
         if (info.highestWriteId != 0) s += " and tc_writeid <= ?";
         if (info.partName != null) s += " and tc_partition = ?";
+        if (info.writeIds != null && info.writeIds.size() > 0) {
+          String[] wriStr = new String[info.writeIds.size()];
+          int i = 0;
+          for (Long writeId: writeIds) {
+            wriStr[i++] = writeId.toString();
+          }
+          s += " and tc_writeid in (" + String.join(",", wriStr) + ")";
+        }
 
         pStmt = dbConn.prepareStatement(s);
         paramCount = 1;
@@ -431,6 +484,14 @@ class CompactionTxnHandler extends TxnHandler {
           suffix.append(" and tc_table = ?");
           if (info.partName != null) {
             suffix.append(" and tc_partition = ?");
+          }
+          if (info.writeIds != null && info.writeIds.size() > 0) {
+            String[] wriStr = new String[info.writeIds.size()];
+            int i = 0;
+            for (Long writeId: writeIds) {
+              wriStr[i++] = writeId.toString();
+            }
+            suffix.append(" and tc_writeid in (").append(String.join(",", wriStr)).append(")");
           }
 
           // Populate the complete query with provided prefix and suffix

--- a/standalone-metastore/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/src/main/thrift/hive_metastore.thrift
@@ -176,6 +176,7 @@ enum LockType {
 enum CompactionType {
     MINOR = 1,
     MAJOR = 2,
+    CLEAN_ABORTED = 3,
 }
 
 enum GrantRevokeType {


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Below changes are only with respect to branch-3.1.

Design: taken from https://issues.apache.org/jira/secure/attachment/12954375/Aborted%20Txn%20w_Direct%20Write.pdf

**Overview:**
1. add a dummy row to TXN_COMPONENTS with operation type 'p' in enqueueLockWithRetry, which will be removed in addDynamicPartition
2. If anytime txn is aborted, this dummy entry will be block initiator to remove this txnId from TXNS
3. Initiator will add a row in COMPACTION_QUEUE (with type 'p') for the above aborted txn with the state as READY_FOR_CLEANING, at a time there will be a single entry of this type for a table in COMPACTION_QUEUE.
4. Cleaner will directly pickup above request, and process it via new cleanAborted code path(scan all partitions and remove aborted dirs), once successful cleaner will remove dummy row from TXN_COMPONENTS

**Cleaner Design:**
- We are keeping cleaner single thread, and this new type of cleanup will be handled similar to any regular cleanup

**Aborted dirs cleanup:**
- In p-type cleanup, cleaner will iterate over all the partitions and remove all delta/base dirs with given aborted writeId list
- added cleanup of aborted base/delta in the worker also

**TXN_COMPONENTS cleanup:**
- If successful, p-type entry will be removed from TXN_COMPONENTS during addDynamicPartitions
- If aborted, cleaner will clean in markCleaned after successful processing of p-type cleanup

**TXNS cleanup:**
- No change, will be cleaned up by the initiator 

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
To fix above mentioned issue.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
No
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
unit-tests added
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
