### PR TITLE
HIVE-24104: NPE due to null key columns in ReduceSink after deduplication

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplicationUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/correlation/ReduceSinkDeDuplicationUtils.java
@@ -570,7 +570,7 @@ public class ReduceSinkDeDuplicationUtils {
         return false;
       }
     }
-    cRS.getConf().setKeyCols(ExprNodeDescUtils.backtrack(cKeysInParentRS, cRS, pRS));
+    cRS.getConf().setKeyCols(cKeysInParentRS);
 
     // Backtrack partition columns of cRS to pRS
     // If we cannot backtrack any of the columns, bail out
@@ -583,7 +583,7 @@ public class ReduceSinkDeDuplicationUtils {
         return false;
       }
     }
-    cRS.getConf().setPartitionCols(ExprNodeDescUtils.backtrack(cPartitionInParentRS, cRS, pRS));
+    cRS.getConf().setPartitionCols(cPartitionInParentRS);
 
     // Backtrack value columns of cRS to pRS
     // If we cannot backtrack any of the columns, bail out
@@ -596,7 +596,7 @@ public class ReduceSinkDeDuplicationUtils {
         return false;
       }
     }
-    cRS.getConf().setValueCols(ExprNodeDescUtils.backtrack(cValueInParentRS, cRS, pRS));
+    cRS.getConf().setValueCols(cValueInParentRS);
 
     // Backtrack bucket columns of cRS to pRS (if any)
     // If we cannot backtrack any of the columns, bail out
@@ -610,7 +610,7 @@ public class ReduceSinkDeDuplicationUtils {
           return false;
         }
       }
-      cRS.getConf().setBucketCols(ExprNodeDescUtils.backtrack(cBucketInParentRS, cRS, pRS));
+      cRS.getConf().setBucketCols(cBucketInParentRS);
     }
 
     // Update column expression map

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
@@ -143,14 +143,14 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
       List<String> outputValueColumnNames, int tag, List<ExprNodeDesc> partitionCols, int numReducers,
       final TableDesc keySerializeInfo, final TableDesc valueSerializeInfo,
       AcidUtils.Operation writeType) {
-    this.keyCols = keyCols;
+    setKeyCols(keyCols);
     this.numDistributionKeys = numDistributionKeys;
-    this.valueCols = valueCols;
+    setValueCols(valueCols);
     this.outputKeyColumnNames = outputKeyColumnNames;
     this.outputValueColumnNames = outputValueColumnNames;
     this.tag = tag;
     this.numReducers = numReducers;
-    this.partitionCols = partitionCols;
+    setPartitionCols(partitionCols);
     this.keySerializeInfo = keySerializeInfo;
     this.valueSerializeInfo = valueSerializeInfo;
     this.distinctColumnIndices = distinctColumnIndices;
@@ -240,6 +240,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
   }
 
   public void setKeyCols(List<ExprNodeDesc> keyCols) {
+    assert keyCols == null || keyCols.stream().allMatch(Objects::nonNull);
     this.keyCols = keyCols;
   }
 
@@ -262,6 +263,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
   }
 
   public void setValueCols(List<ExprNodeDesc> valueCols) {
+    assert valueCols == null || valueCols.stream().allMatch(Objects::nonNull);
     this.valueCols = valueCols;
   }
 
@@ -282,6 +284,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
 
   public void setPartitionCols(
       final List<ExprNodeDesc> partitionCols) {
+    assert partitionCols == null || partitionCols.stream().allMatch(Objects::nonNull);
     this.partitionCols = partitionCols;
   }
 
