### PR TITLE
HIVE-24169: HiveServer2 UDF cache

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3552,6 +3552,8 @@ public class HiveConf extends Configuration {
         "The parent node in ZooKeeper used by HiveServer2 when supporting dynamic service discovery."),
     HIVE_SERVER2_ZOOKEEPER_PUBLISH_CONFIGS("hive.server2.zookeeper.publish.configs", true,
         "Whether we should publish HiveServer2's configs to ZooKeeper."),
+    HIVE_SERVER2_UDF_CACHE_ENABLED("hive.server2.udf.cache.enabled", false,
+        "Whether HiveServer2 UDF cache is enabled. Disabled by default."),
 
     // HiveServer2 global init file location
     HIVE_SERVER2_GLOBAL_INIT_FILE_LOCATION("hive.server2.global.init.file.location", "${env:HIVE_CONF_DIR}",

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
@@ -74,15 +74,18 @@ public final class FunctionUtils {
     }
     return converted;
   }
+  public static void addFunctionResources(FunctionResource[] resources) throws HiveException{
+    addFunctionResources(resources, false);
+  }
 
-  public static void addFunctionResources(FunctionResource[] resources) throws HiveException {
+  public static void addFunctionResources(FunctionResource[] resources, boolean useCache) throws HiveException {
     if (resources != null) {
       Multimap<SessionState.ResourceType, String> mappings = HashMultimap.create();
       for (FunctionResource res : resources) {
         mappings.put(res.getResourceType(), res.getResourceURI());
       }
       for (SessionState.ResourceType type : mappings.keys()) {
-        SessionState.get().add_resources(type, mappings.get(type));
+        SessionState.get().add_resources(type, mappings.get(type), false, useCache);
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -586,9 +586,11 @@ public class Registry {
         FunctionResource[] resources = fi.getResources();
         if (fi.isPersistent()) {
           Map<String, String> udfCacheMap = SessionState.getUDFCacheMap();
-          for(FunctionResource fr : resources){
-            //remove from udf cache if it's saved.
-            udfCacheMap.remove(fr.getResourceURI());
+          if(resources != null) {
+            for (FunctionResource fr : resources) {
+              //remove from udf cache if it's saved.
+              udfCacheMap.remove(fr.getResourceURI());
+            }
           }
           removePersistentFunctionUnderLock(fi);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -583,7 +583,13 @@ public class Registry {
         }
         mFunctions.remove(functionName);
         fi.discarded();
+        FunctionResource[] resources = fi.getResources();
         if (fi.isPersistent()) {
+          Map<String, String> udfCacheMap = SessionState.getUDFCacheMap();
+          for(FunctionResource fr : resources){
+            //remove from udf cache if it's saved.
+            udfCacheMap.remove(fr.getResourceURI());
+          }
           removePersistentFunctionUnderLock(fi);
         }
       }
@@ -666,7 +672,9 @@ public class Registry {
       // At this point we should add any relevant jars that would be needed for the UDf.
       FunctionResource[] resources = function.getResources();
       try {
-        FunctionUtils.addFunctionResources(resources);
+        boolean useCache = function.isPersistent() &&
+            HiveConf.getBoolVar(SessionState.getSessionConf(), ConfVars.HIVE_SERVER2_UDF_CACHE_ENABLED);
+        FunctionUtils.addFunctionResources(resources, useCache);
       } catch (Exception e) {
         LOG.error("Unable to load resources for " + qualifiedName + ":" + e, e);
         return null;

--- a/ql/src/test/org/apache/hadoop/hive/ql/session/TestAddResource.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/session/TestAddResource.java
@@ -109,7 +109,7 @@ public class TestAddResource {
     list.add(createURI(TEST_JAR_DIR + "testjar5.jar"));
 
     //return all the dependency urls
-    Mockito.when(ss.resolveAndDownload(t, query, false)).thenReturn(list);
+    Mockito.when(ss.resolveAndDownload(t, query, false, false)).thenReturn(list);
     addList.add(query);
     ss.add_resources(t, addList);
     Set<String> dependencies = ss.list_resource(t, null);
@@ -145,7 +145,7 @@ public class TestAddResource {
 
     Collections.sort(list);
 
-    Mockito.when(ss.resolveAndDownload(t, query, false)).thenReturn(list);
+    Mockito.when(ss.resolveAndDownload(t, query, false, false)).thenReturn(list);
     for (int i = 0; i < 10; i++) {
       addList.add(query);
     }
@@ -183,8 +183,8 @@ public class TestAddResource {
     list2.add(createURI(TEST_JAR_DIR + "testjar3.jar"));
     list2.add(createURI(TEST_JAR_DIR + "testjar4.jar"));
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query1, false, false)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2, false, false)).thenReturn(list2);
     addList.add(query1);
     addList.add(query2);
     ss.add_resources(t, addList);
@@ -234,8 +234,8 @@ public class TestAddResource {
     Collections.sort(list1);
     Collections.sort(list2);
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query1, false, false)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2, false, false)).thenReturn(list2);
     addList.add(query1);
     addList.add(query2);
     ss.add_resources(t, addList);
@@ -293,9 +293,9 @@ public class TestAddResource {
     Collections.sort(list2);
     Collections.sort(list3);
 
-    Mockito.when(ss.resolveAndDownload(t, query1, false)).thenReturn(list1);
-    Mockito.when(ss.resolveAndDownload(t, query2, false)).thenReturn(list2);
-    Mockito.when(ss.resolveAndDownload(t, query3, false)).thenReturn(list3);
+    Mockito.when(ss.resolveAndDownload(t, query1, false, false)).thenReturn(list1);
+    Mockito.when(ss.resolveAndDownload(t, query2, false, false)).thenReturn(list2);
+    Mockito.when(ss.resolveAndDownload(t, query3, false, false)).thenReturn(list3);
     addList.add(query1);
     addList.add(query2);
     addList.add(query3);


### PR DESCRIPTION

### What changes were proposed in this pull request?
This feature adds a HiveServer2 level UDF cache that can be shared across sessions. 



### Why are the changes needed?
Without this feature, on S3 based system, describe function and select udf() will be localized each and every time, taking 2 minutes to download 300mb. 

### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
manual
