### PR TITLE
HIVE-24203: Implement stats annotation rule for the LateralViewJoinOperator

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/AnnotateWithStatistics.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/AnnotateWithStatistics.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
+import org.apache.hadoop.hive.ql.exec.LateralViewJoinOperator;
 import org.apache.hadoop.hive.ql.exec.LimitOperator;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
@@ -68,6 +69,8 @@ public class AnnotateWithStatistics extends Transform {
         StatsRulesProcFactory.getReduceSinkRule());
     opRules.put(new RuleRegExp("UDTF", UDTFOperator.getOperatorName() + "%"),
             StatsRulesProcFactory.getUDTFRule());
+    opRules.put(new RuleRegExp("LVJ", LateralViewJoinOperator.getOperatorName() + "%"),
+            StatsRulesProcFactory.getLateralViewJoinRule());
 
     // The dispatcher fires the processor corresponding to the closest matching
     // rule and passes the context along

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.exec.CommonJoinOperator;
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.exec.GroupByOperator;
+import org.apache.hadoop.hive.ql.exec.LateralViewJoinOperator;
 import org.apache.hadoop.hive.ql.exec.JoinOperator;
 import org.apache.hadoop.hive.ql.exec.LimitOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
@@ -1861,10 +1862,8 @@ public class StatsRulesProcFactory {
       HiveConf conf = aspCtx.getConf();
       boolean allSatisfyPreCondition = true;
 
-      for (Operator<? extends OperatorDesc> op : parents) {
-        if (op.getStatistics() == null) {
-          return null;
-        }
+      if (!isAllParentsContainStatistics(jop)) {
+        return null;
       }
 
       for (Operator<? extends OperatorDesc> op : parents) {
@@ -2922,6 +2921,97 @@ public class StatsRulesProcFactory {
   }
 
   /**
+   * LateralViewJoinOperator changes the data size and column level statistics.
+   *
+   * A diagram of LATERAL VIEW.
+   *
+   *   [Lateral View Forward]
+   *          /     \
+   *    [Select]  [Select]
+   *        |        |
+   *        |     [UDTF]
+   *        \       /
+   *   [Lateral View Join]
+   *
+   * For each row of the source, the left branch just picks columns and the right branch processes UDTF.
+   * And then LVJ joins a row from the left branch with rows from the right branch.
+   * The join has one-to-many relationship since UDTF can generate multiple rows.
+   *
+   * This rule multiplies the stats from the left branch by T(right) / T(left) and sums up the both sides.
+   */
+  public static class LateralViewJoinStatsRule extends DefaultStatsRule implements SemanticNodeProcessor {
+    @Override
+    public Object process(Node nd, Stack<Node> stack, NodeProcessorCtx procCtx,
+                          Object... nodeOutputs) throws SemanticException {
+      final LateralViewJoinOperator lop = (LateralViewJoinOperator) nd;
+      final AnnotateStatsProcCtx aspCtx = (AnnotateStatsProcCtx) procCtx;
+      final HiveConf conf = aspCtx.getConf();
+
+      if (!isAllParentsContainStatistics(lop)) {
+        return null;
+      }
+
+      final List<Operator<? extends OperatorDesc>> parents = lop.getParentOperators();
+      if (parents.size() != 2) {
+        LOG.warn("LateralViewJoinOperator should have just two parents but actually has "
+                + parents.size() + " parents.");
+        return null;
+      }
+
+      final Statistics selectStats = parents.get(LateralViewJoinOperator.SELECT_TAG).getStatistics().clone();
+      final Statistics udtfStats = parents.get(LateralViewJoinOperator.UDTF_TAG).getStatistics().clone();
+
+      final double factor = (double) udtfStats.getNumRows() / (double) selectStats.getNumRows();
+      final long selectDataSize = StatsUtils.safeMult(selectStats.getDataSize(), factor);
+      final long dataSize = StatsUtils.safeAdd(selectDataSize, udtfStats.getDataSize());
+      Statistics joinedStats = new Statistics(udtfStats.getNumRows(), dataSize, 0, 0);
+
+      if (satisfyPrecondition(selectStats) && satisfyPrecondition(udtfStats)) {
+        final Map<String, ExprNodeDesc> columnExprMap = lop.getColumnExprMap();
+        final RowSchema schema = lop.getSchema();
+
+        joinedStats.updateColumnStatsState(selectStats.getColumnStatsState());
+        final List<ColStatistics> selectColStats = StatsUtils
+                .getColStatisticsFromExprMap(conf, selectStats, columnExprMap, schema);
+        joinedStats.addToColumnStats(multiplyColStats(selectColStats, factor));
+
+        joinedStats.updateColumnStatsState(udtfStats.getColumnStatsState());
+        final List<ColStatistics> udtfColStats = StatsUtils
+                .getColStatisticsFromExprMap(conf, udtfStats, columnExprMap, schema);
+        joinedStats.addToColumnStats(udtfColStats);
+
+        joinedStats = applyRuntimeStats(aspCtx.getParseContext().getContext(), joinedStats, lop);
+        lop.setStatistics(joinedStats);
+
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("[0] STATS-" + lop.toString() + ": " + joinedStats.extendedToString());
+        }
+      } else {
+        joinedStats = applyRuntimeStats(aspCtx.getParseContext().getContext(), joinedStats, lop);
+        lop.setStatistics(joinedStats);
+
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("[1] STATS-" + lop.toString() + ": " + joinedStats.extendedToString());
+        }
+      }
+      return null;
+    }
+
+    private List<ColStatistics> multiplyColStats(List<ColStatistics> colStatistics, double factor) {
+      for (ColStatistics colStats : colStatistics) {
+        colStats.setNumFalses(StatsUtils.safeMult(colStats.getNumFalses(), factor));
+        colStats.setNumTrues(StatsUtils.safeMult(colStats.getNumTrues(), factor));
+        colStats.setNumNulls(StatsUtils.safeMult(colStats.getNumNulls(), factor));
+        // When factor > 1, the same records are duplicated and countDistinct never changes.
+        if (factor < 1.0) {
+          colStats.setCountDistint(StatsUtils.safeMult(colStats.getCountDistint(), factor));
+        }
+      }
+      return colStatistics;
+    }
+  }
+
+  /**
    * Default rule is to aggregate the statistics from all its parent operators.
    */
   public static class DefaultStatsRule implements SemanticNodeProcessor {
@@ -2968,16 +3058,6 @@ public class StatsRulesProcFactory {
       return null;
     }
 
-    // check if all parent statistics are available
-    private boolean isAllParentsContainStatistics(Operator<? extends OperatorDesc> op) {
-      for (Operator<? extends OperatorDesc> parent : op.getParentOperators()) {
-        if (parent.getStatistics() == null) {
-          return false;
-        }
-      }
-      return true;
-    }
-
   }
 
   public static SemanticNodeProcessor getTableScanRule() {
@@ -3012,6 +3092,10 @@ public class StatsRulesProcFactory {
     return new UDTFStatsRule();
   }
 
+  public static SemanticNodeProcessor getLateralViewJoinRule() {
+    return new LateralViewJoinStatsRule();
+  }
+
   public static SemanticNodeProcessor getDefaultRule() {
     return new DefaultStatsRule();
   }
@@ -3019,6 +3103,16 @@ public class StatsRulesProcFactory {
   static boolean satisfyPrecondition(Statistics stats) {
     return stats != null && stats.getBasicStatsState().equals(Statistics.State.COMPLETE)
         && !stats.getColumnStatsState().equals(Statistics.State.NONE);
+  }
+
+  // check if all parent statistics are available
+  private static boolean isAllParentsContainStatistics(Operator<? extends OperatorDesc> op) {
+    for (Operator<? extends OperatorDesc> parent : op.getParentOperators()) {
+      if (parent.getStatistics() == null) {
+        return false;
+      }
+    }
+    return true;
   }
 
   private static Statistics applyRuntimeStats(Context context, Statistics stats, Operator<?> op) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -2958,8 +2958,8 @@ public class StatsRulesProcFactory {
         return null;
       }
 
-      final Statistics selectStats = parents.get(LateralViewJoinOperator.SELECT_TAG).getStatistics().clone();
-      final Statistics udtfStats = parents.get(LateralViewJoinOperator.UDTF_TAG).getStatistics().clone();
+      final Statistics selectStats = parents.get(LateralViewJoinOperator.SELECT_TAG).getStatistics();
+      final Statistics udtfStats = parents.get(LateralViewJoinOperator.UDTF_TAG).getStatistics();
 
       final double factor = (double) udtfStats.getNumRows() / (double) selectStats.getNumRows();
       final long selectDataSize = StatsUtils.safeMult(selectStats.getDataSize(), factor);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -2979,21 +2979,15 @@ public class StatsRulesProcFactory {
         final List<ColStatistics> udtfColStats = StatsUtils
                 .getColStatisticsFromExprMap(conf, udtfStats, columnExprMap, schema);
         joinedStats.addToColumnStats(udtfColStats);
-
-        joinedStats = applyRuntimeStats(aspCtx.getParseContext().getContext(), joinedStats, lop);
-        lop.setStatistics(joinedStats);
-
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("[0] STATS-" + lop.toString() + ": " + joinedStats.extendedToString());
-        }
-      } else {
-        joinedStats = applyRuntimeStats(aspCtx.getParseContext().getContext(), joinedStats, lop);
-        lop.setStatistics(joinedStats);
-
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("[1] STATS-" + lop.toString() + ": " + joinedStats.extendedToString());
-        }
       }
+
+      joinedStats = applyRuntimeStats(aspCtx.getParseContext().getContext(), joinedStats, lop);
+      lop.setStatistics(joinedStats);
+
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("[0] STATS-" + lop.toString() + ": " + joinedStats.extendedToString());
+      }
+
       return null;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -2099,6 +2099,18 @@ public class StatsUtils {
     }
   }
 
