### PR TITLE
HIVE-24297

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cache/LowLevelCacheImpl.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cache/LowLevelCacheImpl.java
@@ -338,6 +338,10 @@ public class LowLevelCacheImpl implements LowLevelCache, BufferUsageManager, Lla
                   buffer, oldVal);
             }
 
+            // This is always set to ranges[i].getLength() prior inserting into the map to avoid inconsistency with the
+            // check above. However once we decided that this new buffer will not be cached, we should unset
+            // declaredCachedLength, so that it can be instantly deallocated at unlockBuffer()'s else branch.
+            buffer.declaredCachedLength = LlapDataBuffer.UNKNOWN_CACHED_LENGTH;
             unlockBuffer(buffer, false);
             buffers[i] = oldVal;
             if (result == null) {


### PR DESCRIPTION
HIVE-23741 introduced an optimization so that CacheTags are not stored on buffer level, but rather on file level, as one cache tag can only relate to one file. With this change a buffer->filecache reference was introduced so that the buffer's tag can be calculated with an extra indirection i.e. buffer.filecache.tag.

However during buffer collision in putFileData method, we don't set the filecache reference of the collided (new) buffer: https://github.com/apache/hive/commit/2e18a7408a8dd49beecad8d66bfe054b7dc474da#diff-d2ccd7cf3042845a0812a5e118f82db49253d82fc86449ffa408903bf434fb6dR309-R311

Later this cases NPE when the new (instantly decRef'ed) buffer is evicted.