### PR TITLE
HIVE-20137: truncate for transactional tables

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
@@ -113,10 +113,10 @@ public class TruncateTableAnalyzer extends AbstractBaseAlterTableAnalyzer {
 
   private void addTruncateTableOutputs(ASTNode root, Table table, Map<String, String> partitionSpec)
       throws SemanticException {
-    boolean shared = AcidUtils.isTransactionalTable(table) &&
+    boolean truncateKeepsDataFiles = AcidUtils.isTransactionalTable(table) &&
         MetastoreConf.getBoolVar(conf, MetastoreConf.ConfVars.TRUNCATE_ACID_USE_BASE);
     WriteEntity.WriteType writeType =
-        shared ? WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE;
+        truncateKeepsDataFiles ? WriteEntity.WriteType.DDL_EXCL_WRITE : WriteEntity.WriteType.DDL_EXCLUSIVE;
     if (partitionSpec == null) {
       if (!table.isPartitioned()) {
         outputs.add(new WriteEntity(table, writeType));

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/WriteEntity.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/WriteEntity.java
@@ -41,6 +41,7 @@ public class WriteEntity extends Entity implements Serializable {
   public static enum WriteType {
     DDL_EXCLUSIVE, // for use in DDL statements that require an exclusive lock,
                    // such as dropping a table or partition
+    DDL_EXCL_WRITE, // for use in DDL operations that can allow concurrent reads, like truncate in acid
     DDL_SHARED, // for use in DDL operations that only need a shared lock, such as creating a table
     DDL_NO_LOCK, // for use in DDL statements that do not require a lock
     INSERT,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -2459,7 +2459,7 @@ public class AcidUtils {
    * small JSON file in this directory that indicates that these files don't have Acid metadata
    * columns and so the values for these columns need to be assigned at read time/compaction.
    */
-  public static class MetaDataFile extends AcidConstants.MetaDataFile {
+  public static class MetaDataFile extends AcidMetaDataFile {
 
     static boolean isCompacted(Path baseOrDeltaDir, FileSystem fs, HdfsDirSnapshot dirSnapshot) throws IOException {
       /**

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -1336,7 +1336,7 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBL.toString()), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBL.toString().toLowerCase()), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
@@ -1355,7 +1355,7 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString() + "/p=a"), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString().toLowerCase() + "/p=a"), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
@@ -1374,14 +1374,14 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString() + "/p=b"), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString().toLowerCase() + "/p=b"), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
     String name = stat[0].getPath().getName();
     Assert.assertEquals("base_0000003", name);
     stat =
-        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString() + "/p=a"), AcidUtils.deltaFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), Table.ACIDTBLPART.toString().toLowerCase() + "/p=a"), AcidUtils.deltaFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 delta and found " + stat.length + " files " + Arrays.toString(stat));
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommandsForMmTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommandsForMmTable.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,6 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.txn.TxnDbUtil;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -584,5 +586,66 @@ public class TestTxnCommandsForMmTable extends TxnCommandsBaseForTests {
     } else {
       Assert.assertEquals("0 base directories expected", 0, sawBaseTimes);
     }
+  }
+
+  @Test
+  public void testTruncateWithBase() throws Exception{
+    runStatementOnDriver("insert into " + TableExtended.MMTBL + " values(1,2),(3,4)");
+    runStatementOnDriver("truncate table " + TableExtended.MMTBL);
+
+    FileSystem fs = FileSystem.get(hiveConf);
+    FileStatus[] stat =
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBL.toString()), AcidUtils.baseFileFilter);
+    if (1 != stat.length) {
+      Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
+    }
+    String name = stat[0].getPath().getName();
+    Assert.assertEquals("base_0000002", name);
+
+    List<String> r = runStatementOnDriver("select * from " + TableExtended.MMTBL);
+    Assert.assertEquals(0, r.size());
+  }
+
+  @Test
+  public void testTruncateWithBaseAllPartition() throws Exception{
+    runStatementOnDriver("insert into " + TableExtended.MMTBLPART + " partition(p='a') values(1,2),(3,4)");
+    runStatementOnDriver("insert into " + TableExtended.MMTBLPART + " partition(p='b') values(1,2),(3,4)");
+    runStatementOnDriver("truncate table " + TableExtended.MMTBLPART);
+
+    FileSystem fs = FileSystem.get(hiveConf);
+    FileStatus[] stat =
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=a"), AcidUtils.baseFileFilter);
+    if (1 != stat.length) {
+      Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
+    }
+    String name = stat[0].getPath().getName();
+    Assert.assertEquals("base_0000003", name);
+
+    List<String> r = runStatementOnDriver("select * from " + TableExtended.MMTBLPART);
+    Assert.assertEquals(0, r.size());
+  }
+
+  @Test
+  public void testTruncateWithBaseOnePartition() throws Exception{
+    runStatementOnDriver("insert into " + TableExtended.MMTBLPART + " partition(p='a') values(1,2),(3,4)");
+    runStatementOnDriver("insert into " + TableExtended.MMTBLPART+ " partition(p='b') values(5,5),(4,4)");
+    runStatementOnDriver("truncate table " + TableExtended.MMTBLPART + " partition(p='b')");
+
+    FileSystem fs = FileSystem.get(hiveConf);
+    FileStatus[] stat =
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=b"), AcidUtils.baseFileFilter);
+    if (1 != stat.length) {
+      Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
+    }
+    String name = stat[0].getPath().getName();
+    Assert.assertEquals("base_0000003", name);
+    stat =
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=a"), AcidUtils.deltaFileFilter);
+    if (1 != stat.length) {
+      Assert.fail("Expecting 1 delta and found " + stat.length + " files " + Arrays.toString(stat));
+    }
+
+    List<String> r = runStatementOnDriver("select * from " + TableExtended.MMTBLPART);
+    Assert.assertEquals(2, r.size());
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommandsForMmTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommandsForMmTable.java
@@ -595,7 +595,7 @@ public class TestTxnCommandsForMmTable extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBL.toString()), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBL.toString().toLowerCase()), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
@@ -614,7 +614,7 @@ public class TestTxnCommandsForMmTable extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=a"), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString().toLowerCase() + "/p=a"), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
@@ -633,14 +633,14 @@ public class TestTxnCommandsForMmTable extends TxnCommandsBaseForTests {
 
     FileSystem fs = FileSystem.get(hiveConf);
     FileStatus[] stat =
-        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=b"), AcidUtils.baseFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString().toLowerCase() + "/p=b"), AcidUtils.baseFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 base and found " + stat.length + " files " + Arrays.toString(stat));
     }
     String name = stat[0].getPath().getName();
     Assert.assertEquals("base_0000003", name);
     stat =
-        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString() + "/p=a"), AcidUtils.deltaFileFilter);
+        fs.listStatus(new Path(getWarehouseDir(), TableExtended.MMTBLPART.toString().toLowerCase() + "/p=a"), AcidUtils.deltaFileFilter);
     if (1 != stat.length) {
       Assert.fail("Expecting 1 delta and found " + stat.length + " files " + Arrays.toString(stat));
     }

--- a/ql/src/test/results/clientpositive/llap/acid_stats3.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_stats3.q.out
@@ -250,11 +250,11 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: stats_part
-                  Statistics: Num rows: 2 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: int)
                     outputColumnNames: key
-                    Statistics: Num rows: 2 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 3 Data size: 12 Basic stats: PARTIAL Column stats: COMPLETE
                     Group By Operator
                       aggregations: count(key)
                       minReductionHashAggr: 0.99
@@ -368,11 +368,11 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: stats_part
-                  Statistics: Num rows: 1 Data size: 4 Basic stats: PARTIAL Column stats: COMPLETE
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
                   Select Operator
                     expressions: key (type: int)
                     outputColumnNames: key
-                    Statistics: Num rows: 1 Data size: 4 Basic stats: PARTIAL Column stats: COMPLETE
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: PARTIAL Column stats: COMPLETE
                     Group By Operator
                       aggregations: count(key)
                       minReductionHashAggr: 0.99

--- a/ql/src/test/results/clientpositive/llap/acid_stats5.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_stats5.q.out
@@ -546,10 +546,10 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	bucketing_version   	2                   
-	numFiles            	3                   
+	numFiles            	0                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	18                  
+	totalSize           	0                   
 	transactional       	true                
 	transactional_properties	insert_only         
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/acid_stats5.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_stats5.q.out
@@ -546,10 +546,10 @@ Table Type:         	MANAGED_TABLE
 Table Parameters:	 	 
 	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
 	bucketing_version   	2                   
-	numFiles            	0                   
+	numFiles            	3                   
 	numRows             	0                   
 	rawDataSize         	0                   
-	totalSize           	0                   
+	totalSize           	18                  
 	transactional       	true                
 	transactional_properties	insert_only         
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -2067,20 +2067,20 @@ STAGE PLANS:
                 TableScan
                   alias: acid_uami_n0
                   filterExpr: ((de) IN (103, 119) and enforce_constraint((893.14 >= CAST( i AS decimal(5,2))) is not false)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 231 Data size: 72488 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: ((de) IN (103, 119) and enforce_constraint((893.14 >= CAST( i AS decimal(5,2))) is not false)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 5 Data size: 1569 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), i (type: int), vc (type: varchar(128))
                       outputColumnNames: _col0, _col1, _col3
-                      Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 5 Data size: 1569 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 5 Data size: 1569 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int), _col3 (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -2090,10 +2090,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 893.14 (type: decimal(5,2)), VALUE._col1 (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 5 Data size: 1569 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 5 Data size: 1569 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -2174,20 +2174,20 @@ STAGE PLANS:
                 TableScan
                   alias: acid_uami_n0
                   filterExpr: (de = 893.14) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 229 Data size: 25404 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
                     predicate: (de = 893.14) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                    Statistics: Num rows: 5 Data size: 554 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), i (type: int)
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                      Statistics: Num rows: 5 Data size: 554 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                        Statistics: Num rows: 5 Data size: 554 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col1 (type: int)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -2197,10 +2197,10 @@ STAGE PLANS:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 893.14 (type: decimal(5,2)), 'apache_hive' (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                Statistics: Num rows: 5 Data size: 554 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                  Statistics: Num rows: 5 Data size: 554 Basic stats: COMPLETE Column stats: NONE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/StatsSetupConst.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/common/StatsSetupConst.java
@@ -149,6 +149,10 @@ public class StatsSetupConst {
   // update should take place, such as with replication.
   public static final String DO_NOT_UPDATE_STATS = "DO_NOT_UPDATE_STATS";
 
+  // This string constant is used by AlterHandler to figure out that it should not attempt to
+  // populate quick stats based on the file listing
+  public static final String DO_NOT_POPULATE_QUICK_STATS = "DO_NOT_POPULATE_QUICK_STATS";
+
   //This string constant will be persisted in metastore to indicate whether corresponding
   //table or partition's statistics and table or partition's column statistics are accurate or not.
   public static final String COLUMN_STATS_ACCURATE = "COLUMN_STATS_ACCURATE";

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1200,6 +1200,9 @@ public class MetastoreConf {
         "hive.metastore.transactional.event.listeners", "",
         "A comma separated list of Java classes that implement the org.apache.riven.MetaStoreEventListener" +
             " interface. Both the metastore event and corresponding listener method will be invoked in the same JDO transaction."),
+    TRUNCATE_ACID_USE_BASE("metastore.acid.truncate.usebase", "hive.metastore.acid.truncate.usebase", true,
+        "If enabled, truncate for transactional tables will not delete the data directories,\n" +
+        "rather create a new base directory with no datafiles."),
     TRY_DIRECT_SQL("metastore.try.direct.sql", "hive.metastore.try.direct.sql", true,
         "Whether the metastore should try to use direct SQL queries instead of the\n" +
             "DataNucleus for certain read paths. This can improve metastore performance when\n" +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -39,6 +39,7 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.security.PrivilegedExceptionAction;
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -3199,6 +3200,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
       //first set basic stats to true
       StatsSetupConst.setBasicStatsState(props, StatsSetupConst.TRUE);
       environmentContext.putToProperties(StatsSetupConst.STATS_GENERATED, StatsSetupConst.TASK);
+      environmentContext.putToProperties(StatsSetupConst.DO_NOT_POPULATE_QUICK_STATS, StatsSetupConst.TRUE);
       //then invalidate column stats
       StatsSetupConst.clearColumnStatsState(props);
       return;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreChecker.java
@@ -17,6 +17,10 @@
  */
 package org.apache.hadoop.hive.metastore;
 
+import static org.apache.hadoop.hive.common.AcidConstants.BASE_PREFIX;
+import static org.apache.hadoop.hive.common.AcidConstants.DELETE_DELTA_PREFIX;
+import static org.apache.hadoop.hive.common.AcidConstants.DELTA_PREFIX;
+import static org.apache.hadoop.hive.common.AcidConstants.VISIBILITY_PREFIX;
 import static org.apache.hadoop.hive.metastore.PartFilterExprUtil.createExpressionProxy;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getAllPartitionsOf;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils.getDataLocation;
@@ -80,11 +84,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 public class HiveMetaStoreChecker {
 
   public static final Logger LOG = LoggerFactory.getLogger(HiveMetaStoreChecker.class);
-  // These constants must be the same as in AcidUtils
-  public static final String BASE_PREFIX = "base_";
-  public static final String DELTA_PREFIX = "delta_";
-  public static final String DELETE_DELTA_PREFIX = "delete_delta_";
-  public static final String VISIBILITY_PREFIX = "_v";
 
   private final IMetaStoreClient msc;
   private final Configuration conf;

--- a/storage-api/src/java/org/apache/hadoop/hive/common/AcidConstants.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/AcidConstants.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.common;
+
+import java.util.regex.Pattern;
+
+/**
+ * Common constants for ACID tables to use in HMS and HS2.
+ */
+public class AcidConstants {
+
+  public static final String BASE_PREFIX = "base_";
+  public static final String DELTA_PREFIX = "delta_";
+  public static final String DELETE_DELTA_PREFIX = "delete_delta_";
+
+  public static final String BUCKET_DIGITS = "%05d";
+  public static final String LEGACY_FILE_BUCKET_DIGITS = "%06d";
+  public static final String DELTA_DIGITS = "%07d";
+  /**
+   * 10K statements per tx.  Probably overkill ... since that many delta files
+   * would not be good for performance
+   */
+  public static final String STATEMENT_DIGITS = "%04d";
+
+  public static final String VISIBILITY_PREFIX = "_v";
+  public static final Pattern VISIBILITY_PATTERN = Pattern.compile(VISIBILITY_PREFIX + "\\d+");
+
+  public static String baseDir(long writeId) {
+    return BASE_PREFIX + String.format(DELTA_DIGITS, writeId);
+  }
+
+  /**
+   * General facility to place a metadata file into a dir created by acid/compactor write.
+   */
+  public static class MetaDataFile {
+    //export command uses _metadata....
+    public static final String METADATA_FILE = "_metadata_acid";
+    public static final String CURRENT_VERSION = "0";
+
+    public enum Field {
+      VERSION("thisFileVersion"), DATA_FORMAT("dataFormat");
+
+      private final String fieldName;
+
+      Field(String fieldName) {
+        this.fieldName = fieldName;
+      }
+
+      @Override
+      public String toString() {
+        return fieldName;
+      }
+    }
+
+    public enum DataFormat {
+      // written by Major compaction
+      COMPACTED, TRUNCATED;
+
+      @Override
+      public String toString() {
+        return name().toLowerCase();
+      }
+    }
+
+  }
+}

--- a/storage-api/src/java/org/apache/hadoop/hive/common/AcidConstants.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/AcidConstants.java
@@ -44,38 +44,4 @@ public class AcidConstants {
     return BASE_PREFIX + String.format(DELTA_DIGITS, writeId);
   }
 
-  /**
-   * General facility to place a metadata file into a dir created by acid/compactor write.
-   */
-  public static class MetaDataFile {
-    //export command uses _metadata....
-    public static final String METADATA_FILE = "_metadata_acid";
-    public static final String CURRENT_VERSION = "0";
-
-    public enum Field {
-      VERSION("thisFileVersion"), DATA_FORMAT("dataFormat");
-
-      private final String fieldName;
-
-      Field(String fieldName) {
-        this.fieldName = fieldName;
-      }
-
-      @Override
-      public String toString() {
-        return fieldName;
-      }
-    }
-
-    public enum DataFormat {
-      // written by Major compaction
-      COMPACTED, TRUNCATED;
-
-      @Override
-      public String toString() {
-        return name().toLowerCase();
-      }
-    }
-
-  }
 }

--- a/storage-api/src/java/org/apache/hadoop/hive/common/AcidMetaDataFile.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/AcidMetaDataFile.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.common;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.codehaus.jackson.map.ObjectMapper;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * General facility to place a metadata file into a dir created by acid/compactor write.
+ */
+public class AcidMetaDataFile {
+  //export command uses _metadata....
+  public static final String METADATA_FILE = "_metadata_acid";
+  public static final String CURRENT_VERSION = "0";
+
+  public enum Field {
+    VERSION("thisFileVersion"), DATA_FORMAT("dataFormat");
+
+    private final String fieldName;
+
+    Field(String fieldName) {
+      this.fieldName = fieldName;
+    }
+
+    @Override
+    public String toString() {
+      return fieldName;
+    }
+  }
+
+  public enum DataFormat {
+    // written by Major compaction
+    COMPACTED,
+    // written by truncate
+    TRUNCATED;
+
+    @Override
+    public String toString() {
+      return name().toLowerCase();
+    }
+  }
+
+  /**
+   * Writes out an AcidMetaDataFile to the given location
+   * @param fs FileSystem
+   * @param basePath directory to write the file
+   * @param format
+   * @throws IOException
+   */
+  public static void writeToFile(FileSystem fs, Path basePath, DataFormat format) throws IOException {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put(Field.VERSION.toString(), CURRENT_VERSION);
+    metadata.put(Field.DATA_FORMAT.toString(), format.toString());
+    String data = new ObjectMapper().writeValueAsString(metadata);
+    try (FSDataOutputStream out = fs
+        .create(new Path(basePath, METADATA_FILE)); OutputStreamWriter writer = new OutputStreamWriter(
+        out, "UTF-8")) {
+      writer.write(data);
+      writer.flush();
+    }
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?
Truncate table for transactional tables no longer deletes all the data, rather just creates an empty base dir.

### Why are the changes needed?
Faster truncate, it can allow concurrent reads

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tests were added