+  public static void scaleColStatistics(List<ColStatistics> colStats, double factor) {
+    for (ColStatistics cs : colStats) {
+      cs.setNumFalses(StatsUtils.safeMult(cs.getNumFalses(), factor));
+      cs.setNumTrues(StatsUtils.safeMult(cs.getNumTrues(), factor));
+      cs.setNumNulls(StatsUtils.safeMult(cs.getNumNulls(), factor));
+      if (factor < 1.0) {
+        final double newNDV = Math.ceil(cs.getCountDistint() * factor);
+        cs.setCountDistint(newNDV > Long.MAX_VALUE ? Long.MAX_VALUE : (long) newNDV);
+      }
+    }
+  }
+
   public static long computeNDVGroupingColumns(List<ColStatistics> colStats, Statistics parentStats,
       boolean expDecay) {
     List<Long> ndvValues =

--- a/ql/src/test/queries/clientpositive/annotate_stats_lateral_view_join.q
+++ b/ql/src/test/queries/clientpositive/annotate_stats_lateral_view_join.q
@@ -1,0 +1,54 @@
+set hive.fetch.task.conversion=none;
+
+-- setting up a table with multiple rows
+drop table if exists annotate_stats_lateral_view_join_test;
+create table annotate_stats_lateral_view_join_test (id int, name string);
+insert into annotate_stats_lateral_view_join_test (id, name) values
+    (1, 'aaaaaaaaaa'),
+    (2, 'bbbbbbbbbbbbbbbbbbbb'),
+    (3, 'cccccccccccccccccccccccccccccc');
+
+analyze table annotate_stats_lateral_view_join_test compute statistics;
+analyze table annotate_stats_lateral_view_join_test compute statistics for columns;
+
+-- with column stats
+set hive.stats.fetch.column.stats=true;
+
+-- 10x tests
+set hive.stats.udtf.factor=10;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+
+-- 0.5x tests
+set hive.stats.udtf.factor=0.5;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+
+-- Default behaviour tests
+set hive.stats.udtf.factor=1;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+
+-- without column stats
+set hive.stats.fetch.column.stats=false;
+
+-- 10x tests
+set hive.stats.udtf.factor=10;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+
+-- 0.5x tests
+set hive.stats.udtf.factor=0.5;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+
+-- Default behaviour tests
+set hive.stats.udtf.factor=1;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;

--- a/ql/src/test/queries/clientpositive/annotate_stats_lateral_view_join.q
+++ b/ql/src/test/queries/clientpositive/annotate_stats_lateral_view_join.q
@@ -19,18 +19,21 @@ set hive.stats.udtf.factor=10;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;
 
 -- 0.5x tests
 set hive.stats.udtf.factor=0.5;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;
 
 -- Default behaviour tests
 set hive.stats.udtf.factor=1;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;
 
 -- without column stats
 set hive.stats.fetch.column.stats=false;
@@ -40,15 +43,18 @@ set hive.stats.udtf.factor=10;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;
 
 -- 0.5x tests
 set hive.stats.udtf.factor=0.5;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;
 
 -- Default behaviour tests
 set hive.stats.udtf.factor=1;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b;
 explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c;
+explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d;

--- a/ql/src/test/results/clientnegative/udf_assert_true.q.out
+++ b/ql/src/test/results/clientnegative/udf_assert_true.q.out
@@ -28,10 +28,10 @@ STAGE PLANS:
                 Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                 Lateral View Join Operator
                   outputColumnNames: _col5
-                  Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                   Limit
                     Number of rows: 2
-                    Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: assert_true((_col5 > 0)) (type: void)
                       outputColumnNames: _col0
@@ -52,10 +52,10 @@ STAGE PLANS:
                   function name: explode
                   Lateral View Join Operator
                     outputColumnNames: _col5
-                    Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                     Limit
                       Number of rows: 2
-                      Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: assert_true((_col5 > 0)) (type: void)
                         outputColumnNames: _col0
@@ -109,10 +109,10 @@ STAGE PLANS:
                 Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                 Lateral View Join Operator
                   outputColumnNames: _col5
-                  Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                   Limit
                     Number of rows: 2
-                    Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: assert_true((_col5 < 2)) (type: void)
                       outputColumnNames: _col0
@@ -133,10 +133,10 @@ STAGE PLANS:
                   function name: explode
                   Lateral View Join Operator
                     outputColumnNames: _col5
-                    Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                     Limit
                       Number of rows: 2
-                      Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: assert_true((_col5 < 2)) (type: void)
                         outputColumnNames: _col0

--- a/ql/src/test/results/clientnegative/udf_assert_true2.q.out
+++ b/ql/src/test/results/clientnegative/udf_assert_true2.q.out
@@ -23,10 +23,10 @@ STAGE PLANS:
                 Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                 Lateral View Join Operator
                   outputColumnNames: _col5
-                  Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                   Limit
                     Number of rows: 2
-                    Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: (1 + assert_true((_col5 < 2))) (type: int)
                       outputColumnNames: _col0
@@ -47,10 +47,10 @@ STAGE PLANS:
                   function name: explode
                   Lateral View Join Operator
                     outputColumnNames: _col5
-                    Statistics: Num rows: 1000 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 500 Data size: 196000 Basic stats: COMPLETE Column stats: COMPLETE
                     Limit
                       Number of rows: 2
-                      Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                       Select Operator
                         expressions: (1 + assert_true((_col5 < 2))) (type: int)
                         outputColumnNames: _col0

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -1,0 +1,1702 @@
+PREHOOK: query: drop table if exists annotate_stats_lateral_view_join_test
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists annotate_stats_lateral_view_join_test
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table annotate_stats_lateral_view_join_test (id int, name string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@annotate_stats_lateral_view_join_test
+POSTHOOK: query: create table annotate_stats_lateral_view_join_test (id int, name string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@annotate_stats_lateral_view_join_test
+PREHOOK: query: insert into annotate_stats_lateral_view_join_test (id, name) values
+    (1, 'aaaaaaaaaa'),
+    (2, 'bbbbbbbbbbbbbbbbbbbb'),
+    (3, 'cccccccccccccccccccccccccccccc')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@annotate_stats_lateral_view_join_test
+POSTHOOK: query: insert into annotate_stats_lateral_view_join_test (id, name) values
+    (1, 'aaaaaaaaaa'),
+    (2, 'bbbbbbbbbbbbbbbbbbbb'),
+    (3, 'cccccccccccccccccccccccccccccc')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@annotate_stats_lateral_view_join_test
+POSTHOOK: Lineage: annotate_stats_lateral_view_join_test.id SCRIPT []
+POSTHOOK: Lineage: annotate_stats_lateral_view_join_test.name SCRIPT []
+PREHOOK: query: analyze table annotate_stats_lateral_view_join_test compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+PREHOOK: Output: default@annotate_stats_lateral_view_join_test
+POSTHOOK: query: analyze table annotate_stats_lateral_view_join_test compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+POSTHOOK: Output: default@annotate_stats_lateral_view_join_test
+PREHOOK: query: analyze table annotate_stats_lateral_view_join_test compute statistics for columns
+PREHOOK: type: ANALYZE_TABLE
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+PREHOOK: Output: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: analyze table annotate_stats_lateral_view_join_test compute statistics for columns
+POSTHOOK: type: ANALYZE_TABLE
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+POSTHOOK: Output: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 30 Data size: 3240 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 3240 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 30 Data size: 3240 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 30 Data size: 3240 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 30 Data size: 11280 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 30 Data size: 1440 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 30 Data size: 11280 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 30 Data size: 1440 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 1 Data size: 108 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 3 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 3 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 660 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 660 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 300 Data size: 13200 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 660 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 300 Data size: 13200 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 33 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 33 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 33 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select a.id, name as n, b.* from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                        Select Operator
+                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                          outputColumnNames: _col0, _col1, _col2
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          File Output Operator
+                            compressed: false
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            table:
+                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col2
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            File Output Operator
+                              compressed: false
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              table:
+                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                              Select Operator
+                                expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                outputColumnNames: _col0, _col1, _col2, _col3
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                File Output Operator
+                                  compressed: false
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  table:
+                                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col2, _col3
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  File Output Operator
+                                    compressed: false
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    table:
+                                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col2, _col3
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    File Output Operator
+                                      compressed: false
+                                      Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                      table:
+                                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -755,14 +755,14 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col5, _col6
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                               Select Operator
                                 expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                 outputColumnNames: _col0, _col1, _col2, _col3
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -776,14 +776,14 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -806,14 +806,14 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -827,14 +827,14 @@ STAGE PLANS:
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col2, _col3
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -887,23 +887,23 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col5, _col6
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                               Lateral View Forward
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
                                   Lateral View Join Operator
                                     outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                    Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                     Select Operator
                                       expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                       File Output Operator
                                         compressed: false
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         table:
                                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -911,20 +911,20 @@ STAGE PLANS:
                                 Select Operator
                                   expressions: array(1,2) (type: array<int>)
                                   outputColumnNames: _col0
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -938,23 +938,23 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 Lateral View Forward
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col5, _col6
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -962,20 +962,20 @@ STAGE PLANS:
                                   Select Operator
                                     expressions: array(1,2) (type: array<int>)
                                     outputColumnNames: _col0
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -998,23 +998,23 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                 Lateral View Forward
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col5, _col6
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -1022,20 +1022,20 @@ STAGE PLANS:
                                   Select Operator
                                     expressions: array(1,2) (type: array<int>)
                                     outputColumnNames: _col0
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -1049,23 +1049,23 @@ STAGE PLANS:
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                   Lateral View Forward
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
                                     Select Operator
                                       expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                       outputColumnNames: _col0, _col1, _col5, _col6
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -1073,20 +1073,20 @@ STAGE PLANS:
                                     Select Operator
                                       expressions: array(1,2) (type: array<int>)
                                       outputColumnNames: _col0
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                        Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                           Select Operator
                                             expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                             outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                             File Output Operator
                                               compressed: false
-                                              Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                              Statistics: Num rows: 1 Data size: 444 Basic stats: COMPLETE Column stats: COMPLETE
                                               table:
                                                   input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                   output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2339,14 +2339,14 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col5, _col6
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                               Select Operator
                                 expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                 outputColumnNames: _col0, _col1, _col2, _col3
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2360,14 +2360,14 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2390,14 +2390,14 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2411,14 +2411,14 @@ STAGE PLANS:
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col2, _col3
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2471,23 +2471,23 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col5, _col6
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Forward
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   Lateral View Join Operator
                                     outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                    Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                     Select Operator
                                       expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                       outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                       File Output Operator
                                         compressed: false
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         table:
                                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2495,20 +2495,20 @@ STAGE PLANS:
                                 Select Operator
                                   expressions: array(1,2) (type: array<int>)
                                   outputColumnNames: _col0
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2522,23 +2522,23 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 Lateral View Forward
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col5, _col6
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2546,20 +2546,20 @@ STAGE PLANS:
                                   Select Operator
                                     expressions: array(1,2) (type: array<int>)
                                     outputColumnNames: _col0
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2582,23 +2582,23 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                 Lateral View Forward
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col5, _col6
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                       Select Operator
                                         expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                         outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         File Output Operator
                                           compressed: false
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           table:
                                               input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                               output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2606,20 +2606,20 @@ STAGE PLANS:
                                   Select Operator
                                     expressions: array(1,2) (type: array<int>)
                                     outputColumnNames: _col0
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2633,23 +2633,23 @@ STAGE PLANS:
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   Lateral View Forward
-                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     Select Operator
                                       expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                       outputColumnNames: _col0, _col1, _col5, _col6
-                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                         Select Operator
                                           expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           File Output Operator
                                             compressed: false
-                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                             table:
                                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -2657,20 +2657,20 @@ STAGE PLANS:
                                     Select Operator
                                       expressions: array(1,2) (type: array<int>)
                                       outputColumnNames: _col0
-                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col5, _col6, _col7
-                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                           Select Operator
                                             expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
                                             outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                             File Output Operator
                                               compressed: false
-                                              Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                              Statistics: Num rows: 1 Data size: 123 Basic stats: COMPLETE Column stats: NONE
                                               table:
                                                   input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                                   output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -320,6 +320,258 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 30 Data size: 11280 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Forward
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 126000 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                  UDTF Operator
+                                    Statistics: Num rows: 3000 Data size: 144000 Basic stats: COMPLETE Column stats: COMPLETE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 30 Data size: 1440 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 300 Data size: 126000 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3000 Data size: 144000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 1680 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 30 Data size: 15240 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 30 Data size: 11280 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 300 Data size: 126000 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3000 Data size: 144000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 30 Data size: 1440 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 300 Data size: 127200 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 300 Data size: 126000 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 300 Data size: 14400 Basic stats: COMPLETE Column stats: COMPLETE
+                                      UDTF Operator
+                                        Statistics: Num rows: 3000 Data size: 144000 Basic stats: COMPLETE Column stats: COMPLETE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 3000 Data size: 1404000 Basic stats: COMPLETE Column stats: COMPLETE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@annotate_stats_lateral_view_join_test
@@ -587,6 +839,258 @@ STAGE PLANS:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                              Lateral View Forward
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  UDTF Operator
+                                    Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 1 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
+                                      UDTF Operator
+                                        Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 0 Data size: 12 Basic stats: PARTIAL Column stats: NONE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: llap
             LLAP IO: all inputs
 
@@ -872,6 +1376,258 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 1356 Basic stats: COMPLETE Column stats: COMPLETE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                        Lateral View Forward
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 3 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Forward
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                  UDTF Operator
+                                    Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                            UDTF Operator
+                              Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 3 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 168 Basic stats: COMPLETE Column stats: COMPLETE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                          Lateral View Forward
+                            Statistics: Num rows: 3 Data size: 1524 Basic stats: COMPLETE Column stats: COMPLETE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 3 Data size: 1128 Basic stats: COMPLETE Column stats: COMPLETE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                Lateral View Forward
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 3 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                              UDTF Operator
+                                Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 3 Data size: 1272 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 3 Data size: 1260 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                      UDTF Operator
+                                        Statistics: Num rows: 3 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 3 Data size: 1404 Basic stats: COMPLETE Column stats: COMPLETE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@annotate_stats_lateral_view_join_test
@@ -1139,6 +1895,258 @@ STAGE PLANS:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Forward
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  UDTF Operator
+                                    Statistics: Num rows: 3000 Data size: 264000 Basic stats: COMPLETE Column stats: NONE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 300 Data size: 13200 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3000 Data size: 264000 Basic stats: COMPLETE Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 30 Data size: 660 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3000 Data size: 264000 Basic stats: COMPLETE Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 30 Data size: 1320 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 300 Data size: 13200 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 300 Data size: 26400 Basic stats: COMPLETE Column stats: NONE
+                                      UDTF Operator
+                                        Statistics: Num rows: 3000 Data size: 264000 Basic stats: COMPLETE Column stats: NONE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 3000 Data size: 528000 Basic stats: COMPLETE Column stats: NONE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: llap
             LLAP IO: all inputs
 
@@ -1424,6 +2432,258 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                              Lateral View Forward
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  UDTF Operator
+                                    Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 1 Data size: 33 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 0 Data size: 27 Basic stats: PARTIAL Column stats: NONE
+                                      UDTF Operator
+                                        Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 0 Data size: 13 Basic stats: PARTIAL Column stats: NONE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@annotate_stats_lateral_view_join_test
@@ -1691,6 +2951,258 @@ STAGE PLANS:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                                           serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+POSTHOOK: query: explain select * from annotate_stats_lateral_view_join_test a lateral view explode(array(1, 2, 3)) b lateral view explode(array(1)) c lateral view explode(array(1, 2)) d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@annotate_stats_lateral_view_join_test
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: a
+                  Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                  Lateral View Forward
+                    Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: id (type: int), name (type: string)
+                      outputColumnNames: id, name
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      Lateral View Join Operator
+                        outputColumnNames: _col0, _col1, _col5
+                        Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                        Lateral View Forward
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Select Operator
+                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                            outputColumnNames: _col0, _col1, _col5
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            Lateral View Join Operator
+                              outputColumnNames: _col0, _col1, _col5, _col6
+                              Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Forward
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                Select Operator
+                                  expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  Lateral View Join Operator
+                                    outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                    Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                      outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                      Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                      File Output Operator
+                                        compressed: false
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        table:
+                                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                Select Operator
+                                  expressions: array(1,2) (type: array<int>)
+                                  outputColumnNames: _col0
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  UDTF Operator
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    function name: explode
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                          Select Operator
+                            expressions: array(1) (type: array<int>)
+                            outputColumnNames: _col0
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            UDTF Operator
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              function name: explode
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                    Select Operator
+                      expressions: array(1,2,3) (type: array<int>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                      UDTF Operator
+                        Statistics: Num rows: 3 Data size: 66 Basic stats: COMPLETE Column stats: NONE
+                        function name: explode
+                        Lateral View Join Operator
+                          outputColumnNames: _col0, _col1, _col5
+                          Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                          Lateral View Forward
+                            Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                            Select Operator
+                              expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int)
+                              outputColumnNames: _col0, _col1, _col5
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              Lateral View Join Operator
+                                outputColumnNames: _col0, _col1, _col5, _col6
+                                Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                Lateral View Forward
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  Select Operator
+                                    expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                    outputColumnNames: _col0, _col1, _col5, _col6
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    Lateral View Join Operator
+                                      outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                      Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                      Select Operator
+                                        expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        File Output Operator
+                                          compressed: false
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          table:
+                                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                  Select Operator
+                                    expressions: array(1,2) (type: array<int>)
+                                    outputColumnNames: _col0
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    UDTF Operator
+                                      Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                      function name: explode
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                            Select Operator
+                              expressions: array(1) (type: array<int>)
+                              outputColumnNames: _col0
+                              Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                              UDTF Operator
+                                Statistics: Num rows: 3 Data size: 132 Basic stats: COMPLETE Column stats: NONE
+                                function name: explode
+                                Lateral View Join Operator
+                                  outputColumnNames: _col0, _col1, _col5, _col6
+                                  Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                  Lateral View Forward
+                                    Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                    Select Operator
+                                      expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
+                                      outputColumnNames: _col0, _col1, _col5, _col6
+                                      Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                      Lateral View Join Operator
+                                        outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                        Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                        Select Operator
+                                          expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                          outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          File Output Operator
+                                            compressed: false
+                                            Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                            table:
+                                                input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                                    Select Operator
+                                      expressions: array(1,2) (type: array<int>)
+                                      outputColumnNames: _col0
+                                      Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                      UDTF Operator
+                                        Statistics: Num rows: 3 Data size: 264 Basic stats: COMPLETE Column stats: NONE
+                                        function name: explode
+                                        Lateral View Join Operator
+                                          outputColumnNames: _col0, _col1, _col5, _col6, _col7
+                                          Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                          Select Operator
+                                            expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int), _col7 (type: int)
+                                            outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                                            Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                            File Output Operator
+                                              compressed: false
+                                              Statistics: Num rows: 3 Data size: 528 Basic stats: COMPLETE Column stats: NONE
+                                              table:
+                                                  input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                                                  output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                                                  serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
             Execution mode: llap
             LLAP IO: all inputs
 

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -503,14 +503,14 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col5, _col6
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                              Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                               Select Operator
                                 expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                 outputColumnNames: _col0, _col1, _col2, _col3
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -524,14 +524,14 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -554,14 +554,14 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                   outputColumnNames: _col0, _col1, _col2, _col3
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -575,14 +575,14 @@ STAGE PLANS:
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
-                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                  Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col5 (type: int), _col6 (type: int)
                                     outputColumnNames: _col0, _col1, _col2, _col3
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                    Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: NONE
+                                      Statistics: Num rows: 0 Data size: 24 Basic stats: PARTIAL Column stats: COMPLETE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/lateral_view.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view.q.out
@@ -49,22 +49,22 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 261000 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col1, _col5
-                        Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                         Top N Key Operator
                           sort order: ++
                           keys: _col0 (type: string), _col5 (type: int)
                           null sort order: zz
-                          Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                           top n: 1
                           Select Operator
                             expressions: _col0 (type: string), _col1 (type: string), _col5 (type: int)
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col2 (type: int)
                               null sort order: zz
                               sort order: ++
-                              Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string)
                     Select Operator
                       expressions: array(1,2,3) (type: array<int>)
@@ -75,22 +75,22 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col5
-                          Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                           Top N Key Operator
                             sort order: ++
                             keys: _col0 (type: string), _col5 (type: int)
                             null sort order: zz
-                            Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                             top n: 1
                             Select Operator
                               expressions: _col0 (type: string), _col1 (type: string), _col5 (type: int)
                               outputColumnNames: _col0, _col1, _col2
-                              Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                               Reduce Output Operator
                                 key expressions: _col0 (type: string), _col2 (type: int)
                                 null sort order: zz
                                 sort order: ++
-                                Statistics: Num rows: 1000 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 500 Data size: 289000 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -710,14 +710,14 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 21040 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col1, _col2
-                        Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                         Select Operator
                           expressions: _col1 (type: array<string>), _col2 (type: string)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                           File Output Operator
                             compressed: false
-                            Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                             table:
                                 input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -731,14 +731,14 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col1, _col2
-                          Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col1 (type: array<string>), _col2 (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                             File Output Operator
                               compressed: false
-                              Statistics: Num rows: 20 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 10 Data size: 42080 Basic stats: COMPLETE Column stats: NONE
                               table:
                                   input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                   output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/lateral_view_cp.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_cp.q.out
@@ -99,7 +99,7 @@ STAGE PLANS:
                       Statistics: Num rows: 550 Data size: 47850 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col2
-                        Statistics: Num rows: 1100 Data size: 95700 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 550 Data size: 95700 Basic stats: COMPLETE Column stats: NONE
                         Group By Operator
                           aggregations: count(_col2)
                           minReductionHashAggr: 0.99
@@ -120,7 +120,7 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col2
-                          Statistics: Num rows: 1100 Data size: 95700 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 550 Data size: 95700 Basic stats: COMPLETE Column stats: NONE
                           Group By Operator
                             aggregations: count(_col2)
                             minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/llap/lateral_view_explode2.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_explode2.q.out
@@ -35,12 +35,12 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col5, _col6
-                        Statistics: Num rows: 1000 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 500 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
                         Top N Key Operator
                           sort order: ++
                           keys: _col5 (type: int), _col6 (type: int)
                           null sort order: zz
-                          Statistics: Num rows: 1000 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
                           top n: 3
                           Group By Operator
                             keys: _col5 (type: int), _col6 (type: int)
@@ -63,12 +63,12 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col5, _col6
-                          Statistics: Num rows: 1000 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
                           Top N Key Operator
                             sort order: ++
                             keys: _col5 (type: int), _col6 (type: int)
                             null sort order: zz
-                            Statistics: Num rows: 1000 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 500 Data size: 200000 Basic stats: COMPLETE Column stats: COMPLETE
                             top n: 3
                             Group By Operator
                               keys: _col5 (type: int), _col6 (type: int)

--- a/ql/src/test/results/clientpositive/llap/lateral_view_noalias.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_noalias.q.out
@@ -137,10 +137,10 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col5, _col6
-                        Statistics: Num rows: 1000 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 500 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
                         Limit
                           Number of rows: 2
-                          Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col5 (type: string), _col6 (type: int)
                             outputColumnNames: _col0, _col1
@@ -160,10 +160,10 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col5, _col6
-                          Statistics: Num rows: 1000 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
                           Limit
                             Number of rows: 2
-                            Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col5 (type: string), _col6 (type: int)
                               outputColumnNames: _col0, _col1
@@ -178,10 +178,10 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 172000 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col5, _col6
-                        Statistics: Num rows: 1000 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 500 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
                         Limit
                           Number of rows: 2
-                          Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col5 (type: string), _col6 (type: int)
                             outputColumnNames: _col0, _col1
@@ -201,10 +201,10 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col5, _col6
-                          Statistics: Num rows: 1000 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 364000 Basic stats: COMPLETE Column stats: COMPLETE
                           Limit
                             Number of rows: 2
-                            Statistics: Num rows: 2 Data size: 1224 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 2 Data size: 536 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col5 (type: string), _col6 (type: int)
                               outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/llap/lateral_view_onview.q.out
+++ b/ql/src/test/results/clientpositive/llap/lateral_view_onview.q.out
@@ -72,18 +72,18 @@ STAGE PLANS:
                         Statistics: Num rows: 500 Data size: 187068 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                          Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                           Top N Key Operator
                             sort order: ++
                             keys: _col0 (type: string), _col4 (type: int)
                             null sort order: zz
-                            Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                             top n: 1
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col4 (type: int)
                               null sort order: zz
                               sort order: ++
-                              Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                               value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
                       Select Operator
                         expressions: array(1,2,3) (type: array<int>)
@@ -94,18 +94,18 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                            Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                             Top N Key Operator
                               sort order: ++
                               keys: _col0 (type: string), _col4 (type: int)
                               null sort order: zz
-                              Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                               top n: 1
                               Reduce Output Operator
                                 key expressions: _col0 (type: string), _col4 (type: int)
                                 null sort order: zz
                                 sort order: ++
-                                Statistics: Num rows: 1000 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 500 Data size: 374136 Basic stats: COMPLETE Column stats: NONE
                                 value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
             Execution mode: llap
             LLAP IO: all inputs
@@ -114,36 +114,36 @@ STAGE PLANS:
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                 Top N Key Operator
                   sort order: ++
                   keys: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey1 (type: int)
                   null sort order: zz
-                  Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                   top n: 1
                   Select Operator
                     expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: array<int>), VALUE._col1 (type: int), VALUE._col2 (type: char(1)), KEY.reducesinkkey1 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: string), _col4 (type: int)
                       null sort order: zz
                       sort order: ++
