### PR TITLE
HIVE-24162: Query based compaction looses bloom filter

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -33,6 +33,7 @@ import org.junit.Before;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -124,17 +125,17 @@ public class CompactorOnTezTest {
 
     void createFullAcidTable(String tblName, boolean isPartitioned, boolean isBucketed)
         throws Exception {
-      createFullAcidTable(null, tblName, isPartitioned, isBucketed, false);
+      createFullAcidTable(null, tblName, isPartitioned, isBucketed, null);
     }
 
     void createFullAcidTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed)
         throws Exception {
-      createFullAcidTable(dbName, tblName, isPartitioned, isBucketed, false);
+      createFullAcidTable(dbName, tblName, isPartitioned, isBucketed, null);
     }
 
     void createFullAcidTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed,
-        boolean addBloomFilter) throws Exception {
-      createTable(dbName, tblName, isPartitioned, isBucketed, false, "orc", addBloomFilter);
+        Map<String, String> additionalTblProperties) throws Exception {
+      createTable(dbName, tblName, isPartitioned, isBucketed, false, "orc", additionalTblProperties);
     }
 
     void createMmTable(String tblName, boolean isPartitioned, boolean isBucketed)
@@ -149,11 +150,11 @@ public class CompactorOnTezTest {
 
     void createMmTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed, String fileFormat)
         throws Exception {
-      createTable(dbName, tblName, isPartitioned, isBucketed, true, fileFormat, false);
+      createTable(dbName, tblName, isPartitioned, isBucketed, true, fileFormat, null);
     }
 
     private void createTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed,
