### PR TITLE
HIVE-24172: Fix TestMmCompactorOnMr

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnMr.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMmCompactorOnMr.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.hive.ql.txn.compactor;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.junit.Before;
 
-@org.junit.Ignore("HIVE-24172")
 public class TestMmCompactorOnMr extends TestMmCompactorOnTez {
   @Before
   public void setMr() {
-    driver.getConf().setVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
+    // NOTE: only compaction will run with MR as execution engine; setup and teardown queries will run with Tez.
+    conf.setVar(HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "mr");
   }
 }


### PR DESCRIPTION
Setting the execution engine as MR in the driver field (driver.getConf().setBoolVar(...)) only affects queries in setup and teardown.
Compaction runs using the conf field. So the execution engine needed to be set to MR in conf so that compaction would pick it up.