### PR TITLE
HIVE-24235: Drop and recreate table during MR compaction leaves behind base/delta directory

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -143,13 +143,12 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
   }
 
   private void verifyTableIdHasNotChanged(CompactionInfo ci, Table originalTable) throws HiveException, MetaException {
-    String fullTableName = originalTable.getDbName() + "." + originalTable.getTableName();
     Table currentTable = resolveTable(ci);
-
     if (originalTable.getId() != currentTable.getId()) {
-      throw new HiveException("Table " + fullTableName + " id (" + currentTable.getId() + ") is not equal to its id "
-          + "when compaction started (" + originalTable.getId() + "). The table might have been dropped and recreated "
-          + "while compaction was running. Marking compaction as failed.");
+      throw new HiveException("Table " + originalTable.getDbName() + "." + originalTable.getTableName()
+          + " id (" + currentTable.getId() + ") is not equal to its id when compaction started ("
+          + originalTable.getId() + "). The table might have been dropped and recreated while compaction was running."
+          + " Marking compaction as failed.");
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hive.common.util.Ref;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -138,6 +139,17 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       if (msc != null) {
         msc.close();
       }
+    }
+  }
+
+  private void verifyTableIdHasNotChanged(CompactionInfo ci, Table originalTable) throws HiveException, MetaException {
+    String fullTableName = originalTable.getDbName() + "." + originalTable.getTableName();
+    Table currentTable = resolveTable(ci);
+
+    if (originalTable.getId() != currentTable.getId()) {
+      throw new HiveException("Table " + fullTableName + " id (" + currentTable.getId() + ") is not equal to its id "
+          + "when compaction started (" + originalTable.getId() + "). The table might have been dropped and recreated "
+          + "while compaction was running. Marking compaction as failed.");
     }
   }
 
@@ -540,6 +552,9 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
           }
         }
         heartbeater.cancel();
+
+        verifyTableIdHasNotChanged(ci, t1);
+
         LOG.info("Completed " + ci.type.toString() + " compaction for " + ci.getFullPartitionName() + " in txn "
             + JavaUtils.txnIdToString(compactorTxnId) + ", marking as compacted.");
         msc.markCompacted(CompactionInfo.compactionInfoToStruct(ci));


### PR DESCRIPTION
### What changes were proposed in this pull request?
Resolve the table again after compaction is finished; compare the id with the table id from when compaction began. If the ids do not match, abort the compaction's transaction.

### Why are the changes needed?

### Does this PR introduce _any_ user-facing change?

### How was this patch tested?
Manual tests