### PR TITLE
HIVE-23583: Upgrade to ant 1.10.9 due to CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <maven.surefire.plugin.version>3.0.0-M4</maven.surefire.plugin.version>
     <!-- Library Dependency Versions -->
     <accumulo.version>1.7.3</accumulo.version>
-    <ant.version>1.9.1</ant.version>
+    <ant.version>1.10.9</ant.version>
     <antlr.version>3.5.2</antlr.version>
     <apache-directory-server.version>1.5.7</apache-directory-server.version>
     <!-- Include arrow for LlapOutputFormatService -->


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade ant 1.9.1 to 1.10.9 due to CVEs.


### Why are the changes needed?
There are CVEs affecting ant 1.9.1


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit tests.