-                      Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: array<int>), _col2 (type: int), _col3 (type: char(1))
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
                   expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: array<int>), VALUE._col1 (type: int), VALUE._col2 (type: char(1)), KEY.reducesinkkey1 (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                  Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 374 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 748 Basic stats: COMPLETE Column stats: NONE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -611,18 +611,18 @@ STAGE PLANS:
                       Statistics: Num rows: 550 Data size: 533500 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                        Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                         Top N Key Operator
                           sort order: ++
                           keys: _col0 (type: string), _col13 (type: int)
                           null sort order: zz
-                          Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                           top n: 1
                           Reduce Output Operator
                             key expressions: _col0 (type: string), _col13 (type: int)
                             null sort order: zz
                             sort order: ++
-                            Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                             value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
                     Select Operator
                       expressions: _col12 (type: array<int>)
@@ -633,54 +633,54 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                          Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                           Top N Key Operator
                             sort order: ++
                             keys: _col0 (type: string), _col13 (type: int)
                             null sort order: zz
-                            Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                             top n: 1
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col13 (type: int)
                               null sort order: zz
                               sort order: ++
-                              Statistics: Num rows: 1100 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 550 Data size: 1067000 Basic stats: COMPLETE Column stats: NONE
                               value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                 Top N Key Operator
                   sort order: ++
                   keys: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey1 (type: int)
                   null sort order: zz
-                  Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                   top n: 1
                   Select Operator
                     expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: char(1)), VALUE._col2 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col7 (type: string), VALUE._col8 (type: string), VALUE._col9 (type: string), VALUE._col10 (type: string), VALUE._col11 (type: array<int>), KEY.reducesinkkey1 (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                    Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: string), _col13 (type: int)
                       null sort order: zz
                       sort order: ++
