### PR TITLE
HIVE-24188: CTLT from MM to External or External to MM are failing with hive.strict.managed.tables & hive.create.as.acid

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeOperation.java
@@ -132,6 +132,7 @@ public class CreateTableLikeOperation extends DDLOperation<CreateTableLikeDesc> 
       setExternalProperties(table);
     } else {
       table.getParameters().remove("EXTERNAL");
+      table.setTableType(TableType.MANAGED_TABLE);
     }
 
     return table;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13590,7 +13590,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
       Table likeTable = getTable(likeTableName, false);
       if (likeTable != null) {
-        if (isTemporary) {
+        if (isTemporary || isExt) {
           updateDefaultTblProps(likeTable.getParameters(), tblProps,
               new ArrayList<>(Arrays.asList(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL,
                   hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES)));

--- a/ql/src/test/queries/clientpositive/create_like2.q
+++ b/ql/src/test/queries/clientpositive/create_like2.q
@@ -7,3 +7,35 @@ ALTER TABLE table1_n20 SET TBLPROPERTIES ('a'='1', 'b'='2', 'c'='3', 'd' = '4');
 SET hive.ddl.createtablelike.properties.whitelist=a,c,D;
 CREATE TABLE table2_n14 LIKE table1_n20;
 DESC FORMATTED table2_n14;
+
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.strict.managed.tables=true;
+set hive.create.as.acid=true;
+set hive.create.as.insert.only=true;
+set hive.default.fileformat.managed=ORC;
+
+create table test_mm(empno int, name string) partitioned by(dept string) stored as orc tblproperties('transactional'='true', 'transactional_properties'='default');
+desc formatted test_mm;
+
+-- Conversion from MM to External
+create external table test_external like test_mm LOCATION '${system:test.tmp.dir}/create_like_mm_to_external';
+desc formatted test_external;
+
+-- Conversion from External to MM
+create table test_mm1 like test_external;
+desc formatted test_mm1;
+
+-- Conversion from External to External
+create external table test_external1 like test_external;
+desc formatted test_external1;
+
+-- Conversion from mm to mm
+create table test_mm2 like test_mm;
+desc formatted test_mm2;
+
+drop table test_mm;
+drop table test_external;
+drop table test_mm1;
+drop table test_external1;
+drop table test_mm2;

--- a/ql/src/test/results/clientpositive/llap/create_like2.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_like2.q.out
@@ -59,3 +59,285 @@ Bucket Columns:     	[]
 Sort Columns:       	[]                  	 
 Storage Desc Params:	 	 
 	serialization.format	1                   
+PREHOOK: query: create table test_mm(empno int, name string) partitioned by(dept string) stored as orc tblproperties('transactional'='true', 'transactional_properties'='default')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_mm
+POSTHOOK: query: create table test_mm(empno int, name string) partitioned by(dept string) stored as orc tblproperties('transactional'='true', 'transactional_properties'='default')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_mm
+PREHOOK: query: desc formatted test_mm
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_mm
+POSTHOOK: query: desc formatted test_mm
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_mm
+# col_name            	data_type           	comment             
+empno               	int                 	                    
+name                	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+dept                	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numPartitions       	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+	transactional       	true                
+	transactional_properties	default             
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+#### A masked pattern was here ####
+PREHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_external
+#### A masked pattern was here ####
+POSTHOOK: type: CREATETABLE
+#### A masked pattern was here ####
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_external
+PREHOOK: query: desc formatted test_external
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_external
+POSTHOOK: query: desc formatted test_external
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_external
+# col_name            	data_type           	comment             
+empno               	int                 	                    
+name                	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+dept                	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	discover.partitions 	true                
+	numFiles            	0                   
+	numPartitions       	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: create table test_mm1 like test_external
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_mm1
+POSTHOOK: query: create table test_mm1 like test_external
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_mm1
+PREHOOK: query: desc formatted test_mm1
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_mm1
+POSTHOOK: query: desc formatted test_mm1
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_mm1
+# col_name            	data_type           	comment             
+empno               	int                 	                    
+name                	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+dept                	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numPartitions       	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+	transactional       	true                
+	transactional_properties	default             
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: create external table test_external1 like test_external
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_external1
+POSTHOOK: query: create external table test_external1 like test_external
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_external1
+PREHOOK: query: desc formatted test_external1
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_external1
+POSTHOOK: query: desc formatted test_external1
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_external1
+# col_name            	data_type           	comment             
+empno               	int                 	                    
+name                	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+dept                	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	discover.partitions 	true                
+	numFiles            	0                   
+	numPartitions       	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: create table test_mm2 like test_mm
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_mm2
+POSTHOOK: query: create table test_mm2 like test_mm
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_mm2
+PREHOOK: query: desc formatted test_mm2
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_mm2
+POSTHOOK: query: desc formatted test_mm2
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_mm2
+# col_name            	data_type           	comment             
+empno               	int                 	                    
+name                	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+dept                	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numPartitions       	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+	transactional       	true                
+	transactional_properties	default             
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: drop table test_mm
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_mm
+PREHOOK: Output: default@test_mm
+POSTHOOK: query: drop table test_mm
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_mm
+POSTHOOK: Output: default@test_mm
+PREHOOK: query: drop table test_external
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_external
+PREHOOK: Output: default@test_external
+POSTHOOK: query: drop table test_external
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_external
+POSTHOOK: Output: default@test_external
+PREHOOK: query: drop table test_mm1
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_mm1
+PREHOOK: Output: default@test_mm1
+POSTHOOK: query: drop table test_mm1
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_mm1
+POSTHOOK: Output: default@test_mm1
+PREHOOK: query: drop table test_external1
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_external1
+PREHOOK: Output: default@test_external1
+POSTHOOK: query: drop table test_external1
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_external1
+POSTHOOK: Output: default@test_external1
+PREHOOK: query: drop table test_mm2
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_mm2
+PREHOOK: Output: default@test_mm2
+POSTHOOK: query: drop table test_mm2
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_mm2
+POSTHOOK: Output: default@test_mm2


### PR DESCRIPTION
What changes were proposed in this pull request?
Included check to skip TXN tblproperties for external table from MMM

Why are the changes needed?
CTLT is failing from MM to External

Does this PR introduce any user-facing change?
no

How was this patch tested?
Using repro sql, included it as part of testcase.