### PR TITLE
HIVE-24288: Temp files created by CompileProcessor are not deleted (N…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
@@ -289,14 +289,15 @@ public class CompileProcessor implements CommandProcessor {
             FileUtils.forceDeleteOnExit(destination);
         } catch (IOException WhatCanYouDo) {
         }
+        try {
+          if (testArchive != null && testArchive.exists())
+            testArchive.deleteOnExit();
+        } catch (Exception WhatCanYouDo) { /* ignore */ }
       }
     }
 
     if (ss != null){
       ss.add_resource(ResourceType.JAR, testArchive.getAbsolutePath());
-      try {
-        testArchive.deleteOnExit();
-      } catch (Exception e) { /* ignore */ }
     }
     CommandProcessorResponse good = new CommandProcessorResponse(null, testArchive.getAbsolutePath());
     return good;

--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
@@ -212,7 +212,8 @@ public class CompileProcessor implements CommandProcessor {
       throw new CommandProcessorException(ioTempDir + " is not a writable directory");
     }
     long runStamp = System.currentTimeMillis();
-    File sessionTempFile = new File(ioTempDir, ss.getUserName() + "_" + runStamp);
+    String user = (ss != null) ? ss.getUserName() : "anonymous";
+    File sessionTempFile = new File(ioTempDir, user + "_" + runStamp);
     if (!sessionTempFile.exists()) {
       sessionTempFile.mkdir();
       setPosixFilePermissions(sessionTempFile, lockout, true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/processors/CompileProcessor.java
@@ -201,7 +201,7 @@ public class CompileProcessor implements CommandProcessor {
    * @throws CompileProcessorException
    */
   CommandProcessorResponse compile(SessionState ss) throws CommandProcessorException {
-    String lockout = "rw-------";
+    String lockout = "rwx------";
     Project proj = new Project();
     String ioTempDir = System.getProperty(IO_TMP_DIR);
     File ioTempFile = new File(ioTempDir);
@@ -215,6 +215,7 @@ public class CompileProcessor implements CommandProcessor {
     File sessionTempFile = new File(ioTempDir, ss.getUserName() + "_" + runStamp);
     if (!sessionTempFile.exists()) {
       sessionTempFile.mkdir();
+      setPosixFilePermissions(sessionTempFile, lockout, true);
     }
     Groovyc g = new Groovyc();
     String jarId = myId + "_" + runStamp;
@@ -226,14 +227,17 @@ public class CompileProcessor implements CommandProcessor {
     sourcePath.setLocation(input);
     g.setSrcdir(sourcePath);
     input.mkdir();
+    setPosixFilePermissions(input, lockout, true);
 
     File fileToWrite = new File(input, this.named);
     try {
       Files.write(Paths.get(fileToWrite.toURI()), code.getBytes(Charset.forName("UTF-8")), StandardOpenOption.CREATE_NEW);
+      setPosixFilePermissions(fileToWrite, lockout, false);
     } catch (IOException e1) {
       throw new CommandProcessorException("writing file", e1);
     }
     destination.mkdir();
+    setPosixFilePermissions(destination, lockout, true);
     try {
       g.execute();
     } catch (BuildException ex){


### PR DESCRIPTION
### What changes were proposed in this pull request?
When you run the "compile" query in Hive CLI, this creates some temp files in java.io.tmp directory that need to be cleaned up after the resource is added to the session.
For example:
compile `import org.apache.hadoop.hive.ql.exec.UDF \;
public class Pyth extends UDF {
  public double evaluate(double a, double b){
    return Math.sqrt((a*a) + (b*b)) \;
  }
} ` AS GROOVY NAMED Pyth.groovy;

in /tmp,
./0_1603130653872in/Pyth.groovy
./0_1603130393407in/Pyth.groovy
./0_1603130541093in/Pyth.groovy

ls -l *.jar
-rw-r--r-- 1 root root 1578 Oct 19 17:59 0_1603130393407.jar
-rw-r--r-- 1 hive hive 1578 Oct 19 18:02 0_1603130541093.jar
-rw-r--r-- 1 hive hive 1578 Oct 19 18:04 0_1603130653872.jar

### Why are the changes needed?
Cleanup needed

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Manually using Hive CLI.
After the fix,
ls -l in /tmp, shows no new .groovy files
Also the jar file has lesser permissions for non-owners
-rw------- 1 root root 1578 Oct 20 00:54 2_1603155248285.jar