### PR TITLE
HIVE-24158: Cleanup isn't complete in OrcFileMergeOperator#closeOp

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/OrcFileMergeOperator.java
@@ -266,8 +266,8 @@ public class OrcFileMergeOperator extends
         for (Map.Entry<Integer, Writer> outWriterEntry : outWriters.entrySet()) {
           Writer outWriter = outWriterEntry.getValue();
           outWriter.close();
-          outWriter = null;
         }
+        outWriters.clear();
       }
     } catch (Exception e) {
       throw new HiveException("Unable to close OrcFileMergeOperator", e);


### PR DESCRIPTION
Field Map<Integer, Writer> outWriters isn't cleared during operation close.