-                      Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: int), _col2 (type: char(1)), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: array<int>)
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
                   expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: char(1)), VALUE._col2 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col7 (type: string), VALUE._col8 (type: string), VALUE._col9 (type: string), VALUE._col10 (type: string), VALUE._col11 (type: array<int>), KEY.reducesinkkey1 (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                  Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 970 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 1940 Basic stats: COMPLETE Column stats: NONE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/lvj_mapjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/lvj_mapjoin.q.out
@@ -121,7 +121,7 @@ STAGE PLANS:
                 TableScan
                   alias: expod1
                   filterExpr: aid is not null (type: boolean)
-                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_39_container, bigKeyColName:aid, smallTablePos:1, keyRatio:2.0
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_39_container, bigKeyColName:aid, smallTablePos:1, keyRatio:1.0
                   Statistics: Num rows: 3 Data size: 5772 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: aid is not null (type: boolean)
@@ -134,11 +134,11 @@ STAGE PLANS:
                         Statistics: Num rows: 3 Data size: 5772 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col0 (type: int), _col5 (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                             Map Join Operator
                               condition map:
                                    Inner Join 0 to 1
@@ -148,17 +148,17 @@ STAGE PLANS:
                               outputColumnNames: _col0, _col1, _col2, _col3
                               input vertices:
                                 1 Map 2
-                              Statistics: Num rows: 6 Data size: 12698 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 3 Data size: 12698 Basic stats: COMPLETE Column stats: NONE
                               Filter Operator
                                 predicate: (_col0 = _col2) (type: boolean)
-                                Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col0 (type: int), _col1 (type: string), _col3 (type: string)
                                   outputColumnNames: _col0, _col1, _col2
-                                  Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -172,11 +172,11 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col5
-                            Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                             Select Operator
                               expressions: _col0 (type: int), _col5 (type: string)
                               outputColumnNames: _col0, _col1
-                              Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                               Map Join Operator
                                 condition map:
                                      Inner Join 0 to 1
@@ -186,17 +186,17 @@ STAGE PLANS:
                                 outputColumnNames: _col0, _col1, _col2, _col3
                                 input vertices:
                                   1 Map 2
-                                Statistics: Num rows: 6 Data size: 12698 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 3 Data size: 12698 Basic stats: COMPLETE Column stats: NONE
                                 Filter Operator
                                   predicate: (_col0 = _col2) (type: boolean)
-                                  Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col0 (type: int), _col1 (type: string), _col3 (type: string)
                                     outputColumnNames: _col0, _col1, _col2
-                                    Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 3 Data size: 6349 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 4232 Basic stats: COMPLETE Column stats: NONE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -220,17 +220,17 @@ STAGE PLANS:
                         Statistics: Num rows: 3 Data size: 5772 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col0 (type: int), _col5 (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                             Reduce Output Operator
                               key expressions: _col0 (type: int)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: int)
-                              Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                               value expressions: _col1 (type: string)
                       Select Operator
                         expressions: bv (type: array<string>)
@@ -241,17 +241,17 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col5
-                            Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                             Select Operator
                               expressions: _col0 (type: int), _col5 (type: string)
                               outputColumnNames: _col0, _col1
-                              Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                               Reduce Output Operator
                                 key expressions: _col0 (type: int)
                                 null sort order: z
                                 sort order: +
                                 Map-reduce partition columns: _col0 (type: int)
-                                Statistics: Num rows: 6 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 3 Data size: 11544 Basic stats: COMPLETE Column stats: NONE
                                 value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: all inputs

--- a/ql/src/test/results/clientpositive/llap/multi_insert_lateral_view.q.out
+++ b/ql/src/test/results/clientpositive/llap/multi_insert_lateral_view.q.out
@@ -80,14 +80,14 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 4310 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), CAST( _col5 AS STRING) (type: string)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
                             compressed: false
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             table:
                                 input format: org.apache.hadoop.mapred.TextInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -96,10 +96,10 @@ STAGE PLANS:
                           Select Operator
                             expressions: _col0 (type: string), _col1 (type: string)
                             outputColumnNames: key, value
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             Group By Operator
                               aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                              minReductionHashAggr: 0.95
+                              minReductionHashAggr: 0.9
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                               Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -117,14 +117,14 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), CAST( _col5 AS STRING) (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             File Output Operator
                               compressed: false
-                              Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                               table:
                                   input format: org.apache.hadoop.mapred.TextInputFormat
                                   output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -133,10 +133,10 @@ STAGE PLANS:
                             Select Operator
                               expressions: _col0 (type: string), _col1 (type: string)
                               outputColumnNames: key, value
-                              Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                                minReductionHashAggr: 0.95
+                                minReductionHashAggr: 0.9
                                 mode: hash
                                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                                 Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -153,14 +153,14 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 4310 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), CAST( _col5 AS STRING) (type: string)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                           File Output Operator
                             compressed: false
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             table:
                                 input format: org.apache.hadoop.mapred.TextInputFormat
                                 output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -169,10 +169,10 @@ STAGE PLANS:
                           Select Operator
                             expressions: _col0 (type: string), _col1 (type: string)
                             outputColumnNames: key, value
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             Group By Operator
                               aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                              minReductionHashAggr: 0.95
