### PR TITLE
HIVE-24065: Bloom filters can be cached after deserialization in VectorInBloomFilterColDynamicValue

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorExpression.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorExpression.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorExpressionDescriptor;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 
 /**
@@ -63,6 +65,7 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 public abstract class VectorExpression implements Serializable {
 
   private static final long serialVersionUID = 1L;
+  protected transient final Logger LOG = LoggerFactory.getLogger(getClass().getName());
 
   /**
    * Child expressions for parameters -- but only those that need to be computed.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorInBloomFilterColDynamicValue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorInBloomFilterColDynamicValue.java
@@ -130,7 +130,7 @@ public class VectorInBloomFilterColDynamicValue extends VectorExpression {
                   BloomKFilter bloomKFilter = BloomKFilter.deserialize(in);
                   return bloomKFilter;
                 } else {
-                  return null;
+                  return new BloomKFilter(1);
                 }
               } finally {
                 IOUtils.closeStream(in);
@@ -164,7 +164,7 @@ public class VectorInBloomFilterColDynamicValue extends VectorExpression {
     }
 
     // In case the dynamic value resolves to a null value
-    if (bloomFilter == null) {
+    if (bloomFilter == null || bloomFilter.getNumBits() == 0) {
       batch.size = 0;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorInBloomFilterColDynamicValue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorInBloomFilterColDynamicValue.java
@@ -18,27 +18,29 @@
 
 package org.apache.hadoop.hive.ql.exec.vector.expressions;
 
-import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.Callable;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.io.NonSyncByteArrayInputStream;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.ObjectCache;
+import org.apache.hadoop.hive.ql.exec.ObjectCacheFactory;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
-import org.apache.hadoop.hive.ql.exec.vector.VectorExpressionDescriptor.Descriptor;
 import org.apache.hadoop.hive.ql.exec.vector.VectorExpressionDescriptor;
+import org.apache.hadoop.hive.ql.exec.vector.VectorExpressionDescriptor.Descriptor;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.DynamicValue;
-import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
-import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hive.common.util.BloomKFilter;
 
@@ -52,6 +54,8 @@ public class VectorInBloomFilterColDynamicValue extends VectorExpression {
   protected transient BloomKFilter bloomFilter;
   protected transient BloomFilterCheck bfCheck;
   protected transient ColumnVector.Type colVectorType;
+
+  private ObjectCache runtimeCache;
 
   public VectorInBloomFilterColDynamicValue(int colNum, DynamicValue bloomFilterDynamicValue) {
     super();
@@ -100,26 +104,43 @@ public class VectorInBloomFilterColDynamicValue extends VectorExpression {
     default:
       throw new IllegalStateException("Unsupported type " + colVectorType);
     }
+
+    String queryId = HiveConf.getVar(conf, HiveConf.ConfVars.HIVEQUERYID);
+    runtimeCache = ObjectCacheFactory.getCache(conf, queryId, false, true);
   }
 
-  private void initValue()  {
-    InputStream in = null;
+  private void initValue() {
     try {
-      Object val = bloomFilterDynamicValue.getValue();
-      if (val != null) {
-        BinaryObjectInspector boi = (BinaryObjectInspector) bloomFilterDynamicValue.getObjectInspector();
-        byte[] bytes = boi.getPrimitiveJavaObject(val);
-        in = new NonSyncByteArrayInputStream(bytes);
-        bloomFilter = BloomKFilter.deserialize(in);
-      } else {
-        bloomFilter = null;
-      }
-      initialized = true;
-    } catch (Exception err) {
-      throw new RuntimeException(err);
-    } finally {
-      IOUtils.closeStream(in);
+      bloomFilter = (BloomKFilter) runtimeCache.retrieve(bloomFilterDynamicValue.getId(),
+          new Callable<Object>() {
+            @Override
+            public Object call() throws IOException {
+              InputStream in = null;
+              try {
+                Object val = bloomFilterDynamicValue.getValue();
+
+                LOG.info("Starting BloomKFilter deserialization for id: {}...",
+                    bloomFilterDynamicValue.getId());
+
+                if (val != null) {
+                  BinaryObjectInspector boi =
+                      (BinaryObjectInspector) bloomFilterDynamicValue.getObjectInspector();
+                  byte[] bytes = boi.getPrimitiveJavaObject(val);
+                  in = new NonSyncByteArrayInputStream(bytes);
+                  BloomKFilter bloomKFilter = BloomKFilter.deserialize(in);
+                  return bloomKFilter;
+                } else {
+                  return null;
+                }
+              } finally {
+                IOUtils.closeStream(in);
+              }
+            }
+          });
+    } catch (HiveException e) {
+      throw new RuntimeException(e);
     }
+    initialized = true;
   }
 
   @Override


### PR DESCRIPTION
Change-Id: I311f131c03392618cc2dac186e7e53a48ede1eb4

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
As the title suggests, expensive bloom filter deserialization can be eliminated by caching the bloom filters. This way, only 1 filter instance per daemon (or container in container mode) will be present.


### Why are the changes needed?
Performance improvement.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested on cluster.
