### PR TITLE
HIVE-24176: Create query-level cache for HMS requests and extend existing local HS2 HMS cache

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -488,7 +488,7 @@ public class HiveConf extends Configuration {
    */
   public static enum ConfVars {
     MSC_CACHE_ENABLED("hive.metastore.client.cache.enabled", true,
-            "This property enables a Caffeiene Cache for Metastore client"),
+            "This property enables a Caffeine Cache for Metastore client"),
     MSC_CACHE_MAX_SIZE("hive.metastore.client.cache.maxSize", "1Gb", new SizeValidator(),
             "Set the maximum size (number of bytes) of the metastore client cache (DEFAULT: 1GB). " +
                     "Only in effect when the cache is enabled"),
@@ -2604,6 +2604,9 @@ public class HiveConf extends Configuration {
             + "The probe side for the row-level filtering is generated either statically in the case of expressions or dynamically for joins"
             + "e.g., use the cached MapJoin hashtable created on the small table side to filter out row columns that are not going "
             + "to be used when reading the large table data. This will result less CPU cycles spent for decoding unused data."),
+
+    HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED("hive.optimize.metadata.query.cache.enabled", true,
+        "This property enables caching metadata for repetitive requests on a per-query basis"),
 
     // CTE
     HIVE_CTE_MATERIALIZE_THRESHOLD("hive.optimize.cte.materialize.threshold", 3,

--- a/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
@@ -218,7 +218,12 @@ public class Compiler {
     }
 
     // Do semantic analysis and plan generation
-    sem.analyze(tree, context);
+    try {
+      sem.startAnalysis();
+      sem.analyze(tree, context);
+    } finally {
+      sem.endAnalysis();
+    }
 
     if (executeHooks) {
       hookCtx.update(sem);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/SessionHiveMetaStoreClient.java
@@ -49,14 +49,28 @@ import org.apache.hadoop.hive.metastore.PartFilterExprUtil;
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
+import org.apache.hadoop.hive.metastore.api.AggrStats;
 import org.apache.hadoop.hive.metastore.api.AlreadyExistsException;
 import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.ConfigValSecurityException;
+import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
+import org.apache.hadoop.hive.metastore.api.ForeignKeysResponse;
+import org.apache.hadoop.hive.metastore.api.GetDatabaseRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionNamesPsRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionNamesPsResponse;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesResult;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthRequest;
 import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthResponse;
+import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsRequest;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsResponse;
 import org.apache.hadoop.hive.metastore.api.InvalidInputException;
 import org.apache.hadoop.hive.metastore.api.InvalidObjectException;
 import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
@@ -64,6 +78,8 @@ import org.apache.hadoop.hive.metastore.api.HiveObjectRef;
 import org.apache.hadoop.hive.metastore.api.HiveObjectType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.NotNullConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.NotNullConstraintsResponse;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionListComposingSpec;
 import org.apache.hadoop.hive.metastore.api.PartitionSpec;
@@ -71,9 +87,19 @@ import org.apache.hadoop.hive.metastore.api.PartitionValuesRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionValuesResponse;
 import org.apache.hadoop.hive.metastore.api.PartitionValuesRow;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
+import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
+import org.apache.hadoop.hive.metastore.api.PartitionsSpecByExprResult;
+import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
+import org.apache.hadoop.hive.metastore.api.PrimaryKeysRequest;
+import org.apache.hadoop.hive.metastore.api.PrimaryKeysResponse;
 import org.apache.hadoop.hive.metastore.api.PrincipalPrivilegeSet;
 import org.apache.hadoop.hive.metastore.api.SetPartitionsStatsRequest;
 import org.apache.hadoop.hive.metastore.api.TableMeta;
+import org.apache.hadoop.hive.metastore.api.TableStatsRequest;
+import org.apache.hadoop.hive.metastore.api.TableStatsResult;
+import org.apache.hadoop.hive.metastore.api.TableValidWriteIds;
+import org.apache.hadoop.hive.metastore.api.UniqueConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.UniqueConstraintsResponse;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
 import org.apache.hadoop.hive.metastore.api.UnknownTableException;
 import org.apache.hadoop.hive.metastore.client.builder.PartitionBuilder;
@@ -206,8 +232,7 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
 
   @Override
   public org.apache.hadoop.hive.metastore.api.Table getTable(String dbname, String name,
-  boolean getColStats, String engine) throws MetaException,
-  TException, NoSuchObjectException {
+      boolean getColStats, String engine) throws MetaException, TException, NoSuchObjectException {
     // First check temp tables
     org.apache.hadoop.hive.metastore.api.Table table = getTempTable(dbname, name);
     if (table != null) {
@@ -1193,7 +1218,8 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
       String defaultPartitionName, int maxParts, List<Partition> result) throws TException {
     org.apache.hadoop.hive.metastore.api.Table table = getTempTable(dbName, tblName);
     if (table == null) {
-      return super.listPartitionsByExpr(catName, dbName, tblName, expr, defaultPartitionName, maxParts, result);
+      return super.listPartitionsByExpr(catName, dbName, tblName, expr,
+          defaultPartitionName, maxParts, result);
     }
     assert result != null;
     result.addAll(getPartitionsForMaxParts(tblName, getPartitionedTempTable(table).listPartitionsByFilter(
@@ -1218,7 +1244,7 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
 
   @Override
   public List<Partition> getPartitionsByNames(String catName, String dbName, String tblName,
-                                              List<String> partNames, boolean getColStats, String engine) throws TException {
+      List<String> partNames, boolean getColStats, String engine) throws TException {
     org.apache.hadoop.hive.metastore.api.Table table = getTempTable(dbName, tblName);
     if (table == null) {
       //(assume) not a temp table - Try underlying client
@@ -1910,4 +1936,427 @@ public class SessionHiveMetaStoreClient extends HiveMetaStoreClientWithLocalCach
     }
     return false;
   }
+
+  @Override
+  protected String getConfigValueInternal(String name, String defaultValue)
+      throws TException, ConfigValSecurityException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.CONFIG_VALUE, name, defaultValue);
+      String v = (String) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getConfigValueInternal(name, defaultValue);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getConfigValueInternal");
+      }
+      return v;
+    }
+    return super.getConfigValueInternal(name, defaultValue);
+  }
+
+  @Override
+  protected Database getDatabaseInternal(GetDatabaseRequest request) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.DATABASE, request);
+      Database v = (Database) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getDatabaseInternal(request);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getDatabaseInternal");
+      }
+      return v;
+    }
+    return super.getDatabaseInternal(request);
+  }
+
+  @Override
+  protected GetTableResult getTableInternal(GetTableRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.TABLE, req);
+      GetTableResult v = (GetTableResult) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getTableInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getTableInternal");
+      }
+      return v;
+    }
+    return super.getTableInternal(req);
+  }
+
+  @Override
+  protected PrimaryKeysResponse getPrimaryKeysInternal(PrimaryKeysRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.PRIMARY_KEYS, req);
+      PrimaryKeysResponse v = (PrimaryKeysResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getPrimaryKeysInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getPrimaryKeysInternal");
+      }
+      return v;
+    }
+    return super.getPrimaryKeysInternal(req);
+  }
+
+  @Override
+  protected ForeignKeysResponse getForeignKeysInternal(ForeignKeysRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.FOREIGN_KEYS, req);
+      ForeignKeysResponse v = (ForeignKeysResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getForeignKeysInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getForeignKeysInternal");
+      }
+      return v;
+    }
+    return super.getForeignKeysInternal(req);
+  }
+
+  @Override
+  protected UniqueConstraintsResponse getUniqueConstraintsInternal(UniqueConstraintsRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.UNIQUE_CONSTRAINTS, req);
+      UniqueConstraintsResponse v = (UniqueConstraintsResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getUniqueConstraintsInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getUniqueConstraintsInternal");
+      }
+      return v;
+    }
+    return super.getUniqueConstraintsInternal(req);
+  }
+
+  @Override
+  protected NotNullConstraintsResponse getNotNullConstraintsInternal(NotNullConstraintsRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.NOT_NULL_CONSTRAINTS, req);
+      NotNullConstraintsResponse v = (NotNullConstraintsResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getNotNullConstraintsInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getNotNullConstraintsInternal");
+      }
+      return v;
+    }
+    return super.getNotNullConstraintsInternal(req);
+  }
+
+  @Override
+  protected TableStatsResult getTableColumnStatisticsInternal(TableStatsRequest rqst) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      MapWrapper cache = new MapWrapper(queryCache);
+      // 1) Retrieve from the cache those ids present, gather the rest
+      Pair<List<ColumnStatisticsObj>, List<String>> p = getTableColumnStatisticsCache(
+          cache, rqst, null);
+      List<String> colStatsMissing = p.getRight();
+      List<ColumnStatisticsObj> colStats = p.getLeft();
+      // 2) If they were all present in the cache, return
+      if (colStatsMissing.isEmpty()) {
+        return new TableStatsResult(colStats);
+      }
+      // 3) If they were not, gather the remaining
+      TableStatsRequest newRqst = new TableStatsRequest(rqst);
+      newRqst.setColNames(colStatsMissing);
+      TableStatsResult r = super.getTableColumnStatisticsInternal(newRqst);
+      // 4) Populate the cache
+      List<ColumnStatisticsObj> newColStats = loadTableColumnStatisticsCache(
+          cache, r, rqst, null);
+      // 5) Sort result (in case there is any assumption) and return
+      return computeTableColumnStatisticsFinal(rqst, colStats, newColStats);
+    }
+    return super.getTableColumnStatisticsInternal(rqst);
+  }
+
+  @Override
+  protected AggrStats getAggrStatsForInternal(PartitionsStatsRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.AGGR_COL_STATS, req);
+      AggrStats v = (AggrStats) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getAggrStatsForInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getAggrStatsForInternal");
+      }
+      return v;
+    }
+    return super.getAggrStatsForInternal(req);
+  }
+
+  @Override
+  protected PartitionsByExprResult getPartitionsByExprInternal(PartitionsByExprRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_BY_EXPR, req);
+      PartitionsByExprResult v = (PartitionsByExprResult) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getPartitionsByExprInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getPartitionsByExprInternal");
+      }
+      return v;
+    }
+    return super.getPartitionsByExprInternal(req);
+  }
+
+  @Override
+  protected PartitionsSpecByExprResult getPartitionsSpecByExprInternal(PartitionsByExprRequest req) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_SPEC_BY_EXPR, req);
+      PartitionsSpecByExprResult v = (PartitionsSpecByExprResult) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.getPartitionsSpecByExprInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=getPartitionsSpecByExprInternal");
+      }
+      return v;
+    }
+    return super.getPartitionsSpecByExprInternal(req);
+  }
+
+  @Override
+  protected List<String> listPartitionNamesInternal(String catName, String dbName, String tableName,
+       int maxParts) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_ALL,
+          catName, dbName, tableName, maxParts);
+      List<String> v = (List<String>) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionNamesInternal(catName, dbName, tableName, maxParts);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionNamesInternalAll");
+      }
+      return v;
+    }
+    return super.listPartitionNamesInternal(catName, dbName, tableName, maxParts);
+  }
+
+  protected List<String> listPartitionNamesInternal(String catName, String dbName, String tableName,
+       List<String> partVals, int maxParts) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS,
+          catName, dbName, tableName, partVals, maxParts);
+      List<String> v = (List<String>) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionNamesInternal(catName, dbName, tableName, partVals, maxParts);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionNamesInternal");
+      }
+      return v;
+    }
+    return super.listPartitionNamesInternal(catName, dbName, tableName, partVals, maxParts);
+  }
+
+  @Override
+  protected GetPartitionNamesPsResponse listPartitionNamesRequestInternal(GetPartitionNamesPsRequest req)
+      throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_REQ, req);
+      GetPartitionNamesPsResponse v = (GetPartitionNamesPsResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionNamesRequestInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionNamesRequestInternal");
+      }
+      return v;
+    }
+    return super.listPartitionNamesRequestInternal(req);
+  }
+
+  @Override
+  protected List<Partition> listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+      int maxParts, String userName, List<String> groupNames) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_AUTH_INFO_ALL,
+          catName, dbName, tableName, maxParts, userName, groupNames);
+      List<Partition> v = (List<Partition>) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionsWithAuthInfoInternal(catName, dbName, tableName, maxParts, userName, groupNames);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionsWithAuthInfoInternalAll");
+      }
+      return v;
+    }
+    return super.listPartitionsWithAuthInfoInternal(catName, dbName, tableName, maxParts, userName, groupNames);
+  }
+
+  @Override
+  protected List<Partition> listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+      List<String> partialPvals, int maxParts, String userName, List<String> groupNames)
+      throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_AUTH_INFO,
+          catName, dbName, tableName, partialPvals, maxParts, userName, groupNames);
+      List<Partition> v = (List<Partition>) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionsWithAuthInfoInternal(catName, dbName, tableName, partialPvals, maxParts, userName, groupNames);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionsWithAuthInfoInternal");
+      }
+      return v;
+    }
+    return super.listPartitionsWithAuthInfoInternal(catName, dbName, tableName, partialPvals, maxParts, userName, groupNames);
+  }
+
+  @Override
+  protected GetPartitionsPsWithAuthResponse listPartitionsWithAuthInfoRequestInternal(GetPartitionsPsWithAuthRequest req)
+      throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      // Retrieve or populate cache
+      CacheKey cacheKey = new CacheKey(KeyType.LIST_PARTITIONS_AUTH_INFO_REQ, req);
+      GetPartitionsPsWithAuthResponse v = (GetPartitionsPsWithAuthResponse) queryCache.get(cacheKey);
+      if (v == null) {
+        v = super.listPartitionsWithAuthInfoRequestInternal(req);
+        queryCache.put(cacheKey, v);
+      } else {
+        LOG.debug("Query level HMS cache: method=listPartitionsWithAuthInfoRequestInternal");
+      }
+      return v;
+    }
+    return super.listPartitionsWithAuthInfoRequestInternal(req);
+  }
+
+  @Override
+  protected GetPartitionsByNamesResult getPartitionsByNamesInternal(GetPartitionsByNamesRequest rqst) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      MapWrapper cache = new MapWrapper(queryCache);
+      // 1) Retrieve from the cache those ids present, gather the rest
+      Pair<List<Partition>, List<String>> p = getPartitionsByNamesCache(
+          cache, rqst, null);
+      List<String> partitionsMissing = p.getRight();
+      List<Partition> partitions = p.getLeft();
+      // 2) If they were all present in the cache, return
+      if (partitionsMissing.isEmpty()) {
+        return new GetPartitionsByNamesResult(partitions);
+      }
+      // 3) If they were not, gather the remaining
+      GetPartitionsByNamesRequest newRqst = new GetPartitionsByNamesRequest(rqst);
+      newRqst.setNames(partitionsMissing);
+      GetPartitionsByNamesResult r = super.getPartitionsByNamesInternal(newRqst);
+      // 4) Populate the cache
+      List<Partition> newPartitions = loadPartitionsByNamesCache(
+          cache, r, rqst, null);
+      // 5) Sort result (in case there is any assumption) and return
+      return computePartitionsByNamesFinal(rqst, partitions, newPartitions);
+    }
+    return super.getPartitionsByNamesInternal(rqst);
+  }
+
+  @Override
+  protected GetValidWriteIdsResponse getValidWriteIdsInternal(GetValidWriteIdsRequest rqst) throws TException {
+    Map<Object, Object> queryCache = getQueryCache();
+    if (queryCache != null) {
+      MapWrapper cache = new MapWrapper(queryCache);
+      // 1) Retrieve from the cache those ids present, gather the rest
+      Pair<List<TableValidWriteIds>, List<String>> p = getValidWriteIdsCache(
+          cache, rqst);
+      List<String> fullTableNamesMissing = p.getRight();
+      List<TableValidWriteIds> tblValidWriteIds = p.getLeft();
+      // 2) If they were all present in the cache, return
+      if (fullTableNamesMissing.isEmpty()) {
+        return new GetValidWriteIdsResponse(tblValidWriteIds);
+      }
+      // 3) If they were not, gather the remaining
+      GetValidWriteIdsRequest newRqst = new GetValidWriteIdsRequest(rqst);
+      newRqst.setFullTableNames(fullTableNamesMissing);
+      GetValidWriteIdsResponse r = super.getValidWriteIdsInternal(newRqst);
+      // 4) Populate the cache
+      List<TableValidWriteIds> newTblValidWriteIds = loadValidWriteIdsCache(
+          cache, r, rqst);
+      // 5) Sort result (in case there is any assumption) and return
+      return computeValidWriteIdsFinal(rqst, tblValidWriteIds, newTblValidWriteIds);
+    }
+    return super.getValidWriteIdsInternal(rqst);
+  }
+
+  /**
+   * Wrapper to create a cache around a Map.
+   */
+  protected static class MapWrapper implements CacheI {
+
+    final Map<Object, Object> m;
+
+    protected MapWrapper(Map<Object, Object> m) {
+      this.m = m;
+    }
+
+    @Override
+    public void put(Object k, Object v) {
+      m.put(k, v);
+    }
+
+    @Override
+    public Object get(Object k) {
+      return m.get(k);
+    }
+  }
+
+  private Map<Object, Object> getQueryCache() {
+    String queryId = getQueryId();
+    if (queryId != null) {
+      SessionState ss = SessionState.get();
+      if (ss != null) {
+        return ss.getQueryCache(queryId);
+      }
+    }
+    return null;
+  }
+
+  private String getQueryId() {
+    try {
+      return Hive.get().getConf().get(HiveConf.ConfVars.HIVEQUERYID.varname);
+    } catch (HiveException e) {
+      LOG.error("Error getting query id. Query level HMS caching will be disabled", e);
+      return null;
+    }
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -1835,4 +1835,18 @@ public abstract class BaseSemanticAnalyzer {
     unparseTranslator.applyTranslations(ctx.getTokenRewriteStream());
   }
 
+  /**
+   * Called when we start analysis of a query.
+   */
+  public void startAnalysis() {
+    // Nothing to do
+  }
+
+  /**
+   * Called when we end analysis of a query.
+   */
+  public void endAnalysis() {
+    // Nothing to do
+  }
+
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -15280,7 +15280,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
     SessionState ss = SessionState.get();
     if (ss == null) {
-      LOG.info("No current SessionState, skipping query caching for: {}", queryId);
+      LOG.info("No current SessionState, skipping metadata query-level caching for: {}", queryId);
+      return;
+    }
+    if (!ss.getConf().getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
+      LOG.info("Metadata query-level caching disabled for: {}", queryId);
       return;
     }
     LOG.info("Starting caching scope for: {}", queryId);
@@ -15292,7 +15296,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
     SessionState ss = SessionState.get();
     if (ss == null) {
-      LOG.info("No current SessionState, skipping query caching for: {}", queryId);
+      return;
+    }
+    if (!ss.getConf().getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
       return;
     }
     LOG.info("Ending caching scope for: {}", queryId);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -15283,25 +15283,22 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       LOG.info("No current SessionState, skipping metadata query-level caching for: {}", queryId);
       return;
     }