+                              minReductionHashAggr: 0.9
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                               Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -190,14 +190,14 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), CAST( _col5 AS STRING) (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                             File Output Operator
                               compressed: false
-                              Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                               table:
                                   input format: org.apache.hadoop.mapred.TextInputFormat
                                   output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -206,10 +206,10 @@ STAGE PLANS:
                             Select Operator
                               expressions: _col0 (type: string), _col1 (type: string)
                               outputColumnNames: key, value
-                              Statistics: Num rows: 20 Data size: 5420 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                                minReductionHashAggr: 0.95
+                                minReductionHashAggr: 0.9
                                 mode: hash
                                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                                 Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -420,20 +420,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 4310 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(_col5)
                           keys: _col0 (type: string)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: double)
                     Select Operator
                       expressions: array((key + 1),(key + 2)) (type: array<double>)
@@ -444,20 +444,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col5)
                             keys: _col0 (type: string)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: double)
                   Lateral View Forward
                     Statistics: Num rows: 10 Data size: 870 Basic stats: COMPLETE Column stats: COMPLETE
@@ -467,20 +467,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 4310 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(_col5)
                           keys: _col0 (type: string)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: double)
                     Select Operator
                       expressions: array((key + 3),(key + 4)) (type: array<double>)
@@ -491,20 +491,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 5910 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col5)
                             keys: _col0 (type: string)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: double)
             Execution mode: llap
             LLAP IO: all inputs
@@ -516,14 +516,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), CAST( _col1 AS STRING) (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -532,10 +532,10 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string)
                     outputColumnNames: key, value
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                      minReductionHashAggr: 0.9
+                      minReductionHashAggr: 0.8
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                       Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -571,14 +571,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), CAST( _col1 AS STRING) (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -587,10 +587,10 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string)
                     outputColumnNames: key, value
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                      minReductionHashAggr: 0.9
+                      minReductionHashAggr: 0.8
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                       Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -767,20 +767,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 5220 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(_col5)
                           keys: _col0 (type: string)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: double)
                     Select Operator
                       expressions: array((key + 1),(key + 2)) (type: array<double>)
@@ -791,20 +791,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(_col5)
                             keys: _col0 (type: string)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: double)
                   Filter Operator
                     predicate: ((key < 200) or (key > 200)) (type: boolean)
@@ -826,14 +826,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), CAST( _col1 AS STRING) (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -842,10 +842,10 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string)
                     outputColumnNames: key, value
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                      minReductionHashAggr: 0.9
+                      minReductionHashAggr: 0.8
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                       Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1170,20 +1170,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 5220 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(DISTINCT _col0)
                           keys: _col5 (type: double), _col0 (type: string)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: double), _col1 (type: string)
                             null sort order: zz
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: double)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: array((key + 1),(key + 2)) (type: array<double>)
                       outputColumnNames: _col0
@@ -1193,20 +1193,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(DISTINCT _col0)
                             keys: _col5 (type: double), _col0 (type: string)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: double), _col1 (type: string)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: double)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                   Lateral View Forward
                     Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -1215,20 +1215,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 5220 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(DISTINCT _col0)
                           keys: _col5 (type: double), _col0 (type: string)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: double), _col1 (type: string)
                             null sort order: zz
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: double)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: array((key + 3),(key + 4)) (type: array<double>)
                       outputColumnNames: _col0
@@ -1238,20 +1238,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(DISTINCT _col0)
                             keys: _col5 (type: double), _col0 (type: string)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: double), _col1 (type: string)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: double)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: string), value (type: string)
                     outputColumnNames: key, value
@@ -1663,20 +1663,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 5220 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(DISTINCT _col5)
                           keys: _col0 (type: string), _col5 (type: double)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string), _col1 (type: double)
                             null sort order: zz
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: array((key + 1),(key + 2)) (type: array<double>)
                       outputColumnNames: _col0
@@ -1686,20 +1686,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(DISTINCT _col5)
                             keys: _col0 (type: string), _col5 (type: double)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col1 (type: double)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                   Lateral View Forward
                     Statistics: Num rows: 10 Data size: 1780 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
@@ -1708,20 +1708,20 @@ STAGE PLANS:
                       Statistics: Num rows: 10 Data size: 5220 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5
-                        Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                         Group By Operator
                           aggregations: sum(DISTINCT _col5)
                           keys: _col0 (type: string), _col5 (type: double)
                           minReductionHashAggr: 0.5
                           mode: hash
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string), _col1 (type: double)
                             null sort order: zz
                             sort order: ++
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: array((key + 3),(key + 4)) (type: array<double>)
                       outputColumnNames: _col0
@@ -1731,20 +1731,20 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5
-                          Statistics: Num rows: 20 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 10 Data size: 6820 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: sum(DISTINCT _col5)
                             keys: _col0 (type: string), _col5 (type: double)
                             minReductionHashAggr: 0.5
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col1 (type: double)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((key < 200) or (key > 200)) (type: boolean)
                     Statistics: Num rows: 6 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1764,14 +1764,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), CAST( _col1 AS STRING) (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -1780,10 +1780,10 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string)
                     outputColumnNames: key, value
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                      minReductionHashAggr: 0.9
+                      minReductionHashAggr: 0.8
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                       Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1819,14 +1819,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 10 Data size: 950 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 475 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col0 (type: string), CAST( _col1 AS STRING) (type: string)
                   outputColumnNames: _col0, _col1
-                  Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -1835,10 +1835,10 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string)
                     outputColumnNames: key, value
