### PR TITLE
HIVE-24333 Cut long methods in Driver to smaller, more manageable pieces (Miklos Gergely)

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql;
 
+import java.io.DataInput;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -149,47 +150,7 @@ public class Driver implements IDriver {
       runInternal(command, alreadyCompiled);
       return new CommandProcessorResponse(getSchema(), null);
     } catch (CommandProcessorException cpe) {
-      SessionState ss = SessionState.get();
-      if (ss == null) {
-        throw cpe;
-      }
-      MetaDataFormatter mdf = MetaDataFormatUtils.getFormatter(ss.getConf());
-      if (!(mdf instanceof JsonMetaDataFormatter)) {
-        throw cpe;
-      }
-      /*Here we want to encode the error in machine readable way (e.g. JSON)
-       * Ideally, errorCode would always be set to a canonical error defined in ErrorMsg.
-       * In practice that is rarely the case, so the messy logic below tries to tease
-       * out canonical error code if it can.  Exclude stack trace from output when
-       * the error is a specific/expected one.
-       * It's written to stdout for backward compatibility (WebHCat consumes it).*/
-      try {
-        if (cpe.getCause() == null) {
-          mdf.error(ss.out, cpe.getMessage(), cpe.getResponseCode(), cpe.getSqlState());
-          throw cpe;
-        }
-        ErrorMsg canonicalErr = ErrorMsg.getErrorMsg(cpe.getResponseCode());
-        if (canonicalErr != null && canonicalErr != ErrorMsg.GENERIC_ERROR) {
-          /*Some HiveExceptions (e.g. SemanticException) don't set
-            canonical ErrorMsg explicitly, but there is logic
-            (e.g. #compile()) to find an appropriate canonical error and
-            return its code as error code. In this case we want to
-            preserve it for downstream code to interpret*/
-          mdf.error(ss.out, cpe.getMessage(), cpe.getResponseCode(), cpe.getSqlState(), null);
-          throw cpe;
-        }
-        if (cpe.getCause() instanceof HiveException) {
-          HiveException rc = (HiveException)cpe.getCause();
-          mdf.error(ss.out, cpe.getMessage(), rc.getCanonicalErrorMsg().getErrorCode(), cpe.getSqlState(),
-              rc.getCanonicalErrorMsg() == ErrorMsg.GENERIC_ERROR ? StringUtils.stringifyException(rc) : null);
-        } else {
-          ErrorMsg canonicalMsg = ErrorMsg.getErrorMsg(cpe.getCause().getMessage());
-          mdf.error(ss.out, cpe.getMessage(), canonicalMsg.getErrorCode(), cpe.getSqlState(),
-              StringUtils.stringifyException(cpe.getCause()));
-        }
-      } catch (HiveException ex) {
-        CONSOLE.printError("Unable to JSON-encode the error", StringUtils.stringifyException(ex));
-      }
+      processRunException(cpe);
       throw cpe;
     }
   }
