### PR TITLE
HIVE-24293: Integer overflow in llap collision mask

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cache/LowLevelCacheImpl.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cache/LowLevelCacheImpl.java
@@ -343,7 +343,7 @@ public class LowLevelCacheImpl implements LowLevelCache, BufferUsageManager, Lla
             if (result == null) {
               result = new long[align64(buffers.length) >>> 6];
             }
-            result[i >>> 6] |= (1 << (i & 63)); // indicate that we've replaced the value
+            result[i >>> 6] |= (1L << (i & 63)); // indicate that we've replaced the value
             break;
           }
           // We found some old value but couldn't incRef it; remove it.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->



### What changes were proposed in this pull request?
bugfix


### Why are the changes needed?
If multiple threads put the same buffer to the cache, only one succeeds. The other one detects this, and replaces its own buffer. This is marked by a bit mask encoded in a long, where the collided buffers are marked with a 1. By shifting the integer 1, it can happen that due to an overflow some buffers will not be removed after a collision, and the reference count decreases below zero, which is not a valid state.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test added