### PR TITLE
HIVE-24031: Infinite planning time on syntactically big queries

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/ASTNode.java
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/ASTNode.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.parse;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 
@@ -74,11 +75,15 @@ public class ASTNode extends CommonTree implements Node,Serializable {
    * @see org.apache.hadoop.hive.ql.lib.Node#getChildren()
    */
   @Override
-  public ArrayList<Node> getChildren() {
+  public List<Node> getChildren() {
     if (super.getChildCount() == 0) {
       return null;
     }
-    return new ArrayList<>((List<? extends Node>) super.getChildren());
+    // We know that children always contains Node instances so the cast is safe.
+    assert this.children.get(0) instanceof Node;
+    @SuppressWarnings("unchecked") // Cast safe by design of the class
+    List<Node> nodeList = (List<Node>) (List<?>) this.children;
+    return Collections.unmodifiableList(nodeList);
   }
 
   /*

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriverIntervals.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestParseDriverIntervals.java
@@ -70,7 +70,7 @@ public class TestParseDriverIntervals {
         return n;
       }
     }
-    ArrayList<Node> children = n.getChildren();
+    List<Node> children = n.getChildren();
     if (children != null) {
       for (Node c : children) {
         ASTNode r = findFunctionNode((ASTNode) c);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/skewed/AlterTableSetSkewedLocationAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/skewed/AlterTableSetSkewedLocationAnalyzer.java
@@ -56,7 +56,7 @@ public class AlterTableSetSkewedLocationAnalyzer extends AbstractAlterTableAnaly
   @Override
   protected void analyzeCommand(TableName tableName, Map<String, String> partitionSpec, ASTNode command)
       throws SemanticException {
-    ArrayList<Node> locationNodes = command.getChildren();
+    List<Node> locationNodes = command.getChildren();
     if (locationNodes == null) {
       throw new SemanticException(ErrorMsg.ALTER_TBL_SKEWED_LOC_NO_LOC.getMsg());
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/MergeSemanticAnalyzer.java
@@ -593,7 +593,7 @@ public class MergeSemanticAnalyzer extends RewriteSemanticAnalyzer {
     assert whenClauseOperation.getType() == HiveParser.TOK_INSERT;
 
     // identify the node that contains the values to insert and the optional column list node
-    ArrayList<Node> children = whenClauseOperation.getChildren();
+    List<Node> children = whenClauseOperation.getChildren();
     ASTNode valuesNode =
         (ASTNode)children.stream().filter(n -> ((ASTNode)n).getType() == HiveParser.TOK_FUNCTION).findFirst().get();
     ASTNode columnListNode =

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13977,7 +13977,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         }
       }
 
-      ArrayList childrenList = next.getChildren();
+      List<Node> childrenList = next.getChildren();
       for (int i = childrenList.size() - 1; i >= 0; i--) {
         stack.push((ASTNode)childrenList.get(i));
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Drop the defensive copy of children inside ASTNode#getChildren.
2. Protect clients by accidentally modifying the list via an
unmodifiable collection.

### Why are the changes needed?
Profiling shows the vast majority of time spend on creating defensive
copies of the node expression list inside ASTNode#getChildren.

The method is called extensively from various places in the code
especially those walking over the expression tree so it needs to be
efficient.

Most of the time creating defensive copies is not necessary. For those
cases (if any) that the list needs to be modified clients should perform
a copy themselves.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
The test was added in a separate branch since it is not meant to be committed upstream for the following reasons:

- the query for reproducing the problem takes up a few MBs
- requires some changes in the default configurations.

If you want to run the test run the following commands: 
```
git checkout -b HIVE-24031-TEST master
git pull git@github.com:zabetak/hive.git HIVE-24031-PLUS-TEST
mvn clean install -DskipTests
cd itests
mvn clean install -DskipTests
cd qtest
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=big_query_with_array_constructor.q -Dtest.output.overwrite
```