### PR TITLE
HIVE-24061: Improve llap task scheduling for better cache hit rate

### DIFF
--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -2416,6 +2416,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
   private void trySchedulingPendingTasks() {
     scheduleLock.lock();
     try {
+      isClusterCapacityFull.set(false);
       pendingScheduleInvocations.set(true);
       scheduleCondition.signal();
     } finally {

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -251,6 +251,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
 
   private final Lock scheduleLock = new ReentrantLock();
   private final Condition scheduleCondition = scheduleLock.newCondition();
+  private final AtomicBoolean isCapacityFull = new AtomicBoolean(false);
   private final AtomicBoolean pendingScheduleInvocations = new AtomicBoolean(false);
   private final ListeningExecutorService schedulerExecutor;
   private final SchedulerCallable schedulerCallable = new SchedulerCallable();
@@ -1373,6 +1374,10 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     return true;
   }
 
+  boolean isRequestedHostPresent(TaskInfo request) {
+    return (request.requestedHosts != null && request.requestedHosts.length > 0);
+  }
+
   /**
    * @param request the list of preferred hosts. null implies any host
    * @return
@@ -1390,7 +1395,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       boolean shouldDelayForLocality = request.shouldDelayForLocality(schedulerAttemptTime);
       LOG.debug("ShouldDelayForLocality={} for task={} on hosts={}", shouldDelayForLocality,
           request.task, requestedHostsDebugStr);
-      if (requestedHosts != null && requestedHosts.length > 0) {
+      if (!isRequestedHostPresent(request)) {
         int prefHostCount = -1;
         boolean requestedHostsWillBecomeAvailable = false;
         for (String host : requestedHosts) {
@@ -1485,6 +1490,14 @@ public class LlapTaskSchedulerService extends TaskScheduler {
 
       if (allNodes.isEmpty()) {
         return SELECT_HOST_RESULT_DELAYED_RESOURCES;
+      }
+
+      // When all nodes are busy, reset locality delay
+      if (activeNodesWithFreeSlots.isEmpty()) {
+        isCapacityFull.set(true);
+        if (request.localityDelayTimeout > 0 && isRequestedHostPresent(request)) {
+          request.resetLocalityDelayInfo();
+        }
       }
 
       // no locality-requested, randomly pick a node containing free slots
@@ -1817,8 +1830,10 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         Iterator<TaskInfo> taskIter = taskListAtPriority.iterator();
         boolean scheduledAllAtPriority = true;
         while (taskIter.hasNext()) {
-          // TODO Optimization: Add a check to see if there's any capacity available. No point in
-          // walking through all active nodes, if they don't have potential capacity.
+          // Early exit where are no slots available
+          if (isCapacityFull.get()) {
+            break;
+          }
           TaskInfo taskInfo = taskIter.next();
           if (taskInfo.getNumPreviousAssignAttempts() == 1) {
             dagStats.registerDelayedAllocation();
@@ -2399,6 +2414,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
   private void trySchedulingPendingTasks() {
     scheduleLock.lock();
     try {
+      isCapacityFull.set(false);
       pendingScheduleInvocations.set(true);
       scheduleCondition.signal();
     } finally {
@@ -2851,7 +2867,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     final String[] requestedHosts;
     final String[] requestedRacks;
     final long requestTime;
-    final long localityDelayTimeout;
+    long localityDelayTimeout;
+    // Adjust locality delay based on scheduling time instead of init time of task info.
+    boolean adjustedLocalityDelay;
     long startTime;
     long preemptTime;
     ContainerId containerId;
@@ -2931,8 +2949,20 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     }
 
     boolean shouldDelayForLocality(long schedulerAttemptTime) {
+      adjustLocalityDelayInfo();
       // getDelay <=0 means the task will be evicted from the queue.
       return localityDelayTimeout > schedulerAttemptTime;
+    }
+
+    void adjustLocalityDelayInfo() {
+      if (localityDelayTimeout > 0 && localityDelayTimeout != Long.MAX_VALUE && !adjustedLocalityDelay) {
+        adjustedLocalityDelay = true;
+        resetLocalityDelayInfo();
+      }
+    }
+
+    void resetLocalityDelayInfo() {
+      localityDelayTimeout = clock.getTime() + localityDelayConf.getNodeLocalityDelay();
     }
 
     boolean shouldForceLocality() {

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1830,7 +1830,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         Iterator<TaskInfo> taskIter = taskListAtPriority.iterator();
         boolean scheduledAllAtPriority = true;
         while (taskIter.hasNext()) {
-          // Early exit where are no slots available
+          // Early exit where there are no slots available
           if (isCapacityFull.get()) {
             break;
           }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24061

Changes:
1. Adjust locality delay when the task is getting scheduled.
2. Reset locality delay when all nodes in the cluster are busy and wouldn't be able to schedule tasks.
3. Optimize schedulePendingTasks to exit early, when all nodes are busy. This helps in reducing lock contention as well.

Patch was tested on a medium scale cluster and observed good improvement in runtime of queries.