### PR TITLE
Fix ranger issue with permanent UDF

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
@@ -126,7 +126,7 @@ public final class FunctionUtils {
     } else if (names.length > 2) {
       throw new HiveException("Function name does not have correct format: " + functionName);
     }
-    // This is to fix the ranger related issue : HIVE-24182
+    // Remove the WINDOW_FUNC_PREFIX prefix, as that is not part of the database name.
     if (names[0].startsWith(Registry.WINDOW_FUNC_PREFIX)) {
       names[0] = names[0].substring(Registry.WINDOW_FUNC_PREFIX.length());
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
@@ -41,8 +41,6 @@ import java.util.List;
  * Function related utilities.
  */
 public final class FunctionUtils {
-  public static final String WINDOW_FUNC_PREFIX = "@_";
-
   private FunctionUtils() {
     throw new UnsupportedOperationException("FunctionUtils should not be instantiated");
   }
@@ -129,8 +127,8 @@ public final class FunctionUtils {
       throw new HiveException("Function name does not have correct format: " + functionName);
     }
     // This is to fix the ranger related issue : HIVE-24182
-    if (names[0].startsWith(WINDOW_FUNC_PREFIX)) {
-      names[0] = names[0].substring(2);
+    if (names[0].startsWith(Registry.WINDOW_FUNC_PREFIX)) {
+      names[0] = names[0].substring(Registry.WINDOW_FUNC_PREFIX.length());
     }
     return names;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionUtils.java
@@ -41,6 +41,8 @@ import java.util.List;
  * Function related utilities.
  */
 public final class FunctionUtils {
+  public static final String WINDOW_FUNC_PREFIX = "@_";
+
   private FunctionUtils() {
     throw new UnsupportedOperationException("FunctionUtils should not be instantiated");
   }
@@ -125,6 +127,10 @@ public final class FunctionUtils {
       return retval;
     } else if (names.length > 2) {
       throw new HiveException("Function name does not have correct format: " + functionName);
+    }
+    // This is to fix the ranger related issue : HIVE-24182
+    if (names[0].startsWith(WINDOW_FUNC_PREFIX)) {
+      names[0] = names[0].substring(2);
     }
     return names;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -73,7 +73,7 @@ public class Registry {
   private static final Logger LOG = LoggerFactory.getLogger(FunctionRegistry.class);
 
   // prefix for window functions, to discern LEAD/LAG UDFs from window functions with the same name
-  private static final String WINDOW_FUNC_PREFIX = "@_";
+  public static final String WINDOW_FUNC_PREFIX = "@_";
 
   /**
    * The mapping from expression function names to expression classes.

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFunctionUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFunctionUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestFunctionUtils {
+
+  @Test
+  public void testSplitQualifiedFunctionName() throws HiveException {
+
+    String function1 = "@_database1.function1";
+    String function2 = "database2.function2";
+
+    String[] output1 = FunctionUtils.splitQualifiedFunctionName(function1);
+    Assert.assertEquals("database1", output1[0]);
+    Assert.assertEquals("function1", output1[1]);
+
+    String[] output2 = FunctionUtils.splitQualifiedFunctionName(function2);
+    Assert.assertEquals("database2", output2[0]);
+    Assert.assertEquals("function2", output2[1]);
+
+  }
+
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFunctionUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestFunctionUtils.java
@@ -27,7 +27,7 @@ public class TestFunctionUtils {
   @Test
   public void testSplitQualifiedFunctionName() throws HiveException {
 
-    String function1 = "@_database1.function1";
+    String function1 = Registry.WINDOW_FUNC_PREFIX + "database1.function1";
     String function2 = "database2.function2";
 
     String[] output1 = FunctionUtils.splitQualifiedFunctionName(function1);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update correct database name, when creating read entities for permanent UDF. 

### Why are the changes needed?
Permanent UDF authorization don't work correctly when ranger is configured. 

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
Unit test and manually on a cluster with Ranger 
