### PR TITLE
HIVE-24116: LLAP: Provide an opportunity for preempted tasks to get b…

### DIFF
--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -2928,6 +2928,8 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     synchronized void setPreemptedInfo(long preemptTime) {
       this.state = State.PREEMPTED;
       this.preemptTime = preemptTime;
+      // Give an opportunity for preempted task to get better locality next time.
+      this.adjustedLocalityDelay = false;
     }
 
     synchronized void setInDelayedQueue(boolean val) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24116

Remote storage reads can be avoided, if an opportunity is provided for these preempted to get better locality in next iteration.