-    if (!ss.getConf().getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
-      LOG.info("Metadata query-level caching disabled for: {}", queryId);
-      return;
+    if (conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
+      LOG.info("Starting caching scope for: {}", queryId);
+      ss.startScope(queryId);
     }
-    LOG.info("Starting caching scope for: {}", queryId);
-    ss.startScope(queryId);
   }
 
   @Override
   public void endAnalysis() {
-    String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
     SessionState ss = SessionState.get();
     if (ss == null) {
       return;
     }
-    if (!ss.getConf().getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
-      return;
+    if (conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED)) {
+      String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
+      LOG.info("Ending caching scope for: {}", queryId);
+      ss.endScope(queryId);
     }
-    LOG.info("Ending caching scope for: {}", queryId);
-    ss.endScope(queryId);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -82,6 +82,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.conf.HiveConf.ResultFileFormat;
 import org.apache.hadoop.hive.conf.HiveConf.StrictChecks;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.TransactionalValidationListener;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -15272,5 +15273,29 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   @Override
   public void executeUnparseTranlations() {
     unparseTranslator.applyTranslations(ctx.getTokenRewriteStream());
+  }
+
+  @Override
+  public void startAnalysis() {
+    String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
+    SessionState ss = SessionState.get();
+    if (ss == null) {
+      LOG.info("No current SessionState, skipping query caching for: {}", queryId);
+      return;
+    }
+    LOG.info("Starting caching scope for: {}", queryId);
+    ss.startScope(queryId);
+  }
+
+  @Override
+  public void endAnalysis() {
+    String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
+    SessionState ss = SessionState.get();
+    if (ss == null) {
+      LOG.info("No current SessionState, skipping query caching for: {}", queryId);
+      return;
+    }
+    LOG.info("Ending caching scope for: {}", queryId);
+    ss.endScope(queryId);
   }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1056,7 +1056,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(writeIdList);
 
-      return getAggrStatsFor(req);
+      return getAggrStatsForInternal(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -1066,7 +1066,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
   }
 
-  protected AggrStats getAggrStatsFor(PartitionsStatsRequest req) throws TException {
+  protected AggrStats getAggrStatsForInternal(PartitionsStatsRequest req) throws TException {
     return client.get_aggr_stats_for(req);
   }
 
@@ -1875,11 +1875,16 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(getDefaultCatalog(conf));
     }
     req.setMaxParts(shrinkMaxtoShort(req.getMaxParts()));
-    GetPartitionsPsWithAuthResponse res = client.get_partitions_ps_with_auth_req(req);
+    GetPartitionsPsWithAuthResponse res = listPartitionsWithAuthInfoRequestInternal(req);
     List<Partition> parts = deepCopyPartitions(
         FilterUtils.filterPartitionsIfEnabled(isClientFilterEnabled, filterHook, res.getPartitions()));
     res.setPartitions(parts);
     return res;
+  }
+
+  protected GetPartitionsPsWithAuthResponse listPartitionsWithAuthInfoRequestInternal(GetPartitionsPsWithAuthRequest req)
+      throws TException {
+    return client.get_partitions_ps_with_auth_req(req);
   }
 
   @Override
