### PR TITLE
HIVE-24053: Pluggable HttpRequestInterceptor for Hive JDBC

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -583,6 +583,18 @@ public class HiveConnection implements java.sql.Connection {
     // Add the request interceptor to the client builder
     httpClientBuilder.addInterceptorFirst(requestInterceptor);
 
+    // Add user defined request interceptor if exists
+    if (sessConfMap.get(JdbcConnectionParams.HTTP_INTERCEPTOR) != null) {
+      String className = sessConfMap.get(JdbcConnectionParams.HTTP_INTERCEPTOR);
+      try {
+        Class<?> userRequestInterceptorClass = Class.forName(className);
+        Object additionInterceptor = userRequestInterceptorClass.newInstance();
+        httpClientBuilder.addInterceptorLast((HttpRequestInterceptor) additionInterceptor);
+      } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+        throw new SQLException("Could not add user passed in http interceptor: " + className, e);
+      }
+    }
+
     // Add an interceptor to add in an XSRF header
     httpClientBuilder.addInterceptorLast(new XsrfHttpRequestInterceptor());
 

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -136,6 +136,8 @@ public class Utils {
     static final String DEFAULT_COOKIE_NAMES_HS2 = "hive.server2.auth";
     // The http header prefix for additional headers which have to be appended to the request
     static final String HTTP_HEADER_PREFIX = "http.header.";
+    // The additional http interceptor class for process http request
+    static final String HTTP_INTERCEPTOR = "http.interceptor";
     // Set the fetchSize
     static final String FETCH_SIZE = "fetchSize";
     static final String INIT_FILE = "initFile";


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This change adds an optional pluggable HttpRequestInterceptor for HiveConnection. It allows client to pass in the name of a customize HttpRequestInterceptor, instantiate the class and adds it to the HttpClient.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Example usage: 
We would like to pass in a HttpRequestInterceptor for OAuth2.0 Authentication purpose. If we pass the Authorization header and access token through http.header in the JDBC connection URL, we can not refresh the token once the connection is established. Instead, we would like to pass the name of the HttpRequestInterceptor, which will acquire and/or refresh the access token and add it as authentication header each time HiveConnection sends the HttpRequest.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
The HiveServer2 JDBC Connection URL will accept an additional session variable "http.interceptor" that allows client to pass in the class name.
Example: http.interceptor=com.example.UserInterceptor

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Tests were not added because the HiveConnection class does not have a test to begin with. The changes in code does not affect HiveConnection behavior. 
It was tested by our custom JDBC Driver which uses the hive-jdbc-4.0.0-SNAPSHOT-standalone.jar.