### PR TITLE
HIVE-24166: use uppercase database name cause alias error

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2182,7 +2182,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         tab = newTab;
       }
       if (tab == null ||
-          tab.getDbName().equals(SessionState.get().getCurrentDatabase())) {
+          tab.getDbName().equals(SessionState.get().getCurrentDatabase().toLowerCase())) {
         Table materializedTab = ctx.getMaterializedTable(cteName);
         if (materializedTab == null) {
           // we first look for this alias from CTE, and then from catalog.


### PR DESCRIPTION

### What changes were proposed in this pull request?

fix alias error when use database`s name is uppercase


### Why are the changes needed?
fix bug

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
test in my env
