### PR TITLE
HIVE-24207: LimitOperator can leverage ObjectCache to bail out quickly

### DIFF
--- a/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniTezCliDriver.java
+++ b/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniTezCliDriver.java
@@ -22,6 +22,8 @@ import java.util.List;
 
 import org.apache.hadoop.hive.cli.control.CliAdapter;
 import org.apache.hadoop.hive.cli.control.CliConfigs;
+import org.apache.hadoop.hive.ql.exec.tez.ObjectCache;
+import org.apache.tez.runtime.common.objectregistry.ObjectRegistryImpl;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -56,6 +58,8 @@ public class TestMiniTezCliDriver {
 
   @Test
   public void testCliDriver() throws Exception {
+    // create a new object cache for tez-based tests which rely on that
+    ObjectCache.setupObjectRegistry(new ObjectRegistryImpl());
     adapter.runTest(name, qfile);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/LimitOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/LimitOperator.java
@@ -19,9 +19,15 @@
 package org.apache.hadoop.hive.ql.exec;
 
 import java.io.Serializable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.tez.LlapObjectCache;
+import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.LimitDesc;
 import org.apache.hadoop.hive.ql.plan.api.OperatorType;
@@ -37,6 +43,9 @@ public class LimitOperator extends Operator<LimitDesc> implements Serializable {
   protected transient int leastRow;
   protected transient int currCount;
   protected transient boolean isMap;
+
+  protected transient ObjectCache runtimeCache;
+  protected transient String limitKey;
 
   /** Kryo ctor. */
   protected LimitOperator() {
@@ -55,17 +64,47 @@ public class LimitOperator extends Operator<LimitDesc> implements Serializable {
     offset = (conf.getOffset() == null) ? 0 : conf.getOffset();
     currCount = 0;
     isMap = hconf.getBoolean("mapred.task.is.map", true);
+
+    String queryId = HiveConf.getVar(getConfiguration(), HiveConf.ConfVars.HIVEQUERYID);
+    this.runtimeCache = ObjectCacheFactory.getCache(getConfiguration(), queryId, false, true);
+
+    // this can happen in HS2 while doing local fetch optimization, where LimitOperator is used
+    if (runtimeCache == null) {
+      if (!HiveConf.isLoadHiveServer2Config()) {
+        throw new IllegalStateException(
+            "Cannot get a query cache object while working outside of HS2, this is unexpected");
+      }
+      // in HS2, this is the only LimitOperator instance for a query, it's safe to fake an object
+      // for further processing
+      this.runtimeCache = new LlapObjectCache();
+    }
+    this.limitKey = getOperatorId() + "_record_count";
+
+    AtomicInteger currentCountForAllTasks = getCurrentCount();
+    int currentCountForAllTasksInt = currentCountForAllTasks.get();
+
+    if (currentCountForAllTasksInt >= limit) {
+      LOG.info("LimitOperator exits early as query limit already reached: {} >= {}",
+          currentCountForAllTasksInt, limit);
+      onLimitReached();
+    }
   }
 
   @Override
   public void process(Object row, int tag) throws HiveException {
-    if (offset <= currCount && currCount < (offset + limit)) {
+    AtomicInteger currentCountForAllTasks = getCurrentCount();
+    int currentCountForAllTasksInt = currentCountForAllTasks.get();
+
+    if (offset <= currCount && currCount < (offset + limit) && offset <= currentCountForAllTasksInt
+        && currentCountForAllTasksInt < (offset + limit)) {
       forward(row, inputObjInspectors[tag]);
       currCount++;
+      currentCountForAllTasks.incrementAndGet();
     } else if (offset > currCount) {
       currCount++;
+      currentCountForAllTasks.incrementAndGet();
     } else {
-      setDone(true);
+      onLimitReached();
     }
   }
 
@@ -83,6 +122,23 @@ public class LimitOperator extends Operator<LimitDesc> implements Serializable {
     return OperatorType.LIMIT;
   }
 
+  protected void onLimitReached() {
+    super.setDone(true);
+
+    String limitReachedKey = getLimitReachedKey(getConfiguration());
+
+    try {
+      runtimeCache.retrieve(limitReachedKey, new Callable<AtomicBoolean>() {
+        @Override
+        public AtomicBoolean call() {
+          return new AtomicBoolean(false);
+        }
+      }).set(true);
+    } catch (HiveException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   @Override
   public void closeOp(boolean abort) throws HiveException {
     if (!isMap && currCount < leastRow) {
@@ -91,4 +147,20 @@ public class LimitOperator extends Operator<LimitDesc> implements Serializable {
     super.closeOp(abort);
   }
 
+  public AtomicInteger getCurrentCount() {
+    try {
+      return runtimeCache.retrieve(limitKey, new Callable<AtomicInteger>() {
+        @Override
+        public AtomicInteger call() {
+          return new AtomicInteger();
+        }
+      });
+    } catch (HiveException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static String getLimitReachedKey(Configuration conf) {
+    return conf.get(TezProcessor.HIVE_TEZ_VERTEX_NAME) + "_limit_reached";
+  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestLimitOperator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestLimitOperator.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.exec;
+
+import java.util.Random;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.io.api.LlapProxy;
+import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.tez.ObjectCache;
+import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.LimitDesc;
+import org.apache.tez.runtime.common.objectregistry.ObjectRegistryImpl;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestLimitOperator {
+
+  private static final Object fakeObjectToPass = new Object();
+  private Random random = new Random(TestLimitOperator.class.toString().hashCode());
+
+  @Test
+  public void testGlobalLimitReached() throws HiveException {
+    // no offset
+    testGlobalLimitReachedInDaemonOrContainer(true, 0, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 0, 2);
+
+    // offset < limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 1, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 1, 2);
+
+    // offset = limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 2, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 2, 2);
+
+    // offset > limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 3, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 3, 2);
+  }
+
+  private void testGlobalLimitReachedInDaemonOrContainer(boolean isDaemon, int offset, int limit)
+      throws HiveException {
+    int numProcessedElements = 0; // from FakeVectorRowBatchFromObjectIterables
+
+    LlapProxy.setDaemon(isDaemon);
+    if (!isDaemon) {// init tez object registry
+      ObjectCache.setupObjectRegistry(new ObjectRegistryImpl());
+    }
+
+    HiveConf conf = new HiveConf();
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVEQUERYID, "query-" + random.nextInt(10000));
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "tez");
+    conf.set(TezProcessor.HIVE_TEZ_VERTEX_NAME, "Map 1");
+
+    LimitOperator lo1 = new LimitOperator(new CompilationOpContext());
+    lo1.setConf(new LimitDesc(offset, limit));
+    lo1.initialize(conf, null);
+    lo1.initializeOp(conf);
+
+    LimitOperator lo2 = new LimitOperator(new CompilationOpContext());
+    lo2.setConf(new LimitDesc(offset, limit));
+    lo2.initialize(conf, null);
+    lo2.initializeOp(conf);
+
+    Assert.assertEquals(0, lo1.currCount);
+    Assert.assertEquals(0, lo2.currCount);
+
+    // operator id is important, as it's the base of the limit cache key
+    // these operator instances represent the same operator running in different tasks
+    Assert.assertEquals("LIM_0", lo1.getOperatorId());
+    Assert.assertEquals("LIM_0", lo2.getOperatorId());
+
+    // assertion no.1: unlike VectorLimitOperator, we op.process checks limit before every element,
+    // so we can notice limit reached while processing the offset+limit+1st element, so op.getDone()
+    // is true if we already processed at least limit + offset
+
+    // assertion no.2: number of processed rows properly set to global cache and is equal to the
+    // count by which op.process was called
+
+    // assertion no.3: the local counter is in sync with the global counter (in this test case, no
+    // other tasks work concurrently)
+
+    // element: 1,2
+    processRowNTimes(lo1, 2);
+    numProcessedElements += 2;
+    Assert.assertEquals(numProcessedElements > limit + offset, lo1.getDone());
+    Assert.assertEquals(Math.min(numProcessedElements, limit + offset),
+        lo1.getCurrentCount().get());
+    Assert.assertEquals(lo1.getCurrentCount().get(), lo1.currCount);
+
+    // element: 3
+    processRowNTimes(lo1, 1);
+    numProcessedElements += 1;
+    Assert.assertEquals(numProcessedElements > limit + offset, lo1.getDone());
+    Assert.assertEquals(Math.min(numProcessedElements, limit + offset),
+        lo1.getCurrentCount().get());
+    Assert.assertEquals(lo1.getCurrentCount().get(), lo1.currCount);
+
+    // element: 4
+    processRowNTimes(lo1, 1);
+    numProcessedElements += 1;
+    Assert.assertEquals(numProcessedElements > limit + offset, lo1.getDone());
+    Assert.assertEquals(Math.min(numProcessedElements, limit + offset),
+        lo1.getCurrentCount().get());
+    Assert.assertEquals(lo1.getCurrentCount().get(), lo1.currCount);
+
+    // if lo1 already processed enough rows, lo2 will turn to done without processing any elements
+    // lo2.getCurrentCount().get() should return the same as lo1.getCurrentCount().get()
+    Assert.assertEquals(Math.min(numProcessedElements, limit + offset),
+        lo2.getCurrentCount().get());
+    // ...but lo2's current count hasn't been touched yet, as process hasn't been called
+    Assert.assertEquals(0, lo2.currCount);
+    // getDone() = false before processing
+    Assert.assertEquals(false, lo2.getDone());
+
+    // try to process one more element with op2
+    processRowNTimes(lo2, 1);
+    // op2 will be noticed as done only if "numProcessedElements" (the number of elements processed
+    // by lo1) is more than limit + offset + 1, because in that case lo2 has nothing to do
+    boolean lo2DoneExpected = numProcessedElements > limit + offset + 1;
+    Assert.assertEquals(lo2DoneExpected, lo2.getDone());
+    // if lo2 is done, it hasn't processed any elements (currCount=0), otherwise it processed the
+    // new element
+    int lo2Count = lo2.currCount;
+    Assert.assertEquals(lo2DoneExpected ? 0 : 1, lo2.currCount);
+
+    // repeat once more (to test cases where limit+offset+1 < number of all elements to process
+    processRowNTimes(lo2, 1);
+    if (!lo2DoneExpected) {// if lo2 had the chance to process one more element (!done) ...
+      // ... let's count that in
+      numProcessedElements += 1;
+      if (lo2.getDone()) { // turn to done after processing => hasn't processed any element
+        Assert.assertEquals(lo2Count, lo2.currCount);
+      } else { // hasn't turned to done after processing => processed 1 more element
+        Assert.assertEquals(lo2Count + 1, lo2.currCount);
+      }
+    } else {
+      // current count hasn't changed
+      Assert.assertEquals(lo2Count, lo2.currCount);
+    }
+    lo2DoneExpected = numProcessedElements > limit + offset + 1;
+    Assert.assertEquals(lo2DoneExpected, lo2.getDone());
+  }
+
+  private void processRowNTimes(LimitOperator op, int n) throws HiveException {
+    for (int i = 0; i < n; i++) {
+      op.process(fakeObjectToPass, 0);
+    }
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorLimitOperator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/TestVectorLimitOperator.java
@@ -19,21 +19,29 @@
 package org.apache.hadoop.hive.ql.exec.vector;
 
 import java.util.Arrays;
+import java.util.Random;
 
 import org.junit.Assert;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.llap.io.api.LlapProxy;
 import org.apache.hadoop.hive.ql.CompilationOpContext;
+import org.apache.hadoop.hive.ql.exec.tez.ObjectCache;
+import org.apache.hadoop.hive.ql.exec.tez.TezProcessor;
 import org.apache.hadoop.hive.ql.exec.vector.util.FakeVectorRowBatchFromObjectIterables;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.LimitDesc;
 import org.apache.hadoop.hive.ql.plan.VectorLimitDesc;
+import org.apache.tez.runtime.common.objectregistry.ObjectRegistryImpl;
 import org.junit.Test;
 
 /**
  * Unit test for the vectorized LIMIT operator.
  */
 public class TestVectorLimitOperator {
+
+  private Random random = new Random(TestVectorLimitOperator.class.toString().hashCode());
 
   @Test
   public void testLimitLessThanBatchSize() throws HiveException {
@@ -50,15 +58,75 @@ public class TestVectorLimitOperator {
     validateVectorLimitOperator(5, 0, 0);
   }
 
+  @Test
+  public void testGlobalLimitReached() throws HiveException {
+    // no offset
+    testGlobalLimitReachedInDaemonOrContainer(true, 0, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 0, 2);
+
+    // offset < limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 1, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 1, 2);
+
+    // offset = limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 2, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 2, 2);
+
+    // offset > limit
+    testGlobalLimitReachedInDaemonOrContainer(true, 3, 2);
+    testGlobalLimitReachedInDaemonOrContainer(false, 3, 2);
+  }
+
+  private void testGlobalLimitReachedInDaemonOrContainer(boolean isDaemon, int offset, int limit)
+      throws HiveException {
+    int actualNumberOfElements = 4; // from FakeVectorRowBatchFromObjectIterables
+
+    LlapProxy.setDaemon(isDaemon);
+    if (!isDaemon) {// init tez object registry
+      ObjectCache.setupObjectRegistry(new ObjectRegistryImpl());
+    }
+
+    HiveConf conf = new HiveConf();
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVEQUERYID, "query-" + random.nextInt(10000));
+    HiveConf.setVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE, "tez");
+    conf.set(TezProcessor.HIVE_TEZ_VERTEX_NAME, "Map 1");
+
+    VectorLimitOperator lo1 = new VectorLimitOperator(new CompilationOpContext(),
+        new LimitDesc(offset, limit), null, new VectorLimitDesc());
+    lo1.initialize(conf, null);
+    lo1.initializeOp(conf);
+
+    VectorLimitOperator lo2 = new VectorLimitOperator(new CompilationOpContext(),
+        new LimitDesc(offset, limit), null, new VectorLimitDesc());
+    lo2.initialize(conf, null);
+    lo2.initializeOp(conf);
+
+    // operator id is important, as it's the base of the limit cache key
+    // these operator instances represent the same operator running in different tasks
+    Assert.assertEquals("LIM_0", lo1.getOperatorId());
+    Assert.assertEquals("LIM_0", lo2.getOperatorId());
+
+    lo1.process(getBatch(500).produceNextBatch(), 0);
+    // lo1 is not done, as that's not checked after forwarding, only before next batch
+    Assert.assertFalse(lo1.getDone());
+    // number of processed rows properly set to global cache and is equal to limit+offset or equal
+    // to batch size if limit+offset > batch size (because the operator cannot read through the
+    // current batch obviously)
+    Assert.assertEquals(Math.min(limit + offset, actualNumberOfElements), lo1.getCurrentCount().get());
+
+    // if lo1 already processed enough rows, lo2 will turn to done without processing any elements
+    lo2.process(getBatch(500).produceNextBatch(), 0);
+    Assert.assertEquals(limit + offset <= actualNumberOfElements  ? true : false, lo2.getDone());
+
+    // lo1 is done now, as limit is check before processing batch
+    lo1.process(getBatch(500).produceNextBatch(), 0);
+    Assert.assertTrue(lo1.getDone());
+  }
+
   private void validateVectorLimitOperator(int limit, int batchSize, int expectedBatchSize)
       throws HiveException {
 
-    @SuppressWarnings("unchecked")
-    FakeVectorRowBatchFromObjectIterables frboi = new FakeVectorRowBatchFromObjectIterables(
-        batchSize,
-        new String[] {"tinyint", "double"},
-        Arrays.asList(new Object[] {1, 2, 3, 4}),
-        Arrays.asList(new Object[] {323.0, 34.5, null, 89.3}));
+    FakeVectorRowBatchFromObjectIterables frboi = getBatch(batchSize);
 
     // Get next batch
     VectorizedRowBatch vrb = frboi.produceNextBatch();
@@ -75,6 +143,16 @@ public class TestVectorLimitOperator {
 
     // Verify batch size
     Assert.assertEquals(vrb.size, expectedBatchSize);
+  }
+
+  private FakeVectorRowBatchFromObjectIterables getBatch(int batchSize) throws HiveException {
+    @SuppressWarnings("unchecked")
+    FakeVectorRowBatchFromObjectIterables frboi = new FakeVectorRowBatchFromObjectIterables(
+        batchSize,
+        new String[] {"tinyint", "double"},
+        Arrays.asList(new Object[] {1, 2, 3, 4}),
+        Arrays.asList(new Object[] {323.0, 34.5, null, 89.3}));
+    return frboi;
   }
 }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/util/FakeVectorRowBatchFromObjectIterables.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/util/FakeVectorRowBatchFromObjectIterables.java
@@ -22,7 +22,6 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -182,13 +181,13 @@ public class FakeVectorRowBatchFromObjectIterables extends FakeVectorRowBatchBas
   public VectorizedRowBatch produceNextBatch() {
     batch.size = 0;
     batch.selectedInUse = false;
+
     for (int i=0; i < types.length; ++i) {
       ColumnVector col = batch.cols[i];
       col.noNulls = true;
       col.isRepeating = false;
     }
     while (!eof && batch.size < this.batchSize){
-      int r = batch.size;
       for (int i=0; i < types.length; ++i) {
         Iterator<Object> it = iterators.get(i);
         if (!it.hasNext()) {

--- a/ql/src/test/queries/clientpositive/authorization_view_1.q
+++ b/ql/src/test/queries/clientpositive/authorization_view_1.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.security.authorization.manager=org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider;
+set hive.exec.reducers.max=1;
 
 create table src_autho_test_n8 as select * from src;
 

--- a/ql/src/test/queries/clientpositive/authorization_view_disable_cbo_1.q
+++ b/ql/src/test/queries/clientpositive/authorization_view_disable_cbo_1.q
@@ -1,6 +1,7 @@
 --! qt:dataset:src
 set hive.security.authorization.manager=org.apache.hadoop.hive.ql.security.authorization.DefaultHiveAuthorizationProvider;
 set hive.cbo.enable=false;
+set hive.exec.reducers.max=1;
 
 create table src_autho_test_n9 as select * from src;
 

--- a/ql/src/test/queries/clientpositive/input14_limit.q
+++ b/ql/src/test/queries/clientpositive/input14_limit.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.stats.column.autogather=false;
+set hive.exec.reducers.max=1;
 
 CREATE TABLE dest1_n13(key INT, value STRING) STORED AS TEXTFILE;
 

--- a/ql/src/test/results/clientpositive/llap/authorization_view_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_view_1.q.out
@@ -250,12 +250,12 @@ POSTHOOK: Input: default@v2_n7
 POSTHOOK: Input: default@v_n9
 #### A masked pattern was here ####
 val_0
+val_10
 val_100
+val_103
 val_104
+val_105
 val_11
 val_111
 val_113
-val_116
-val_119
-val_125
-val_133
+val_114

--- a/ql/src/test/results/clientpositive/llap/authorization_view_disable_cbo_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/authorization_view_disable_cbo_1.q.out
@@ -250,15 +250,15 @@ POSTHOOK: Input: default@v2_n8
 POSTHOOK: Input: default@v_n10
 #### A masked pattern was here ####
 val_0
+val_10
 val_100
+val_103
 val_104
+val_105
 val_11
 val_111
 val_113
-val_116
-val_119
-val_125
-val_133
+val_114
 PREHOOK: query: select key from v_n10 cluster by key limit 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src_autho_test_n9
@@ -293,13 +293,13 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src_autho_test_n9
 POSTHOOK: Input: default@v_n10
 #### A masked pattern was here ####
+0
+0
+0
+0
+0
+0
 10
 10
 100
 100
-100
-100
-103
-103
-103
-103


### PR DESCRIPTION
Change-Id: I12d2719acdf80ffa3a5c14b1c3fce2d4cbe00911


### What changes were proposed in this pull request?
Using an object cache, LimitOperator/VectorLimitOperator/TezProcessor can exit quickly if a limit is already reached. 

### Why are the changes needed?
Performance benefit.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Tested on cluster.
