### PR TITLE
HIVE-24302: Cleaner shouldn't run if it can't remove obsolete files

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -97,7 +97,7 @@ public class Cleaner extends MetaStoreCompactorThread {
           long minOpenTxnId = txnHandler.findMinOpenTxnIdForCleaner();
           LOG.info("Cleaning based on min open txn id: " + minOpenTxnId);
           List<CompletableFuture> cleanerList = new ArrayList<>();
-          for (CompactionInfo compactionInfo : txnHandler.findReadyToClean()) {
+          for (CompactionInfo compactionInfo : txnHandler.findReadyToClean(minOpenTxnId)) {
             cleanerList.add(CompletableFuture.runAsync(CompactorUtil.ThrowingRunnable.unchecked(() ->
                   clean(compactionInfo, minOpenTxnId)), cleanerExecutor));
           }

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -63,6 +63,7 @@ import static junit.framework.Assert.fail;
  */
 public class TestCompactionTxnHandler {
 
+  public static final int A_LOT = 100000;
   private HiveConf conf = new HiveConf();
   private TxnStore txnHandler;
 
@@ -183,15 +184,15 @@ public class TestCompactionTxnHandler {
     CompactionRequest rqst = new CompactionRequest("foo", "bar", CompactionType.MINOR);
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
     assertNotNull(ci);
 
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     txnHandler.markCompacted(ci);
     assertNull(txnHandler.findNextToCompact("fred"));
 
-    List<CompactionInfo> toClean = txnHandler.findReadyToClean();
+    List<CompactionInfo> toClean = txnHandler.findReadyToClean(A_LOT);
     assertEquals(1, toClean.size());
     assertNull(txnHandler.findNextToCompact("fred"));
 
@@ -212,20 +213,20 @@ public class TestCompactionTxnHandler {
     CompactionRequest rqst = new CompactionRequest("foo", "bar", CompactionType.MINOR);
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
     assertNotNull(ci);
 
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     txnHandler.markCompacted(ci);
     assertNull(txnHandler.findNextToCompact("fred"));
 
-    List<CompactionInfo> toClean = txnHandler.findReadyToClean();
+    List<CompactionInfo> toClean = txnHandler.findReadyToClean(A_LOT);
     assertEquals(1, toClean.size());
     assertNull(txnHandler.findNextToCompact("fred"));
     txnHandler.markCleaned(ci);
     assertNull(txnHandler.findNextToCompact("fred"));
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
 
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     assertEquals(1, rsp.getCompactsSize());
@@ -262,11 +263,11 @@ public class TestCompactionTxnHandler {
     CompactionRequest rqst = new CompactionRequest(dbName, tableName, CompactionType.MINOR);
     rqst.setPartitionname(partitionName);
     txnHandler.compact(rqst);
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     CompactionInfo ci = txnHandler.findNextToCompact(workerId);
     assertNotNull(ci);
 
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     ci.errorMessage = errorMessage;
     txnHandler.markFailed(ci);
     assertNull(txnHandler.findNextToCompact(workerId));
@@ -501,12 +502,12 @@ public class TestCompactionTxnHandler {
     // Now clean them and check that they are removed from the count.
     CompactionRequest rqst = new CompactionRequest("mydb", "mytable", CompactionType.MAJOR);
     txnHandler.compact(rqst);
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     ci = txnHandler.findNextToCompact("fred");
     assertNotNull(ci);
     txnHandler.markCompacted(ci);
 
-    List<CompactionInfo> toClean = txnHandler.findReadyToClean();
+    List<CompactionInfo> toClean = txnHandler.findReadyToClean(A_LOT);
     assertEquals(1, toClean.size());
     txnHandler.markCleaned(ci);
 
@@ -525,12 +526,12 @@ public class TestCompactionTxnHandler {
     rqst = new CompactionRequest("mydb", "foo", CompactionType.MAJOR);
     rqst.setPartitionname("bar");
     txnHandler.compact(rqst);
-    assertEquals(0, txnHandler.findReadyToClean().size());
+    assertEquals(0, txnHandler.findReadyToClean(A_LOT).size());
     ci = txnHandler.findNextToCompact("fred");
     assertNotNull(ci);
     txnHandler.markCompacted(ci);
 
-    toClean = txnHandler.findReadyToClean();
+    toClean = txnHandler.findReadyToClean(A_LOT);
     assertEquals(1, toClean.size());
     txnHandler.markCleaned(ci);
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
@@ -19,11 +19,14 @@ package org.apache.hadoop.hive.ql.txn.compactor;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.AbortTxnRequest;
+import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionRequest;
 import org.apache.hadoop.hive.metastore.api.CompactionType;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.ShowCompactRequest;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
+import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.txn.CompactionInfo;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
@@ -61,9 +64,11 @@ public class TestCleaner extends CompactorTest {
     CompactionRequest rqst = new CompactionRequest("default", "camtc", CompactionType.MAJOR);
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     startCleaner();
 
@@ -94,9 +99,11 @@ public class TestCleaner extends CompactorTest {
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     startCleaner();
 
@@ -125,9 +132,11 @@ public class TestCleaner extends CompactorTest {
     CompactionRequest rqst = new CompactionRequest("default", "camitc", CompactionType.MINOR);
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     startCleaner();
 
@@ -165,16 +174,18 @@ public class TestCleaner extends CompactorTest {
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     startCleaner();
 
     // Check there are no compactions requests left.
     ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
     Assert.assertEquals(1, rsp.getCompactsSize());
-    Assert.assertTrue(TxnStore.SUCCEEDED_RESPONSE.equals(rsp.getCompacts().get(0).getState()));
+    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
 
     // Check that the files are removed
     List<Path> paths = getDirectories(conf, t, p);
@@ -204,9 +215,11 @@ public class TestCleaner extends CompactorTest {
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     txnHandler.markCompacted(ci);
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     startCleaner();
 
@@ -234,9 +247,11 @@ public class TestCleaner extends CompactorTest {
     CompactionRequest rqst = new CompactionRequest("default", "dt", CompactionType.MINOR);
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     // Drop table will clean the table entry from the compaction queue and hence cleaner have no effect
     ms.dropTable("default", "dt");
@@ -263,9 +278,11 @@ public class TestCleaner extends CompactorTest {
     rqst.setPartitionname("ds=today");
     txnHandler.compact(rqst);
     CompactionInfo ci = txnHandler.findNextToCompact("fred");
+    long compactionTxn = openTxn();
     ci.runAs = System.getProperty("user.name");
-    txnHandler.updateCompactorState(ci, openTxn());
+    txnHandler.updateCompactorState(ci, compactionTxn);
     txnHandler.markCompacted(ci);
+    txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
 
     // Drop partition will clean the partition entry from the compaction queue and hence cleaner have no effect
     ms.dropPartition("default", "dp", Collections.singletonList("today"), true);
@@ -298,9 +315,11 @@ public class TestCleaner extends CompactorTest {
       rqst.setPartitionname("ds=today"+i);
       txnHandler.compact(rqst);
       CompactionInfo ci = txnHandler.findNextToCompact("fred");
+      long compactionTxn = openTxn();
       ci.runAs = System.getProperty("user.name");
-      txnHandler.updateCompactorState(ci, openTxn());
+      txnHandler.updateCompactorState(ci, compactionTxn);
       txnHandler.markCompacted(ci);
+      txnHandler.commitTxn(new CommitTxnRequest(compactionTxn));
     }
 
     conf.setIntVar(HiveConf.ConfVars.HIVE_COMPACTOR_CLEANER_THREADS_NUM, 3);
@@ -328,6 +347,196 @@ public class TestCleaner extends CompactorTest {
       Assert.assertTrue(sawBase);
       Assert.assertTrue(sawDelta);
     }
+  }
+
+  /**
+   * If there's an open txn blocking the cleaner, the cleaner shouldn't run until all the files rendered obsolete by
+   * that compaction will be all cleaned up.
+   * Arbitrarily picked minor compaction to run here.
+   * @throws Exception
+   */
+  @Test public void testCleanerStaysInQueueUntilItCanRun() throws Exception {
+    Table t = newTable("default", "camtc", false);
+
+    // open a txn, leave it open
+    long openTxn = openTxn();
+
+    // write into table
+    addBaseFile(t, null, 20L, 20);
+    addDeltaFile(t, null, 21L, 22L, 2);
+    addDeltaFile(t, null, 23L, 24L, 2);
+    addDeltaFile(t, null, 24L, 25L, 2);
+    burnThroughTransactions("default", "camtc", 25);
+
+    // compact and clean
+    CompactionRequest rqst = new CompactionRequest("default", "camtc", CompactionType.MINOR);
+    txnHandler.compact(rqst);
+    startWorker();
+    startCleaner();
+
+    // Check that the files are NOT removed, and there are 2 new deltas from compaction (a delta and a delete_delta)
+    List<Path> paths = getDirectories(conf, t, null);
+    Assert.assertEquals(6, paths.size());
+
+    // Check that the compaction is still in the queue, with status "ready for cleaning" 
+    ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(1, rsp.getCompactsSize());
+    Assert.assertEquals(TxnStore.CLEANING_RESPONSE, rsp.getCompacts().get(0).getState());
+
+    // abort txn 1 (doesn't matter if aborted or committed, the point is it's no longer open).
+    // Then start Cleaner again
+    txnHandler.abortTxn(new AbortTxnRequest(openTxn));
+    startCleaner();
+
+    // Check there are no compactions requests left.
+    rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(1, rsp.getCompactsSize());
+    Assert.assertTrue(TxnStore.SUCCEEDED_RESPONSE.equals(rsp.getCompacts().get(0).getState()));
+
+    // Check that the obsolete files (3 deltas) are removed. What's left: base_20, delta_21_25, delete_delta_21_25
+    paths = getDirectories(conf, t, null);
+    Assert.assertEquals(3, paths.size());
+    Collections.sort(paths);
+    Assert.assertEquals("base_20", paths.get(0).getName());
+    Assert.assertEquals("delete_delta_0000021_0000025_v0000027", paths.get(1).getName());
+    Assert.assertEquals("delta_0000021_0000025_v0000027", paths.get(2).getName());
+  }
+
+  /**
+   * Same as testCleanerStaysInQueueUntilItCanRun, except open txn is opened after inserts and we open a txn after 
+   * compaction (which shouldn't impact cleaning).
+   */
+  @Test public void testCleanerStaysInQueueUntilItCanRun2() throws Exception {
+    Table t = newTable("default", "camtc", false);
+
+    // write into table
+    addBaseFile(t, null, 20L, 20);
+    addDeltaFile(t, null, 21L, 22L, 2);
+    addDeltaFile(t, null, 23L, 24L, 2);
+    addDeltaFile(t, null, 24L, 25L, 2);
+    burnThroughTransactions("default", "camtc", 25);
+
+    // open a txn, leave it open
+    long openTxn = openTxn();
+
+    // compact
+    CompactionRequest rqst = new CompactionRequest("default", "camtc", CompactionType.MAJOR);
+    txnHandler.compact(rqst);
+    startWorker();
+
+    // open another txn, leave it open. shouldn't affect anything – cleaner should run.
+    long openTxn2 = openTxn();
+
+    // Clean. Check that the files are NOT removed
+    startCleaner();
+    List<Path> paths = getDirectories(conf, t, null);
+    Assert.assertEquals(5, paths.size());
+
+    // Check that the compaction is still in the queue, with status "ready for cleaning" 
+    ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(1, rsp.getCompactsSize());
+    Assert.assertEquals(TxnStore.CLEANING_RESPONSE, rsp.getCompacts().get(0).getState());
+
+    // abort open txn 1 (doesn't matter if aborted or committed, the point is it's no longer open)
+    txnHandler.abortTxn(new AbortTxnRequest(openTxn));
+
+    // Clean again
+    startCleaner();
+
+    // Check there are no compactions requests left and that the files are removed, leaving only the base dir
+    rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(1, rsp.getCompactsSize());
+    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
+    paths = getDirectories(conf, t, null);
+    Assert.assertEquals(1, paths.size());
+    Assert.assertEquals("base_0000025_v0000027", paths.get(0).getName());
+
+    //cleanup
+    txnHandler.abortTxn(new AbortTxnRequest(openTxn2));
+  }
+
+  /**
+   * Same as previous, except we run 2 compactions, then start the cleaning process. Test that the first CQ entry gets 
+   * cleaned up to its base dir, then the second gets cleaned up to its base dir.
+   * @throws Exception
+   */
+  @Test public void testCleanerStaysInQueueUntilItCanRunMultipleCompactions() throws Exception {
+    Table t = newTable("default", "camtc", false);
+
+    // write into table
+    addBaseFile(t, null, 20L, 20);
+    addDeltaFile(t, null, 21L, 22L, 2);
+    addDeltaFile(t, null, 23L, 24L, 2);
+    addDeltaFile(t, null, 24L, 25L, 2);
+    burnThroughTransactions("default", "camtc", 25);
+
+    // compact, don't clean
+    CompactionRequest rqst = new CompactionRequest("default", "camtc", CompactionType.MAJOR);
+    txnHandler.compact(rqst);
+    startWorker();
+
+    // open a txn, leave it open
+    long openTxn = openTxn();
+
+    // write another couple deltas
+    addDeltaFile(t, null, 26L, 27L, 2);
+    addDeltaFile(t, null, 28L, 29L, 2);
+    burnThroughTransactions("default", "camtc", 4);
+
+    // compact
+    txnHandler.compact(rqst);
+    startWorker();
+
+    // check directories before cleaning
+    List<Path> paths = getDirectories(conf, t, null);
+    Assert.assertEquals(8, paths.size());
+    Collections.sort(paths);
+    Assert.assertEquals("base_0000025_v0000026", paths.get(0).getName());
+    Assert.assertEquals("base_0000029_v0000032", paths.get(1).getName());
+    Assert.assertEquals("base_20", paths.get(2).getName());
+    Assert.assertEquals("delta_0000021_0000022", paths.get(3).getName());
+    Assert.assertEquals("delta_0000023_0000024", paths.get(4).getName());
+    Assert.assertEquals("delta_0000024_0000025", paths.get(5).getName());
+    Assert.assertEquals("delta_0000026_0000027", paths.get(6).getName());
+    Assert.assertEquals("delta_0000028_0000029", paths.get(7).getName());
+
+    // clean
+    startCleaner();
+
+    // Check that the new files are NOT removed, but the old ones (writeId<=25) are removed
+    paths = getDirectories(conf, t, null);
+    Assert.assertEquals(4, paths.size());
+    Collections.sort(paths);
+    Assert.assertEquals("base_0000025_v0000026", paths.get(0).getName());
+    Assert.assertEquals("base_0000029_v0000032", paths.get(1).getName());
+    Assert.assertEquals("delta_0000026_0000027", paths.get(2).getName());
+    Assert.assertEquals("delta_0000028_0000029", paths.get(3).getName());
+    
+
+    // Check that the second compaction is still in the queue, with status "ready for cleaning" 
+    ShowCompactResponse rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(2, rsp.getCompactsSize());
+    List<ShowCompactResponseElement> showCompactResponseElements = rsp.getCompacts();
+    Collections.sort(showCompactResponseElements);
+    Assert.assertEquals(TxnStore.CLEANING_RESPONSE, showCompactResponseElements.get(0).getState());
+    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, showCompactResponseElements.get(1).getState());
+
+    // abort the open txn (doesn't matter if aborted or committed, the point is it's no longer open)
+    txnHandler.abortTxn(new AbortTxnRequest(openTxn));
+
+    // clean again
+    startCleaner();
+
+    // Check there are no compactions requests left.
+    rsp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals(2, rsp.getCompactsSize());
+    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
+    Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(1).getState());
+
+    // Check that all files are removed except the last base
+    paths = getDirectories(conf, t, null);
+    Assert.assertEquals(1, paths.size());
+    Assert.assertEquals("base_0000029_v0000032", paths.get(0).getName());
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
@@ -388,7 +388,7 @@ public interface TxnStore extends Configurable {
    * @return information on the entry in the queue.
    */
   @RetrySemantics.ReadOnly
-  List<CompactionInfo> findReadyToClean() throws MetaException;
+  List<CompactionInfo> findReadyToClean(long minOpenTxnId) throws MetaException;
 
   /**
    * This will remove an entry from the queue after


### PR DESCRIPTION
# What changes were proposed in this pull request?
If the global min open txnid blocks cleaner for a certain table, then cleaner will skip that compaction queue entry and leave it in the queue for later.

### Why are the changes needed?
If the global min open txnid blocks cleaner for a certain table, then cleaner "runs", doesn't delete any files, and marks compaction as succeeded as if everything were fine.

### Does this PR introduce _any_ user-facing change?
Yes, if the global min open txnid blocks cleaner for a certain table, then cleaner will skip that compaction queue entry and leave it in the queue for later.

### How was this patch tested?
Unit tests