@@ -1889,8 +1894,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     // TODO should we add capabilities here as well as it returns Partition objects
     long t1 = System.currentTimeMillis();
     try {
-      List<Partition> parts = client.get_partitions_with_auth(prependCatalogToDbName(catName,
-              dbName, conf), tableName, shrinkMaxtoShort(maxParts), userName, groupNames);
+      List<Partition> parts = listPartitionsWithAuthInfoInternal(catName, dbName, tableName,
+          maxParts, userName, groupNames);
 
       return deepCopyPartitions(FilterUtils.filterPartitionsIfEnabled(isClientFilterEnabled, filterHook, parts));
     } finally {
@@ -1900,6 +1905,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected List<Partition> listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+        int maxParts, String userName, List<String> groupNames) throws TException {
+    return client.get_partitions_with_auth(prependCatalogToDbName(catName, dbName, conf),
+        tableName, shrinkMaxtoShort(maxParts), userName, groupNames);
   }
 
   @Override
@@ -1920,8 +1931,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     // TODO should we add capabilities here as well as it returns Partition objects
     long t1 = System.currentTimeMillis();
     try {
-      List<Partition> parts = client.get_partitions_ps_with_auth(prependCatalogToDbName(catName,
-              dbName, conf), tableName, partialPvals, shrinkMaxtoShort(maxParts), userName, groupNames);
+      List<Partition> parts = listPartitionsWithAuthInfoInternal(
+          catName, dbName, tableName, partialPvals, maxParts, userName, groupNames);
 
       return deepCopyPartitions(FilterUtils.filterPartitionsIfEnabled(isClientFilterEnabled, filterHook,
               parts));
@@ -1932,6 +1943,13 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected List<Partition> listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+      List<String> partialPvals, int maxParts, String userName, List<String> groupNames)
+      throws TException {
+    return client.get_partitions_ps_with_auth(prependCatalogToDbName(catName,
+        dbName, conf), tableName, partialPvals, shrinkMaxtoShort(maxParts), userName, groupNames);
   }
 
   @Override
@@ -1995,7 +2013,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return req;
   }
 
-  protected PartitionsByExprResult getPartitionsByExprResult(PartitionsByExprRequest req) throws TException {
+  protected PartitionsByExprResult getPartitionsByExprInternal(PartitionsByExprRequest req) throws TException {
     return client.get_partitions_by_expr(req);
   }
 
@@ -2013,7 +2031,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       PartitionsByExprResult r = null;
 
       try {
-        r = getPartitionsByExprResult(req);
+        r = getPartitionsByExprInternal(req);
       } catch (TApplicationException te) {
         rethrowException(te);
       }
@@ -2045,10 +2063,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             "Metastore doesn't support listPartitionsByExpr: " + te.getMessage());
   }
 
-  protected PartitionsSpecByExprResult getPartitionsSpecByExprResult(PartitionsByExprRequest req) throws TException {
+  protected PartitionsSpecByExprResult getPartitionsSpecByExprInternal(PartitionsByExprRequest req) throws TException {
     return client.get_partitions_spec_by_expr(req);
   }
-
 
   @Override
   public boolean listPartitionsSpecByExpr(PartitionsByExprRequest req, List<PartitionSpec> result)
@@ -2059,7 +2076,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       assert result != null;
       PartitionsSpecByExprResult r = null;
       try {
-        r = getPartitionsSpecByExprResult(req);
+        r = getPartitionsSpecByExprInternal(req);
       } catch (TApplicationException te) {
         rethrowException(te);
       }
@@ -2102,7 +2119,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null) {
         request.setProcessorIdentifier(processorIdentifier);
       }
