### PR TITLE
[HIVE-16352] add ability to AvroGenericRecordReader to skip invalid sync blocks

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -70,7 +70,8 @@ public class AvroSerdeUtils {
     AVRO_SERDE_SCHEMA("avro.serde.schema"),
     AVRO_SERDE_TYPE("avro.serde.type"),
     AVRO_SERDE_SKIP_BYTES("avro.serde.skip.bytes"),
-    SCHEMA_RETRIEVER("avro.schema.retriever");
+    SCHEMA_RETRIEVER("avro.schema.retriever"),
+    AVRO_SERDE_ERROR_SKIP("avro.serde.error.skip");
 
     private final String propName;
 
@@ -97,7 +98,7 @@ public class AvroSerdeUtils {
       + AvroTableProperties.SCHEMA_LITERAL.getPropName() + " nor "
       + AvroTableProperties.SCHEMA_URL.getPropName() + " specified, can't determine table schema";
 
-
+  public static final boolean DEFAULT_AVRO_SERDE_ERROR_SKIP = false;
 
   /**
    * Determine the schema to that's been provided for Avro serde work.


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. add AvroGenericRecordReader.nextRecord
2. optimize AvroGenericRecordReader.next adding ability to skip invalid sync blocks
3. add enum value AVRO_SERDE_ERROR_SKIP to AvroSerdeUtils.AvroTableProperties

### Why are the changes needed?

when reading the Avro file which has a bad file format in Hive, we want to skip the invalid sync errors simply
https://issues.apache.org/jira/browse/HIVE-16352


### Does this PR introduce _any_ user-facing change?

NO. The default value of AVRO_SERDE_ERROR_SKIP is false keeping the original logic

### How was this patch tested?

add unit test cases in TestAvroGenericRecordReader.class
