### PR TITLE
HIVE-24159: Kafka storage handler broken in secure environment pt2: short-circuit on non-secure environment

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -285,6 +285,9 @@ public class DagUtils {
   }
 
   private void getKafkaCredentials(MapWork work, DAG dag, JobConf conf) {
+    if (!UserGroupInformation.isSecurityEnabled()){
+      return;
+    }
     Token<?> tokenCheck = dag.getCredentials().getToken(KAFKA_DELEGATION_TOKEN_KEY);
     if (tokenCheck != null) {
       LOG.debug("Kafka credentials already added, skipping...");


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Check secure env before taking care of delegation tokens.

### Why are the changes needed?
Broken kafka_storage_handler.q test after HIVE-23408

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Tested with temporarily enabled qtest.