-      Database d = client.get_database_req(request);
+      Database d = getDatabaseInternal(request);
 
       return deepCopy(FilterUtils.filterDbIfEnabled(isClientFilterEnabled, filterHook, d));
     } finally {
@@ -2112,6 +2129,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected Database getDatabaseInternal(GetDatabaseRequest request) throws TException {
+    return client.get_database_req(request);
   }
 
   @Override
@@ -2189,8 +2210,13 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       gpbnr.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
     if (processorIdentifier != null)
       gpbnr.setProcessorIdentifier(processorIdentifier);
-    List<Partition> parts = client.get_partitions_by_names_req(gpbnr).getPartitions();
+    List<Partition> parts = getPartitionsByNamesInternal(gpbnr).getPartitions();
     return deepCopyPartitions(FilterUtils.filterPartitionsIfEnabled(isClientFilterEnabled, filterHook, parts));
+  }
+
+  protected GetPartitionsByNamesResult getPartitionsByNamesInternal(GetPartitionsByNamesRequest gpbnr)
+      throws TException {
+    return client.get_partitions_by_names_req(gpbnr);
   }
 
   @Override
@@ -2259,7 +2285,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = client.get_table_req(req).getTable();
+      Table t = getTableInternal(req).getTable();
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -2269,6 +2295,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected GetTableResult getTableInternal(GetTableRequest req) throws TException {
+    return client.get_table_req(req);
   }
 
   @Override
@@ -2301,7 +2331,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       if (processorIdentifier != null)
         req.setProcessorIdentifier(processorIdentifier);
 
-      Table t = client.get_table_req(req).getTable();
+      Table t = getTableInternal(req).getTable();
 
       return deepCopy(FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, t));
     } finally {
@@ -2511,7 +2541,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       GetTableRequest req = new GetTableRequest(dbName, tableName);
       req.setCatName(catName);
       req.setCapabilities(version);
-      Table table = client.get_table_req(req).getTable();
+      Table table = getTableInternal(req).getTable();
       return FilterUtils.filterTableIfEnabled(isClientFilterEnabled, filterHook, table) != null;
     } catch (NoSuchObjectException e) {
       return false;
@@ -2533,7 +2563,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     if( req.getCatName() == null ) {
       req.setCatName(getDefaultCatalog(conf));
     }
-    GetPartitionNamesPsResponse res = client.get_partition_names_ps_req(req);
+    GetPartitionNamesPsResponse res = listPartitionNamesRequestInternal(req);
     List<String> partNames = FilterUtils.filterPartitionNamesIfEnabled(
             isClientFilterEnabled, filterHook, getDefaultCatalog(conf), req.getDbName(),
             req.getTblName(), res.getNames());
@@ -2541,14 +2571,24 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     return res;
   }
 
+  protected GetPartitionNamesPsResponse listPartitionNamesRequestInternal(GetPartitionNamesPsRequest req)
+      throws TException {
+    return client.get_partition_names_ps_req(req);
+  }
+
   @Override
   public List<String> listPartitionNames(String catName, String dbName, String tableName,
                                          int maxParts) throws TException {
-    List<String> partNames =
-        client.get_partition_names(
-            prependCatalogToDbName(catName, dbName, conf), tableName, shrinkMaxtoShort(maxParts));
+    List<String> partNames = listPartitionNamesInternal(
+        catName, dbName, tableName, maxParts);
     return FilterUtils.filterPartitionNamesIfEnabled(
         isClientFilterEnabled, filterHook, catName, dbName, tableName, partNames);
+  }
+
+  protected List<String> listPartitionNamesInternal(String catName, String dbName, String tableName,
+      int maxParts) throws TException {
+    return client.get_partition_names(
+        prependCatalogToDbName(catName, dbName, conf), tableName, shrinkMaxtoShort(maxParts));
   }
 
   @Override
@@ -2560,10 +2600,16 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   @Override
   public List<String> listPartitionNames(String catName, String db_name, String tbl_name,
                                          List<String> part_vals, int max_parts) throws TException {
-    List<String> partNames = client.get_partition_names_ps(prependCatalogToDbName(catName, db_name, conf), tbl_name,
-        part_vals, shrinkMaxtoShort(max_parts));
+    List<String> partNames = listPartitionNamesInternal(
+        catName, db_name, tbl_name, part_vals, max_parts);
     return FilterUtils.filterPartitionNamesIfEnabled(
         isClientFilterEnabled, filterHook, catName, db_name, tbl_name, partNames);
+  }
+
+  protected List<String> listPartitionNamesInternal(String catName, String db_name, String tbl_name,
+      List<String> part_vals, int max_parts) throws TException {
+    return client.get_partition_names_ps(prependCatalogToDbName(catName, db_name, conf), tbl_name,
+        part_vals, shrinkMaxtoShort(max_parts));
   }
 
   @Override
@@ -2723,7 +2769,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         req.setCatName(getDefaultCatalog(conf));
       }
 
-      return client.get_primary_keys(req).getPrimaryKeys();
+      return getPrimaryKeysInternal(req).getPrimaryKeys();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -2731,6 +2777,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected PrimaryKeysResponse getPrimaryKeysInternal(PrimaryKeysRequest req) throws TException {
+    return client.get_primary_keys(req);
   }
 
   @Override
@@ -2743,7 +2793,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         req.setCatName(getDefaultCatalog(conf));
       }
 
-      return client.get_foreign_keys(req).getForeignKeys();
+      return getForeignKeysInternal(req).getForeignKeys();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -2751,6 +2801,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected ForeignKeysResponse getForeignKeysInternal(ForeignKeysRequest req) throws TException {
+    return client.get_foreign_keys(req);
   }
 
   @Override
@@ -2763,7 +2817,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         req.setCatName(getDefaultCatalog(conf));
       }
 
-      return client.get_unique_constraints(req).getUniqueConstraints();
+      return getUniqueConstraintsInternal(req).getUniqueConstraints();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -2771,6 +2825,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected UniqueConstraintsResponse getUniqueConstraintsInternal(UniqueConstraintsRequest req) throws TException {
+    return client.get_unique_constraints(req);
   }
 
   @Override
@@ -2783,7 +2841,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
         req.setCatName(getDefaultCatalog(conf));
       }
 
-      return client.get_not_null_constraints(req).getNotNullConstraints();
+      return getNotNullConstraintsInternal(req).getNotNullConstraints();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -2791,6 +2849,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected NotNullConstraintsResponse getNotNullConstraintsInternal(NotNullConstraintsRequest req) throws TException {
+    return client.get_not_null_constraints(req);
   }
 
   @Override
@@ -2881,7 +2943,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       rqst.setEngine(engine);
       rqst.setValidWriteIdList(getValidWriteIdList(TableName.getDbTable(dbName, tableName)));
 
-      return client.get_table_statistics_req(rqst).getTableStats();
+      return getTableColumnStatisticsInternal(rqst).getTableStats();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -2889,6 +2951,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected TableStatsResult getTableColumnStatisticsInternal(TableStatsRequest rqst) throws TException {
+    return client.get_table_statistics_req(rqst);
   }
 
   @Override
@@ -2912,7 +2978,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       rqst.setCatName(catName);
       rqst.setValidWriteIdList(validWriteIdList);
 
-      return client.get_table_statistics_req(rqst).getTableStats();
+      return getTableColumnStatisticsInternal(rqst).getTableStats();
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -3007,7 +3073,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     long t1 = System.currentTimeMillis();
 
     try {
-      return client.get_config_value(name, defaultValue);
+      return getConfigValueInternal(name, defaultValue);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {
@@ -3015,6 +3081,11 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
             diff, "HMS client");
       }
     }
+  }
+
+  protected String getConfigValueInternal(String name, String defaultValue)
+      throws TException, ConfigValSecurityException {
+    return client.get_config_value(name, defaultValue);
   }
 
   @Override
@@ -3455,7 +3526,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   @Override
   public ValidWriteIdList getValidWriteIds(String fullTableName) throws TException {
     GetValidWriteIdsRequest rqst = new GetValidWriteIdsRequest(Collections.singletonList(fullTableName));
-    GetValidWriteIdsResponse validWriteIds = client.get_valid_write_ids(rqst);
+    GetValidWriteIdsResponse validWriteIds = getValidWriteIdsInternal(rqst);
     return TxnCommonUtils.createValidReaderWriteIdList(validWriteIds.getTblValidWriteIds().get(0));
   }
 
@@ -3463,7 +3534,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   public ValidWriteIdList getValidWriteIds(String fullTableName, Long writeId) throws TException {
     GetValidWriteIdsRequest rqst = new GetValidWriteIdsRequest(Collections.singletonList(fullTableName));
     rqst.setWriteId(writeId);
-    GetValidWriteIdsResponse validWriteIds = client.get_valid_write_ids(rqst);
+    GetValidWriteIdsResponse validWriteIds = getValidWriteIdsInternal(rqst);
     return TxnCommonUtils.createValidReaderWriteIdList(validWriteIds.getTblValidWriteIds().get(0));
   }
 
@@ -3472,7 +3543,11 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       List<String> tablesList, String validTxnList) throws TException {
     GetValidWriteIdsRequest rqst = new GetValidWriteIdsRequest(tablesList);
     rqst.setValidTxnList(validTxnList);
-    return client.get_valid_write_ids(rqst).getTblValidWriteIds();
+    return getValidWriteIdsInternal(rqst).getTblValidWriteIds();
+  }
+
+  protected GetValidWriteIdsResponse getValidWriteIdsInternal(GetValidWriteIdsRequest rqst) throws TException {
+    return client.get_valid_write_ids(rqst);
   }
 
   @Override
