### PR TITLE
HIVE-24089: Run QB compaction as table directory user with impersonation

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -1759,17 +1759,19 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     doAnswer(invocationOnMock -> {
       return null;
     }).when(sdMock).getLocation();
+    CompactionInfo ciMock = mock(CompactionInfo.class);
+    ciMock.runAs = "hive";
     List<String> emptyQueries = new ArrayList<>();
     HiveConf hiveConf = new HiveConf();
     hiveConf.set(ValidTxnList.VALID_TXNS_KEY, "8:9223372036854775807::");
 
     // Check for default case.
-    qc.runCompactionQueries(hiveConf, null, sdMock, null, null, null, emptyQueries, emptyQueries, emptyQueries);
+    qc.runCompactionQueries(hiveConf, null, sdMock, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries);
     Assert.assertEquals("all", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
 
     // Check for case where  hive.llap.io.etl.skip.format is explicitly set to none - as to always use cache.
     hiveConf.setVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT, "none");
-    qc.runCompactionQueries(hiveConf, null, sdMock, null, null, null, emptyQueries, emptyQueries, emptyQueries);
+    qc.runCompactionQueries(hiveConf, null, sdMock, null, ciMock, null, emptyQueries, emptyQueries, emptyQueries);
     Assert.assertEquals("none", hiveConf.getVar(HiveConf.ConfVars.LLAP_IO_ETL_SKIP_FORMAT));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactor.java
@@ -94,7 +94,8 @@ abstract class QueryCompactor {
       List<String> createQueries, List<String> compactionQueries, List<String> dropQueries)
       throws IOException {
     Util.disableLlapCaching(conf);
-    String user = UserGroupInformation.getCurrentUser().getShortUserName();
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_SERVER2_ENABLE_DOAS, true);
+    String user = compactionInfo.runAs;
     SessionState sessionState = DriverUtils.setUpSessionState(conf, user, true);
     long compactorTxnId = CompactorMR.CompactorMap.getCompactorTxnId(conf);
     try {


### PR DESCRIPTION
Currently QB compaction runs as the session user, unlike MR compaction which runs as the table/partition directory owner (see CompactorThread#findUserToRunAs).

We should make QB compaction run as the table/partition directory owner and enable user impersonation during compaction to avoid any issues with temp directories.