-                    Statistics: Num rows: 10 Data size: 2710 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 1355 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: max(length(key)), avg(COALESCE(length(key),0)), count(1), count(key), compute_bit_vector(key, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
-                      minReductionHashAggr: 0.9
+                      minReductionHashAggr: 0.8
                       mode: hash
                       outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
                       Statistics: Num rows: 1 Data size: 472 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/nested_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/nested_column_pruning.q.out
@@ -635,23 +635,23 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 3632 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col3, _col10
-                        Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Forward
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col10 (type: int)
                             outputColumnNames: _col10
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col10, _col11
-                              Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                               Select Operator
                                 expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                 outputColumnNames: _col0, _col1
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -659,20 +659,20 @@ STAGE PLANS:
                           Select Operator
                             expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                             outputColumnNames: _col0
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -686,23 +686,23 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col3, _col10
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Lateral View Forward
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Select Operator
                               expressions: _col10 (type: int)
                               outputColumnNames: _col10
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -710,20 +710,20 @@ STAGE PLANS:
                             Select Operator
                               expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                               outputColumnNames: _col0
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col10, _col11
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                     outputColumnNames: _col0, _col1
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/orc_nested_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_nested_column_pruning.q.out
@@ -635,23 +635,23 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 3632 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col3, _col10
-                        Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Forward
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col10 (type: int)
                             outputColumnNames: _col10
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col10, _col11
-                              Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                               Select Operator
                                 expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                 outputColumnNames: _col0, _col1
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -659,20 +659,20 @@ STAGE PLANS:
                           Select Operator
                             expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                             outputColumnNames: _col0
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -686,23 +686,23 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col3, _col10
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Lateral View Forward
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Select Operator
                               expressions: _col10 (type: int)
                               outputColumnNames: _col10
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -710,20 +710,20 @@ STAGE PLANS:
                             Select Operator
                               expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                               outputColumnNames: _col0
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col10, _col11
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                     outputColumnNames: _col0, _col1
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/reduce_deduplicate_null_keys.q.out
+++ b/ql/src/test/results/clientpositive/llap/reduce_deduplicate_null_keys.q.out
@@ -76,16 +76,16 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 344 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col4, _col5
-                        Statistics: Num rows: 2 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 1 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col4 (type: int), (_col4 + 1) (type: int)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: CASE WHEN ((_col0 = _col1)) THEN (1) ELSE (2) END (type: int)
                             null sort order: z
                             sort order: +
-                            Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: array('a','b') (type: array<string>)
                       outputColumnNames: _col0
@@ -95,16 +95,16 @@ STAGE PLANS:
                         function name: posexplode
                         Lateral View Join Operator
                           outputColumnNames: _col4, _col5
-                          Statistics: Num rows: 2 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1 Data size: 752 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col4 (type: int), (_col4 + 1) (type: int)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: CASE WHEN ((_col0 = _col1)) THEN (1) ELSE (2) END (type: int)
                               null sort order: z
                               sort order: +
-                              Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: llap
             LLAP IO: all inputs
         Reducer 2 
@@ -113,10 +113,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int)
                 outputColumnNames: _col0
-                Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/select_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/select_column_pruning.q.out
@@ -63,22 +63,22 @@ STAGE PLANS:
                         Statistics: Num rows: 5 Data size: 8001 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col14
-                          Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                           Top N Key Operator
                             sort order: ++
                             keys: _col0 (type: string), _col14 (type: int)
                             null sort order: zz
-                            Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                             top n: 1
                             Select Operator
                               expressions: _col0 (type: string), _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col14 (type: int)
                               outputColumnNames: _col0, _col1, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                              Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                               Reduce Output Operator
                                 key expressions: _col0 (type: string), _col11 (type: int)
                                 null sort order: zz
                                 sort order: ++
-                                Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                                 value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
                       Select Operator
                         expressions: array(1,2,3) (type: array<int>)
@@ -89,22 +89,22 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col1, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col14
-                            Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                             Top N Key Operator
                               sort order: ++
                               keys: _col0 (type: string), _col14 (type: int)
                               null sort order: zz
-                              Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                               top n: 1
                               Select Operator
                                 expressions: _col0 (type: string), _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col14 (type: int)
                                 outputColumnNames: _col0, _col1, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                                Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                                 Reduce Output Operator
                                   key expressions: _col0 (type: string), _col11 (type: int)
                                   null sort order: zz
                                   sort order: ++
-                                  Statistics: Num rows: 10 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 5 Data size: 16002 Basic stats: COMPLETE Column stats: NONE
                                   value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -113,36 +113,36 @@ STAGE PLANS:
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                 Top N Key Operator
                   sort order: ++
                   keys: KEY.reducesinkkey0 (type: string), KEY.reducesinkkey1 (type: int)
                   null sort order: zz
-                  Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                   top n: 1
                   Select Operator
                     expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: array<int>), VALUE._col2 (type: char(1)), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col7 (type: string), VALUE._col8 (type: string), VALUE._col9 (type: string), KEY.reducesinkkey1 (type: int)
                     outputColumnNames: _col0, _col1, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                    Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: string), _col11 (type: int)
                       null sort order: zz
                       sort order: ++
-                      Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                       value expressions: _col1 (type: array<int>), _col3 (type: char(1)), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Limit
                 Number of rows: 1
-                Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                 Select Operator
                   expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: array<int>), 100 (type: int), VALUE._col2 (type: char(1)), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col7 (type: string), VALUE._col8 (type: string), VALUE._col9 (type: string), KEY.reducesinkkey1 (type: int)
                   outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
-                  Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 1 Data size: 1600 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 1 Data size: 3200 Basic stats: COMPLETE Column stats: NONE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin6.q.out
+++ b/ql/src/test/results/clientpositive/llap/skewjoin_mapjoin6.q.out
@@ -108,10 +108,10 @@ STAGE PLANS:
                             Statistics: Num rows: 6 Data size: 13886 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col0, _col1, _col2
-                              Statistics: Num rows: 12 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 6 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
                               File Output Operator
                                 compressed: false
-                                Statistics: Num rows: 12 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 6 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
                                 table:
                                     input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                     output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -125,10 +125,10 @@ STAGE PLANS:
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col2
-                                Statistics: Num rows: 12 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 6 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 12 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 6 Data size: 27772 Basic stats: COMPLETE Column stats: NONE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/udtf_json_tuple.q.out
+++ b/ql/src/test/results/clientpositive/llap/udtf_json_tuple.q.out
@@ -77,16 +77,16 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 3179 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9
-                        Statistics: Num rows: 12 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string)
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                          Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string)
                     Select Operator
                       expressions: jstring (type: string), 'f1' (type: string), 'f2' (type: string), 'f3' (type: string), 'f4' (type: string), 'f5' (type: string)
@@ -97,16 +97,16 @@ STAGE PLANS:
                         function name: json_tuple
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9
-                          Statistics: Num rows: 12 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string)
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
-                              Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -116,10 +116,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -261,16 +261,16 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 3179 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9
-                        Statistics: Num rows: 12 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), _col6 (type: string), _col9 (type: string)
                           outputColumnNames: _col0, _col1, _col2
-                          Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: string), _col2 (type: string)
                     Select Operator
                       expressions: jstring (type: string), 'f1' (type: string), 'f2' (type: string), 'f3' (type: string), 'f4' (type: string), 'f5' (type: string)
@@ -281,16 +281,16 @@ STAGE PLANS:
                         function name: json_tuple
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9
-                          Statistics: Num rows: 12 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 6364 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), _col6 (type: string), _col9 (type: string)
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
-                              Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -300,10 +300,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: string)
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -363,15 +363,15 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 2669 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col5, _col6, _col7, _col8, _col9
-                        Statistics: Num rows: 12 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col6 (type: string)
                           outputColumnNames: _col6
-                          Statistics: Num rows: 12 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: count()
                             keys: _col6 (type: string)
-                            minReductionHashAggr: 0.9166667
+                            minReductionHashAggr: 0.8333333
                             mode: hash
                             outputColumnNames: _col0, _col1
                             Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -394,15 +394,15 @@ STAGE PLANS:
                           Statistics: Num rows: 6 Data size: 3185 Basic stats: COMPLETE Column stats: COMPLETE
                           Lateral View Join Operator
                             outputColumnNames: _col5, _col6, _col7, _col8, _col9
-                            Statistics: Num rows: 12 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col6 (type: string)
                               outputColumnNames: _col6
-                              Statistics: Num rows: 12 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 5854 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: count()
                                 keys: _col6 (type: string)
-                                minReductionHashAggr: 0.9166667
+                                minReductionHashAggr: 0.8333333
                                 mode: hash
                                 outputColumnNames: _col0, _col1
                                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/udtf_parse_url_tuple.q.out
+++ b/ql/src/test/results/clientpositive/llap/udtf_parse_url_tuple.q.out
@@ -96,16 +96,16 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 3159 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                        Statistics: Num rows: 12 Data size: 8598 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 8598 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: string), _col13 (type: string)
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                          Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string)
                     Select Operator
                       expressions: fullurl (type: string), 'HOST' (type: string), 'PATH' (type: string), 'QUERY' (type: string), 'REF' (type: string), 'PROTOCOL' (type: string), 'FILE' (type: string), 'AUTHORITY' (type: string), 'USERINFO' (type: string), 'QUERY:k1' (type: string)
@@ -116,16 +116,16 @@ STAGE PLANS:
                         function name: parse_url_tuple
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                          Statistics: Num rows: 12 Data size: 8598 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 8598 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string), _col10 (type: string), _col11 (type: string), _col12 (type: string), _col13 (type: string)
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
-                              Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string), _col7 (type: string), _col8 (type: string), _col9 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -135,10 +135,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string), VALUE._col6 (type: string), VALUE._col7 (type: string), VALUE._col8 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
-                Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -280,16 +280,16 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 3159 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
-                        Statistics: Num rows: 12 Data size: 10266 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 10266 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), _col5 (type: string), _col7 (type: string), _col13 (type: string), _col14 (type: string), _col15 (type: string), _col16 (type: string)
                           outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                          Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string)
                             null sort order: z
                             sort order: +
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string)
                     Select Operator
                       expressions: fullurl (type: string), 'HOST' (type: string), 'PATH' (type: string), 'QUERY' (type: string), 'REF' (type: string), 'PROTOCOL' (type: string), 'FILE' (type: string), 'AUTHORITY' (type: string), 'USERINFO' (type: string), 'QUERY:k1' (type: string), 'host' (type: string), 'query' (type: string), 'QUERY:nonExistCol' (type: string)
@@ -300,16 +300,16 @@ STAGE PLANS:
                         function name: parse_url_tuple
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16
-                          Statistics: Num rows: 12 Data size: 10266 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 10266 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), _col5 (type: string), _col7 (type: string), _col13 (type: string), _col14 (type: string), _col15 (type: string), _col16 (type: string)
                             outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                            Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string)
                               null sort order: z
                               sort order: +
-                              Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string), _col2 (type: string), _col3 (type: string), _col4 (type: string), _col5 (type: string), _col6 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -319,10 +319,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: string), VALUE._col2 (type: string), VALUE._col3 (type: string), VALUE._col4 (type: string), VALUE._col5 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 12 Data size: 1020 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 510 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -381,15 +381,15 @@ STAGE PLANS:
                       Statistics: Num rows: 6 Data size: 2649 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                        Statistics: Num rows: 12 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 6 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col5 (type: string)
                           outputColumnNames: _col5
