### PR TITLE
HIVE-24286: Render date and time with progress of Hive on Tez

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
@@ -28,6 +28,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.StringWriter;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -40,6 +42,7 @@ class RenderStrategy {
 
   private abstract static class BaseUpdateFunction implements UpdateFunction {
     private static final int PRINT_INTERVAL = 3000;
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss,SSS");
 
     final TezJobMonitor monitor;
     private final PerfLogger perfLogger;
@@ -57,7 +60,8 @@ class RenderStrategy {
       renderProgress(monitor.progressMonitor(status, vertexProgressMap));
       String report = getReport(vertexProgressMap);
       if (showReport(report)) {
-        renderReport(report);
+        String time = FORMATTER.format(LocalDateTime.now());
+        renderReport(time + "\t" + report);
         lastReport = report;
         lastPrintTime = System.currentTimeMillis();
       }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?

Add date and time to progress logs for Hive on Tez like MapReduce and Spark.

### Why are the changes needed?

For convenience. The date and time will give us more insights when looking through logs.

### Does this PR introduce _any_ user-facing change?

This PR has the only changes for logging. We may add a configuration if this can be a breaking change and we can't accept it.


### How was this patch tested?

Run `beeline --hiveconf hive.server2.in.place.progress=false` and check the progress logs. I have checked the following logs show up.

```
INFO  : 2020-10-19 13:32:41,162	Map 1: 0/1	Reducer 2: 0/1	
INFO  : 2020-10-19 13:32:44,231	Map 1: 0/1	Reducer 2: 0/1	
INFO  : 2020-10-19 13:32:46,813	Map 1: 0(+1)/1	Reducer 2: 0/1	
INFO  : 2020-10-19 13:32:49,878	Map 1: 0(+1)/1	Reducer 2: 0/1	
INFO  : 2020-10-19 13:32:51,416	Map 1: 1/1	Reducer 2: 0/1	
INFO  : 2020-10-19 13:32:51,936	Map 1: 1/1	Reducer 2: 0(+1)/1	
INFO  : 2020-10-19 13:32:52,877	Map 1: 1/1	Reducer 2: 1/1	
```
