### PR TITLE
Hive 22758 and HIVE-20001 combine

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -161,7 +161,11 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
       throw hiveException(ex);
     }
 
-    Path path = getDbLocation(db);
+    Path path;
+    path = wh.determineDatabaseExternalPath(db);
+    if (path == null) {
+      path = getDbLocation(db);
+    }
 
     // extract drop privileges
     DropPrivilegeExtractor privExtractor = new DropPrivilegeExtractor(readRequiredPriv,

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -205,6 +205,24 @@ public class Warehouse {
     }
   }
 
+  /**
+   *  Returns the external path if it exists in the expected location. Null otherwise
+   * @param db
+   * @return the path if it exists, null otherwise
+   * file system.
+   */
+  public Path determineDatabaseExternalPath(Database db){
+    if (hasExternalWarehouseRoot()) {
+      try {
+        return getDefaultExternalDatabasePath(db.getName());
+      } catch (MetaException e) {
+        LOG.warn("Unable to determine external path for database " + db.getName());
+      }
+    }
+    return null;
+  }
+
+
   private String dbDirFromDbName(Database db) throws MetaException {
     return db.getName().toLowerCase() + DATABASE_WAREHOUSE_SUFFIX;
   }
@@ -296,7 +314,7 @@ public class Warehouse {
     }
   }
 
-  private boolean hasExternalWarehouseRoot() {
+  public boolean hasExternalWarehouseRoot() {
     return !StringUtils.isBlank(whRootExternalString);
   }
 
@@ -410,6 +428,16 @@ public class Warehouse {
     } catch (IOException e) {
       throw new MetaException(org.apache.hadoop.util.StringUtils.stringifyException(e));
     }
+  }
+
+  public boolean deleteDirIfEmpty(Path f) throws MetaException, IOException {
+    FileSystem fs = getFs(f);
+    if (FileUtils.isDirEmpty(fs, f)) {
+      return deleteDir(f, false, false, false);
+    } else {
+      LOG.info("Will not delete external directory " + f + " since it's not empty");
+    }
+    return true;
   }
 
   public boolean deleteDir(Path f, boolean recursive, Database db) throws MetaException {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -1215,6 +1215,11 @@ public abstract class TestHiveMetaStore {
   @Test
   public void testExternalDirectory() throws Exception{
     String externalDirString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL);
+
+    if (externalDirString == null) {
+      externalDirString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE);
+    }
+
     Path externalDir = new Path(externalDirString);
     silentDropDatabase(TEST_DB1_NAME);
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.metastore;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.sql.Connection;
@@ -44,6 +45,7 @@ import java.lang.reflect.*;
 import static org.mockito.Mockito.mock;
 
 import com.google.common.collect.Sets;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsFilterSpec;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsProjectionSpec;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsRequest;
@@ -59,6 +61,7 @@ import org.apache.hadoop.hive.metastore.utils.FileUtils;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.hadoop.hive.metastore.utils.MetastoreVersionInfo;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.datanucleus.api.jdo.JDOPersistenceManager;
 import org.datanucleus.api.jdo.JDOPersistenceManagerFactory;
 import org.junit.Assert;
@@ -1208,6 +1211,51 @@ public abstract class TestHiveMetaStore {
 
     assertTrue("Database creation succeeded even with permission problem", createFailed);
   }
+
+  @Test
+  public void testExternalDirectory() throws Exception{
+    String externalDirString = MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL);
+    Path externalDir = new Path(externalDirString);
+    silentDropDatabase(TEST_DB1_NAME);
+
+    String dbLocation =
+            MetastoreConf.getVar(conf, ConfVars.WAREHOUSE) + "/test/_testDB_create_";
+
+    String dbExternalLocation = externalDirString + "/testdb1.db";
+
+
+    FileSystem fs = FileSystem.get(new Path(dbLocation).toUri(), conf);
+    fs.mkdirs(
+            new Path(MetastoreConf.getVar(conf, ConfVars.WAREHOUSE)),
+            new FsPermission((short) 700));
+
+    fs.mkdirs(externalDir, new FsPermission((short) 0777));
+
+    Database db = new DatabaseBuilder()
+            .setName(TEST_DB1_NAME)
+            .setLocation(dbLocation)
+            .build(conf);
+    client.createDatabase(db);
+    FileStatus fileStatus = fs.getFileStatus(new Path(dbExternalLocation));
+
+    assertTrue("External folder should have been created", fileStatus.isDirectory());
+    assertEquals("External folder should have the right permissions", new FsPermission((short) 0755),
+            fileStatus.getPermission());
+    assertEquals("External folder should be owned by the right username",
+            UserGroupInformation.getCurrentUser().getShortUserName(), fileStatus.getOwner());
+    client.dropDatabase(db.getName());
+
+    try {
+      fs.getFileStatus(new Path(dbExternalLocation));
+      fail("External directory should have been deleted");
+    } catch (FileNotFoundException e) {
+    } finally {
+      fs.delete(new Path(MetastoreConf.getVar(conf, ConfVars.WAREHOUSE) + "/test"), true);
+      fs.delete(new Path(MetastoreConf.getVar(conf,
+              ConfVars.WAREHOUSE_EXTERNAL) + "/test"), true);
+    }
+  }
+
 
   @Test
   public void testDatabaseLocation() throws Throwable {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAddPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAddPartitions.java
@@ -541,7 +541,7 @@ public class TestAddPartitions extends MetaStoreClientTest {
         client.getPartition(DB_NAME, tableName, Lists.newArrayList(DEFAULT_YEAR_VALUE));
     Assert.assertNotNull(resultPart);
     Assert.assertNotNull(resultPart.getSd());
-    String defaultTableLocation = table.getSd().getLocation();
+    String defaultTableLocation = metaStore.getExternalWarehouseRoot() + "/" + DB_NAME + ".db/" + tableName;
     String defaulPartitionLocation = defaultTableLocation + "/year=2017";
     Assert.assertEquals(defaulPartitionLocation, resultPart.getSd().getLocation());
   }


### PR DESCRIPTION
Fix for With doas set to true, running select query as hrt_qa user on external table fails due to permission denied to read /warehouse/tablespace/managed directory. and Create database with permission error when doas set to true