-                          Statistics: Num rows: 12 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 6 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: count()
                             keys: _col5 (type: string)
-                            minReductionHashAggr: 0.9166667
+                            minReductionHashAggr: 0.8333333
                             mode: hash
                             outputColumnNames: _col0, _col1
                             Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -412,15 +412,15 @@ STAGE PLANS:
                           Statistics: Num rows: 6 Data size: 5439 Basic stats: COMPLETE Column stats: COMPLETE
                           Lateral View Join Operator
                             outputColumnNames: _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
-                            Statistics: Num rows: 12 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 6 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col5 (type: string)
                               outputColumnNames: _col5
-                              Statistics: Num rows: 12 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 6 Data size: 8088 Basic stats: COMPLETE Column stats: COMPLETE
                               Group By Operator
                                 aggregations: count()
                                 keys: _col5 (type: string)
-                                minReductionHashAggr: 0.9166667
+                                minReductionHashAggr: 0.8333333
                                 mode: hash
                                 outputColumnNames: _col0, _col1
                                 Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/union26.q.out
+++ b/ql/src/test/results/clientpositive/llap/union26.q.out
@@ -113,24 +113,24 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 351000 Basic stats: COMPLETE Column stats: COMPLETE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col1, _col7
-                        Statistics: Num rows: 1000 Data size: 379000 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 500 Data size: 379000 Basic stats: COMPLETE Column stats: COMPLETE
                         Select Operator
                           expressions: _col0 (type: string), _col1 (type: string)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
                             aggregations: count(1)
                             keys: _col0 (type: string), _col1 (type: string)
                             minReductionHashAggr: 0.0
                             mode: hash
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col1 (type: string)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                              Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col2 (type: bigint)
                     Select Operator
                       expressions: array(1,2,3) (type: array<int>)
@@ -141,24 +141,24 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col7
-                          Statistics: Num rows: 1000 Data size: 379000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 500 Data size: 379000 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col0 (type: string), _col1 (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 1000 Data size: 178000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                             Group By Operator
                               aggregations: count(1)
                               keys: _col0 (type: string), _col1 (type: string)
                               minReductionHashAggr: 0.0
                               mode: hash
                               outputColumnNames: _col0, _col1, _col2
-                              Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                               Reduce Output Operator
                                 key expressions: _col0 (type: string), _col1 (type: string)
                                 null sort order: zz
                                 sort order: ++
                                 Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                                Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col2 (type: bigint)
             Execution mode: llap
             LLAP IO: all inputs
@@ -179,13 +179,13 @@ STAGE PLANS:
                   minReductionHashAggr: 0.0
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: string), _col1 (type: string)
                     null sort order: zz
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                    Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint)
         Reducer 4 
             Execution mode: vectorized, llap
@@ -195,14 +195,14 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string), KEY._col1 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: _col2 (type: bigint), _col0 (type: string), _col1 (type: string)
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 895 Data size: 166470 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 645 Data size: 119970 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/unionDistinct_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/unionDistinct_1.q.out
@@ -6994,13 +6994,13 @@ STAGE PLANS:
                         minReductionHashAggr: 0.99
                         mode: hash
                         outputColumnNames: _col0, _col1
-                        Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col0 (type: string), _col1 (type: string)
                           null sort order: zz
                           sort order: ++
                           Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                          Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
             Execution mode: vectorized
         Map 4 
             Map Operator Tree:
@@ -7032,23 +7032,23 @@ STAGE PLANS:
                       Statistics: Num rows: 500 Data size: 5312 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col0, _col1, _col7
-                        Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 500 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
                         Select Operator
                           expressions: _col0 (type: string), _col1 (type: string)
                           outputColumnNames: _col0, _col1
-                          Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 500 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
                           Group By Operator
                             keys: _col0 (type: string), _col1 (type: string)
                             minReductionHashAggr: 0.99
                             mode: hash
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col1 (type: string)
                               null sort order: zz
                               sort order: ++
                               Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                              Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: array(1,2,3) (type: array<int>)
                       outputColumnNames: _col0
@@ -7058,23 +7058,23 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col7
-                          Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 500 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col0 (type: string), _col1 (type: string)
                             outputColumnNames: _col0, _col1
-                            Statistics: Num rows: 1000 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 500 Data size: 10624 Basic stats: COMPLETE Column stats: NONE
                             Group By Operator
                               keys: _col0 (type: string), _col1 (type: string)
                               minReductionHashAggr: 0.99
                               mode: hash
                               outputColumnNames: _col0, _col1
-                              Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
                               Reduce Output Operator
                                 key expressions: _col0 (type: string), _col1 (type: string)
                                 null sort order: zz
                                 sort order: ++
                                 Map-reduce partition columns: _col0 (type: string), _col1 (type: string)
-                                Statistics: Num rows: 1550 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1050 Data size: 16467 Basic stats: COMPLETE Column stats: NONE
         Reducer 3 
             Execution mode: vectorized
             Reduce Operator Tree:
@@ -7082,20 +7082,20 @@ STAGE PLANS:
                 keys: KEY._col0 (type: string), KEY._col1 (type: string)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 775 Data size: 8233 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 525 Data size: 8233 Basic stats: COMPLETE Column stats: NONE
                 Group By Operator
                   aggregations: count(1)
                   keys: _col0 (type: string), _col1 (type: string)
                   mode: complete
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 387 Data size: 4111 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 262 Data size: 4108 Basic stats: COMPLETE Column stats: NONE
                   Select Operator
                     expressions: _col2 (type: bigint), _col0 (type: string), _col1 (type: string)
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 387 Data size: 4111 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 262 Data size: 4108 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 387 Data size: 4111 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 262 Data size: 4108 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/union_lateralview.q.out
+++ b/ql/src/test/results/clientpositive/llap/union_lateralview.q.out
@@ -86,17 +86,17 @@ STAGE PLANS:
                         Statistics: Num rows: 1000 Data size: 290000 Basic stats: COMPLETE Column stats: COMPLETE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col3
-                          Statistics: Num rows: 2000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col3 (type: int), _col0 (type: string), _col1 (type: string)
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: string)
-                              Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col0 (type: int), _col2 (type: string)
                       Select Operator
                         expressions: _col2 (type: array<int>)
@@ -107,17 +107,17 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col1, _col3
-                            Statistics: Num rows: 2000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col3 (type: int), _col0 (type: string), _col1 (type: string)
                               outputColumnNames: _col0, _col1, _col2
-                              Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                               Reduce Output Operator
                                 key expressions: _col1 (type: string)
                                 null sort order: z
                                 sort order: +
                                 Map-reduce partition columns: _col1 (type: string)
-                                Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col0 (type: int), _col2 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -139,17 +139,17 @@ STAGE PLANS:
                         Statistics: Num rows: 1000 Data size: 290000 Basic stats: COMPLETE Column stats: COMPLETE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col3
-                          Statistics: Num rows: 2000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 1000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
                           Select Operator
                             expressions: _col3 (type: int), _col0 (type: string), _col1 (type: string)
                             outputColumnNames: _col0, _col1, _col2
-                            Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: string)
                               null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: string)
-                              Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col0 (type: int), _col2 (type: string)
                       Select Operator
                         expressions: _col2 (type: array<int>)
@@ -160,17 +160,17 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col1, _col3
-                            Statistics: Num rows: 2000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 1000 Data size: 346000 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col3 (type: int), _col0 (type: string), _col1 (type: string)
                               outputColumnNames: _col0, _col1, _col2
-                              Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                               Reduce Output Operator
                                 key expressions: _col1 (type: string)
                                 null sort order: z
                                 sort order: +
                                 Map-reduce partition columns: _col1 (type: string)
-                                Statistics: Num rows: 2000 Data size: 462000 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1000 Data size: 231000 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col0 (type: int), _col2 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -197,14 +197,14 @@ STAGE PLANS:
                   0 _col1 (type: string)
                   1 key (type: string)
                 outputColumnNames: _col0, _col2, _col3
-                Statistics: Num rows: 3104 Data size: 468967 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1552 Data size: 234527 Basic stats: COMPLETE Column stats: COMPLETE
                 Select Operator
                   expressions: UDFToInteger(_col3) (type: int), _col0 (type: int), _col2 (type: string)
                   outputColumnNames: _col0, _col1, _col2
-                  Statistics: Num rows: 3104 Data size: 294880 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1552 Data size: 147440 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 3104 Data size: 294880 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1552 Data size: 147440 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.TextInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat
@@ -213,7 +213,7 @@ STAGE PLANS:
                   Select Operator
                     expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
                     outputColumnNames: key, arr_ele, value
-                    Statistics: Num rows: 3104 Data size: 294880 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1552 Data size: 147440 Basic stats: COMPLETE Column stats: COMPLETE
                     Group By Operator
                       aggregations: min(key), max(key), count(1), count(key), compute_bit_vector(key, 'hll'), min(arr_ele), max(arr_ele), count(arr_ele), compute_bit_vector(arr_ele, 'hll'), max(length(value)), avg(COALESCE(length(value),0)), count(value), compute_bit_vector(value, 'hll')
                       minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/llap/vector_orc_nested_column_pruning.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_orc_nested_column_pruning.q.out
@@ -868,23 +868,23 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 3632 Basic stats: COMPLETE Column stats: NONE
                       Lateral View Join Operator
                         outputColumnNames: _col3, _col10
-                        Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                         Lateral View Forward
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Select Operator
                             expressions: _col10 (type: int)
                             outputColumnNames: _col10
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Lateral View Join Operator
                               outputColumnNames: _col10, _col11
-                              Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                               Select Operator
                                 expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                 outputColumnNames: _col0, _col1
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 File Output Operator
                                   compressed: false
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   table:
                                       input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                       output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -892,20 +892,20 @@ STAGE PLANS:
                           Select Operator
                             expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                             outputColumnNames: _col0
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -919,23 +919,23 @@ STAGE PLANS:
                         function name: explode
                         Lateral View Join Operator
                           outputColumnNames: _col3, _col10
