### PR TITLE
HIVE-24199: Incorrect result when subquey in exists contains limit

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -472,6 +472,7 @@ public enum ErrorMsg {
   WITHIN_GROUP_PARAMETER_MISMATCH(10422,
           "The number of hypothetical direct arguments ({0}) must match the number of ordering columns ({1})", true),
   AMBIGUOUS_STRUCT_ATTRIBUTE(10423, "Attribute \"{0}\" specified more than once in structured type.", true),
+  OFFSET_NOT_SUPPORTED_IN_SUBQUERY(10424, "OFFSET is not supported in subquery of exists", true),
 
   //========================== 20000 range starts here ========================//
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelOptMaterializationValidator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelOptMaterializationValidator.java
@@ -233,8 +233,8 @@ public class HiveRelOptMaterializationValidator extends HiveRelShuttleImpl {
     return visitChildren(union);
   }
 
-  // Note: Not currently part of the HiveRelNode interface
-  private RelNode visit(HiveSortLimit sort) {
+  @Override
+  public RelNode visit(HiveSortLimit sort) {
     setAutomaticRewritingInvalidReason("Statement has unsupported clause: order by.");
     checkExpr(sort.getFetchExpr());
     checkExpr(sort.getOffsetExpr());

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttle.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttle.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveAggregate;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveJoin;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveSortLimit;
 
 /**
  * Visitor that has methods for the common logical relational expressions.
@@ -35,6 +36,7 @@ public interface HiveRelShuttle extends RelShuttle {
     RelNode visit(HiveFilter filter);
     RelNode visit(HiveJoin join);
     RelNode visit(HiveAggregate aggregate);
+    RelNode visit(HiveSortLimit hiveSortLimit);
 }
 
 // End RelShuttle.java

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttleImpl.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveRelShuttleImpl.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveAggregate;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveJoin;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveSortLimit;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -146,6 +147,11 @@ public class HiveRelShuttleImpl implements HiveRelShuttle {
 
     public RelNode visit(LogicalMatch match) {
       return visitChildren(match);
+    }
+
+    @Override
+    public RelNode visit(HiveSortLimit hiveSortLimit) {
+        return visitChildren(hiveSortLimit);
     }
 }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSubQueryRemoveRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSubQueryRemoveRule.java
@@ -413,6 +413,9 @@ public class HiveSubQueryRemoveRule extends RelOptRule {
       // Query has 'exists' and correlation:
       // select * from web_sales ws1
       // where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+      //
+      // HiveRelDecorrelator will replace LogicalCorrelate with a SemiJoin. Hence the right hand side won't be
+      // evaluated for every row coming from left and SortLimit cuts the right result set incorrectly. (HIVE-24199)
       builder.push(e.rel.accept(new HiveSortLimitRemover()));
     } else {
       // Query may has exists but no correlation

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSubQueryRemoveRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveSubQueryRemoveRule.java
@@ -29,6 +29,7 @@ import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rex.LogicVisitor;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexVisitorImpl;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
@@ -57,11 +58,13 @@ import java.util.function.Predicate;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSubqueryRuntimeException;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
+import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelShuttleImpl;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveSubQRemoveRelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.SubqueryConf;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveAggregate;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveFilter;
 import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveProject;
+import org.apache.hadoop.hive.ql.optimizer.calcite.reloperators.HiveSortLimit;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_CONVERT_ANTI_JOIN;
 
@@ -372,9 +375,9 @@ public class HiveSubQueryRemoveRule extends RelOptRule {
     //   on e.deptno = dt.deptno
     //
 
-    builder.push(e.rel);
     final List<RexNode> fields = new ArrayList<>();
     if (e.getKind() == SqlKind.IN) {
+      builder.push(e.rel);
       fields.addAll(builder.fields());
       // Transformation: sq_count_check(count(*), true) FILTER is generated on top
       //  of subquery which is then joined (LEFT or INNER) with outer query
@@ -406,6 +409,16 @@ public class HiveSubQueryRemoveRule extends RelOptRule {
         offset = offset + 1;
         builder.push(e.rel);
       }
+    } else if (e.getKind() == SqlKind.EXISTS && !variablesSet.isEmpty()) {
+      // Query has 'exists' and correlation:
+      // select * from web_sales ws1
+      // where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+      builder.push(e.rel.accept(new HiveSortLimitRemover()));
+    } else {
+      // Query may has exists but no correlation
+      // select * from web_sales ws1
+      // where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1);
+      builder.push(e.rel);
     }
     boolean isCandidateForAntiJoin = false;
     // First, the cross join
@@ -680,6 +693,27 @@ public class HiveSubQueryRemoveRule extends RelOptRule {
       }
     } else if (relNode instanceof HiveProject || relNode instanceof HiveFilter) {
       subqueryRestriction(relNode.getInput(0));
+    }
+  }
+
+  public static class HiveSortLimitRemover extends HiveRelShuttleImpl {
+    @Override
+    public RelNode visit(HiveSortLimit sort) {
+      RexNode rexNode = sort.getOffsetExpr();
+      if (rexNode != null && rexNode.getKind() == SqlKind.LITERAL) {
+        RexLiteral offsetExpr = (RexLiteral)rexNode;
+        if (!BigDecimal.ZERO.equals(offsetExpr.getValue())) {
+          throw new RuntimeException(org.apache.hadoop.hive.ql.ErrorMsg.OFFSET_NOT_SUPPORTED_IN_SUBQUERY.getMsg());
+        }
+      }
+      rexNode = sort.getFetchExpr();
+      if (rexNode != null && rexNode.getKind() == SqlKind.LITERAL) {
+        RexLiteral fetchExpr = (RexLiteral) rexNode;
+        if (BigDecimal.ZERO.equals(fetchExpr.getValue())) {
+          return super.visit(sort);
+        }
+      }
+      return super.visit(sort.getInput());
     }
   }
 }

--- a/ql/src/test/queries/clientnegative/offset_in_subquery.q
+++ b/ql/src/test/queries/clientnegative/offset_in_subquery.q
@@ -1,0 +1,4 @@
+create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc;
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1 offset 20);

--- a/ql/src/test/queries/clientpositive/subquery_join_rewrite.q
+++ b/ql/src/test/queries/clientpositive/subquery_join_rewrite.q
@@ -1,0 +1,108 @@
+create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc;
+
+insert into web_sales values
+(null, null),
+(1, 1),
+(1, 2),
+(null, null),
+(null, null),
+(2, 1),
+(2, 2),
+(null, null);
+
+-- EXISTS, co-relation, LIMIT
+explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+
+explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0);
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0);
+
+-- NOT EXISTS, co-relation, LIMIT
+explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
+
+-- EXISTS, co-relation, ORDER BY
+explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number);
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number);
+
+
+-- NOT EXISTS, co-relation, ORDER BY
+explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number);
+
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number);
+
+
+-- EXISTS, LIMIT
+explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1);
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1);
+
+explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0);
+
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0);
+
+
+-- IN, LIMIT
+explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1);
+
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1);
+
+
+explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1);
+
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1);
+
+
+-- NOT IN, LIMIT
+explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1);
+
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1);
+
+
+explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1);
+
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1);
+
+explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2);
+
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2);

--- a/ql/src/test/results/clientnegative/offset_in_subquery.q.out
+++ b/ql/src/test/results/clientnegative/offset_in_subquery.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@web_sales
+POSTHOOK: query: create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@web_sales
+FAILED: RuntimeException [Error 10424]: OFFSET is not supported in subquery of exists

--- a/ql/src/test/results/clientpositive/llap/subquery_join_rewrite.q.out
+++ b/ql/src/test/results/clientpositive/llap/subquery_join_rewrite.q.out
@@ -1,0 +1,494 @@
+PREHOOK: query: create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@web_sales
+POSTHOOK: query: create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@web_sales
+PREHOOK: query: insert into web_sales values
+(null, null),
+(1, 1),
+(1, 2),
+(null, null),
+(null, null),
+(2, 1),
+(2, 2),
+(null, null)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@web_sales
+POSTHOOK: query: insert into web_sales values
+(null, null),
+(1, 1),
+(1, 2),
+(null, null),
+(null, null),
+(2, 1),
+(2, 2),
+(null, null)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@web_sales
+POSTHOOK: Lineage: web_sales.ws_order_number SCRIPT []
+POSTHOOK: Lineage: web_sales.ws_warehouse_sk SCRIPT []
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $2)], joinType=[semi])
+  HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+  HiveProject(ws_order_number=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+1	1
+1	2
+2	1
+2	2
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $2)], joinType=[semi])
+  HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+  HiveProject(ws_order_number=[$0])
+    HiveSortLimit(fetch=[0])
+      HiveProject(ws_order_number=[$0])
+        HiveFilter(condition=[IS NOT NULL($0)])
+          HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAntiJoin(condition=[=($0, $3)], joinType=[anti])
+  HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+    HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+  HiveProject(literalTrue=[true], ws_order_number=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+NULL	NULL
+NULL	NULL
+NULL	NULL
+NULL	NULL
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $2)], joinType=[semi])
+  HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+  HiveProject(ws_order_number=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+1	1
+1	2
+2	1
+2	2
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAntiJoin(condition=[=($0, $3)], joinType=[anti])
+  HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+    HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+  HiveProject(literalTrue=[true], ws_order_number0=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where not exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number order by ws2.ws_order_number)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+NULL	NULL
+NULL	NULL
+NULL	NULL
+NULL	NULL
+Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+    HiveProject($f0=[true])
+      HiveSortLimit(fetch=[1])
+        HiveProject(ws_order_number=[CAST(2):INTEGER])
+          HiveFilter(condition=[=($0, 2)])
+            HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+NULL	NULL
+2	2
+2	1
+NULL	NULL
+NULL	NULL
+1	2
+1	1
+NULL	NULL
+Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+      HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+    HiveProject($f0=[true])
+      HiveSortLimit(fetch=[0])
+        HiveProject(ws_order_number=[CAST(2):INTEGER])
+          HiveFilter(condition=[=($0, 2)])
+            HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where exists (select 1 from web_sales ws2 where ws2.ws_order_number = 2 limit 0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveJoin(condition=[=($0, $2)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+    HiveProject(ws_order_number=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveProject(ws_order_number=[$0])
+          HiveSortLimit(sort0=[$0], dir0=[ASC], fetch=[1])
+            HiveProject(ws_order_number=[$0])
+              HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+1	1
+1	2
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveJoin(condition=[=($0, $2)], joinType=[inner], algorithm=[none], cost=[not available])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+    HiveProject(ws_order_number=[$0])
+      HiveFilter(condition=[IS NOT NULL($0)])
+        HiveProject(ws_order_number=[$0])
+          HiveSortLimit(sort0=[$0], dir0=[ASC-nulls-first], fetch=[1])
+            HiveProject(ws_order_number=[$0])
+              HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+PREHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveFilter(condition=[OR(=($2, 0), AND(IS NULL($5), >=($3, $2), IS NOT NULL($0)))])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1], c=[$4], ck=[$5], ws_order_number0=[$2], literalTrue=[$3])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveJoin(condition=[=($0, $2)], joinType=[left], algorithm=[none], cost=[not available])
+          HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+            HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+          HiveProject(ws_order_number=[$0], literalTrue=[true])
+            HiveFilter(condition=[IS NOT NULL($0)])
+              HiveProject(ws_order_number=[$0])
+                HiveSortLimit(sort0=[$0], dir0=[ASC], fetch=[1])
+                  HiveProject(ws_order_number=[$0])
+                    HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+        HiveProject(c=[$0], ck=[$1])
+          HiveAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+            HiveProject(ws_order_number=[$0])
+              HiveSortLimit(sort0=[$0], dir0=[ASC], fetch=[1])
+                HiveProject(ws_order_number=[$0])
+                  HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+2	2
+2	1
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveFilter(condition=[OR(=($2, 0), AND(IS NULL($5), >=($3, $2), IS NOT NULL($0)))])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1], c=[$4], ck=[$5], ws_order_number0=[$2], literalTrue=[$3])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveJoin(condition=[=($0, $2)], joinType=[left], algorithm=[none], cost=[not available])
+          HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+            HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+          HiveProject(ws_order_number=[$0], literalTrue=[true])
+            HiveFilter(condition=[IS NOT NULL($0)])
+              HiveProject(ws_order_number=[$0])
+                HiveSortLimit(sort0=[$0], dir0=[ASC-nulls-first], fetch=[1])
+                  HiveProject(ws_order_number=[$0])
+                    HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+        HiveProject(c=[$0], ck=[$1])
+          HiveAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+            HiveProject(ws_order_number=[$0])
+              HiveSortLimit(sort0=[$0], dir0=[ASC-nulls-first], fetch=[1])
+                HiveProject(ws_order_number=[$0])
+                  HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls first limit 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+  HiveFilter(condition=[OR(=($2, 0), AND(IS NULL($5), >=($3, $2), IS NOT NULL($0)))])
+    HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1], c=[$4], ck=[$5], ws_order_number0=[$2], literalTrue=[$3])
+      HiveJoin(condition=[true], joinType=[inner], algorithm=[none], cost=[not available])
+        HiveJoin(condition=[=($0, $2)], joinType=[left], algorithm=[none], cost=[not available])
+          HiveProject(ws_order_number=[$0], ws_warehouse_sk=[$1])
+            HiveTableScan(table=[[default, web_sales]], table:alias=[ws1])
+          HiveProject(ws_order_number=[$0], literalTrue=[true])
+            HiveFilter(condition=[IS NOT NULL($0)])
+              HiveProject(ws_order_number=[$0])
+                HiveSortLimit(sort0=[$0], dir0=[ASC], offset=[2], fetch=[1])
+                  HiveProject(ws_order_number=[$0])
+                    HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+        HiveProject(c=[$0], ck=[$1])
+          HiveAggregate(group=[{}], c=[COUNT()], ck=[COUNT($0)])
+            HiveProject(ws_order_number=[$0])
+              HiveSortLimit(sort0=[$0], dir0=[ASC], offset=[2], fetch=[1])
+                HiveProject(ws_order_number=[$0])
+                  HiveTableScan(table=[[default, web_sales]], table:alias=[ws2])
+
+Warning: Shuffle Join MERGEJOIN[36][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 3' is a cross product
+PREHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+POSTHOOK: query: select * from web_sales ws1
+where ws1.ws_order_number not in (select ws2.ws_order_number from web_sales ws2 order by ws2.ws_order_number nulls last limit 1 offset 2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@web_sales
+#### A masked pattern was here ####
+1	2
+1	1


### PR DESCRIPTION
### What changes were proposed in this pull request?
* Fix incorrect result when subquey in exists contains limit.
* Error when query has a subquery with offset

### Why are the changes needed?
* Fix correctness issue
```
create table web_sales (ws_order_number int, ws_warehouse_sk int) stored as orc;

insert into web_sales values
(1, 1),
(1, 2),
(2, 1),
(2, 2);
```
Query
```
select * from web_sales ws1
where exists (select 1 from web_sales ws2 where ws1.ws_order_number = ws2.ws_order_number limit 1);
```
should return 4 rows but returns only 2.

* Correctness can not be guaranteed if subquery has offset.


### Does this PR introduce _any_ user-facing change?
Semantic exception is thrown when user tries to execute a query which has a subquery with offset.
See `offset_in_subquery.q`

### How was this patch tested?
```
mvn test -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=subquery_join_rewrite.q -pl itests/qtest -Pitests -Dtest.output.overwrite
mvn test -DskipSparkTests -Dtest=TestNegativeCliDriver -Dqfile=offset_in_subquery.q -pl itests/qtest -Pitests -Dtest.output.overwrite
```