-        boolean insertOnly, String fileFormat, boolean addBloomFilter) throws Exception {
+        boolean insertOnly, String fileFormat, Map<String, String> additionalTblProperties) throws Exception {
       if (dbName != null) {
         tblName = dbName + "." + tblName;
       }
@@ -168,8 +169,10 @@ public class CompactorOnTezTest {
       }
       query.append(" stored as ").append(fileFormat);
       query.append(" TBLPROPERTIES('transactional'='true',");
-      if (addBloomFilter) {
-        query.append("'orc.bloom.filter.columns'='b', 'orc.bloom.filter.fpp'='0.02',");
+      if (additionalTblProperties != null) {
+        for (Map.Entry<String, String> e : additionalTblProperties.entrySet()) {
+          query.append("'").append(e.getKey()).append("'='").append(e.getValue()).append("', ");
+        }
       }
       if (insertOnly) {
         query.append(" 'transactional_properties'='insert_only')");

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -124,12 +124,17 @@ public class CompactorOnTezTest {
 
     void createFullAcidTable(String tblName, boolean isPartitioned, boolean isBucketed)
         throws Exception {
-      createFullAcidTable(null, tblName, isPartitioned, isBucketed);
+      createFullAcidTable(null, tblName, isPartitioned, isBucketed, false);
     }
 
     void createFullAcidTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed)
         throws Exception {
-      createTable(dbName, tblName, isPartitioned, isBucketed, false, "orc");
+      createFullAcidTable(dbName, tblName, isPartitioned, isBucketed, false);
+    }
+
+    void createFullAcidTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed,
+        boolean addBloomFilter) throws Exception {
+      createTable(dbName, tblName, isPartitioned, isBucketed, false, "orc", addBloomFilter);
     }
 
     void createMmTable(String tblName, boolean isPartitioned, boolean isBucketed)
@@ -144,11 +149,11 @@ public class CompactorOnTezTest {
 
     void createMmTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed, String fileFormat)
         throws Exception {
-      createTable(dbName, tblName, isPartitioned, isBucketed, true, fileFormat);
+      createTable(dbName, tblName, isPartitioned, isBucketed, true, fileFormat, false);
     }
 
     private void createTable(String dbName, String tblName, boolean isPartitioned, boolean isBucketed,
-        boolean insertOnly, String fileFormat) throws Exception {
+        boolean insertOnly, String fileFormat, boolean addBloomFilter) throws Exception {
       if (dbName != null) {
         tblName = dbName + "." + tblName;
       }
@@ -163,6 +168,9 @@ public class CompactorOnTezTest {
       }
       query.append(" stored as ").append(fileFormat);
       query.append(" TBLPROPERTIES('transactional'='true',");
+      if (addBloomFilter) {
+        query.append("'orc.bloom.filter.columns'='b', 'orc.bloom.filter.fpp'='0.02',");
+      }
       if (insertOnly) {
         query.append(" 'transactional_properties'='insert_only')");
       } else {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -21,8 +21,10 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -147,7 +149,10 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     String dbName = "default";
     String tblName = "testMajorCompaction";
     TestDataProvider testDataProvider = new TestDataProvider();
-    testDataProvider.createFullAcidTable(dbName, tblName, false, false, true);
+    Map<String, String> additionalTblProperties = new HashMap<>();
+    additionalTblProperties.put("orc.bloom.filter.columns", "b");
+    additionalTblProperties.put("orc.bloom.filter.fpp", "0.02");
+    testDataProvider.createFullAcidTable(dbName, tblName, false, false, additionalTblProperties);
     testDataProvider.insertTestData(tblName);
     // Find the location of the table
     IMetaStoreClient msClient = new HiveMetaStoreClient(conf);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -54,11 +54,13 @@ import org.apache.hive.streaming.HiveStreamingConnection;
 import org.apache.hive.streaming.StreamingConnection;
 import org.apache.hive.streaming.StrictDelimitedInputWriter;
 import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto;
 import org.apache.orc.Reader;
 import org.apache.orc.RecordReader;
+import org.apache.orc.StripeInformation;
 import org.apache.orc.TypeDescription;
+import org.apache.orc.impl.RecordReaderImpl;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Test;
 
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
@@ -133,6 +135,50 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
     CompactorTestUtilities.checkAcidVersion(fs.listFiles(new Path(table.getSd().getLocation()), true), fs, true,
         new String[] { AcidUtils.BASE_PREFIX});
     conf.setBoolVar(HiveConf.ConfVars.HIVE_WRITE_ACID_VERSION_FILE, originalEnableVersionFile);
+  }
+
+  /**
+   * Query based compaction should respect the orc.bloom.filter properties
+   * @throws Exception
+   */
+  @Test
+  public void testMajorCompactionWithBloomFilter() throws Exception {
+
+    String dbName = "default";
+    String tblName = "testMajorCompaction";
+    TestDataProvider testDataProvider = new TestDataProvider();
+    testDataProvider.createFullAcidTable(dbName, tblName, false, false, true);
+    testDataProvider.insertTestData(tblName);
+    // Find the location of the table
+    IMetaStoreClient msClient = new HiveMetaStoreClient(conf);
+    Table table = msClient.getTable(dbName, tblName);
+    FileSystem fs = FileSystem.get(conf);
+    // Verify deltas are present
+    Assert.assertEquals("Delta directories does not match before compaction",
+        Arrays.asList("delta_0000001_0000001_0000", "delta_0000002_0000002_0000",
+            "delta_0000004_0000004_0000"),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.deltaFileFilter, table, null));
+    // Check bucket file contains the bloomFilter
+    checkBloomFilterInAcidFile(fs, new Path(table.getSd().getLocation(), "delta_0000001_0000001_0000/bucket_00000_0"));
+
+    // Run major compaction and cleaner
+    CompactorTestUtil.runCompaction(conf, dbName, tblName, CompactionType.MAJOR, true);
+    CompactorTestUtil.runCleaner(conf);
+    verifySuccessfulCompaction(1);
+    // Should contain only one base directory now
+    String expectedBase = "base_0000005_v0000008";
+    Assert.assertEquals("Base directory does not match after major compaction",
+        Collections.singletonList(expectedBase),
+        CompactorTestUtil.getBaseOrDeltaNames(fs, AcidUtils.baseFileFilter, table, null));
+    // Check base dir contents
+    List<String> expectedBucketFiles = Arrays.asList("bucket_00000");
+    Assert.assertEquals("Bucket names are not matching after compaction", expectedBucketFiles,
+        CompactorTestUtil
+            .getBucketFileNames(fs, table, null, expectedBase));
+    // Check bucket file contents
+    checkBucketIdAndRowIdInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase), 0);
+
+    checkBloomFilterInAcidFile(fs, new Path(table.getSd().getLocation(), expectedBase + "/bucket_00000"));
   }
 
   /**
@@ -1725,6 +1771,18 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
           rowId = 0;
         }
       }
+    }
+  }
+
+  private void checkBloomFilterInAcidFile(FileSystem fs, Path bucketFilePath) throws IOException {
+    Reader orcReader = OrcFile.createReader(bucketFilePath,
+        OrcFile.readerOptions(fs.getConf()).filesystem(fs));
+    StripeInformation stripe = orcReader.getStripes().get(0);
+    try (RecordReaderImpl rows = (RecordReaderImpl)orcReader.rows()) {
+      boolean bloomFilter = rows.readStripeFooter(stripe).getStreamsList().stream().anyMatch(
+          s -> s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER_UTF8
+              || s.getKind() == OrcProto.Stream.Kind.BLOOM_FILTER);
+      Assert.assertTrue("Bloom filter is missing", bloomFilter);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
@@ -557,7 +557,7 @@ class CompactionQueryBuilder {
           }
           tblProperties.put(e.getKey(), HiveStringUtils.escapeHiveCommand(e.getValue()));
         }
-      } else if (crud) {
+      } else {
         for (Map.Entry<String, String> e : sourceTab.getParameters().entrySet()) {
           if (e.getKey().startsWith("orc.")) {
             tblProperties.put(e.getKey(), HiveStringUtils.escapeHiveCommand(e.getValue()));

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactionQueryBuilder.java
@@ -543,18 +543,26 @@ class CompactionQueryBuilder {
     if (crud && minor && isBucketed) {
       tblProperties.put("bucketing_version", String.valueOf(bucketingVersion));
     }
-    if (insertOnly && sourceTab != null) { // to avoid NPEs, skip this part if sourceTab is null
-      // Exclude all standard table properties.
-      Set<String> excludes = getHiveMetastoreConstants();
-      excludes.addAll(StatsSetupConst.TABLE_PARAMS_STATS_KEYS);
-      for (Map.Entry<String, String> e : sourceTab.getParameters().entrySet()) {
-        if (e.getValue() == null) {
-          continue;
+    if (sourceTab != null) { // to avoid NPEs, skip this part if sourceTab is null
+      if (insertOnly) {
+        // Exclude all standard table properties.
+        Set<String> excludes = getHiveMetastoreConstants();
+        excludes.addAll(StatsSetupConst.TABLE_PARAMS_STATS_KEYS);
+        for (Map.Entry<String, String> e : sourceTab.getParameters().entrySet()) {
+          if (e.getValue() == null) {
+            continue;
+          }
+          if (excludes.contains(e.getKey())) {
+            continue;
+          }
+          tblProperties.put(e.getKey(), HiveStringUtils.escapeHiveCommand(e.getValue()));
         }
-        if (excludes.contains(e.getKey())) {
-          continue;
+      } else if (crud) {
+        for (Map.Entry<String, String> e : sourceTab.getParameters().entrySet()) {
+          if (e.getKey().startsWith("orc.")) {
+            tblProperties.put(e.getKey(), HiveStringUtils.escapeHiveCommand(e.getValue()));
+          }
         }
-        tblProperties.put(e.getKey(), HiveStringUtils.escapeHiveCommand(e.getValue()));
       }
     }
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Keep the orc.bloom.filter during Query based compaction.

### Why are the changes needed?
Fix the bug

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Test added