-                          Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                          Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                           Lateral View Forward
-                            Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                            Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                             Select Operator
                               expressions: _col10 (type: int)
                               outputColumnNames: _col10
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               Lateral View Join Operator
                                 outputColumnNames: _col10, _col11
-                                Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                 Select Operator
                                   expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                   outputColumnNames: _col0, _col1
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   File Output Operator
                                     compressed: false
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     table:
                                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -943,20 +943,20 @@ STAGE PLANS:
                             Select Operator
                               expressions: _col3.f12 (type: array<struct<f13:string,f14:int>>)
                               outputColumnNames: _col0
-                              Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 2 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 7264 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col10, _col11
-                                  Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                  Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                   Select Operator
                                     expressions: _col10 (type: int), _col11 (type: struct<f13:string,f14:int>)
                                     outputColumnNames: _col0, _col1
-                                    Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                     File Output Operator
                                       compressed: false
-                                      Statistics: Num rows: 4 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 14528 Basic stats: COMPLETE Column stats: NONE
                                       table:
                                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
@@ -5275,13 +5275,13 @@ STAGE PLANS:
                         Statistics: Num rows: 26 Data size: 8710 Basic stats: COMPLETE Column stats: COMPLETE
                         Lateral View Join Operator
                           outputColumnNames: _col0, _col1, _col2, _col4
-                          Statistics: Num rows: 52 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
+                          Statistics: Num rows: 26 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: string), _col2 (type: int), _col4 (type: int)
                             null sort order: azz
                             sort order: +++
                             Map-reduce partition columns: _col0 (type: string)
-                            Statistics: Num rows: 52 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 26 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
                             value expressions: _col1 (type: string)
                       Select Operator
                         expressions: Const array<int> [1, 2, 3] (type: array<int>)
@@ -5292,13 +5292,13 @@ STAGE PLANS:
                           function name: explode
                           Lateral View Join Operator
                             outputColumnNames: _col0, _col1, _col2, _col4
-                            Statistics: Num rows: 52 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
+                            Statistics: Num rows: 26 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: string), _col2 (type: int), _col4 (type: int)
                               null sort order: azz
                               sort order: +++
                               Map-reduce partition columns: _col0 (type: string)
-                              Statistics: Num rows: 52 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 26 Data size: 10166 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col1 (type: string)
             Execution mode: llap
             LLAP IO: all inputs
@@ -5319,7 +5319,7 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: int)
                 outputColumnNames: _col0, _col1, _col2, _col4
-                Statistics: Num rows: 52 Data size: 13780 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 26 Data size: 6890 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
@@ -5339,14 +5339,14 @@ STAGE PLANS:
                               name: sum
                               window function: GenericUDAFSumLong
                               window frame: ROWS PRECEDING(2)~CURRENT
-                  Statistics: Num rows: 52 Data size: 13780 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 26 Data size: 6890 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: string), _col1 (type: string), _col4 (type: int), _col2 (type: int), sum_window_0 (type: bigint)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                    Statistics: Num rows: 52 Data size: 14196 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 26 Data size: 7098 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 52 Data size: 14196 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 26 Data size: 7098 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/nonmr_fetch.q.out
+++ b/ql/src/test/results/clientpositive/nonmr_fetch.q.out
@@ -1074,10 +1074,10 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 351000 Basic stats: COMPLETE Column stats: COMPLETE
               Lateral View Join Operator
                 outputColumnNames: _col0, _col7
-                Statistics: Num rows: 1000 Data size: 1311000 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 500 Data size: 1311000 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 20
-                  Statistics: Num rows: 20 Data size: 30320 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 20 Data size: 16280 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col0 (type: string), _col7 (type: string)
                     outputColumnNames: _col0, _col1
@@ -1092,10 +1092,10 @@ STAGE PLANS:
                 function name: explode
                 Lateral View Join Operator
                   outputColumnNames: _col0, _col7
-                  Statistics: Num rows: 1000 Data size: 1311000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 500 Data size: 1311000 Basic stats: COMPLETE Column stats: COMPLETE
                   Limit
                     Number of rows: 20
-                    Statistics: Num rows: 20 Data size: 30320 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 20 Data size: 16280 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: _col0 (type: string), _col7 (type: string)
                       outputColumnNames: _col0, _col1

--- a/ql/src/test/results/clientpositive/skewjoinopt10.q.out
+++ b/ql/src/test/results/clientpositive/skewjoinopt10.q.out
@@ -119,10 +119,10 @@ STAGE PLANS:
                   Statistics: Num rows: 7 Data size: 14088 Basic stats: COMPLETE Column stats: NONE
                   Lateral View Join Operator
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -136,10 +136,10 @@ STAGE PLANS:
                     function name: explode
                     Lateral View Join Operator
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -155,10 +155,10 @@ STAGE PLANS:
                   Statistics: Num rows: 7 Data size: 14088 Basic stats: COMPLETE Column stats: NONE
                   Lateral View Join Operator
                     outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                     File Output Operator
                       compressed: false
-                      Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -172,10 +172,10 @@ STAGE PLANS:
                     function name: explode
                     Lateral View Join Operator
                       outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
-                        Statistics: Num rows: 14 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 7 Data size: 28176 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                             output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat

--- a/ql/src/test/results/clientpositive/tez/tez_union_udtf.q.out
+++ b/ql/src/test/results/clientpositive/tez/tez_union_udtf.q.out
@@ -50,7 +50,7 @@ Stage-3
                             <-Map 1 [CONTAINS]
                               File Output Operator [FS_31]
                                 table:{"name:":"default.x"}
-                                Select Operator [SEL_30] (rows=6 width=91)
+                                Select Operator [SEL_30] (rows=4 width=91)
                                   Output:["_col0","_col1"]
                                   Select Operator [SEL_28] (rows=2 width=91)
                                     Output:["_col1"]
@@ -61,17 +61,17 @@ Stage-3
                               Reduce Output Operator [RS_34]
                                 Group By Operator [GBY_33] (rows=1 width=400)
                                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"],aggregations:["max(length(col1))","avg(COALESCE(length(col1),0))","count(1)","count(col1)","compute_bit_vector(col1, 'hll')","min(col2)","max(col2)","count(col2)","compute_bit_vector(col2, 'hll')"]
-                                  Select Operator [SEL_32] (rows=6 width=91)
+                                  Select Operator [SEL_32] (rows=4 width=91)
                                     Output:["col1","col2"]
                                      Please refer to the previous Select Operator [SEL_30]
                             <-Map 4 [CONTAINS]
                               File Output Operator [FS_45]
                                 table:{"name:":"default.x"}
-                                Select Operator [SEL_44] (rows=6 width=91)
+                                Select Operator [SEL_44] (rows=4 width=91)
                                   Output:["_col0","_col1"]
-                                  Select Operator [SEL_42] (rows=4 width=87)
+                                  Select Operator [SEL_42] (rows=2 width=87)
                                     Output:["_col1"]
-                                    Lateral View Join Operator [LVJ_40] (rows=4 width=239)
+                                    Lateral View Join Operator [LVJ_40] (rows=2 width=479)
                                       Output:["_col5"]
                                       Select Operator [SEL_38] (rows=2 width=431)
                                         Lateral View Forward [LVF_37] (rows=2 width=86)
@@ -82,16 +82,16 @@ Stage-3
                               Reduce Output Operator [RS_48]
                                 Group By Operator [GBY_47] (rows=1 width=400)
                                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"],aggregations:["max(length(col1))","avg(COALESCE(length(col1),0))","count(1)","count(col1)","compute_bit_vector(col1, 'hll')","min(col2)","max(col2)","count(col2)","compute_bit_vector(col2, 'hll')"]
-                                  Select Operator [SEL_46] (rows=6 width=91)
+                                  Select Operator [SEL_46] (rows=4 width=91)
                                     Output:["col1","col2"]
                                      Please refer to the previous Select Operator [SEL_44]
                               File Output Operator [FS_45]
                                 table:{"name:":"default.x"}
-                                Select Operator [SEL_44] (rows=6 width=91)
+                                Select Operator [SEL_44] (rows=4 width=91)
                                   Output:["_col0","_col1"]
-                                  Select Operator [SEL_42] (rows=4 width=87)
+                                  Select Operator [SEL_42] (rows=2 width=87)
                                     Output:["_col1"]
-                                    Lateral View Join Operator [LVJ_40] (rows=4 width=239)
+                                    Lateral View Join Operator [LVJ_40] (rows=2 width=479)
                                       Output:["_col5"]
                                       UDTF Operator [UDTF_41] (rows=2 width=48)
                                         function name:explode
@@ -101,7 +101,7 @@ Stage-3
                               Reduce Output Operator [RS_48]
                                 Group By Operator [GBY_47] (rows=1 width=400)
                                   Output:["_col0","_col1","_col2","_col3","_col4","_col5","_col6","_col7","_col8"],aggregations:["max(length(col1))","avg(COALESCE(length(col1),0))","count(1)","count(col1)","compute_bit_vector(col1, 'hll')","min(col2)","max(col2)","count(col2)","compute_bit_vector(col2, 'hll')"]
-                                  Select Operator [SEL_46] (rows=6 width=91)
+                                  Select Operator [SEL_46] (rows=4 width=91)
                                     Output:["col1","col2"]
                                      Please refer to the previous Select Operator [SEL_44]
             Stage-4(CONDITIONAL)


### PR DESCRIPTION
### What changes were proposed in this pull request?

Estimate statistics of LATERAL VIEW correctly.

StatsRulesProcFactory doesn't have any rules to handle a JOIN by LATERAL VIEW.
This can cause an underestimation in case that UDTF in LATERAL VIEW generates multiple rows.

### Why are the changes needed?

Significant underestimation can happen when LATERAL VIEW increases the number of records a lot and the source table has large.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Added one test case.