### PR TITLE
HIVE-24093: Remove unused hive.debug.localtask

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2323,8 +2323,6 @@ public class HiveConf extends Configuration {
         "the local task. If GC time percentage exceeds this number, the local task will abort by " +
         "itself. Applies to Hive-on-Spark only"),
 
-    HIVEDEBUGLOCALTASK("hive.debug.localtask",false, ""),
-
     HIVEINPUTFORMAT("hive.input.format", "org.apache.hadoop.hive.ql.io.CombineHiveInputFormat",
         "The default input format. Set this to HiveInputFormat if you encounter problems with CombineHiveInputFormat."),
     HIVETEZINPUTFORMAT("hive.tez.input.format", "org.apache.hadoop.hive.ql.io.HiveInputFormat",


### PR DESCRIPTION
hive.debug.local.task was added in HIVE-1642. Even then, it was never used. It was possibly a leftover from development/debugging. There are no references to either HIVEDEBUGLOCALTASK or hive.debug.localtask in the codebase.

Change-Id: I27a385c264c362f6507eee4e29caf52f46e7dcba
