### PR TITLE
HIVE-24222: Upgrade ORC to 1.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
     <libthrift.version>0.9.3</libthrift.version>
     <log4j2.version>2.10.0</log4j2.version>
     <opencsv.version>2.3</opencsv.version>
-    <orc.version>1.5.6</orc.version>
+    <orc.version>1.5.12</orc.version>
     <mockito-all.version>1.10.19</mockito-all.version>
     <mina.version>2.0.0-M5</mina.version>
     <netty.version>4.1.17.Final</netty.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This is a backport of HIVE-24222 and this PR aims to upgrade Apache ORC from 1.5.6 to 1.5.12.

### Why are the changes needed?

This will bring the latest bug fixes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI with the existing test cases.