### PR TITLE
HIVE-24342: isPathEncrypted should make sure resolved path also from HDFS.

### DIFF
--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1256,9 +1256,14 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     private boolean isFileInHdfs(FileSystem fs, Path path) throws IOException {
       String hdfsScheme = "hdfs";
       boolean isHdfs = hdfsScheme.equalsIgnoreCase(path.toUri().getScheme());
-      // In case of viewhdfs we need to lookup where the actual file is to know
-      // the filesystem in use. The resolvePath is a sure shot way of knowing
-      // which file system the file is.
+      // The ViewHDFS supports that, any non-hdfs paths can be mounted as hdfs
+      // paths. Here HDFSEncryptionShim actually works only for hdfs paths. But
+      // in the case of ViewHDFS, paths can be with hdfs scheme, but they might
+      // actually resolve to other fs.
+      // ex: hdfs://ns1/test ---> o3fs://b.v.ozone1/test
+      // So, we need to lookup where the actual file is to know the filesystem
+      // in use. The resolvePath is a sure shot way of knowing which file system
+      // the file is.
       if (isHdfs && isMountedFs(fs)) {
         isHdfs = hdfsScheme.equals(fs.resolvePath(path).toUri().getScheme());
       }

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1246,8 +1246,8 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     /**
      * Returns true if the given fs supports mount functionality. In general we
      * can have child file systems only in the case of mount fs like
-     * ViewFileSystem, ViewFsOverloadScheme or ViewDistributedFileSystem.
-     * Returns false if the getChildFileSystems API returns null.
+     * ViewFsOverloadScheme or ViewDistributedFileSystem. Returns false if the
+     * getChildFileSystems API returns null.
      */
     private boolean isMountedFs(FileSystem fs) {
       return fs.getChildFileSystems() != null;
@@ -1256,7 +1256,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     private boolean isFileInHdfs(FileSystem fs, Path path) throws IOException {
       String hdfsScheme = "hdfs";
       boolean isHdfs = hdfsScheme.equalsIgnoreCase(path.toUri().getScheme());
-      // In case of viewfs we need to lookup where the actual file is to know
+      // In case of viewhdfs we need to lookup where the actual file is to know
       // the filesystem in use. The resolvePath is a sure shot way of knowing
       // which file system the file is.
       if (isHdfs && isMountedFs(fs)) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24342

### What changes were proposed in this pull request?
if the path is hdfs and if the fs is mounted fs, then we will use resolvePath to recheck whether the path is really on hdfs. In the case ViewFS based file systems, the target fs could be on some other fs, ex: o3fs://


### Why are the changes needed?
This is needed for supporting ViewHDFS like functionality as it supported mounting other fs-es under hdfs paths.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
This has been tested in real cluster installation with mounting to o3fs paths. The JIRA description provided the details about verification. After this fix, querying from table succeeded.
