### PR TITLE
HIVE-24068: Add re-execution plugin for handling DAG submission and unmanaged AM failures

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5113,7 +5113,7 @@ public class HiveConf extends Configuration {
 
     HIVE_QUERY_REEXECUTION_ENABLED("hive.query.reexecution.enabled", true,
         "Enable query reexecutions"),
-    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize,reexecute_lost_am",
+    HIVE_QUERY_REEXECUTION_STRATEGIES("hive.query.reexecution.strategies", "overlay,reoptimize,reexecute_lost_am,dagsubmit",
         "comma separated list of plugin can be used:\n"
             + "  overlay: hiveconf subtree 'reexec.overlay' is used as an overlay in case of an execution errors out\n"
             + "  reoptimize: collects operator statistics during execution and recompile the query after a failure\n"

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverFactory.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.ql.reexec.ReExecDriver;
 import org.apache.hadoop.hive.ql.reexec.ReExecutionRetryLockPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReExecuteLostAMQueryPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReExecutionOverlayPlugin;
+import org.apache.hadoop.hive.ql.reexec.ReExecutionDagSubmitPlugin;
 import org.apache.hadoop.hive.ql.reexec.ReOptimizePlugin;
 
 import com.google.common.base.Strings;
@@ -74,6 +75,9 @@ public final class DriverFactory {
     }
     if("reexecute_lost_am".equals(name)) {
       return new ReExecuteLostAMQueryPlugin();
+    }
+    if (name.equals("dagsubmit")) {
+      return new ReExecutionDagSubmitPlugin();
     }
     throw new RuntimeException(
         "Unknown re-execution plugin: " + name + " (" + ConfVars.HIVE_QUERY_REEXECUTION_STRATEGIES.varname + ")");

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -24,26 +24,38 @@ import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
 import org.apache.hadoop.hive.ql.hooks.HookContext;
 import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.regex.Pattern;
 
+/**
+ * Re-Executes a query if tez AM failed because of node/container failure.
+ */
 public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
+  private static final Logger LOG = LoggerFactory.getLogger(ReExecuteLostAMQueryPlugin.class);
   private boolean retryPossible;
   private int maxExecutions = 1;
 
-  // Lost am container have exit code -100, due to node failures.
-  private Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
+  // Lost am container have exit code -100, due to node failures. This pattern of exception is thrown when AM is managed
+  // by HS2.
+  private final Pattern lostAMContainerErrorPattern = Pattern.compile(".*AM Container for .* exited .* exitCode: -100.*");
 
   class LocalHook implements ExecuteWithHookContext {
-
     @Override
     public void run(HookContext hookContext) throws Exception {
       if (hookContext.getHookType() == HookContext.HookType.ON_FAILURE_HOOK) {
         Throwable exception = hookContext.getException();
 
-        if (exception != null && exception.getMessage() != null
-            && lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()) {
-          retryPossible = true;
+        if (exception != null && exception.getMessage() != null) {
+          // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovery it, failure of unmanaged
+          // AMs will throw AM record not being found in zookeeper (or other discovery service where AM is registered)
+          String unmanagedAMFailure = "AM record not found (likely died)";
+          if (lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()
+                  || exception.getMessage().contains(unmanagedAMFailure)) {
+            retryPossible = true;
+          }
+          LOG.info("Got exception message: {} retryPossible: {}", exception.getMessage(), retryPossible);
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecuteLostAMQueryPlugin.java
@@ -48,8 +48,8 @@ public class ReExecuteLostAMQueryPlugin implements IReExecutionPlugin {
         Throwable exception = hookContext.getException();
 
         if (exception != null && exception.getMessage() != null) {
-          // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovery it, failure of unmanaged
-          // AMs will throw AM record not being found in zookeeper (or other discovery service where AM is registered)
+          // When HS2 does not manage the AMs, tez AMs are registered with zookeeper and HS2 discovers it,
+          // failure of unmanaged AMs will throw AM record not being found in zookeeper.
           String unmanagedAMFailure = "AM record not found (likely died)";
           if (lostAMContainerErrorPattern.matcher(exception.getMessage()).matches()
                   || exception.getMessage().contains(unmanagedAMFailure)) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecutionDagSubmitPlugin.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/reexec/ReExecutionDagSubmitPlugin.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.reexec;
+
+import org.apache.hadoop.hive.ql.Driver;
+import org.apache.hadoop.hive.ql.hooks.ExecuteWithHookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext;
+import org.apache.hadoop.hive.ql.hooks.HookContext.HookType;
+import org.apache.hadoop.hive.ql.plan.mapper.PlanMapper;
+import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Re-Executes a query when DAG submission fails after get session returned successfully.
+ */
+public class ReExecutionDagSubmitPlugin implements IReExecutionPlugin {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReExecutionDagSubmitPlugin.class);
+  class LocalHook implements ExecuteWithHookContext {
+
+    @Override
+    public void run(HookContext hookContext) throws Exception {
+      if (hookContext.getHookType() == HookType.ON_FAILURE_HOOK) {
+        Throwable exception = hookContext.getException();
+        if (exception != null) {
+          if (exception.getMessage() != null) {
+            // there could be race condition where getSession could return a healthy AM but by the time DAG is submitted
+            // the AM could become unhealthy/unreachable (possible DNS or network issues) which can fail tez DAG
+            // submission. Since the DAG hasn't started execution yet this failure can be safely restarted.
+            if (exception.getMessage().contains("Dag submit failed")) {
+              retryPossible = true;
+            }
+            LOG.info("Got exception message: {} retryPossible: {}", exception.getMessage(), retryPossible);
+          }
+        }
+      }
+    }
+  }
+
+  @Override
+  public void initialize(Driver driver) {
+    driver.getHookRunner().addOnFailureHook(new LocalHook());
+  }
+
+  private boolean retryPossible;
+
+  @Override
+  public void prepareToReExecute() {
+  }
+
+  @Override
+  public boolean shouldReExecute(int executionNum, PlanMapper pm1, PlanMapper pm2) {
+    return retryPossible;
+  }
+
+  @Override
+  public void beforeExecute(int executionIndex, boolean explainReOptimization) {
+  }
+
+  @Override
+  public boolean shouldReExecute(int executionNum, CommandProcessorException ex) {
+    return retryPossible;
+  }
+
+  @Override
+  public void afterExecute(PlanMapper planMapper, boolean success) {
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
DAG submission failure can also happen in environments where AM container died causing DNS issues. DAG submissions are safe to retry as the DAG hasn't started execution yet. There are retries at getSession and submitDAG level individually but some submitDAG failure has to retry getSession as well as AM could be unreachable, this can be handled in re-execution plugin. This PR adds a new re-execution plugin for intermittent DAG submission failures. 

### Why are the changes needed?
To make hive resilient to environments with network/DNS issues.

### Does this PR introduce _any_ user-facing change?
Yes. Adds the re-exec plugin as default option.


### How was this patch tested?
Manually. Tez code was changed to explicitly throw UnknownHostException to simulate DNS/network issue and tested to make sure retry happens.