@@ -466,6 +469,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
   }
 
   public void setBucketCols(List<ExprNodeDesc> bucketCols) {
+    assert bucketCols == null || bucketCols.stream().allMatch(Objects::nonNull);
     this.bucketCols = bucketCols;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceSinkDesc.java
@@ -239,7 +239,7 @@ public class ReduceSinkDesc extends AbstractOperatorDesc {
     return keyCols;
   }
 
-  public void setKeyCols(final java.util.ArrayList<ExprNodeDesc> keyCols) {
+  public void setKeyCols(List<ExprNodeDesc> keyCols) {
     this.keyCols = keyCols;
   }
 

--- a/ql/src/test/queries/clientpositive/dynamic_semijoin_reduction_on_aggcol.q
+++ b/ql/src/test/queries/clientpositive/dynamic_semijoin_reduction_on_aggcol.q
@@ -1,3 +1,4 @@
+--! qt:disabled:flaky HIVE-24112
 --! qt:dataset:src
 set hive.explain.user=false;
 set hive.tez.dynamic.partition.pruning=true;

--- a/ql/src/test/queries/clientpositive/reduce_deduplicate_null_keys.q
+++ b/ql/src/test/queries/clientpositive/reduce_deduplicate_null_keys.q
@@ -1,0 +1,40 @@
+-- HIVE-24104: NPE due to null key columns in ReduceSink after deduplication
+-- The query in this test case is not very meaningful but corresponds to a reduced and anonymized version of a query
+-- used in production.
+CREATE TABLE TA(id int);
+INSERT INTO TA VALUES(10);
+
+-- The explain does not fail with NPE but the problem is already present in the plan. The reduce deduplication creates
+-- ReduceSink operators with nulls in the key columns something that in this case leads to NPE at runtime.
+EXPLAIN
+WITH
+TC AS
+(SELECT
+   TB.i A,
+   TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+    CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C;
+-- Execution fails before HIVE-24104
+WITH
+TC AS
+(SELECT
+     TB.i A,
+     TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+     CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C;

--- a/ql/src/test/results/clientpositive/llap/reduce_deduplicate_null_keys.q.out
+++ b/ql/src/test/results/clientpositive/llap/reduce_deduplicate_null_keys.q.out
@@ -1,0 +1,168 @@
+PREHOOK: query: CREATE TABLE TA(id int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@TA
+POSTHOOK: query: CREATE TABLE TA(id int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@TA
+PREHOOK: query: INSERT INTO TA VALUES(10)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ta
+POSTHOOK: query: INSERT INTO TA VALUES(10)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ta
+POSTHOOK: Lineage: ta.id SCRIPT []
+PREHOOK: query: EXPLAIN
+WITH
+TC AS
+(SELECT
+   TB.i A,
+   TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+    CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ta
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+WITH
+TC AS
+(SELECT
+   TB.i A,
+   TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+    CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ta
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ta
+                  Statistics: Num rows: 1 Data size: 2 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 1 Data size: 2 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      Statistics: Num rows: 1 Data size: 344 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col4, _col5
+                        Statistics: Num rows: 2 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col4 (type: int), (_col4 + 1) (type: int)
+                          outputColumnNames: _col0, _col1
+                          Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Reduce Output Operator
+                            key expressions: CASE WHEN ((_col0 = _col1)) THEN (1) ELSE (2) END (type: int)
+                            null sort order: z
+                            sort order: +
+                            Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: array('a','b') (type: array<string>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 408 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: posexplode
+                        Lateral View Join Operator
+                          outputColumnNames: _col4, _col5
+                          Statistics: Num rows: 2 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col4 (type: int), (_col4 + 1) (type: int)
+                            outputColumnNames: _col0, _col1
+                            Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Reduce Output Operator
+                              key expressions: CASE WHEN ((_col0 = _col1)) THEN (1) ELSE (2) END (type: int)
+                              null sort order: z
+                              sort order: +
+                              Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int)
+                outputColumnNames: _col0
+                Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: WITH
+TC AS
+(SELECT
+     TB.i A,
+     TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+     CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ta
+#### A masked pattern was here ####
+POSTHOOK: query: WITH
+TC AS
+(SELECT
+     TB.i A,
+     TB.i+1 B
+FROM TA
+LATERAL VIEW POSEXPLODE(ARRAY('a','b')) TB as i, x
+ORDER BY A),
+TD AS
+(SELECT
+     CASE WHEN A = B THEN 1 ELSE 2 END C
+FROM TC)
+SELECT C
+FROM TD
+ORDER BY C
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ta
+#### A masked pattern was here ####
+2
+2


### PR DESCRIPTION
### What changes were proposed in this pull request?

Remove double backtracking of columns inside ReduceSinkDeDuplicationUtils#ggressiveDedup.

### Why are the changes needed?

To prevent NPE during planning or execution. Examples in the JIRA case.

### Does this PR introduce _any_ user-facing change?

Changes in the EXPLAIN plans but probably for the best.


### How was this patch tested?
`mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile=reduce_deduplicate_null_keys.q`