### PR TITLE
HIVE-24178: Add managed location to SHOW CREATE DATABASE (Miklos Gergely)

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseOperation.java
@@ -60,6 +60,10 @@ public class ShowCreateDatabaseOperation extends DDLOperation<ShowCreateDatabase
     }
     createDbCommand.append("LOCATION\n  '");
     createDbCommand.append(database.getLocationUri()).append("'\n");
+    if (database.getManagedLocationUri() != null) {
+      createDbCommand.append("MANAGEDLOCATION\n  '");
+      createDbCommand.append(database.getManagedLocationUri()).append("'\n");
+    }
     String propertiesToString = DDLUtils.propertiesToString(database.getParameters(), null);
     if (!propertiesToString.isEmpty()) {
       createDbCommand.append("WITH DBPROPERTIES (\n");

--- a/ql/src/test/queries/clientpositive/database_location.q
+++ b/ql/src/test/queries/clientpositive/database_location.q
@@ -28,6 +28,8 @@ CREATE DATABASE db3
 LOCATION '${hiveconf:hive.metastore.warehouse.dir}/db3_ext'
 MANAGEDLOCATION '${hiveconf:hive.metastore.warehouse.dir}/db3';
 
+SHOW CREATE DATABASE db3;
+
 DESCRIBE DATABASE db3;
 
 EXPLAIN

--- a/ql/src/test/results/clientpositive/llap/database_location.q.out
+++ b/ql/src/test/results/clientpositive/llap/database_location.q.out
@@ -173,6 +173,17 @@ POSTHOOK: query: CREATE DATABASE db3
 POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:db3
 #### A masked pattern was here ####
+PREHOOK: query: SHOW CREATE DATABASE db3
+PREHOOK: type: SHOW_CREATEDATABASE
+PREHOOK: Input: database:db3
+POSTHOOK: query: SHOW CREATE DATABASE db3
+POSTHOOK: type: SHOW_CREATEDATABASE
+POSTHOOK: Input: database:db3
+CREATE DATABASE `db3`
+LOCATION
+#### A masked pattern was here ####
+MANAGEDLOCATION
+#### A masked pattern was here ####
 PREHOOK: query: DESCRIBE DATABASE db3
 PREHOOK: type: DESCDATABASE
 PREHOOK: Input: database:db3


### PR DESCRIPTION

### What changes were proposed in this pull request?
To add the missing managed location part to the SHOW CREATE DATABASE command.

### Why are the changes needed?
Because it is missing from there, and the purpose of this command is to provide a statement that would create a database as similar as possible.

### Does this PR introduce _any_ user-facing change?
Users will see a better result for their SHOW CREATE DATABASE commands.

### How was this patch tested?
A new SHOW CREATE DATABASE was added into database_location.q.