### PR TITLE
HIVE-24259: [CachedStore] Optimise get all constraint api

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStoreUpdateUsingEvents.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStoreUpdateUsingEvents.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
 import org.apache.hive.hcatalog.listener.DbNotificationListener;
+import org.apache.thrift.TException;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -387,6 +388,9 @@ public class TestCachedStoreUpdateUsingEvents {
     dropConstraintRequest = new DropConstraintRequest(dbName, parentTableName, parentPkBase.get(0).getPk_name());
     hmsHandler.drop_constraint(dropConstraintRequest);
 
+    sharedCache.refreshAllTableConstraintsInCache(DEFAULT_CATALOG_NAME, dbName, tblName, new SQLAllTableConstraints());
+    sharedCache.refreshAllTableConstraintsInCache(DEFAULT_CATALOG_NAME, dbName, parentTableName, new SQLAllTableConstraints());
+
     // Validate cache store constraint is dropped
     assertRawStoreAndCachedStoreConstraint(DEFAULT_CATALOG_NAME, dbName, tblName);
 
@@ -402,6 +406,20 @@ public class TestCachedStoreUpdateUsingEvents {
     hmsHandler.add_default_constraint(new AddDefaultConstraintRequest(dcBase));
     hmsHandler.add_check_constraint(new AddCheckConstraintRequest(ccBase));
 
+    SQLAllTableConstraints constraints = new SQLAllTableConstraints();
+    constraints.setPrimaryKeys(pkBase);
+    constraints.setForeignKeys(fkBase);
+    constraints.setCheckConstraints(ccBase);
+    constraints.setDefaultConstraints(dcBase);
+    constraints.setNotNullConstraints(nnBase);
+    constraints.setUniqueConstraints(ucBase);
+
+    SQLAllTableConstraints constraintsParent = new SQLAllTableConstraints();
+    constraintsParent.setPrimaryKeys(parentPkBase);
+
+    sharedCache.refreshAllTableConstraintsInCache(DEFAULT_CATALOG_NAME, dbName, tblName, constraints);
+    sharedCache.refreshAllTableConstraintsInCache(DEFAULT_CATALOG_NAME, dbName, parentTableName, constraintsParent);
+
     // Validating constraint values from Cache with rawStore
     assertRawStoreAndCachedStoreConstraint(DEFAULT_CATALOG_NAME, dbName, tblName);
 
@@ -413,17 +431,11 @@ public class TestCachedStoreUpdateUsingEvents {
     sharedCache.getSdCache().clear();
   }
 
-  public void assertRawStoreAndCachedStoreConstraint(String catName, String dbName, String tblName)
-      throws MetaException, NoSuchObjectException {
+  public void assertRawStoreAndCachedStoreConstraint(String catName, String dbName, String tblName) throws TException {
     SQLAllTableConstraints rawStoreConstraints = rawStore.getAllTableConstraints(catName, dbName, tblName);
-    SQLAllTableConstraints cachedStoreConstraints = new SQLAllTableConstraints();
-    cachedStoreConstraints.setPrimaryKeys(sharedCache.listCachedPrimaryKeys(catName, dbName, tblName));
-    cachedStoreConstraints.setForeignKeys(sharedCache.listCachedForeignKeys(catName, dbName, tblName, null, null));
-    cachedStoreConstraints.setNotNullConstraints(sharedCache.listCachedNotNullConstraints(catName, dbName, tblName));
-    cachedStoreConstraints.setDefaultConstraints(sharedCache.listCachedDefaultConstraint(catName, dbName, tblName));
-    cachedStoreConstraints.setCheckConstraints(sharedCache.listCachedCheckConstraint(catName, dbName, tblName));
-    cachedStoreConstraints.setUniqueConstraints(sharedCache.listCachedUniqueConstraint(catName, dbName, tblName));
-    Assert.assertEquals(rawStoreConstraints, cachedStoreConstraints);
+    AllTableConstraintsResponse
+        constraints = hmsHandler.get_all_table_constraints(new AllTableConstraintsRequest(dbName, tblName, catName));
+    Assert.assertEquals(rawStoreConstraints, constraints.getAllTableConstraints());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CacheUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CacheUtils.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.hadoop.hive.metastore.RawStore;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SkewedInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
@@ -29,6 +30,8 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.cache.SharedCache.PartitionWrapper;
 import org.apache.hadoop.hive.metastore.cache.SharedCache.TableWrapper;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
+
+import static org.apache.hadoop.hive.metastore.cache.CachedStore.shouldCacheTable;
 
 public class CacheUtils {
   private static final String delimit = "\u0001";

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -805,18 +805,8 @@ public class CachedStore implements RawStore, Configurable {
               updateTablePartitionColStats(rawStore, catName, dbName, tblName);
               // Update aggregate partition column stats for a table in cache
               updateTableAggregatePartitionColStats(rawStore, catName, dbName, tblName);
-              // Update the table primary keys for a table in cache
-              updateTablePrimaryKeys(rawStore, catName, dbName, tblName);
-              // Update the table foreign keys for a table in cache
-              updateTableForeignKeys(rawStore, catName, dbName, tblName);
-              // Update the table unique constraints for a table in cache
-              updateTableUniqueConstraints(rawStore, catName, dbName, tblName);
-              // Update the table not null constraints for a table in cache
-              updateTableNotNullConstraints(rawStore, catName, dbName, tblName);
-              // Update the table default constraints for a table in cache
-              updateTableDefaultConstraints(rawStore, catName, dbName, tblName);
-              // Update the table check constraints for a table in cache
-              updateTableCheckConstraints(rawStore, catName, dbName, tblName);
+              // Update Table Constraint
+              updateAllTableConstraints(rawStore, catName, dbName, tblName);
             }
           }
         }
@@ -905,140 +895,28 @@ public class CachedStore implements RawStore, Configurable {
       }
     }
 
-    private void updateTableForeignKeys(RawStore rawStore, String catName, String dbName, String tblName) {
+    private void updateAllTableConstraints(RawStore rawStore, String catName, String dbName, String tblName) {
       catName = StringUtils.normalizeIdentifier(catName);
       dbName = StringUtils.normalizeIdentifier(dbName);
       tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached foreign keys objects for catalog: {}, database: {}, table: {}", catName,
+      LOG.debug("CachedStore: updating cached table constraints objects for catalog: {}, database: {}, table: {}", catName,
           dbName, tblName);
-      List<SQLForeignKey> fks = null;
+      SQLAllTableConstraints constraints = null;
       try {
-        Deadline.startTimer("getForeignKeys");
-        fks = rawStore.getForeignKeys(catName, null, null, dbName, tblName);
+        Deadline.startTimer("getAllTableConstraints");
+        constraints = rawStore.getAllTableConstraints(catName, dbName, tblName);
         Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info("Updating CachedStore: unable to update foreign keys of catalog: " + catName + ", database: " + dbName
+      } catch (MetaException | NoSuchObjectException e) {
+        LOG.info("Updating CachedStore: unable to update table constraints of catalog: " + catName + ", database: " + dbName
             + ", table: " + tblName, e);
       }
-      if (fks != null) {
-        sharedCache.refreshForeignKeysInCache(catName, dbName, tblName, fks);
-        LOG.debug("CachedStore: updated cached foreign keys objects for catalog: {}, database: {}, table: {}", catName,
+      if (constraints != null) {
+        sharedCache.refreshAllTableConstraintsInCache(catName, dbName, tblName, constraints);
+        LOG.debug("CachedStore: updated cached table constraints objects for catalog: {}, database: {}, table: {}", catName,
             dbName, tblName);
       }
     }
 
-    private void updateTableNotNullConstraints(RawStore rawStore, String catName, String dbName, String tblName) {
-      catName = StringUtils.normalizeIdentifier(catName);
-      dbName = StringUtils.normalizeIdentifier(dbName);
-      tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached not null constraints for catalog: {}, database: {}, table: {}", catName,
-          dbName, tblName);
-      List<SQLNotNullConstraint> nns = null;
-      try {
-        Deadline.startTimer("getNotNullConstraints");
-        nns = rawStore.getNotNullConstraints(catName, dbName, tblName);
-        Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info("Updating CachedStore: unable to update not null constraints of catalog: " + catName + ", database: "
-            + dbName + ", table: " + tblName, e);
-      }
-      if (nns != null) {
-        sharedCache.refreshNotNullConstraintsInCache(catName, dbName, tblName, nns);
-        LOG.debug("CachedStore: updated cached not null constraints for catalog: {}, database: {}, table: {}", catName,
-            dbName, tblName);
-      }
-    }
-
-    private void updateTableUniqueConstraints(RawStore rawStore, String catName, String dbName, String tblName) {
-      catName = StringUtils.normalizeIdentifier(catName);
-      dbName = StringUtils.normalizeIdentifier(dbName);
-      tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached unique constraints for catalog: {}, database: {}, table: {}", catName,
-          dbName, tblName);
-      List<SQLUniqueConstraint> ucs = null;
-      try {
-        Deadline.startTimer("getUniqueConstraints");
-        ucs = rawStore.getUniqueConstraints(catName, dbName, tblName);
-        Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info(
-            "Updating CachedStore: unable to update unique constraints of catalog: " + catName + ", database: " + dbName
-                + ", table: " + tblName, e);
-      }
-      if (ucs != null) {
-        sharedCache.refreshUniqueConstraintsInCache(catName, dbName, tblName, ucs);
-        LOG.debug("CachedStore: updated cached unique constraints for catalog: {}, database: {}, table: {}", catName,
-            dbName, tblName);
-      }
-    }
-
-    private void updateTablePrimaryKeys(RawStore rawStore, String catName, String dbName, String tblName) {
-      catName = StringUtils.normalizeIdentifier(catName);
-      dbName = StringUtils.normalizeIdentifier(dbName);
-      tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached primary keys objects for catalog: {}, database: {}, table: {}", catName,
-          dbName, tblName);
-      List<SQLPrimaryKey> pks = null;
-      try {
-        Deadline.startTimer("getPrimaryKeys");
-        pks = rawStore.getPrimaryKeys(catName, dbName, tblName);
-        Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info("Updating CachedStore: unable to update primary keys of catalog: " + catName + ", database: " + dbName
-            + ", table: " + tblName, e);
-      }
-      if (pks != null) {
-        sharedCache.refreshPrimaryKeysInCache(catName, dbName, tblName, pks);
-        LOG.debug("CachedStore: updated cached primary keys objects for catalog: {}, database: {}, table: {}", catName,
-            dbName, tblName);
-      }
-    }
-
-    private void updateTableDefaultConstraints(RawStore rawStore, String catName, String dbName, String tblName) {
-      catName = StringUtils.normalizeIdentifier(catName);
-      dbName = StringUtils.normalizeIdentifier(dbName);
-      tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached default Constraint objects for catalog: {}, database: {}, table: {}",
-          catName, dbName, tblName);
-      List<SQLDefaultConstraint> dc = null;
-      try {
-        Deadline.startTimer("getDefaultConstraints");
-        dc = rawStore.getDefaultConstraints(catName, dbName, tblName);
-        Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info(
-            "Updating CachedStore: unable to update default Constraint of catalog: " + catName + ", database: " + dbName
-                + ", table: " + tblName, e);
-      }
-      if (dc != null) {
-        sharedCache.refreshDefaultConstraintsInCache(catName, dbName, tblName, dc);
-        LOG.debug("CachedStore: updated cached default constraint objects for catalog: {}, database: {}, table: {}",
-            catName, dbName, tblName);
-      }
-    }
-
-    private void updateTableCheckConstraints(RawStore rawStore, String catName, String dbName, String tblName) {
-      catName = StringUtils.normalizeIdentifier(catName);
-      dbName = StringUtils.normalizeIdentifier(dbName);
-      tblName = StringUtils.normalizeIdentifier(tblName);
-      LOG.debug("CachedStore: updating cached check constraint objects for catalog: {}, database: {}, table: {}",
-          catName, dbName, tblName);
-      List<SQLCheckConstraint> cc = null;
-      try {
-        Deadline.startTimer("getCheckConstraints");
-        cc = rawStore.getCheckConstraints(catName, dbName, tblName);
-        Deadline.stopTimer();
-      } catch (MetaException e) {
-        LOG.info(
-            "Updating CachedStore: unable to update check constraint of catalog: " + catName + ", database: " + dbName
-                + ", table: " + tblName, e);
-      }
-      if (cc != null) {
-        sharedCache.refreshCheckConstraintsInCache(catName, dbName, tblName, cc);
-        LOG.debug("CachedStore: updated cached check constraint objects for catalog: {}, database: {}, table: {}",
-            catName, dbName, tblName);
-      }
-    }
 
     private void updateTablePartitions(RawStore rawStore, String catName, String dbName, String tblName) {
       LOG.debug("CachedStore: updating cached partition objects for catalog: {}, database: {}, table: {}", catName,
@@ -1325,6 +1203,7 @@ public class CachedStore implements RawStore, Configurable {
     }
     validateTableType(tbl);
     sharedCache.addTableToCache(catName, dbName, tblName, tbl);
+    sharedCache.addTableConstraintsToCache(catName, dbName, tblName, new SQLAllTableConstraints());
   }
 
   @Override public boolean dropTable(String catName, String dbName, String tblName)
@@ -2674,28 +2553,18 @@ public class CachedStore implements RawStore, Configurable {
     catName = StringUtils.normalizeIdentifier(catName);
     dbName = StringUtils.normalizeIdentifier(dbName);
     tblName = StringUtils.normalizeIdentifier(tblName);
-    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
       return rawStore.getPrimaryKeys(catName, dbName, tblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, dbName, tblName);
-    if (tbl == null) {
-      // The table containing the primary keys is not yet loaded in cache
-      return rawStore.getPrimaryKeys(catName, dbName, tblName);
-    }
-    List<SQLPrimaryKey> keys = sharedCache.listCachedPrimaryKeys(catName, dbName, tblName);
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getPrimaryKeys(catName, dbName, tblName);
-    }
-
-    return keys;
+    return sharedCache.listCachedPrimaryKeys(catName, dbName, tblName);
   }
 
   @Override
   public List<SQLForeignKey> getForeignKeys(String catName, String parentDbName, String parentTblName,
       String foreignDbName, String foreignTblName) throws MetaException {
     // Get correct ForeignDBName and TableName
-    if (StringUtils.isEmpty(foreignDbName)|| StringUtils.isEmpty(foreignTblName) || StringUtils.isEmpty(parentDbName) || StringUtils.isEmpty(parentTblName)) {
+    if (StringUtils.isEmpty(foreignDbName) || StringUtils.isEmpty(foreignTblName) || StringUtils.isEmpty(parentDbName)
+        || StringUtils.isEmpty(parentTblName)) {
       return rawStore.getForeignKeys(catName, parentDbName, parentTblName, foreignDbName, foreignTblName);
     }
 
@@ -2705,22 +2574,10 @@ public class CachedStore implements RawStore, Configurable {
     parentDbName = StringUtils.isEmpty(parentDbName) ? "" : normalizeIdentifier(parentDbName);
     parentTblName = StringUtils.isEmpty(parentTblName) ? "" : StringUtils.normalizeIdentifier(parentTblName);
 
-    if (!shouldCacheTable(catName, foreignDbName, foreignTblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, foreignDbName, foreignTblName)) {
       return rawStore.getForeignKeys(catName, parentDbName, parentTblName, foreignDbName, foreignTblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, foreignDbName, foreignTblName);
-    if (tbl == null) {
-      // The table containing the foreign keys is not yet loaded in cache
-      return rawStore.getForeignKeys(catName, parentDbName, parentTblName, foreignDbName, foreignTblName);
-    }
-    List<SQLForeignKey> keys =
-        sharedCache.listCachedForeignKeys(catName, foreignDbName, foreignTblName, parentDbName, parentTblName);
-
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getForeignKeys(catName, parentDbName, parentTblName, foreignDbName, foreignTblName);
-    }
-    return keys;
+    return sharedCache.listCachedForeignKeys(catName, foreignDbName, foreignTblName, parentDbName, parentTblName);
   }
 
   @Override
@@ -2729,21 +2586,10 @@ public class CachedStore implements RawStore, Configurable {
     catName = StringUtils.normalizeIdentifier(catName);
     dbName = StringUtils.normalizeIdentifier(dbName);
     tblName = StringUtils.normalizeIdentifier(tblName);
-    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
       return rawStore.getUniqueConstraints(catName, dbName, tblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, dbName, tblName);
-    if (tbl == null) {
-      // The table containing the unique constraints is not yet loaded in cache
-      return rawStore.getUniqueConstraints(catName, dbName, tblName);
-    }
-    List<SQLUniqueConstraint> keys = sharedCache.listCachedUniqueConstraint(catName, dbName, tblName);
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getUniqueConstraints(catName, dbName, tblName);
-    }
-
-    return keys;
+    return sharedCache.listCachedUniqueConstraint(catName, dbName, tblName);
   }
 
   @Override
@@ -2752,21 +2598,10 @@ public class CachedStore implements RawStore, Configurable {
     catName = normalizeIdentifier(catName);
     dbName = StringUtils.normalizeIdentifier(dbName);
     tblName = StringUtils.normalizeIdentifier(tblName);
-    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
       return rawStore.getNotNullConstraints(catName, dbName, tblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, dbName, tblName);
-    if (tbl == null) {
-      // The table containing the not null constraints is not yet loaded in cache
-      return rawStore.getNotNullConstraints(catName, dbName, tblName);
-    }
-    List<SQLNotNullConstraint> keys = sharedCache.listCachedNotNullConstraints(catName, dbName, tblName);
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getNotNullConstraints(catName, dbName, tblName);
-    }
-
-    return keys;
+    return sharedCache.listCachedNotNullConstraints(catName, dbName, tblName);
   }
 
   /**
@@ -2783,21 +2618,10 @@ public class CachedStore implements RawStore, Configurable {
     catName = StringUtils.normalizeIdentifier(catName);
     dbName = StringUtils.normalizeIdentifier(dbName);
     tblName = StringUtils.normalizeIdentifier(tblName);
-    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
       return rawStore.getDefaultConstraints(catName, dbName, tblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, dbName, tblName);
-    if (tbl == null) {
-      // The table containing the default constraints is not yet loaded in cache
-      return rawStore.getDefaultConstraints(catName, dbName, tblName);
-    }
-    List<SQLDefaultConstraint> keys = sharedCache.listCachedDefaultConstraint(catName, dbName, tblName);
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getDefaultConstraints(catName, dbName, tblName);
-    }
-
-    return keys;
+    return sharedCache.listCachedDefaultConstraint(catName, dbName, tblName);
   }
 
   /**
@@ -2814,21 +2638,10 @@ public class CachedStore implements RawStore, Configurable {
     catName = StringUtils.normalizeIdentifier(catName);
     dbName = StringUtils.normalizeIdentifier(dbName);
     tblName = StringUtils.normalizeIdentifier(tblName);
-    if (!shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())) {
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
       return rawStore.getCheckConstraints(catName, dbName, tblName);
     }
-
-    Table tbl = sharedCache.getTableFromCache(catName, dbName, tblName);
-    if (tbl == null) {
-      // The table containing the check constraints is not yet loaded in cache
-      return rawStore.getCheckConstraints(catName, dbName, tblName);
-    }
-    List<SQLCheckConstraint> keys = sharedCache.listCachedCheckConstraint(catName, dbName, tblName);
-    if (CollectionUtils.isEmpty(keys)) {
-      return rawStore.getCheckConstraints(catName, dbName, tblName);
-    }
-
-    return keys;
+    return sharedCache.listCachedCheckConstraint(catName, dbName, tblName);
   }
 
   /**
@@ -2842,14 +2655,13 @@ public class CachedStore implements RawStore, Configurable {
   @Override
   public SQLAllTableConstraints getAllTableConstraints(String catName, String dbName, String tblName)
       throws MetaException, NoSuchObjectException {
-    SQLAllTableConstraints sqlAllTableConstraints = new SQLAllTableConstraints();
-    sqlAllTableConstraints.setPrimaryKeys(getPrimaryKeys(catName, dbName, tblName));
-    sqlAllTableConstraints.setForeignKeys(getForeignKeys(catName, null, null, dbName, tblName));
-    sqlAllTableConstraints.setUniqueConstraints(getUniqueConstraints(catName, dbName, tblName));
-    sqlAllTableConstraints.setDefaultConstraints(getDefaultConstraints(catName, dbName, tblName));
-    sqlAllTableConstraints.setCheckConstraints(getCheckConstraints(catName, dbName, tblName));
-    sqlAllTableConstraints.setNotNullConstraints(getNotNullConstraints(catName, dbName, tblName));
-    return sqlAllTableConstraints;
+    catName = StringUtils.normalizeIdentifier(catName);
+    dbName = StringUtils.normalizeIdentifier(dbName);
+    tblName = StringUtils.normalizeIdentifier(tblName);
+    if (shouldGetConstraintFromRawStore(catName, dbName, tblName)) {
+      return rawStore.getAllTableConstraints(catName, dbName, tblName);
+    }
+    return sharedCache.listCachedAllTableConstraints(catName, dbName, tblName);
   }
 
   @Override
@@ -2866,14 +2678,8 @@ public class CachedStore implements RawStore, Configurable {
     if (!shouldCacheTable(catName, dbName, tblName)) {
       return constraints;
     }
-    sharedCache.addTableToCache(StringUtils.normalizeIdentifier(tbl.getCatName()),
-        StringUtils.normalizeIdentifier(tbl.getDbName()), StringUtils.normalizeIdentifier(tbl.getTableName()), tbl);
-    sharedCache.addForeignKeysToCache(catName, dbName, tblName, constraints.getForeignKeys());
-    sharedCache.addPrimaryKeysToCache(catName, dbName, tblName, constraints.getPrimaryKeys());
-    sharedCache.addNotNullConstraintsToCache(catName, dbName, tblName, constraints.getNotNullConstraints());
-    sharedCache.addUniqueConstraintsToCache(catName, dbName, tblName, constraints.getUniqueConstraints());
-    sharedCache.addCheckConstraintsToCache(catName, dbName, tblName, constraints.getCheckConstraints());
-    sharedCache.addDefaultConstraintsToCache(catName, dbName, tblName, constraints.getDefaultConstraints());
+    sharedCache.addTableToCache(catName, dbName, tblName, tbl);
+    sharedCache.addTableConstraintsToCache(catName, dbName, tblName, constraints);
     return constraints;
   }
 
@@ -3340,4 +3146,8 @@ public class CachedStore implements RawStore, Configurable {
     return rawStore.getAllStoredProcedures(request);
   }
 
+  private boolean shouldGetConstraintFromRawStore(String catName, String dbName, String tblName) {
+    return !shouldCacheTable(catName, dbName, tblName) || (canUseEvents && rawStore.isActiveTransaction())
+        || !sharedCache.isTableConstraintValid(catName, dbName, tblName);
+  }
 }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. Redundant check if table is present or not
2. Currently in order to get all constraint form the cachedstore. 6 different call is made with in the cached store. Which led to 6 different call to raw store

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
1. Check only once if table exit in cached store.
2. Instead of calling individual constraint in cached store. Add a method which return all constraint at once and if data is not consistent then fall back to rawstore.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
running all UTs