### PR TITLE
HIVE-24221: Use vectorizable expression to combine multiple columns in semijoin bloom filters

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SemiJoinReductionMerge.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SemiJoinReductionMerge.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hive.ql.plan.DynamicValue;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDynamicValueDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.FilterDesc;
@@ -57,7 +58,6 @@ import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFMax;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFMin;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFBetween;
 import org.apache.hadoop.hive.ql.udf.generic.GenericUDFInBloomFilter;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFMurmurHash;
 import org.apache.hadoop.hive.ql.util.NullOrdering;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
@@ -242,8 +242,7 @@ public class SemiJoinReductionMerge extends Transform {
       hashArgs.add(targetColumn);
     }
 
-    ExprNodeDesc hashExp =
-        new ExprNodeGenericFuncDesc(TypeInfoFactory.intTypeInfo, new GenericUDFMurmurHash(), "hash", hashArgs);
+    ExprNodeDesc hashExp = ExprNodeDescUtils.murmurHash(hashArgs);
 
     assert dynamicIds.size() == 1 : "There should be one column left untreated the one with the bloom filter";
     DynamicValue bloomDynamic = new DynamicValue(dynamicIds.poll(), TypeInfoFactory.binaryTypeInfo);
@@ -302,8 +301,7 @@ public class SemiJoinReductionMerge extends Transform {
       colDescs.add(col);
       selectColumnExprMap.put(colName, col);
     }
-    ExprNodeDesc hashExp =
-        new ExprNodeGenericFuncDesc(TypeInfoFactory.intTypeInfo, new GenericUDFMurmurHash(), "hash", colDescs);
+    ExprNodeDesc hashExp = ExprNodeDescUtils.murmurHash(colDescs);
     String hashName = HiveConf.getColumnInternalName(colDescs.size() + 1);
     colNames.add(hashName);
     columnInfos.add(new ColumnInfo(hashName, hashExp.getTypeInfo(), "", false));

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TezCompiler.java
@@ -1910,7 +1910,7 @@ public class TezCompiler extends TaskCompiler {
         List<ExprNodeDesc> targetColumns = rti.getTargetColumns();
         // In semijoin branches the SEL operator has the following forms:
         // SEL[c1] - single column semijoin reduction
-        // SEL[c1, c2,..., ck, hash(c1, c2,...,ck)] - multi column semijoin reduction
+        // SEL[c1, c2,..., ck, hash(hash(hash(c1, c2),...),ck)] - multi column semijoin reduction
         // The source columns in the above cases are c1, c2,...,ck.
         // We need to exclude the hash(...) expression, if it is present.
         List<ExprNodeDesc> sourceColumns = sel.getConf().getColList().subList(0, targetColumns.size());

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_2.q.out
@@ -92,10 +92,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: t1
-                  filterExpr: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null and timestamp_col_9 BETWEEN DynamicValue(RS_22_tt2_timestamp_col_18_min) AND DynamicValue(RS_22_tt2_timestamp_col_18_max) and in_bloom_filter(timestamp_col_9, DynamicValue(RS_22_tt2_timestamp_col_18_bloom_filter)) and decimal2016_col_26 BETWEEN DynamicValue(RS[102]_col0) AND DynamicValue(RS[102]_col1) and tinyint_col_3 BETWEEN DynamicValue(RS[102]_col2) AND DynamicValue(RS[102]_col3) and bigint_col_7 BETWEEN DynamicValue(RS[102]_col4) AND DynamicValue(RS[102]_col5) and in_bloom_filter(hash(decimal2016_col_26,tinyint_col_3,bigint_col_7), DynamicValue(RS[102]_col6))) (type: boolean)
+                  filterExpr: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null and timestamp_col_9 BETWEEN DynamicValue(RS_22_tt2_timestamp_col_18_min) AND DynamicValue(RS_22_tt2_timestamp_col_18_max) and in_bloom_filter(timestamp_col_9, DynamicValue(RS_22_tt2_timestamp_col_18_bloom_filter)) and decimal2016_col_26 BETWEEN DynamicValue(RS[102]_col0) AND DynamicValue(RS[102]_col1) and tinyint_col_3 BETWEEN DynamicValue(RS[102]_col2) AND DynamicValue(RS[102]_col3) and bigint_col_7 BETWEEN DynamicValue(RS[102]_col4) AND DynamicValue(RS[102]_col5) and in_bloom_filter(hash(hash(decimal2016_col_26,tinyint_col_3),bigint_col_7), DynamicValue(RS[102]_col6))) (type: boolean)
                   Statistics: Num rows: 1 Data size: 164 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null and decimal2016_col_26 BETWEEN DynamicValue(RS[102]_col0) AND DynamicValue(RS[102]_col1) and tinyint_col_3 BETWEEN DynamicValue(RS[102]_col2) AND DynamicValue(RS[102]_col3) and bigint_col_7 BETWEEN DynamicValue(RS[102]_col4) AND DynamicValue(RS[102]_col5) and timestamp_col_9 BETWEEN DynamicValue(RS_22_tt2_timestamp_col_18_min) AND DynamicValue(RS_22_tt2_timestamp_col_18_max) and in_bloom_filter(hash(decimal2016_col_26,tinyint_col_3,bigint_col_7), DynamicValue(RS[102]_col6)) and in_bloom_filter(timestamp_col_9, DynamicValue(RS_22_tt2_timestamp_col_18_bloom_filter))) (type: boolean)
