### PR TITLE
[WIP]HIVE-23406: SharedWorkOptimizer should check nullSortOrders when comparing ReduceSink operators

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SharedWorkOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SharedWorkOptimizer.java
@@ -1503,6 +1503,7 @@ public class SharedWorkOptimizer extends Transform {
         StringUtils.equals(op1Conf.getParitionColsString(), op2Conf.getParitionColsString()) &&
         op1Conf.getTag() == op2Conf.getTag() &&
         StringUtils.equals(op1Conf.getOrder(), op2Conf.getOrder()) &&
+        StringUtils.equals(op1Conf.getNullOrder(), op2Conf.getNullOrder()) &&
         op1Conf.getTopN() == op2Conf.getTopN() &&
         canDeduplicateReduceTraits(op1Conf, op2Conf)) {
         return true;


### PR DESCRIPTION
### What changes were proposed in this pull request?
SharedWorkOptimizer compares ReduceSinkOperators by comparing the operators' configs in ReduceSinkDesc but it doesn't check null sort order.

### Why are the changes needed?
ReduceSinkOperators are considered to be equal if both operators has a ReduceSinkDesc object holding the same configuration. However null sort order was not checked during similarity check.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Run SharedWorkOptimizer q tests. 