### PR TITLE
HIVE-23685: Removing user's extra resources while executing File Merge Task

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/merge/MergeFileTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/merge/MergeFileTask.java
@@ -145,11 +145,7 @@ public class MergeFileTask extends Task<MergeFileWork> implements Serializable,
       // submit the job
       JobClient jc = new JobClient(job);
 
-      String addedJars = Utilities.getResourceFiles(job,
-          SessionState.ResourceType.JAR);
-      if (!addedJars.isEmpty()) {
-        job.set("tmpjars", addedJars);
-      }
+      // There is no need for Mergefile Task to add extra jars.
 
       // make this client wait if job trcker is not behaving well.
       Throttle.checkJobTracker(job, LOG);


### PR DESCRIPTION
Hi, we find that MapReduce's file merge map containers will download user's extra resources(such as: added jars, files, archives) before launching task. When these resources are large or the network is busy, file merge jobs will be timeout, causing the query be failed. As we all know, file merge task will run correctly just with hive-exec.jar and MapReduce framework. Therefore, there is no need to download user's resources. The patch below prevents setting `tmpjars` for FileMerge Task.


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

Remove `tmpjars` for `MergeFileTask`.




### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

For queries with some large jars, it's unnecessary for `MergeFileTask` to download extra resources and when the network is not good, containers might be time-out.



### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

It has been tested in our product env.