@@ -197,14 +158,139 @@ public class Driver implements IDriver {
   private void runInternal(String command, boolean alreadyCompiled) throws CommandProcessorException {
     DriverState.setDriverState(driverState);
 
+    QueryPlan plan = driverContext.getPlan();
+    if (plan != null && plan.isPrepareQuery() && !plan.isExplain()) {
+      LOG.info("Skip running tasks for prepare plan");
+      return;
+    }
+
+    setInitialStateForRun(alreadyCompiled);
+
+    // a flag that helps to set the correct driver state in finally block by tracking if
+    // the method has been returned by an error or not.
+    boolean isFinishedWithError = true;
+    try {
+      HiveDriverRunHookContext hookContext = new HiveDriverRunHookContextImpl(driverContext.getConf(),
+          alreadyCompiled ? context.getCmd() : command);
+      runPreDriverHooks(hookContext);
+
+      if (!alreadyCompiled) {
+        compileInternal(command, true);
+      } else {
+        driverContext.getPlan().setQueryStartTime(driverContext.getQueryDisplay().getQueryStartTime());
+      }
+
+      // Reset the PerfLogger so that it doesn't retain any previous values.
+      // Any value from compilation phase can be obtained through the map set in queryDisplay during compilation.
+      PerfLogger perfLogger = SessionState.getPerfLogger(true);
+
+      // the reason that we set the txn manager for the cxt here is because each query has its own ctx object.
+      // The txn mgr is shared across the same instance of Driver, which can run multiple queries.
+      context.setHiveTxnManager(driverContext.getTxnManager());
+
+      DriverUtils.checkInterrupted(driverState, driverContext, "at acquiring the lock.", null, null);
+
+      lockAndRespond();
+
+      if (validateTxnList()) {
+        // the reason that we set the txn manager for the cxt here is because each query has its own ctx object.
+        // The txn mgr is shared across the same instance of Driver, which can run multiple queries.
+        context.setHiveTxnManager(driverContext.getTxnManager());
+        perfLogger = SessionState.getPerfLogger(true);
+      }
+      execute();
+      driverTxnHandler.handleTransactionAfterExecution();
+
+      driverContext.getQueryDisplay().setPerfLogStarts(QueryDisplay.Phase.EXECUTION, perfLogger.getStartTimes());
+      driverContext.getQueryDisplay().setPerfLogEnds(QueryDisplay.Phase.EXECUTION, perfLogger.getEndTimes());
+
+      runPostDriverHooks(hookContext);
+      isFinishedWithError = false;
+    } finally {
+      if (driverState.isAborted()) {
+        closeInProcess(true);
+      } else {
+        releaseResources();
+      }
+
+      driverState.executionFinishedWithLocking(isFinishedWithError);
+    }
+
+    SessionState.getPerfLogger().cleanupPerfLogMetrics();
+  }
+
+  /**
+   * @return If the txn manager should be set.
+   */
+  private boolean validateTxnList() throws CommandProcessorException {
+    int retryShapshotCount = 0;
+    int maxRetrySnapshotCount = HiveConf.getIntVar(driverContext.getConf(),
+        HiveConf.ConfVars.HIVE_TXN_MAX_RETRYSNAPSHOT_COUNT);
+    boolean shouldSet = false;
+
+    try {
+      do {
+        driverContext.setOutdatedTxn(false);
+        // Inserts will not invalidate the snapshot, that could cause duplicates.
+        if (!driverTxnHandler.isValidTxnListState()) {
+          LOG.info("Re-compiling after acquiring locks, attempt #" + retryShapshotCount);
+          // Snapshot was outdated when locks were acquired, hence regenerate context, txn list and retry.
+          // TODO: Lock acquisition should be moved before analyze, this is a bit hackish.
+          // Currently, we acquire a snapshot, compile the query with that snapshot, and then - acquire locks.
+          // If snapshot is still valid, we continue as usual.
+          // But if snapshot is not valid, we recompile the query.
+          if (driverContext.isOutdatedTxn()) {
+            // Later transaction invalidated the snapshot, a new transaction is required
+            LOG.info("Snapshot is outdated, re-initiating transaction ...");
+            driverContext.getTxnManager().rollbackTxn();
+
+            String userFromUGI = DriverUtils.getUserFromUGI(driverContext);
+            driverContext.getTxnManager().openTxn(context, userFromUGI, driverContext.getTxnType());
+            lockAndRespond();
+          }
+          driverContext.setRetrial(true);
+          driverContext.getBackupContext().addSubContext(context);
+          driverContext.getBackupContext().setHiveLocks(context.getHiveLocks());
+          context = driverContext.getBackupContext();
+
+          driverContext.getConf().set(ValidTxnList.VALID_TXNS_KEY,
+              driverContext.getTxnManager().getValidTxns().toString());
+
+          if (driverContext.getPlan().hasAcidResourcesInQuery()) {
+            compileInternal(context.getCmd(), true);
+            driverTxnHandler.recordValidWriteIds();
+            driverTxnHandler.setWriteIdForAcidFileSinks();
+          }
+          // Since we're reusing the compiled plan, we need to update its start time for current run
+          driverContext.getPlan().setQueryStartTime(driverContext.getQueryDisplay().getQueryStartTime());
+        }
+        // Re-check snapshot only in case we had to release locks and open a new transaction,
+        // otherwise exclusive locks should protect output tables/partitions in snapshot from concurrent writes.
+      } while (driverContext.isOutdatedTxn() && ++retryShapshotCount <= maxRetrySnapshotCount);
+
+      shouldSet = shouldSetTxnManager(retryShapshotCount, maxRetrySnapshotCount);
+    } catch (LockException | SemanticException e) {
+      DriverUtils.handleHiveException(driverContext, e, 13, null);
+    }
+
+    return shouldSet;
+  }
+
+  private boolean shouldSetTxnManager(int retryShapshotCount, int maxRetrySnapshotCount)
+      throws CommandProcessorException {
+    if (retryShapshotCount > maxRetrySnapshotCount) {
+      // Throw exception
+      HiveException e = new HiveException(
+          "Operation could not be executed, " + SNAPSHOT_WAS_OUTDATED_WHEN_LOCKS_WERE_ACQUIRED + ".");
+      DriverUtils.handleHiveException(driverContext, e, 14, null);
+    }
+
+    return retryShapshotCount != 0;
+  }
+
+  private void setInitialStateForRun(boolean alreadyCompiled) throws CommandProcessorException {
     driverState.lock();
     try {
-      if (driverContext != null && driverContext.getPlan() != null
-          && driverContext.getPlan().isPrepareQuery()
-          && !driverContext.getPlan().isExplain()) {
-        LOG.info("Skip running tasks for prepare plan");
-        return;
-      }
       if (alreadyCompiled) {
         if (driverState.isCompiled()) {
           driverState.executing();
@@ -219,144 +305,17 @@ public class Driver implements IDriver {
     } finally {
       driverState.unlock();
     }
+  }
 
-    // a flag that helps to set the correct driver state in finally block by tracking if
-    // the method has been returned by an error or not.
-    boolean isFinishedWithError = true;
+  private void runPreDriverHooks(HiveDriverRunHookContext hookContext) throws CommandProcessorException {
     try {
-      HiveDriverRunHookContext hookContext = new HiveDriverRunHookContextImpl(driverContext.getConf(),
-          alreadyCompiled ? context.getCmd() : command);
-      // Get all the driver run hooks and pre-execute them.
-      try {
-        driverContext.getHookRunner().runPreDriverHooks(hookContext);
-      } catch (Exception e) {
-        String errorMessage = "FAILED: Hive Internal Error: " + Utilities.getNameMessage(e);
-        CONSOLE.printError(errorMessage + "\n" + StringUtils.stringifyException(e));
-        throw DriverUtils.createProcessorException(driverContext, 12, errorMessage,
-            ErrorMsg.findSQLState(e.getMessage()), e);
-      }
-
-      if (!alreadyCompiled) {
-        // compile internal will automatically reset the perf logger
-        compileInternal(command, true);
-      } else {
-        // Since we're reusing the compiled plan, we need to update its start time for current run
-        driverContext.getPlan().setQueryStartTime(driverContext.getQueryDisplay().getQueryStartTime());
-      }
-
-      //Reset the PerfLogger so that it doesn't retain any previous values.
-      // Any value from compilation phase can be obtained through the map set in queryDisplay during compilation.
-      PerfLogger perfLogger = SessionState.getPerfLogger(true);
-
-      // the reason that we set the txn manager for the cxt here is because each
-      // query has its own ctx object. The txn mgr is shared across the
-      // same instance of Driver, which can run multiple queries.
-      context.setHiveTxnManager(driverContext.getTxnManager());
-
-      DriverUtils.checkInterrupted(driverState, driverContext, "at acquiring the lock.", null, null);
-
-      lockAndRespond();
-
-      int retryShapshotCnt = 0;
-      int maxRetrySnapshotCnt = HiveConf.getIntVar(driverContext.getConf(),
-        HiveConf.ConfVars.HIVE_TXN_MAX_RETRYSNAPSHOT_COUNT);
-
-      try {
-        do {
-          driverContext.setOutdatedTxn(false);
-          // Inserts will not invalidate the snapshot, that could cause duplicates.
-          if (!driverTxnHandler.isValidTxnListState()) {
-            LOG.info("Re-compiling after acquiring locks, attempt #" + retryShapshotCnt);
-            // Snapshot was outdated when locks were acquired, hence regenerate context, txn list and retry.
-            // TODO: Lock acquisition should be moved before analyze, this is a bit hackish.
-            // Currently, we acquire a snapshot, compile the query with that snapshot, and then - acquire locks.
-            // If snapshot is still valid, we continue as usual.
-            // But if snapshot is not valid, we recompile the query.
-            if (driverContext.isOutdatedTxn()) {
-              // Later transaction invalidated the snapshot, a new transaction is required
-              LOG.info("Snapshot is outdated, re-initiating transaction ...");
-              driverContext.getTxnManager().rollbackTxn();
-
-              String userFromUGI = DriverUtils.getUserFromUGI(driverContext);
-              driverContext.getTxnManager().openTxn(context, userFromUGI, driverContext.getTxnType());
-              lockAndRespond();
-            }
-            driverContext.setRetrial(true);
-            driverContext.getBackupContext().addSubContext(context);
-            driverContext.getBackupContext().setHiveLocks(context.getHiveLocks());
-            context = driverContext.getBackupContext();
-
-            driverContext.getConf().set(ValidTxnList.VALID_TXNS_KEY,
-              driverContext.getTxnManager().getValidTxns().toString());
-
-            if (driverContext.getPlan().hasAcidResourcesInQuery()) {
-              compileInternal(context.getCmd(), true);
-              driverTxnHandler.recordValidWriteIds();
-              driverTxnHandler.setWriteIdForAcidFileSinks();
-            }
-            // Since we're reusing the compiled plan, we need to update its start time for current run
-            driverContext.getPlan().setQueryStartTime(driverContext.getQueryDisplay().getQueryStartTime());
-          }
-          // Re-check snapshot only in case we had to release locks and open a new transaction,
-          // otherwise exclusive locks should protect output tables/partitions in snapshot from concurrent writes.
-        } while (driverContext.isOutdatedTxn() && ++retryShapshotCnt <= maxRetrySnapshotCnt);
-
-        if (retryShapshotCnt > maxRetrySnapshotCnt) {
-          // Throw exception
-          HiveException e = new HiveException(
-              "Operation could not be executed, " + SNAPSHOT_WAS_OUTDATED_WHEN_LOCKS_WERE_ACQUIRED + ".");
-          DriverUtils.handleHiveException(driverContext, e, 14, null);
-
-        } else if (retryShapshotCnt != 0) {
-          //Reset the PerfLogger
-          perfLogger = SessionState.getPerfLogger(true);
-
-          // the reason that we set the txn manager for the cxt here is because each
-          // query has its own ctx object. The txn mgr is shared across the
-          // same instance of Driver, which can run multiple queries.
-          context.setHiveTxnManager(driverContext.getTxnManager());
-        }
-      } catch (LockException | SemanticException e) {
-        DriverUtils.handleHiveException(driverContext, e, 13, null);
-      }
-
-      try {
-        taskQueue = new TaskQueue(context); // for canceling the query (should be bound to session?)
-        Executor executor = new Executor(context, driverContext, driverState, taskQueue);
-        executor.execute();
-      } catch (CommandProcessorException cpe) {
-        driverTxnHandler.rollback(cpe);
-        throw cpe;
-      }
-
-      //if needRequireLock is false, the release here will do nothing because there is no lock
-      driverTxnHandler.handleTransactionAfterExecution();
-
-      driverContext.getQueryDisplay().setPerfLogStarts(QueryDisplay.Phase.EXECUTION, perfLogger.getStartTimes());
-      driverContext.getQueryDisplay().setPerfLogEnds(QueryDisplay.Phase.EXECUTION, perfLogger.getEndTimes());
-
-      // Take all the driver run hooks and post-execute them.
-      try {
-        driverContext.getHookRunner().runPostDriverHooks(hookContext);
-      } catch (Exception e) {
-        String errorMessage = "FAILED: Hive Internal Error: " + Utilities.getNameMessage(e);
-        CONSOLE.printError(errorMessage + "\n" + StringUtils.stringifyException(e));
-        throw DriverUtils.createProcessorException(driverContext, 12, errorMessage,
-            ErrorMsg.findSQLState(e.getMessage()), e);
-      }
-      isFinishedWithError = false;
-    } finally {
-      if (driverState.isAborted()) {
-        closeInProcess(true);
-      } else {
-        // only release the related resources ctx, taskQueue as normal
-        releaseResources();
-      }
-
-      driverState.executionFinishedWithLocking(isFinishedWithError);
+      driverContext.getHookRunner().runPreDriverHooks(hookContext);
+    } catch (Exception e) {
+      String errorMessage = "FAILED: Hive Internal Error: " + Utilities.getNameMessage(e);
+      CONSOLE.printError(errorMessage + "\n" + StringUtils.stringifyException(e));
+      throw DriverUtils.createProcessorException(driverContext, 12, errorMessage,
+          ErrorMsg.findSQLState(e.getMessage()), e);
     }
-
-    SessionState.getPerfLogger().cleanupPerfLogMetrics();
   }
 
   public void lockAndRespond() throws CommandProcessorException {
@@ -372,6 +331,71 @@ public class Driver implements IDriver {
       driverTxnHandler.rollback(cpe);
       throw cpe;
     }
+  }
+
+  private void execute() throws CommandProcessorException {
+    try {
+      taskQueue = new TaskQueue(context); // for canceling the query (should be bound to session?)
+      Executor executor = new Executor(context, driverContext, driverState, taskQueue);
+      executor.execute();
+    } catch (CommandProcessorException cpe) {
+      driverTxnHandler.rollback(cpe);
+      throw cpe;
+    }
+  }
+
+  private void runPostDriverHooks(HiveDriverRunHookContext hookContext) throws CommandProcessorException {
+    try {
+      driverContext.getHookRunner().runPostDriverHooks(hookContext);
+    } catch (Exception e) {
+      String errorMessage = "FAILED: Hive Internal Error: " + Utilities.getNameMessage(e);
+      CONSOLE.printError(errorMessage + "\n" + StringUtils.stringifyException(e));
+      throw DriverUtils.createProcessorException(driverContext, 12, errorMessage,
+          ErrorMsg.findSQLState(e.getMessage()), e);
+    }
+  }
+
+  private void processRunException(CommandProcessorException cpe) {
+    SessionState ss = SessionState.get();
+    if (ss == null) {
+      return;
+    }
+
+    MetaDataFormatter mdf = MetaDataFormatUtils.getFormatter(ss.getConf());
+    if (!(mdf instanceof JsonMetaDataFormatter)) {
+      return;
+    }
+
+    /* Here we want to encode the error in machine readable way (e.g. JSON). Ideally, errorCode would always be set
+     * to a canonical error defined in ErrorMsg. In practice that is rarely the case, so the messy logic below tries
+     * to tease out canonical error code if it can.  Exclude stack trace from output when the error is a
+     * specific/expected one. It's written to stdout for backward compatibility (WebHCat consumes it).*/
+    try {
+      if (cpe.getCause() == null) {
+        mdf.error(ss.out, cpe.getMessage(), cpe.getResponseCode(), cpe.getSqlState());
+        return;
+      }
+      ErrorMsg canonicalErr = ErrorMsg.getErrorMsg(cpe.getResponseCode());
+      if (canonicalErr != null && canonicalErr != ErrorMsg.GENERIC_ERROR) {
+        /* Some HiveExceptions (e.g. SemanticException) don't set canonical ErrorMsg explicitly, but there is logic
+         * (e.g. #compile()) to find an appropriate canonical error and return its code as error code. In this case
+         * we want to preserve it for downstream code to interpret */
+        mdf.error(ss.out, cpe.getMessage(), cpe.getResponseCode(), cpe.getSqlState(), null);
+        return;
+      }
+      if (cpe.getCause() instanceof HiveException) {
+        HiveException rc = (HiveException)cpe.getCause();
+        mdf.error(ss.out, cpe.getMessage(), rc.getCanonicalErrorMsg().getErrorCode(), cpe.getSqlState(),
+            rc.getCanonicalErrorMsg() == ErrorMsg.GENERIC_ERROR ? StringUtils.stringifyException(rc) : null);
+      } else {
+        ErrorMsg canonicalMsg = ErrorMsg.getErrorMsg(cpe.getCause().getMessage());
+        mdf.error(ss.out, cpe.getMessage(), canonicalMsg.getErrorCode(), cpe.getSqlState(),
+            StringUtils.stringifyException(cpe.getCause()));
+      }
+    } catch (HiveException ex) {
+      CONSOLE.printError("Unable to JSON-encode the error", StringUtils.stringifyException(ex));
+    }
+    return;
   }
 
   @Override
@@ -429,8 +453,7 @@ public class Driver implements IDriver {
       }
     }
     //Save compile-time PerfLogging for WebUI.
-    //Execution-time Perf logs are done by either another thread's PerfLogger
-    //or a reset PerfLogger.
+    //Execution-time Perf logs are done by either another thread's PerfLogger or a reset PerfLogger.
     driverContext.getQueryDisplay().setPerfLogStarts(QueryDisplay.Phase.COMPILATION, perfLogger.getStartTimes());
     driverContext.getQueryDisplay().setPerfLogEnds(QueryDisplay.Phase.COMPILATION, perfLogger.getEndTimes());
   }
@@ -638,46 +661,30 @@ public class Driver implements IDriver {
     }
 
     if (isFetchingTable()) {
-      /**
-       * If resultset serialization to thrift object is enabled, and if the destination table is
-       * indeed written using ThriftJDBCBinarySerDe, read one row from the output sequence file,
-       * since it is a blob of row batches.
-       */
-      if (driverContext.getFetchTask().getWork().isUsingThriftJDBCBinarySerDe()) {
-        maxRows = 1;
-      }
-      driverContext.getFetchTask().setMaxRows(maxRows);
-      return driverContext.getFetchTask().fetch(results);
+      return getFetchingTableResults(results);
     }
 
     if (driverContext.getResStream() == null) {
-      driverContext.setResStream(context.getStream());
-    }
-    if (driverContext.getResStream() == null) {
-      return false;
+      // If the driver does not have a stream and neither does the context, return
+      DataInput contextStream = context.getStream();
+      if (contextStream == null) {
+        return false;
+      }
+      driverContext.setResStream(contextStream);
     }
 
     int numRows = 0;
     ByteStream.Output bos = new ByteStream.Output();
     while (numRows < maxRows) {
-      final String row;
-
       if (driverContext.getResStream() == null) {
         return (numRows > 0);
       }
 
       bos.reset();
-      Utilities.StreamStatus ss;
+      Utilities.StreamStatus streamStatus;
       try {
-        ss = Utilities.readColumn(driverContext.getResStream(), bos);
-        if (bos.getLength() > 0) {
-          row = new String(bos.getData(), 0, bos.getLength(), StandardCharsets.UTF_8);
-        } else if (ss == Utilities.StreamStatus.TERMINATED) {
-          row = "";
-        } else {
-          row = null;
-        }
-
+        streamStatus = Utilities.readColumn(driverContext.getResStream(), bos);
+        String row = getRow(bos, streamStatus);
         if (row != null) {
           numRows++;
           results.add(row);
@@ -687,11 +694,34 @@ public class Driver implements IDriver {
         return false;
       }
 
-      if (ss == Utilities.StreamStatus.EOF) {
+      if (streamStatus == Utilities.StreamStatus.EOF) {
         driverContext.setResStream(context.getStream());
       }
     }
     return true;
+  }
+
+  @SuppressWarnings("rawtypes")
+  private boolean getFetchingTableResults(List results) throws IOException {
+    // If result set serialization to thrift object is enabled, and if the destination table is indeed written using
+    // ThriftJDBCBinarySerDe, read one row from the output sequence file, since it is a blob of row batches.
+    if (driverContext.getFetchTask().getWork().isUsingThriftJDBCBinarySerDe()) {
+      maxRows = 1;
+    }
+    driverContext.getFetchTask().setMaxRows(maxRows);
+    return driverContext.getFetchTask().fetch(results);
+  }
+
+  private String getRow(ByteStream.Output bos, Utilities.StreamStatus streamStatus) {
+    final String row;
+    if (bos.getLength() > 0) {
+      row = new String(bos.getData(), 0, bos.getLength(), StandardCharsets.UTF_8);
+    } else if (streamStatus == Utilities.StreamStatus.TERMINATED) {
+      row = "";
+    } else {
+      row = null;
+    }
+    return row;
   }
 
   // Close and release resources within a running query process. Since it runs under

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverContext.java
@@ -156,16 +156,16 @@ public class DriverContext {
     return txnType;
   }
 
-  public void setOutdatedTxn(boolean outdated) {
-    this.outdatedTxn = outdated;
+  public void setTxnType(TxnType txnType) {
+    this.txnType = txnType;
   }
 
   public boolean isOutdatedTxn() {
     return outdatedTxn;
   }
 
-  public void setTxnType(TxnType txnType) {
-    this.txnType = txnType;
+  public void setOutdatedTxn(boolean outdated) {
+    this.outdatedTxn = outdated;
   }
 
   public StatsSource getStatsSource() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
The Driver class has some very long methods, they are now having a more manageable size. Also some minor checkstyle errors were fixed in some Driver associated classes

### Why are the changes needed?
To make the Driver class more understandable.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
All the tests are still running.