### PR TITLE
[MINOR]Fix typo in CombineHiveInputFormat

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/CombineHiveInputFormat.java
@@ -692,7 +692,7 @@ public class CombineHiveInputFormat<K extends WritableComparable, V extends Writ
   }
 
   /**
-   * Create a generic Hive RecordReader than can iterate over all chunks in a
+   * Create a generic Hive RecordReader that can iterate over all chunks in a
    * CombinedFileSplit.
    */
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

Fix a typo in the java doc of `org.apache.hadoop.hive.ql.io.CombineHiveInputFormat#getRecordReader`

### Why are the changes needed?
java doc used a wrong  word

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No need