+                    predicate: (bigint_col_7 is not null and decimal2016_col_26 is not null and tinyint_col_3 is not null and timestamp_col_9 is not null and decimal2016_col_26 BETWEEN DynamicValue(RS[102]_col0) AND DynamicValue(RS[102]_col1) and tinyint_col_3 BETWEEN DynamicValue(RS[102]_col2) AND DynamicValue(RS[102]_col3) and bigint_col_7 BETWEEN DynamicValue(RS[102]_col4) AND DynamicValue(RS[102]_col5) and timestamp_col_9 BETWEEN DynamicValue(RS_22_tt2_timestamp_col_18_min) AND DynamicValue(RS_22_tt2_timestamp_col_18_max) and in_bloom_filter(hash(hash(decimal2016_col_26,tinyint_col_3),bigint_col_7), DynamicValue(RS[102]_col6)) and in_bloom_filter(timestamp_col_9, DynamicValue(RS_22_tt2_timestamp_col_18_bloom_filter))) (type: boolean)
                     Statistics: Num rows: 1 Data size: 164 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: bigint_col_7 (type: bigint), decimal2016_col_26 (type: decimal(20,16)), tinyint_col_3 (type: tinyint), timestamp_col_9 (type: timestamp)
@@ -131,7 +131,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: NONE
                         value expressions: _col3 (type: smallint)
                       Select Operator
-                        expressions: _col1 (type: decimal(34,16)), _col2 (type: tinyint), UDFToLong(_col0) (type: bigint), hash(_col1,_col2,UDFToLong(_col0)) (type: int)
+                        expressions: _col1 (type: decimal(34,16)), _col2 (type: tinyint), UDFToLong(_col0) (type: bigint), hash(hash(_col1,_col2),UDFToLong(_col0)) (type: int)
                         outputColumnNames: _col0, _col1, _col2, _col4
                         Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: NONE
                         Group By Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query17.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query17.q.out
@@ -178,10 +178,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 3591605541540 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 3424422808632 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_quantity (type: int), ss_sold_date_sk (type: bigint)
@@ -252,7 +252,7 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary)
                         Select Operator
-                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(_col1,_col0,_col2) (type: int)
+                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(hash(_col1,_col0),_col2) (type: int)
                           outputColumnNames: _col0, _col1, _col2, _col4
                           Statistics: Num rows: 1119808180 Data size: 30172163968 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query25.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query25.q.out
