### PR TITLE
HIVE-24149. HiveStreamingConnection doesn't close HMS connection (amagyar)

### DIFF
--- a/streaming/src/java/org/apache/hive/streaming/HiveStreamingConnection.java
+++ b/streaming/src/java/org/apache/hive/streaming/HiveStreamingConnection.java
@@ -686,6 +686,12 @@ public class HiveStreamingConnection implements StreamingConnection {
       if (manageTransactions) {
         getMSC().close();
         getHeatbeatMSC().close();
+        try {
+          // Close the HMS that is used for addWriteNotificationLog
+          Hive.get(conf).getSynchronizedMSC().close();
+        } catch (Exception e) {
+          LOG.warn("Error while closing HMS connection", e);
+        }
       }
       //remove shutdown hook entry added while creating this connection via HiveStreamingConnection.Builder#connect()
       if (!ShutdownHookManager.isShutdownInProgress()) {


### PR DESCRIPTION
There 3 HMS connections used by HiveStreamingConnection. One for TX one for hearbeat and for notifications. The close method only closes the first 2 leaving the last one open which eventually overloads HMS and it becomes unresponsive.