### PR TITLE
HIVE-24179: Memory leak in HS2 DbTxnManager when compiling SHOW LOCKS statement

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowDbLocksAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowDbLocksAnalyzer.java
@@ -47,13 +47,7 @@ public class ShowDbLocksAnalyzer extends BaseSemanticAnalyzer {
     String dbName = stripQuotes(root.getChild(0).getText());
     boolean isExtended = (root.getChildCount() > 1);
 
-    HiveTxnManager txnManager = null;
-    try {
-      txnManager = TxnManagerFactory.getTxnManagerFactory().getTxnManager(conf);
-    } catch (LockException e) {
-      throw new SemanticException(e.getMessage());
-    }
-
+    assert txnManager != null : "Transaction manager should be set before calling analyze";
     ShowLocksDesc desc = new ShowLocksDesc(ctx.getResFile(), dbName, isExtended, txnManager.useNewShowLocksFormat());
     Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
     rootTasks.add(task);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowLocksAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowLocksAnalyzer.java
@@ -67,15 +67,9 @@ public class ShowLocksAnalyzer extends BaseSemanticAnalyzer {
       }
     }
 
-    HiveTxnManager txnManager = null;
-    try {
-      txnManager = TxnManagerFactory.getTxnManagerFactory().getTxnManager(conf);
-    } catch (LockException e) {
-      throw new SemanticException(e.getMessage());
-    }
-
-    ShowLocksDesc desc = new ShowLocksDesc(ctx.getResFile(), tableName, partitionSpec, isExtended,
-        txnManager.useNewShowLocksFormat());
+    assert txnManager != null : "Transaction manager should be set before calling analyze";
+    ShowLocksDesc desc =
+        new ShowLocksDesc(ctx.getResFile(), tableName, partitionSpec, isExtended, txnManager.useNewShowLocksFormat());
     Task<DDLWork> task = TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc));
     rootTasks.add(task);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -168,7 +168,6 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
   // ExecutorService for sending heartbeat to metastore periodically.
   private static ScheduledExecutorService heartbeatExecutorService = null;
   private ScheduledFuture<?> heartbeatTask = null;
-  private Runnable shutdownRunner = null;
   private static final int SHUTDOWN_HOOK_PRIORITY = 0;
   private final ReentrantLock heartbeatTaskLock = new ReentrantLock();
 
@@ -197,19 +196,8 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       throw new LockException(e);
     }
   }
+
   DbTxnManager() {
-    shutdownRunner = new Runnable() {
-      @Override
-      public void run() {
-        if (heartbeatExecutorService != null
-            && !heartbeatExecutorService.isShutdown()
-            && !heartbeatExecutorService.isTerminated()) {
-          LOG.info("Shutting down Heartbeater thread pool.");
-          heartbeatExecutorService.shutdown();
-        }
-      }
-    };
-    ShutdownHookManager.addShutdownHook(shutdownRunner, SHUTDOWN_HOOK_PRIORITY);
   }
 
   @Override
@@ -878,9 +866,6 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
   protected void destruct() {
     try {
       stopHeartbeat();
-      if (shutdownRunner != null) {
-        ShutdownHookManager.removeShutdownHook(shutdownRunner);
-      }
       if (isTxnOpen()) {
         rollbackTxn();
       }
@@ -898,18 +883,17 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     if (conf == null) {
       throw new RuntimeException("Must call setHiveConf before any other methods.");
     }
-    initHeartbeatExecutorService();
+    initHeartbeatExecutorService(conf.getIntVar(HiveConf.ConfVars.HIVE_TXN_HEARTBEAT_THREADPOOL_SIZE));
   }
 
-  private synchronized void initHeartbeatExecutorService() {
-    synchronized (DbTxnManager.class) {
-      if (heartbeatExecutorService != null && !heartbeatExecutorService.isShutdown()
-          && !heartbeatExecutorService.isTerminated()) {
+  private synchronized static void initHeartbeatExecutorService(int corePoolSize) {
+      if(heartbeatExecutorService != null) {
         return;
       }
+      // The following code will be executed only once when the service is not initialized
       heartbeatExecutorService =
           Executors.newScheduledThreadPool(
-              conf.getIntVar(HiveConf.ConfVars.HIVE_TXN_HEARTBEAT_THREADPOOL_SIZE),
+              corePoolSize,
               new ThreadFactory() {
                 private final AtomicInteger threadCounter = new AtomicInteger();
 
@@ -919,6 +903,13 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
                 }
               });
       ((ScheduledThreadPoolExecutor) heartbeatExecutorService).setRemoveOnCancelPolicy(true);
+      ShutdownHookManager.addShutdownHook(DbTxnManager::shutdownHeartbeatExecutorService, SHUTDOWN_HOOK_PRIORITY);
+  }
+
+  private synchronized static void shutdownHeartbeatExecutorService() {
+    if (heartbeatExecutorService != null && !heartbeatExecutorService.isShutdown()) {
+      LOG.info("Shutting down Heartbeater thread pool.");
+      heartbeatExecutorService.shutdown();
     }
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Avoid multiple shutdown hooks for the same threadpool in DbTxnManager
2. Close new HiveTxnManager in ShowLocksAnalyzer to release resources

### Why are the changes needed?

Avoid the memory leak when executing `SHOW LOCKS` statements and simplify code.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?

`mvn test -pl itests/hive-unit -Dtest=TestDbTxnManagerMemoryLeak -Pitests`

If it finishes then there is no memory leak, otherwise most of the time you get an OutOfMemoryError. 
See the JIRA case for more details.

**The commit with the test is not meant to be merged into master**