@@ -178,10 +178,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 12292602293640 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 11720403920960 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_net_profit (type: decimal(7,2)), ss_sold_date_sk (type: bigint)
@@ -252,7 +252,7 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary)
                         Select Operator
-                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(_col1,_col0,_col2) (type: int)
+                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(hash(_col1,_col0),_col2) (type: int)
                           outputColumnNames: _col0, _col1, _col2, _col4
                           Statistics: Num rows: 874594659 Data size: 23306185380 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query29.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query29.q.out
@@ -90,10 +90,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 3591605541540 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(hash(ss_customer_sk,ss_item_sk),ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 3424422808632 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_quantity (type: int), ss_sold_date_sk (type: bigint)
@@ -259,7 +259,7 @@ STAGE PLANS:
                               Statistics: Num rows: 1 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
                               value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary)
                         Select Operator
-                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(_col1,_col0,_col2) (type: int)
+                          expressions: _col1 (type: bigint), _col0 (type: bigint), _col2 (type: bigint), hash(hash(_col1,_col0),_col2) (type: int)
                           outputColumnNames: _col0, _col1, _col2, _col4
                           Statistics: Num rows: 498600693 Data size: 12778354332 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query50.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query50.q.out
@@ -46,7 +46,7 @@ STAGE PLANS:
                           Statistics: Num rows: 126693621 Data size: 3040646912 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col3 (type: bigint)
                         Select Operator
-                          expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), hash(_col0,_col1,_col2) (type: int)
+                          expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), hash(hash(_col0,_col1),_col2) (type: int)
                           outputColumnNames: _col0, _col1, _col2, _col4
                           Statistics: Num rows: 126693621 Data size: 2533872428 Basic stats: COMPLETE Column stats: COMPLETE
                           Group By Operator
@@ -103,10 +103,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk BETWEEN DynamicValue(RS[101]_col0) AND DynamicValue(RS[101]_col1) and ss_customer_sk BETWEEN DynamicValue(RS[101]_col2) AND DynamicValue(RS[101]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[101]_col4) AND DynamicValue(RS[101]_col5) and in_bloom_filter(hash(ss_item_sk,ss_customer_sk,ss_ticket_number), DynamicValue(RS[101]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk BETWEEN DynamicValue(RS[101]_col0) AND DynamicValue(RS[101]_col1) and ss_customer_sk BETWEEN DynamicValue(RS[101]_col2) AND DynamicValue(RS[101]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[101]_col4) AND DynamicValue(RS[101]_col5) and in_bloom_filter(hash(hash(ss_item_sk,ss_customer_sk),ss_ticket_number), DynamicValue(RS[101]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 3269343211320 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk BETWEEN DynamicValue(RS[101]_col0) AND DynamicValue(RS[101]_col1) and ss_customer_sk BETWEEN DynamicValue(RS[101]_col2) AND DynamicValue(RS[101]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[101]_col4) AND DynamicValue(RS[101]_col5) and in_bloom_filter(hash(ss_item_sk,ss_customer_sk,ss_ticket_number), DynamicValue(RS[101]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_item_sk BETWEEN DynamicValue(RS[101]_col0) AND DynamicValue(RS[101]_col1) and ss_customer_sk BETWEEN DynamicValue(RS[101]_col2) AND DynamicValue(RS[101]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[101]_col4) AND DynamicValue(RS[101]_col5) and in_bloom_filter(hash(hash(ss_item_sk,ss_customer_sk),ss_ticket_number), DynamicValue(RS[101]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 3117161206208 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_sold_date_sk (type: bigint)


### PR DESCRIPTION

### What changes were proposed in this pull request?

Use hash(hash(hash(a,b),c),d) instead of hash(a,b,c,d) when constructing
the multi-col semijoin reducer.

### Why are the changes needed?
In order to use fully vectorized execution on multi-col semijoin reducers.

### Does this PR introduce _any_ user-facing change?
Only changes in EXPLAIN plans.

### How was this patch tested?
`mvn test -Dtest=TestTezPerfCliDriver -Dqfile="query50.q"`