@@ -4005,7 +4080,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setCatName(catName);
       req.setValidWriteIdList(getValidWriteIdList(TableName.getDbTable(dbName, tblName)));
 
-      return getAggrStatsFor(req);
+      return getAggrStatsForInternal(req);
     } finally {
       long diff = System.currentTimeMillis() - t1;
       if (LOG.isDebugEnabled()) {

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientWithLocalCache.java
@@ -19,16 +19,44 @@ package org.apache.hadoop.hive.metastore;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
+import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.api.ForeignKeysRequest;
+import org.apache.hadoop.hive.metastore.api.ForeignKeysResponse;
+import org.apache.hadoop.hive.metastore.api.GetDatabaseRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionNamesPsRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionNamesPsResponse;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsByNamesResult;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthRequest;
+import org.apache.hadoop.hive.metastore.api.GetPartitionsPsWithAuthResponse;
 import org.apache.hadoop.hive.metastore.api.GetTableRequest;
+import org.apache.hadoop.hive.metastore.api.GetTableResult;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsRequest;
+import org.apache.hadoop.hive.metastore.api.GetValidWriteIdsResponse;
 import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.NotNullConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.NotNullConstraintsResponse;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprRequest;
 import org.apache.hadoop.hive.metastore.api.PartitionsByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsSpecByExprResult;
 import org.apache.hadoop.hive.metastore.api.PartitionsStatsRequest;
+import org.apache.hadoop.hive.metastore.api.PrimaryKeysRequest;
+import org.apache.hadoop.hive.metastore.api.PrimaryKeysResponse;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.TableStatsRequest;
+import org.apache.hadoop.hive.metastore.api.TableStatsResult;
+import org.apache.hadoop.hive.metastore.api.TableValidWriteIds;
+import org.apache.hadoop.hive.metastore.api.UniqueConstraintsRequest;
+import org.apache.hadoop.hive.metastore.api.UniqueConstraintsResponse;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.util.IncrementalObjectSizeEstimator;
 import org.apache.hadoop.hive.ql.util.IncrementalObjectSizeEstimator.ObjectEstimator;
@@ -37,6 +65,8 @@ import org.apache.thrift.TException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Objects;
+
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.parseDbName;
 
 /**
  * This class introduces a caching layer in HS2 for metadata for some selected query APIs. It extends
@@ -81,25 +111,79 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
   private static void initSizeEstimator() {
     sizeEstimator = new HashMap<>();
     IncrementalObjectSizeEstimator.createEstimators(CacheKey.class, sizeEstimator);
-    Arrays.stream(KeyType.values()).forEach(e -> {
-      IncrementalObjectSizeEstimator.createEstimators(e.keyClass, sizeEstimator);
-      IncrementalObjectSizeEstimator.createEstimators(e.valueClass, sizeEstimator);}
-    );
+    for (KeyType e : KeyType.values()) {
+      for (Class<?> c : e.keyClass) {
+        IncrementalObjectSizeEstimator.createEstimators(c, sizeEstimator);
+      }
+      IncrementalObjectSizeEstimator.createEstimators(e.valueClass, sizeEstimator);
+    }
   }
 
   /**
    * KeyType is used to differentiate the request types. More types can be added in future.
    */
   public enum KeyType {
-    PARTITIONS_BY_EXPR(PartitionsByExprRequest.class, PartitionsByExprResult.class),
-    PARTITIONS_SPEC_BY_EXPR(PartitionsByExprRequest.class, PartitionsSpecByExprResult.class),
-    AGGR_COL_STATS(PartitionsStatsRequest.class, AggrStats.class);
+    // String <-- getConfigValueInternal(String name, String defaultValue)
+    CONFIG_VALUE(String.class, String.class, String.class),
+    // Database <-- getDatabaseInternal(GetDatabaseRequest request)
+    DATABASE(Database.class, GetDatabaseRequest.class),
+    // GetTableResult <-- getTableInternal(GetTableRequest req)
+    TABLE(GetTableResult.class, GetTableRequest.class),
+    // PrimaryKeysResponse <-- getPrimaryKeysInternal(PrimaryKeysRequest req)
+    PRIMARY_KEYS(PrimaryKeysResponse.class, PrimaryKeysRequest.class),
+    // ForeignKeysResponse <-- getForeignKeysInternal(ForeignKeysRequest req)
+    FOREIGN_KEYS(ForeignKeysResponse.class, ForeignKeysRequest.class),
+    // UniqueConstraintsResponse <-- getUniqueConstraintsInternal(UniqueConstraintsRequest req)
+    UNIQUE_CONSTRAINTS(UniqueConstraintsResponse.class, UniqueConstraintsRequest.class),
+    // NotNullConstraintsResponse <-- getNotNullConstraintsInternal(NotNullConstraintsRequest req)
+    NOT_NULL_CONSTRAINTS(NotNullConstraintsResponse.class, NotNullConstraintsRequest.class),
+    // TableStatsResult <-- getTableColumnStatisticsInternal(TableStatsRequest rqst)
+    // Stored individually as:
+    // ColumnStatisticsObj <-- String dbName, String tblName, List<string> colNames,
+    //      String catName, String validWriteIdList, String engine, long id, (TableWatermark tw ?)
+    TABLE_COLUMN_STATS(ColumnStatisticsObj.class, String.class, String.class, List.class,
+        String.class, String.class, String.class, long.class, TableWatermark.class),
+    // AggrStats <-- getAggrStatsForInternal(PartitionsStatsRequest req), (TableWatermark tw ?)
+    AGGR_COL_STATS(AggrStats.class, PartitionsStatsRequest.class, TableWatermark.class),
+    // PartitionsByExprResult <-- getPartitionsByExprInternal(PartitionsByExprRequest req), (TableWatermark tw ?)
+    PARTITIONS_BY_EXPR(PartitionsByExprResult.class, PartitionsByExprRequest.class, TableWatermark.class),
+    // PartitionsSpecByExprResult <-- getPartitionsSpecByExprInternal(PartitionsByExprRequest req), (TableWatermark tw ?)
+    PARTITIONS_SPEC_BY_EXPR(PartitionsSpecByExprResult.class, PartitionsByExprRequest.class, TableWatermark.class),
+    // List<String> <-- listPartitionNamesInternal(String catName, String dbName, String tableName,
+    //       int maxParts)
+    LIST_PARTITIONS_ALL(List.class, String.class, String.class, String.class, int.class),
+    // List<String> <-- listPartitionNamesInternal(String catName, String dbName, String tableName,
+    //       List<String> partVals, int maxParts)
+    LIST_PARTITIONS(List.class, String.class, String.class, String.class, List.class, int.class),
+    // GetPartitionNamesPsResponse <-- listPartitionNamesRequestInternal(GetPartitionNamesPsRequest req)
+    LIST_PARTITIONS_REQ(GetPartitionNamesPsResponse.class, GetPartitionNamesPsRequest.class),
+    // List<Partition> <- listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+    //      int maxParts, String userName, List<String> groupNames)
+    LIST_PARTITIONS_AUTH_INFO_ALL(List.class, String.class, String.class, String.class, int.class,
+        String.class, List.class),
+    // List<Partition> <- listPartitionsWithAuthInfoInternal(String catName, String dbName, String tableName,
+    //      List<String> partialPvals, int maxParts, String userName, List<String> groupNames)
+    LIST_PARTITIONS_AUTH_INFO(List.class, String.class, String.class, String.class, List.class, int.class,
+        String.class, List.class),
+    // GetPartitionsPsWithAuthResponse <- listPartitionsWithAuthInfoRequestInternal(GetPartitionsPsWithAuthRequest req)
+    LIST_PARTITIONS_AUTH_INFO_REQ(GetPartitionsPsWithAuthResponse.class, GetPartitionsPsWithAuthRequest.class),
+    // GetPartitionsByNamesResult <-- getPartitionsByNamesInternal(GetPartitionsByNamesRequest gpbnr)
+    // Stored individually as:
+    // Partition <-- String db_name, String tbl_name, List<String> partValues, boolean get_col_stats,
+    //      List<string> processorCapabilities, String processorIdentifier, String engine,
+    //      String validWriteIdList, (TableWatermark tw ?)
+    PARTITIONS_BY_NAMES(Partition.class, String.class, String.class, List.class, boolean.class,
+        List.class, String.class, String.class, String.class, TableWatermark.class),
+    // GetValidWriteIdsResponse <-- getValidWriteIdsInternal(GetValidWriteIdsRequest rqst)
+    // Stored individually as:
+    // TableValidWriteIds <-- String fullTableName, String validTxnList, long writeId, (long tableId ?)
+    VALID_WRITE_IDS(TableValidWriteIds.class, String.class, String.class, long.class, long.class);
 
-    private final Class<?> keyClass;
+    private final List<Class<?>> keyClass;
     private final Class<?> valueClass;
 
-    KeyType(Class<?> keyClass, Class<?> valueClass) {
-      this.keyClass = keyClass;
+    KeyType(Class<?> valueClass, Class<?>... keyClasses) {
+      this.keyClass = Collections.unmodifiableList(Arrays.asList(keyClasses));
       this.valueClass = valueClass;
     }
   }
@@ -109,11 +193,11 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
    */
   public static class CacheKey{
     KeyType IDENTIFIER;
-    Object obj;
+    List<Object> obj;
 
-    public CacheKey(KeyType IDENTIFIER, Object obj) {
+    public CacheKey(KeyType IDENTIFIER, Object... objs) {
       this.IDENTIFIER = IDENTIFIER;
-      this.obj = obj;
+      this.obj = Collections.unmodifiableList(Arrays.asList(objs));
     }
 
     @Override
@@ -135,37 +219,6 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
     }
   }
 
-  public static class PartitionsStatsCustomRequest {
-    PartitionsStatsRequest request;
-    String validWriteIdList;
-    long tableId;
-
-    public PartitionsStatsCustomRequest(PartitionsStatsRequest req, String validWriteIdList, long tableId) {
-      this.request = req;
-      this.validWriteIdList = validWriteIdList;
-      this.tableId = tableId;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (o == null || getClass() != o.getClass()) {
-        return false;
-      }
-      PartitionsStatsCustomRequest that = (PartitionsStatsCustomRequest) o;
-      return tableId == that.tableId &&
-          Objects.equals(request, that.request) &&
-          Objects.equals(validWriteIdList, that.validWriteIdList);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(request, validWriteIdList, tableId);
-    }
-  }
-
   private static int getWeight(CacheKey key, Object val) {
     ObjectEstimator keySizeEstimator = sizeEstimator.get(key.getClass());
     ObjectEstimator valSizeEstimator = sizeEstimator.get(key.IDENTIFIER.valueClass);
@@ -177,27 +230,19 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
     return keySize + valSize;
   }
 
-  private Object load(CacheKey key) {
-    try {
-      return getResultObject(key);
-    } catch (TException e) {
-      throw new UncheckedCacheException(e);
-    }
-  }
-
-/**
- * Initializes the cache
- */
+  /**
+   * Initializes the cache
+   */
   private static void initCache() {
     int initSize = 100;
     Caffeine<CacheKey, Object> cacheBuilder = Caffeine.newBuilder()
-            .initialCapacity(initSize)
-            .maximumWeight(MAX_SIZE)
-            .weigher(HiveMetaStoreClientWithLocalCache::getWeight)
-            .removalListener((key, val, cause) -> {
-              if (LOG.isDebugEnabled()) {
-                LOG.debug("Caffeine - ({}, {}) was removed ({})", key, val, cause);
-              }});
+        .initialCapacity(initSize)
+        .maximumWeight(MAX_SIZE)
+        .weigher(HiveMetaStoreClientWithLocalCache::getWeight)
+        .removalListener((key, val, cause) -> {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Caffeine - ({}, {}) was removed ({})", key, val, cause);
+          }});
     if (RECORD_STATS) {
       cacheBuilder.recordStats();
     }
@@ -205,147 +250,168 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
     cacheObjName = mscLocalCache.toString().substring(mscLocalCache.toString().indexOf("Cache@"));
   }
 
-  /**
-   * This method is used to load the cache by calling relevant APIs, depending on the type of the request.
-   *
-   * @param cacheKey key of the cache, containing an identifier and a request object
-   * @return Result object / null
-   * @throws TException
-   */
-  private Object getResultObject(CacheKey cacheKey) throws TException {
-    Object result = null;
-
-    switch (cacheKey.IDENTIFIER) {
-      case PARTITIONS_BY_EXPR:
-        result = super.getPartitionsByExprResult((PartitionsByExprRequest)cacheKey.obj);
-        break;
-      case PARTITIONS_SPEC_BY_EXPR:
-        result = super.getPartitionsSpecByExprResult((PartitionsByExprRequest)cacheKey.obj);
-        break;
-      case AGGR_COL_STATS:
-        PartitionsStatsCustomRequest customRequest = (PartitionsStatsCustomRequest) cacheKey.obj;
-        result = super.getAggrStatsFor(customRequest.request);
-        break;
-      default:
-        break;
-    }
-
-    return result;
-  }
-
   @Override
-  protected PartitionsByExprResult getPartitionsByExprResult(PartitionsByExprRequest req) throws TException {
+  protected PartitionsByExprResult getPartitionsByExprInternal(PartitionsByExprRequest req) throws TException {
     PartitionsByExprResult r;
 
     // table should be transactional to get responses from the cache
-    if (isCacheEnabledAndInitialized() && isRequestCacheable(req, KeyType.PARTITIONS_BY_EXPR)) {
+    TableWatermark watermark = new TableWatermark(
+        req.getValidWriteIdList(), req.getId());
+    if (isCacheEnabledAndInitialized() && watermark.isValid()) {
       CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_BY_EXPR, req);
-      try {
-        r = (PartitionsByExprResult) mscLocalCache.get(cacheKey, this::load); // get either the result or an Exception
+      r = (PartitionsByExprResult) mscLocalCache.getIfPresent(cacheKey);
+      if (r == null) {
+        r = super.getPartitionsByExprInternal(req);
+        mscLocalCache.put(cacheKey, r);
+      }
 
-        if (LOG.isDebugEnabled() && RECORD_STATS) {
-          LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
-        }
-
-      } catch (UncheckedCacheException e) {
-        if (e.getCause() instanceof MetaException) {
-          throw (MetaException) e.getCause();
-        } else if (e.getCause() instanceof TException) {
-          throw (TException) e.getCause();
-        } else {
-          throw new TException(e.getCause());
-        }
+      if (LOG.isDebugEnabled() && RECORD_STATS) {
+        LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
       }
     } else {
-      r = client.get_partitions_by_expr(req);
+      r = super.getPartitionsByExprInternal(req);
     }
 
     return r;
   }
 
   @Override
-  protected PartitionsSpecByExprResult getPartitionsSpecByExprResult(PartitionsByExprRequest req) throws TException {
+  protected PartitionsSpecByExprResult getPartitionsSpecByExprInternal(PartitionsByExprRequest req) throws TException {
     PartitionsSpecByExprResult r;
 
     // table should be transactional to get responses from the cache
-    if (isCacheEnabledAndInitialized() && isRequestCacheable(req, KeyType.PARTITIONS_SPEC_BY_EXPR)) {
+    TableWatermark watermark = new TableWatermark(
+        req.getValidWriteIdList(), req.getId());
+    if (isCacheEnabledAndInitialized() && watermark.isValid()) {
       CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_SPEC_BY_EXPR, req);
-      try {
-        r = (PartitionsSpecByExprResult) mscLocalCache.get(cacheKey, this::load); // get either the result or an Exception
+      r = (PartitionsSpecByExprResult) mscLocalCache.getIfPresent(cacheKey);
+      if (r == null) {
+        r = super.getPartitionsSpecByExprInternal(req);
+        mscLocalCache.put(cacheKey, r);
+      }
 
-        if (LOG.isDebugEnabled() && RECORD_STATS) {
-          LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
-        }
-
-      } catch (UncheckedCacheException e) {
-        if (e.getCause() instanceof MetaException) {
-          throw (MetaException) e.getCause();
-        } else if (e.getCause() instanceof TException) {
-          throw (TException) e.getCause();
-        } else {
-          throw new TException(e.getCause());
-        }
+      if (LOG.isDebugEnabled() && RECORD_STATS) {
+        LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
       }
     } else {
-      r = client.get_partitions_spec_by_expr(req);
+      r = super.getPartitionsSpecByExprInternal(req);
     }
 
     return r;
   }
-
 
   @Override
-  protected AggrStats getAggrStatsFor(PartitionsStatsRequest req) throws TException {
-    AggrStats r;
-
-    Table tbl = getTable(req.getDbName(), req.getTblName());
-    PartitionsStatsCustomRequest customRequest = new PartitionsStatsCustomRequest(req,
-        getValidWriteIdList(TableName.getDbTable(req.getDbName(), req.getTblName())), tbl.getId());
-
-    if (isCacheEnabledAndInitialized() && isRequestCacheable(customRequest, KeyType.AGGR_COL_STATS)) {
-      CacheKey cacheKey = new CacheKey(KeyType.AGGR_COL_STATS, customRequest);
-      try {
-        r = (AggrStats) mscLocalCache.get(cacheKey, this::load);
+  protected TableStatsResult getTableColumnStatisticsInternal(TableStatsRequest req) throws TException {
+    if (isCacheEnabledAndInitialized()) {
+      Table tbl = getTable(req.getDbName(), req.getTblName());
+      String validWriteIdList = getValidWriteIdList(TableName.getDbTable(req.getDbName(), req.getTblName()));
+      long tableId = tbl.getId();
+      TableWatermark watermark = new TableWatermark(
+          validWriteIdList, tableId);
+      if (watermark.isValid()) {
+        CacheWrapper cache = new CacheWrapper(mscLocalCache);
+        // 1) Retrieve from the cache those ids present, gather the rest
+        Pair<List<ColumnStatisticsObj>, List<String>> p = getTableColumnStatisticsCache(
+            cache, req, watermark);
+        List<String> colStatsMissing = p.getRight();
+        List<ColumnStatisticsObj> colStats = p.getLeft();
+        // 2) If they were all present in the cache, return
+        if (colStatsMissing.isEmpty()) {
+          return new TableStatsResult(colStats);
+        }
+        // 3) If they were not, gather the remaining
+        TableStatsRequest newRqst = new TableStatsRequest(req);
+        newRqst.setColNames(colStatsMissing);
+        TableStatsResult r = super.getTableColumnStatisticsInternal(newRqst);
+        // 4) Populate the cache
+        List<ColumnStatisticsObj> newColStats = loadTableColumnStatisticsCache(
+            cache, r, req, watermark);
+        // 5) Sort result (in case there is any assumption) and return
+        TableStatsResult result = computeTableColumnStatisticsFinal(req, colStats, newColStats);
 
         if (LOG.isDebugEnabled() && RECORD_STATS) {
           LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
         }
-      } catch (UncheckedCacheException e) {
-        if (e.getCause() instanceof MetaException) {
-          throw (MetaException) e.getCause();
-        } else if (e.getCause() instanceof TException) {
-          throw (TException) e.getCause();
-        } else {
-          throw new TException(e.getCause());
+
+        return result;
+      }
+    }
+
+    return super.getTableColumnStatisticsInternal(req);
+  }
+
+  @Override
+  protected AggrStats getAggrStatsForInternal(PartitionsStatsRequest req) throws TException {
+    AggrStats r;
+
+    if (isCacheEnabledAndInitialized()) {
+      Table tbl = getTable(req.getDbName(), req.getTblName());
+      String validWriteIdList = getValidWriteIdList(TableName.getDbTable(req.getDbName(), req.getTblName()));
+      long tableId = tbl.getId();
+      TableWatermark watermark = new TableWatermark(
+          validWriteIdList, tableId);
+      if (watermark.isValid()) {
+        CacheKey cacheKey = new CacheKey(KeyType.AGGR_COL_STATS, req, watermark);
+        r = (AggrStats) mscLocalCache.getIfPresent(cacheKey);
+        if (r == null) {
+          r = super.getAggrStatsForInternal(req);
+          mscLocalCache.put(cacheKey, r);
         }
+
+        if (LOG.isDebugEnabled() && RECORD_STATS) {
+          LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
+        }
+      } else {
+        r = super.getAggrStatsForInternal(req);
       }
     } else {
-      r = super.getAggrStatsFor(req);
+      r = super.getAggrStatsForInternal(req);
     }
 
     return r;
   }
 
-  /**
-   * This method determines if the request should be cached.
-   * @param request Request object
-   * @return boolean
-   */
-  private boolean isRequestCacheable(Object request, KeyType keyType) {
-    switch (keyType) {
-      //cache only requests for transactional tables, with a valid table id
-      case PARTITIONS_BY_EXPR:
-      case PARTITIONS_SPEC_BY_EXPR:
-        PartitionsByExprRequest req = (PartitionsByExprRequest) request;
-        return req.getValidWriteIdList() != null && req.getId() != -1;
-      case AGGR_COL_STATS:
-        PartitionsStatsCustomRequest customRequest = (PartitionsStatsCustomRequest) request;
-        return customRequest.tableId != -1 && customRequest.validWriteIdList != null;
-        // Requests of other types can have different conditions and should be added here.
-      default:
-        return false;
+  @Override
+  protected GetPartitionsByNamesResult getPartitionsByNamesInternal(GetPartitionsByNamesRequest rqst) throws TException {
+    if (isCacheEnabledAndInitialized()) {
+      String dbName = parseDbName(rqst.getDb_name(), conf)[1];
+      Table tbl = getTable(dbName, rqst.getTbl_name());
+      String validWriteIdList = getValidWriteIdList(TableName.getDbTable(dbName, rqst.getTbl_name()));
+      long tableId = tbl.getId();
+      TableWatermark watermark = new TableWatermark(
+          validWriteIdList, tableId);
+      if (watermark.isValid()) {
+        CacheWrapper cache = new CacheWrapper(mscLocalCache);
+        // 1) Retrieve from the cache those ids present, gather the rest
+        Pair<List<Partition>, List<String>> p = getPartitionsByNamesCache(
+            cache, rqst, watermark);
+        List<String> partitionsMissing = p.getRight();
+        List<Partition> partitions = p.getLeft();
+        // 2) If they were all present in the cache, return
+        if (partitionsMissing.isEmpty()) {
+          return new GetPartitionsByNamesResult(partitions);
+        }
+        // 3) If they were not, gather the remaining
+        GetPartitionsByNamesRequest newRqst = new GetPartitionsByNamesRequest(rqst);
+        newRqst.setNames(partitionsMissing);
+        GetPartitionsByNamesResult r = super.getPartitionsByNamesInternal(newRqst);
+        // 4) Populate the cache
+        List<Partition> newPartitions = loadPartitionsByNamesCache(
+            cache, r, rqst, watermark);
+        // 5) Sort result (in case there is any assumption) and return
+        GetPartitionsByNamesResult result = computePartitionsByNamesFinal(rqst, partitions, newPartitions);
+
+        if (LOG.isDebugEnabled() && RECORD_STATS) {
+          LOG.debug(cacheObjName + ": " + mscLocalCache.stats().toString());
+        }
+
+        return result;
+      }
     }
+
+    return super.getPartitionsByNamesInternal(rqst);
   }
+
 
   /**
    * Checks if cache is enabled and initialized
@@ -355,14 +421,265 @@ public class HiveMetaStoreClientWithLocalCache extends HiveMetaStoreClient {
   private boolean isCacheEnabledAndInitialized() {
     return IS_CACHE_ENABLED && mscLocalCache != null;
   }
-}
 
-/**
- * This unchecked exception is thrown from the load method because checked exception is
- * not thrown from the functional interface
- */
-class UncheckedCacheException extends RuntimeException {
-  public UncheckedCacheException(Throwable t) {
-    super(t);
+
+  protected final Pair<List<ColumnStatisticsObj>, List<String>> getTableColumnStatisticsCache(CacheI cache,
+      TableStatsRequest rqst, TableWatermark watermark) {
+    List<String> colStatsMissing = new ArrayList<>();
+    List<ColumnStatisticsObj> colStats = new ArrayList<>();
+    for (String colName : rqst.getColNames()) {
+      CacheKey cacheKey = new CacheKey(KeyType.TABLE_COLUMN_STATS,
+          rqst.getDbName(), rqst.getTblName(), colName,
+          rqst.getCatName(), rqst.getValidWriteIdList(),
+          rqst.getEngine(), rqst.getId(), watermark);
+      ColumnStatisticsObj v = (ColumnStatisticsObj) cache.get(cacheKey);
+      if (v == null) {
+        colStatsMissing.add(colName);
+      } else {
+        if (watermark == null) {
+          LOG.debug("Query level HMS cache: method=getTableColumnStatisticsInternal");
+        } else {
+          LOG.debug("HS2 level HMS cache: method=getTableColumnStatisticsInternal");
+        }
+        colStats.add(v);
+      }
+    }
+    return Pair.of(colStats, colStatsMissing);
   }
+
+  protected final List<ColumnStatisticsObj> loadTableColumnStatisticsCache(CacheI cache,
+      TableStatsResult r, TableStatsRequest rqst, TableWatermark watermark) {
+    List<ColumnStatisticsObj> newColStats = new ArrayList<>();
+    for (ColumnStatisticsObj colStat : r.getTableStats()) {
+      CacheKey cacheKey = new CacheKey(KeyType.TABLE_COLUMN_STATS,
+          rqst.getDbName(), rqst.getTblName(), colStat.getColName(),
+          rqst.getCatName(), rqst.getValidWriteIdList(),
+          rqst.getEngine(), rqst.getId(), watermark);
+      cache.put(cacheKey, colStat);
+      newColStats.add(colStat);
+    }
+    return newColStats;
+  }
+
+  protected final TableStatsResult computeTableColumnStatisticsFinal(TableStatsRequest rqst,
+      List<ColumnStatisticsObj> colStats, List<ColumnStatisticsObj> newColStats) {
+    List<ColumnStatisticsObj> result = new ArrayList<>();
+    int i = 0, j = 0;
+    for (String colName : rqst.getColNames()) {
+      if (i >= colStats.size() || j >= newColStats.size()) {
+        break;
+      }
+      if (colStats.get(i).getColName().equals(colName)) {
+        result.add(colStats.get(i));
+        i++;
+      } else if (newColStats.get(j).getColName().equals(colName)) {
+        result.add(newColStats.get(j));
+        j++;
+      }
+    }
+    while (i < colStats.size()) {
+      result.add(colStats.get(i));
+      i++;
+    }
+    while (j < newColStats.size()) {
+      result.add(newColStats.get(j));
+      j++;
+    }
+    return new TableStatsResult(result);
+  }
+
+
+  protected final Pair<List<Partition>, List<String>> getPartitionsByNamesCache(CacheI cache,
+      GetPartitionsByNamesRequest rqst, TableWatermark watermark) throws MetaException {
+    List<String> partitionsMissing = new ArrayList<>();
+    List<Partition> partitions = new ArrayList<>();
+    for (String partitionName : rqst.getNames()) {
+      CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_BY_NAMES,
+          rqst.getDb_name(), rqst.getTbl_name(), Warehouse.getPartValuesFromPartName(partitionName),
+          rqst.isGet_col_stats(), rqst.getProcessorCapabilities(), rqst.getProcessorIdentifier(),
+          rqst.getEngine(), rqst.getValidWriteIdList(), watermark);
+      Partition v = (Partition) cache.get(cacheKey);
+      if (v == null) {
+        partitionsMissing.add(partitionName);
+      } else {
+        if (watermark == null) {
+          LOG.debug("Query level HMS cache: method=getPartitionsByNamesInternal");
+        } else {
+          LOG.debug("HS2 level HMS cache: method=getPartitionsByNamesInternal");
+        }
+        partitions.add(v);
+      }
+    }
+    return Pair.of(partitions, partitionsMissing);
+  }
+
+  protected final List<Partition> loadPartitionsByNamesCache(CacheI cache,
+      GetPartitionsByNamesResult r, GetPartitionsByNamesRequest rqst, TableWatermark watermark) {
+    List<Partition> newPartitions = new ArrayList<>();
+    for (Partition partition : r.getPartitions()) {
+      CacheKey cacheKey = new CacheKey(KeyType.PARTITIONS_BY_NAMES,
+          rqst.getDb_name(), rqst.getTbl_name(), partition.getValues(),
+          rqst.isGet_col_stats(), rqst.getProcessorCapabilities(), rqst.getProcessorIdentifier(),
+          rqst.getEngine(), rqst.getValidWriteIdList(), watermark);
+      cache.put(cacheKey, partition);
+      newPartitions.add(partition);
+    }
+    return newPartitions;
+  }
+
+  protected final GetPartitionsByNamesResult computePartitionsByNamesFinal(GetPartitionsByNamesRequest rqst,
+      List<Partition> partitions, List<Partition> newPartitions) throws MetaException {
+    List<Partition> result = new ArrayList<>();
+    int i = 0, j = 0;
+    for (String partitionName : rqst.getNames()) {
+      if (i >= partitions.size() || j >= newPartitions.size()) {
+        break;
+      }
+      List<String> pv = Warehouse.getPartValuesFromPartName(partitionName);
+      if (partitions.get(i).getValues().equals(pv)) {
+        result.add(partitions.get(i));
+        i++;
+      } else if (newPartitions.get(j).getValues().equals(pv)) {
+        result.add(newPartitions.get(j));
+        j++;
+      }
+    }
+    while (i < partitions.size()) {
+      result.add(partitions.get(i));
+      i++;
+    }
+    while (j < newPartitions.size()) {
+      result.add(newPartitions.get(j));
+      j++;
+    }
+    return new GetPartitionsByNamesResult(result);
+  }
+
+
+  protected final Pair<List<TableValidWriteIds>, List<String>> getValidWriteIdsCache(CacheI cache,
+      GetValidWriteIdsRequest rqst) throws TException {
+    List<String> fullTableNamesMissing = new ArrayList<>();
+    List<TableValidWriteIds> tblValidWriteIds = new ArrayList<>();
+    for (String fullTableName : rqst.getFullTableNames()) {
+      CacheKey cacheKey = new CacheKey(KeyType.VALID_WRITE_IDS,
+          fullTableName, rqst.getValidTxnList(), rqst.getWriteId(), -1);
+      TableValidWriteIds v = (TableValidWriteIds) cache.get(cacheKey);
+      if (v == null) {
+        fullTableNamesMissing.add(fullTableName);
+      } else {
+        LOG.debug("Query level HMS cache: method=getValidWriteIdsInternal");
+        tblValidWriteIds.add(v);
+      }
+    }
+    return Pair.of(tblValidWriteIds, fullTableNamesMissing);
+  }
+
+  protected final List<TableValidWriteIds> loadValidWriteIdsCache(CacheI cache,
+      GetValidWriteIdsResponse r, GetValidWriteIdsRequest rqst)
+      throws TException {
+    List<TableValidWriteIds> newTblValidWriteIds = new ArrayList<>();
+    for (TableValidWriteIds tableValidWriteIds : r.getTblValidWriteIds()) {
+      newTblValidWriteIds.add(tableValidWriteIds);
+      // Add to the cache
+      CacheKey cacheKey = new CacheKey(KeyType.VALID_WRITE_IDS,
+          tableValidWriteIds.getFullTableName(), rqst.getValidTxnList(), rqst.getWriteId(), -1);
+      cache.put(cacheKey, tableValidWriteIds);
+    }
+    return newTblValidWriteIds;
+  }
+
+  protected final GetValidWriteIdsResponse computeValidWriteIdsFinal(GetValidWriteIdsRequest rqst,
+       List<TableValidWriteIds> tblValidWriteIds, List<TableValidWriteIds> newTblValidWriteIds) {
+    List<TableValidWriteIds> result = new ArrayList<>();
+    int i = 0, j = 0;
+    for (String fullTableName : rqst.getFullTableNames()) {
+      if (i >= tblValidWriteIds.size() || j >= newTblValidWriteIds.size()) {
+        break;
+      }
+      if (tblValidWriteIds.get(i).getFullTableName().equals(fullTableName)) {
+        result.add(tblValidWriteIds.get(i));
+        i++;
+      } else if (newTblValidWriteIds.get(j).getFullTableName().equals(fullTableName)) {
+        result.add(newTblValidWriteIds.get(j));
+        j++;
+      }
+    }
+    while (i < tblValidWriteIds.size()) {
+      result.add(tblValidWriteIds.get(i));
+      i++;
+    }
+    while (j < newTblValidWriteIds.size()) {
+      result.add(newTblValidWriteIds.get(j));
+      j++;
+    }
+    return new GetValidWriteIdsResponse(result);
+  }
+
+
+  /**
+   * Wrapper to create a cache around a Caffeine Cache.
+   */
+  protected static class CacheWrapper implements CacheI {
+    final Cache<CacheKey, Object> c;
+
+    protected CacheWrapper(Cache<CacheKey, Object> c) {
+      this.c = c;
+    }
+
+    @Override
+    public void put(Object k, Object v) {
+      c.put((CacheKey) k, v);
+    }
+
+    @Override
+    public Object get(Object k) {
+      return c.getIfPresent(k);
+    }
+  }
+
+  /**
+   * Cache interface.
+   */
+  protected interface CacheI {
+    void put(Object k, Object v);
+
+    Object get(Object k);
+  }
+
+
+  /**
+   * Internal class to identify uniquely a Table.
+   */
+  protected static class TableWatermark {
+    final String validWriteIdList;
+    final long tableId;
+
+    protected TableWatermark(String validWriteIdList, long tableId) {
+      this.validWriteIdList = validWriteIdList;
+      this.tableId = tableId;
+    }
+
+    public boolean isValid() {
+      return validWriteIdList != null && tableId != -1;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TableWatermark that = (TableWatermark) o;
+      return tableId == that.tableId &&
+          Objects.equals(validWriteIdList, that.validWriteIdList);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(validWriteIdList, tableId);
+    }
+  }
+
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -4087,4 +4087,5 @@ public interface IMetaStoreClient {
 
   ReplicationMetricList getReplicationMetrics(GetReplicationMetricsRequest
                                                 replicationMetricsRequest) throws MetaException, TException;
+
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR creates a query-level cache for HMS requests. The lifecycle of that cache is associated to the lifecycle of the query. This basically means that each unique request to certain HMS APIs should only be served once from HMS, while follow-up repetitive calls will be retrieved from cache. The initial implementation includes caching for 19 APIs.

This PR also extends existing local HS2 HMS cache implementation introduced in HIVE-23949 to support other requests (getTableColumnStatistics, getPartitionsByNames). In fact, implementation relies on some of the logic introduced in that JIRA since there are some commonalities.


### Why are the changes needed?

This should improve compilation latency.


### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing tests.

