### PR TITLE
HIVE-24245: Vectorized PTF with count and distinct over partition producing incorrect results.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorBytesCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorBytesCountDistinct.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+/**
+ * Bytes (String) implementation for VectorPTFEvaluatorCountDistinct.
+ */
+public class VectorPTFEvaluatorBytesCountDistinct extends VectorPTFEvaluatorCountDistinct {
+
+  public VectorPTFEvaluatorBytesCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  protected Object getValue(ColumnVector colVector, int i) {
+    BytesColumnVector inV = (BytesColumnVector) colVector;
+    return new String(inV.vector[i], inV.start[i], inV.length[i]);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorCountDistinct.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * This class evaluates count(column) for a PTF group where a distinct keyword is applied to the
+ * partitioning column itself, e.g.:
+ *
+ * SELECT
+ *   txt1,
+ *   txt2,
+ *   count(distinct txt1) over(partition by txt1) as n,
+ *   count(distinct txt2) over(partition by txt2) as m
+ * FROM example;
+ *
+ * In this case, the framework is still supposed to ensure sorting
+ * on the key (let's say txt1 for the first Reducer stage), but the original
+ * VectorPTFEvaluatorCount is not aware that a distinct keyword was applied
+ * to the key column. This case would be simple, because such function should
+ * return 1 every time. However, that's just a corner-case, a real scenario is
+ * when the partitioning column is not the same. In such cases, a real count
+ * distinct implementation is needed:
+ *
+ * SELECT
+ *   txt1,
+ *   txt2,
+ *   count(distinct txt2) over(partition by txt1) as n,
+ *   count(distinct txt1) over(partition by txt2) as m
+ * FROM example;
+ */
+public abstract class VectorPTFEvaluatorCountDistinct extends VectorPTFEvaluatorCount {
+
+  protected Set<Object> uniqueObjects;
+
+  public VectorPTFEvaluatorCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  @Override
+  public void evaluateGroupBatch(VectorizedRowBatch batch) throws HiveException {
+
+    evaluateInputExpr(batch);
+
+    // We do not filter when PTF is in reducer.
+    Preconditions.checkState(!batch.selectedInUse);
+
+    final int size = batch.size;
+    if (size == 0) {
+      return;
+    }
+    ColumnVector colVector = batch.cols[inputColumnNum];
+    if (colVector.isRepeating) {
+      if (colVector.noNulls || !colVector.isNull[0]) {
+        countValue(colVector, 0);
+      }
+    } else {
+      boolean[] batchIsNull = colVector.isNull;
+      for (int i = 0; i < size; i++) {
+        if (!batchIsNull[i]) {
+          countValue(colVector, i);
+        }
+      }
+    }
+  }
+
+  protected void countValue(ColumnVector colVector, int i) {
+    Object value = getValue(colVector, i);
+    uniqueObjects.add(value);
+  }
+
+  protected abstract Object getValue(ColumnVector colVector, int i);
+
+  @Override
+  public long getLongGroupResult() {
+    return uniqueObjects.size();
+  }
+
+  @Override
+  public void resetEvaluator() {
+    super.resetEvaluator();
+    uniqueObjects = new HashSet<>();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDecimalCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDecimalCountDistinct.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DecimalColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+/**
+ * Double implementation for VectorPTFEvaluatorCountDistinct.
+ */
+public class VectorPTFEvaluatorDecimalCountDistinct extends VectorPTFEvaluatorCountDistinct {
+
+  public VectorPTFEvaluatorDecimalCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  protected Object getValue(ColumnVector colVector, int i) {
+    return ((DecimalColumnVector) colVector).vector[i];
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDoubleCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorDoubleCountDistinct.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DoubleColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+/**
+ * Double implementation for VectorPTFEvaluatorCountDistinct.
+ */
+public class VectorPTFEvaluatorDoubleCountDistinct extends VectorPTFEvaluatorCountDistinct {
+
+  public VectorPTFEvaluatorDoubleCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  protected Object getValue(ColumnVector colVector, int i) {
+    return ((DoubleColumnVector) colVector).vector[i];
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLongCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLongCountDistinct.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+/**
+ * Long implementation for VectorPTFEvaluatorCountDistinct.
+ */
+public class VectorPTFEvaluatorLongCountDistinct extends VectorPTFEvaluatorCountDistinct {
+
+  public VectorPTFEvaluatorLongCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  protected Object getValue(ColumnVector colVector, int i) {
+    return ((LongColumnVector) colVector).vector[i];
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorTimestampCountDistinct.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorTimestampCountDistinct.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+
+/**
+ * Timestamp implementation for VectorPTFEvaluatorCountDistinct.
+ */
+public class VectorPTFEvaluatorTimestampCountDistinct extends VectorPTFEvaluatorCountDistinct {
+
+  public VectorPTFEvaluatorTimestampCountDistinct(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    resetEvaluator();
+  }
+
+  protected Object getValue(ColumnVector colVector, int i) {
+    TimestampColumnVector inV = (TimestampColumnVector) colVector;
+    return inV.time[i] + 31 * inV.nanos[i];
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -4831,15 +4831,15 @@ public class Vectorizer implements PhysicalPlanResolver {
     return parent;
   }
 
-  private static void fillInPTFEvaluators(
-      List<WindowFunctionDef> windowsFunctions,
-      String[] evaluatorFunctionNames,
+  private static void fillInPTFEvaluators(List<WindowFunctionDef> windowsFunctions,
+      String[] evaluatorFunctionNames, boolean[] evaluatorsAreDistinct,
       WindowFrameDef[] evaluatorWindowFrameDefs,
       List<ExprNodeDesc>[] evaluatorInputExprNodeDescLists) throws HiveException {
     final int functionCount = windowsFunctions.size();
     for (int i = 0; i < functionCount; i++) {
       WindowFunctionDef winFunc = windowsFunctions.get(i);
       evaluatorFunctionNames[i] = winFunc.getName();
+      evaluatorsAreDistinct[i] = winFunc.isDistinct();
       evaluatorWindowFrameDefs[i] = winFunc.getWindowFrame();
 
       List<PTFExpressionDef> args = winFunc.getArgs();
@@ -4942,12 +4942,14 @@ public class Vectorizer implements PhysicalPlanResolver {
     }
 
     String[] evaluatorFunctionNames = new String[functionCount];
+    boolean[] evaluatorsAreDistinct = new boolean[functionCount];
     WindowFrameDef[] evaluatorWindowFrameDefs = new WindowFrameDef[functionCount];
     List<ExprNodeDesc>[] evaluatorInputExprNodeDescLists = (List<ExprNodeDesc>[]) new List<?>[functionCount];
 
     fillInPTFEvaluators(
         windowsFunctions,
         evaluatorFunctionNames,
+        evaluatorsAreDistinct,
         evaluatorWindowFrameDefs,
         evaluatorInputExprNodeDescLists);
 
@@ -4961,6 +4963,7 @@ public class Vectorizer implements PhysicalPlanResolver {
     vectorPTFDesc.setPartitionExprNodeDescs(partitionExprNodeDescs);
 
     vectorPTFDesc.setEvaluatorFunctionNames(evaluatorFunctionNames);
+    vectorPTFDesc.setEvaluatorsAreDistinct(evaluatorsAreDistinct);
     vectorPTFDesc.setEvaluatorWindowFrameDefs(evaluatorWindowFrameDefs);
     vectorPTFDesc.setEvaluatorInputExprNodeDescLists(evaluatorInputExprNodeDescLists);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFCount.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFCount.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.ql.udf.generic;
 
 import java.util.HashSet;
+import java.util.Set;
 
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
@@ -180,14 +181,13 @@ public class GenericUDAFCount implements GenericUDAFResolver2 {
           if (((CountAgg) agg).uniqueObjects == null) {
             ((CountAgg) agg).uniqueObjects = new HashSet<ObjectInspectorObject>();
           }
-          HashSet<ObjectInspectorObject> uniqueObjs = ((CountAgg) agg).uniqueObjects;
+          Set<ObjectInspectorObject> uniqueObjs = ((CountAgg) agg).uniqueObjects;
 
           ObjectInspectorObject obj = new ObjectInspectorObject(
               ObjectInspectorUtils.copyToStandardObject(parameters, inputOI, ObjectInspectorCopyOption.JAVA),
               outputOI);
-          if (!uniqueObjs.contains(obj)) {
-            uniqueObjs.add(obj);
-          } else {
+          boolean inserted = uniqueObjs.add(obj);
+          if (!inserted){
             countThisRow = false;
           }
         }

--- a/ql/src/test/queries/clientpositive/vector_ptf_count_distinct.q
+++ b/ql/src/test/queries/clientpositive/vector_ptf_count_distinct.q
@@ -1,0 +1,522 @@
+CREATE TABLE ptf_count_distinct (
+  id int,
+  txt1 string,
+  txt2 string);
+
+INSERT INTO ptf_count_distinct VALUES
+  (1,'2010005759','7164335675012038'),
+  (2,'2010005759','7164335675012038');
+
+SELECT "*** Testing STRING, same values ***";
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 in aggregations ***";
+explain SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct;
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 in aggregations ***";
+EXPLAIN SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct;
+
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 1 in aggregations (both columns only have 1 distinct value) ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 1 in aggregations (both columns have only 1 distinct value) ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct;
+
+
+CREATE TABLE ptf_count_distinct_different_values (
+  id int,
+  txt1 string,
+  txt2 string);
+
+INSERT INTO ptf_count_distinct_different_values VALUES
+  (1,'1010005758','7164335675012038'),
+  (2,'2010005759','7164335675012038');
+
+
+SELECT "*** Testing STRING, different values ***";
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1;
+
+
+
+
+
+
+
+
+SELECT "*** Testing INT/LONG ***";
+CREATE TABLE ptf_count_distinct_different_values_long (
+  id int,
+  long1 int,
+  long2 int);
+
+INSERT INTO ptf_count_distinct_different_values_long VALUES
+  (1, 1010005758, 716433567),
+  (2, 2010005759, 716433567);
+
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1;
+
+
+
+
+
+
+
+
+SELECT "*** Testing DOUBLE ***";
+CREATE TABLE ptf_count_distinct_different_values_double (
+  id int,
+  double1 double,
+  double2 double);
+
+INSERT INTO ptf_count_distinct_different_values_double VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1);
+
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1;
+
+
+
+
+
+
+
+
+
+SELECT "*** Testing DECIMAL ***";
+CREATE TABLE ptf_count_distinct_different_values_decimal (
+  id int,
+  decimal1 decimal,
+  decimal2 decimal);
+
+INSERT INTO ptf_count_distinct_different_values_decimal VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1);
+
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1;
+
+
+
+
+
+
+
+
+
+SELECT "*** Testing TIMESTAMP ***";
+CREATE TABLE ptf_count_distinct_different_values_timestamp (
+  id int,
+  timestamp1 timestamp,
+  timestamp2 timestamp);
+
+INSERT INTO ptf_count_distinct_different_values_timestamp VALUES
+  (1, '2015-11-29 09:30:00', '2020-11-29 09:30:00'),
+  (2, '2015-11-29 09:30:01', '2020-11-29 09:30:00');
+
+set hive.vectorized.execution.ptf.enabled=true;
+SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+set hive.vectorized.execution.ptf.enabled=false;
+SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***";
+
+EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***";
+EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;
+
+SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1;

--- a/ql/src/test/results/clientpositive/llap/vector_ptf_count_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_ptf_count_distinct.q.out
@@ -1,0 +1,6618 @@
+PREHOOK: query: CREATE TABLE ptf_count_distinct (
+  id int,
+  txt1 string,
+  txt2 string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct
+POSTHOOK: query: CREATE TABLE ptf_count_distinct (
+  id int,
+  txt1 string,
+  txt2 string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct
+PREHOOK: query: INSERT INTO ptf_count_distinct VALUES
+  (1,'2010005759','7164335675012038'),
+  (2,'2010005759','7164335675012038')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct
+POSTHOOK: query: INSERT INTO ptf_count_distinct VALUES
+  (1,'2010005759','7164335675012038'),
+  (2,'2010005759','7164335675012038')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct
+POSTHOOK: Lineage: ptf_count_distinct.id SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct.txt1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct.txt2 SCRIPT []
+PREHOOK: query: SELECT "*** Testing STRING, same values ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing STRING, same values ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing STRING, same values ***
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 in aggregations ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 in aggregations ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 in aggregations ***
+PREHOOK: query: explain SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: explain SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: txt1 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt1 (type: string)
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col1 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt1 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt1 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 1:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col1:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col1 (type: string)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 0:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkStringOperator
+                          keyColumns: 1:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:string
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 0:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+2010005759	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 in aggregations ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 in aggregations ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 in aggregations ***
+PREHOOK: query: EXPLAIN SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: txt1 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt1 (type: string)
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col1 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+2010005759	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 1 in aggregations (both columns only have 1 distinct value) ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 1 in aggregations (both columns only have 1 distinct value) ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 1 in aggregations (both columns only have 1 distinct value) ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt2 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt2 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 2:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col1:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 1:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: string)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkStringOperator
+                          keyColumns: 1:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:string
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 2:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+2010005759	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 1 in aggregations (both columns have only 1 distinct value) ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 1 in aggregations (both columns have only 1 distinct value) ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 1 in aggregations (both columns have only 1 distinct value) ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt2 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt2 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 2:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: string)
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as n,
+    count(distinct txt2) over(partition by txt1) as m
+FROM ptf_count_distinct
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct
+#### A masked pattern was here ####
+2010005759	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: CREATE TABLE ptf_count_distinct_different_values (
+  id int,
+  txt1 string,
+  txt2 string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct_different_values
+POSTHOOK: query: CREATE TABLE ptf_count_distinct_different_values (
+  id int,
+  txt1 string,
+  txt2 string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct_different_values
+PREHOOK: query: INSERT INTO ptf_count_distinct_different_values VALUES
+  (1,'1010005758','7164335675012038'),
+  (2,'2010005759','7164335675012038')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct_different_values
+POSTHOOK: query: INSERT INTO ptf_count_distinct_different_values VALUES
+  (1,'1010005758','7164335675012038'),
+  (2,'2010005759','7164335675012038')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct_different_values
+POSTHOOK: Lineage: ptf_count_distinct_different_values.id SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values.txt1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values.txt2 SCRIPT []
+PREHOOK: query: SELECT "*** Testing STRING, different values ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing STRING, different values ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing STRING, different values ***
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt2 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt2 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 2:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col1:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 1:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: string)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkStringOperator
+                          keyColumns: 1:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:string
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 2:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:string, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:string, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+1010005758	7164335675012038	2	1
+2010005759	7164335675012038	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt1 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt1 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 1:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col1:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col1 (type: string)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 0:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkStringOperator
+                          keyColumns: 1:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:string
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorBytesCountDistinct]
+                      functionInputExpressions: [col 0:string]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:string]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, string, string]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:string
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 0:string, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:string, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as n,
+    count(distinct txt2) over(partition by txt2) as m
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+1010005758	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_txt1_over_txt2, 1 for distinct_txt2_over_txt1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt2 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt2 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 2:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt1 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: string)
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: string), VALUE._col2 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:string, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt2) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt1) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+1010005758	7164335675012038	2	1
+2010005759	7164335675012038	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_txt1_over_txt2 and distinct_txt2_over_txt1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values
+                  Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:txt1:string, 2:txt2:string, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: txt1 (type: string)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: txt1 (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkStringOperator
+                        keyColumns: 1:string
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:string
+                    Statistics: Num rows: 2 Data size: 388 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: txt2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, txt1:string, txt2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col1 (type: string)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: string, _col2: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: string), _col2 (type: string)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: string)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: string)
+                      Statistics: Num rows: 2 Data size: 924 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: string)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: string, _col3: string
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 940 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: string), _col3 (type: string), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: string)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: string), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:string, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 420 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    txt1,
+    txt2,
+    count(distinct txt1) over(partition by txt1) as distinct_txt1_over_txt2,
+    count(distinct txt2) over(partition by txt2) as distinct_txt2_over_txt1
+FROM ptf_count_distinct_different_values
+ORDER BY txt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values
+#### A masked pattern was here ####
+1010005758	7164335675012038	1	1
+2010005759	7164335675012038	1	1
+PREHOOK: query: SELECT "*** Testing INT/LONG ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing INT/LONG ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing INT/LONG ***
+PREHOOK: query: CREATE TABLE ptf_count_distinct_different_values_long (
+  id int,
+  long1 int,
+  long2 int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct_different_values_long
+POSTHOOK: query: CREATE TABLE ptf_count_distinct_different_values_long (
+  id int,
+  long1 int,
+  long2 int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct_different_values_long
+PREHOOK: query: INSERT INTO ptf_count_distinct_different_values_long VALUES
+  (1, 1010005758, 716433567),
+  (2, 2010005759, 716433567)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct_different_values_long
+POSTHOOK: query: INSERT INTO ptf_count_distinct_different_values_long VALUES
+  (1, 1010005758, 716433567),
+  (2, 2010005759, 716433567)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct_different_values_long
+POSTHOOK: Lineage: ptf_count_distinct_different_values_long.id SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_long.long1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_long.long2 SCRIPT []
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_long
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:long1:int, 2:long2:int, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: long2 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: long2 (type: int)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkLongOperator
+                        keyColumns: 2:int
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:int
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: long1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, long1:int, long2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col1:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), KEY.reducesinkkey0 (type: int)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: int, _col2: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLongCountDistinct]
+                      functionInputExpressions: [col 1:int]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:int]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, int, int]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: int), _col2 (type: int)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkLongOperator
+                          keyColumns: 1:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:int
+                      Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: int)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:bigint, VALUE._col2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: int), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: int, _col3: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLongCountDistinct]
+                      functionInputExpressions: [col 2:int]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:int]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, int, int]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: int), _col3 (type: int), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:int, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:int, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+1010005758	716433567	2	1
+2010005759	716433567	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_long
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:long1:int, 2:long2:int, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: long1 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: long1 (type: int)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkLongOperator
+                        keyColumns: 1:int
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:int
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: long2 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, long1:int, long2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col1:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col1 (type: int)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: int, _col2: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLongCountDistinct]
+                      functionInputExpressions: [col 0:int]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:int]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, int, int]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: int), _col2 (type: int)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkLongOperator
+                          keyColumns: 1:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:int
+                      Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: int)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:bigint, VALUE._col2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: int), KEY.reducesinkkey0 (type: int)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: int, _col3: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLongCountDistinct]
+                      functionInputExpressions: [col 0:int]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:int]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, int, int]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: int), _col3 (type: int), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:int
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 0:int, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:int, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+1010005758	716433567	1	1
+2010005759	716433567	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_long1_over_long2, 1 for distinct_long2_over_long1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_long
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:long1:int, 2:long2:int, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: long2 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: long2 (type: int)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkLongOperator
+                        keyColumns: 2:int
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:int
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: long1 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, long1:int, long2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: int), KEY.reducesinkkey0 (type: int)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: int, _col2: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: int), _col2 (type: int)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: int)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: int), VALUE._col2 (type: int)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: int, _col3: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: int), _col3 (type: int), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:int, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long2) as distinct_long1_over_long2,
+    count(distinct long2) over(partition by long1) as distinct_long2_over_long1
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+1010005758	716433567	2	1
+2010005759	716433567	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_long1_over_long1 and distinct_long2_over_long2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_long
+                  Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:long1:int, 2:long2:int, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: long1 (type: int)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: long1 (type: int)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkLongOperator
+                        keyColumns: 1:int
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:int
+                    Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: long2 (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, long1:int, long2:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col1 (type: int)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: int, _col2: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: int), _col2 (type: int)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: int)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: int)
+                      Statistics: Num rows: 2 Data size: 552 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: int)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: int), KEY.reducesinkkey0 (type: int)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: int, _col3: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: int), _col3 (type: int), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:int, VALUE._col0:int, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), VALUE._col0 (type: int), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    long1,
+    long2,
+    count(distinct long1) over(partition by long1) as distinct_long1_over_long1,
+    count(distinct long2) over(partition by long2) as distinct_long2_over_long2
+FROM ptf_count_distinct_different_values_long
+ORDER BY long1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_long
+#### A masked pattern was here ####
+1010005758	716433567	1	1
+2010005759	716433567	1	1
+PREHOOK: query: SELECT "*** Testing DOUBLE ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing DOUBLE ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing DOUBLE ***
+PREHOOK: query: CREATE TABLE ptf_count_distinct_different_values_double (
+  id int,
+  double1 double,
+  double2 double)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct_different_values_double
+POSTHOOK: query: CREATE TABLE ptf_count_distinct_different_values_double (
+  id int,
+  double1 double,
+  double2 double)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct_different_values_double
+PREHOOK: query: INSERT INTO ptf_count_distinct_different_values_double VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct_different_values_double
+POSTHOOK: query: INSERT INTO ptf_count_distinct_different_values_double VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct_different_values_double
+POSTHOOK: Lineage: ptf_count_distinct_different_values_double.double1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_double.double2 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_double.id SCRIPT []
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_double
+                  Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:double1:double, 2:double2:double, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: double2 (type: double)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: double2 (type: double)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:double
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:double
+                    Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: double1 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, double1:double, double2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col1:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: double), KEY.reducesinkkey0 (type: double)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: double, _col2: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDoubleCountDistinct]
+                      functionInputExpressions: [col 1:double]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:double]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, double, double]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: double), _col2 (type: double)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: double)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: double)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:double
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:double
+                      Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: double)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:bigint, VALUE._col2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: double), VALUE._col2 (type: double)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: double, _col3: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDoubleCountDistinct]
+                      functionInputExpressions: [col 2:double]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:double]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, double, double]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: double), _col3 (type: double), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: double)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:double
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:double, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:double, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col0 (type: double), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+1.0100057581E9	7.164335671E8	2	1
+2.0100057591E9	7.164335671E8	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_double
+                  Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:double1:double, 2:double2:double, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: double1 (type: double)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: double1 (type: double)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:double
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:double
+                    Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: double2 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, double1:double, double2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col1:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col1 (type: double)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: double, _col2: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDoubleCountDistinct]
+                      functionInputExpressions: [col 0:double]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:double]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, double, double]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: double), _col2 (type: double)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: double)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: double)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:double
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:double
+                      Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: double)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:bigint, VALUE._col2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: double), KEY.reducesinkkey0 (type: double)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: double, _col3: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDoubleCountDistinct]
+                      functionInputExpressions: [col 0:double]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:double]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, double, double]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: double), _col3 (type: double), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: double)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:double
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 0:double, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:double, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col0 (type: double), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+1.0100057581E9	7.164335671E8	1	1
+2.0100057591E9	7.164335671E8	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_double1_over_double2, 1 for distinct_double2_over_double1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_double
+                  Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:double1:double, 2:double2:double, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: double2 (type: double)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: double2 (type: double)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:double
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:double
+                    Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: double1 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, double1:double, double2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: double), KEY.reducesinkkey0 (type: double)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: double, _col2: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: double), _col2 (type: double)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: double)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: double)
+                      Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: double), VALUE._col2 (type: double)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: double, _col3: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: double), _col3 (type: double), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: double)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:double, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col0 (type: double), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double2) as distinct_double1_over_double2,
+    count(distinct double2) over(partition by double1) as distinct_double2_over_double1
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+1.0100057581E9	7.164335671E8	2	1
+2.0100057591E9	7.164335671E8	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_double1_over_double1 and distinct_double2_over_double2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_double
+                  Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:double1:double, 2:double2:double, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: double1 (type: double)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: double1 (type: double)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:double
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:double
+                    Statistics: Num rows: 2 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: double2 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, double1:double, double2:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col1 (type: double)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: double, _col2: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: double), _col2 (type: double)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: double)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: double)
+                      Statistics: Num rows: 2 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: double)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: double), KEY.reducesinkkey0 (type: double)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: double, _col3: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 584 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: double), _col3 (type: double), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: double)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: double), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:double, VALUE._col0:double, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: double), VALUE._col0 (type: double), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    double1,
+    double2,
+    count(distinct double1) over(partition by double1) as distinct_double1_over_double1,
+    count(distinct double2) over(partition by double2) as distinct_double2_over_double2
+FROM ptf_count_distinct_different_values_double
+ORDER BY double1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_double
+#### A masked pattern was here ####
+1.0100057581E9	7.164335671E8	1	1
+2.0100057591E9	7.164335671E8	1	1
+PREHOOK: query: SELECT "*** Testing DECIMAL ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing DECIMAL ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing DECIMAL ***
+PREHOOK: query: CREATE TABLE ptf_count_distinct_different_values_decimal (
+  id int,
+  decimal1 decimal,
+  decimal2 decimal)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct_different_values_decimal
+POSTHOOK: query: CREATE TABLE ptf_count_distinct_different_values_decimal (
+  id int,
+  decimal1 decimal,
+  decimal2 decimal)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct_different_values_decimal
+PREHOOK: query: INSERT INTO ptf_count_distinct_different_values_decimal VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct_different_values_decimal
+POSTHOOK: query: INSERT INTO ptf_count_distinct_different_values_decimal VALUES
+  (1, 1010005758.1, 716433567.1),
+  (2, 2010005759.1, 716433567.1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct_different_values_decimal
+POSTHOOK: Lineage: ptf_count_distinct_different_values_decimal.decimal1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_decimal.decimal2 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_decimal.id SCRIPT []
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_decimal
+                  Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:decimal1:decimal(10,0)/DECIMAL_64, 2:decimal2:decimal(10,0)/DECIMAL_64, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: decimal2 (type: decimal(10,0))
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: decimal2 (type: decimal(10,0))
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:decimal(10,0)
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:decimal(10,0)
+                    Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: decimal1 (type: decimal(10,0))
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, decimal1:decimal(10,0)/DECIMAL_64, decimal2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col1:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, decimal(10,0)]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: decimal(10,0)), KEY.reducesinkkey0 (type: decimal(10,0))
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: decimal(10,0), _col2: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDecimalCountDistinct]
+                      functionInputExpressions: [ConvertDecimal64ToDecimal(col 1:decimal(10,0)/DECIMAL_64) -> 3:decimal(10,0)]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:decimal(10,0)]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, decimal(10,0), decimal(10,0)]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0)), _col2 (type: decimal(10,0))
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: decimal(10,0))
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: decimal(10,0))
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:decimal(10,0)
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:decimal(10,0)
+                      Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: decimal(10,0))
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:bigint, VALUE._col2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, decimal(10,0)]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col2 (type: decimal(10,0))
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: decimal(10,0), _col3: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDecimalCountDistinct]
+                      functionInputExpressions: [ConvertDecimal64ToDecimal(col 2:decimal(10,0)/DECIMAL_64) -> 4:decimal(10,0)]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:decimal(10,0)]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, decimal(10,0), decimal(10,0)]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: decimal(10,0)), _col3 (type: decimal(10,0)), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: decimal(10,0))
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:decimal(10,0)
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:decimal(10,0), 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: decimal(10,0)), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:decimal(10,0)/DECIMAL_64, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col0 (type: decimal(10,0)), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+1010005758	716433567	2	1
+2010005759	716433567	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_decimal
+                  Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:decimal1:decimal(10,0)/DECIMAL_64, 2:decimal2:decimal(10,0)/DECIMAL_64, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: decimal1 (type: decimal(10,0))
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: decimal1 (type: decimal(10,0))
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:decimal(10,0)
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:decimal(10,0)
+                    Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: decimal2 (type: decimal(10,0))
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, decimal1:decimal(10,0)/DECIMAL_64, decimal2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col1:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col1 (type: decimal(10,0))
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: decimal(10,0), _col2: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDecimalCountDistinct]
+                      functionInputExpressions: [col 0:decimal(10,0)]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:decimal(10,0)]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, decimal(10,0), decimal(10,0)]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0)), _col2 (type: decimal(10,0))
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: decimal(10,0))
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: decimal(10,0))
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:decimal(10,0)
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:decimal(10,0)
+                      Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0))
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:bigint, VALUE._col2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: decimal(10,0)), KEY.reducesinkkey0 (type: decimal(10,0))
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: decimal(10,0), _col3: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorDecimalCountDistinct]
+                      functionInputExpressions: [col 0:decimal(10,0)]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:decimal(10,0)]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, decimal(10,0), decimal(10,0)]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: decimal(10,0)), _col3 (type: decimal(10,0)), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: decimal(10,0))
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:decimal(10,0)
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 0:decimal(10,0), 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: decimal(10,0)), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:decimal(10,0)/DECIMAL_64, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col0 (type: decimal(10,0)), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+1010005758	716433567	1	1
+2010005759	716433567	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_decimal1_over_decimal2, 1 for distinct_decimal2_over_decimal1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_decimal
+                  Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:decimal1:decimal(10,0)/DECIMAL_64, 2:decimal2:decimal(10,0)/DECIMAL_64, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: decimal2 (type: decimal(10,0))
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: decimal2 (type: decimal(10,0))
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:decimal(10,0)
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:decimal(10,0)
+                    Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: decimal1 (type: decimal(10,0))
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, decimal1:decimal(10,0)/DECIMAL_64, decimal2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: decimal(10,0)), KEY.reducesinkkey0 (type: decimal(10,0))
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: decimal(10,0), _col2: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0)), _col2 (type: decimal(10,0))
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: decimal(10,0))
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: decimal(10,0))
+                      Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: decimal(10,0))
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col2 (type: decimal(10,0))
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: decimal(10,0), _col3: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: decimal(10,0)), _col3 (type: decimal(10,0)), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: decimal(10,0))
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: decimal(10,0)), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:decimal(10,0)/DECIMAL_64, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col0 (type: decimal(10,0)), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal2) as distinct_decimal1_over_decimal2,
+    count(distinct decimal2) over(partition by decimal1) as distinct_decimal2_over_decimal1
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+1010005758	716433567	2	1
+2010005759	716433567	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_decimal1_over_decimal1 and distinct_decimal2_over_decimal2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_decimal
+                  Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:decimal1:decimal(10,0)/DECIMAL_64, 2:decimal2:decimal(10,0)/DECIMAL_64, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: decimal1 (type: decimal(10,0))
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: decimal1 (type: decimal(10,0))
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:decimal(10,0)
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:decimal(10,0)
+                    Statistics: Num rows: 2 Data size: 448 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: decimal2 (type: decimal(10,0))
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, decimal1:decimal(10,0)/DECIMAL_64, decimal2:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col1 (type: decimal(10,0))
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: decimal(10,0), _col2: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0)), _col2 (type: decimal(10,0))
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: decimal(10,0))
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: decimal(10,0))
+                      Statistics: Num rows: 2 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: decimal(10,0))
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: decimal(10,0)), KEY.reducesinkkey0 (type: decimal(10,0))
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: decimal(10,0), _col3: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 1000 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: decimal(10,0)), _col3 (type: decimal(10,0)), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: decimal(10,0))
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: decimal(10,0)), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:decimal(10,0), VALUE._col0:decimal(10,0)/DECIMAL_64, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: decimal(10,0)), VALUE._col0 (type: decimal(10,0)), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 480 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    decimal1,
+    decimal2,
+    count(distinct decimal1) over(partition by decimal1) as distinct_decimal1_over_decimal1,
+    count(distinct decimal2) over(partition by decimal2) as distinct_decimal2_over_decimal2
+FROM ptf_count_distinct_different_values_decimal
+ORDER BY decimal1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_decimal
+#### A masked pattern was here ####
+1010005758	716433567	1	1
+2010005759	716433567	1	1
+PREHOOK: query: SELECT "*** Testing TIMESTAMP ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Testing TIMESTAMP ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Testing TIMESTAMP ***
+PREHOOK: query: CREATE TABLE ptf_count_distinct_different_values_timestamp (
+  id int,
+  timestamp1 timestamp,
+  timestamp2 timestamp)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ptf_count_distinct_different_values_timestamp
+POSTHOOK: query: CREATE TABLE ptf_count_distinct_different_values_timestamp (
+  id int,
+  timestamp1 timestamp,
+  timestamp2 timestamp)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ptf_count_distinct_different_values_timestamp
+PREHOOK: query: INSERT INTO ptf_count_distinct_different_values_timestamp VALUES
+  (1, '2015-11-29 09:30:00', '2020-11-29 09:30:00'),
+  (2, '2015-11-29 09:30:01', '2020-11-29 09:30:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@ptf_count_distinct_different_values_timestamp
+POSTHOOK: query: INSERT INTO ptf_count_distinct_different_values_timestamp VALUES
+  (1, '2015-11-29 09:30:00', '2020-11-29 09:30:00'),
+  (2, '2015-11-29 09:30:01', '2020-11-29 09:30:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@ptf_count_distinct_different_values_timestamp
+POSTHOOK: Lineage: ptf_count_distinct_different_values_timestamp.id SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_timestamp.timestamp1 SCRIPT []
+POSTHOOK: Lineage: ptf_count_distinct_different_values_timestamp.timestamp2 SCRIPT []
+PREHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_timestamp
+                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:timestamp1:timestamp, 2:timestamp2:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: timestamp2 (type: timestamp)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: timestamp2 (type: timestamp)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:timestamp
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:timestamp
+                    Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: timestamp1 (type: timestamp)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, timestamp1:timestamp, timestamp2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col1:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: timestamp), KEY.reducesinkkey0 (type: timestamp)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0]
+                Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: timestamp, _col2: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorTimestampCountDistinct]
+                      functionInputExpressions: [col 1:timestamp]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:timestamp]
+                      outputColumns: [2, 1, 0]
+                      outputTypes: [bigint, timestamp, timestamp]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: timestamp), _col2 (type: timestamp)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 1, 0]
+                    Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: timestamp)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: timestamp)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:timestamp
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:timestamp
+                      Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: timestamp)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:bigint, VALUE._col2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: timestamp), VALUE._col2 (type: timestamp)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
+                Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: timestamp, _col3: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorTimestampCountDistinct]
+                      functionInputExpressions: [col 2:timestamp]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:timestamp]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [bigint, bigint, timestamp, timestamp]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: timestamp), _col3 (type: timestamp), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3]
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: timestamp)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 0:timestamp
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:timestamp, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: timestamp), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:timestamp, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col0 (type: timestamp), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+2015-11-29 09:30:00	2020-11-29 09:30:00	2	1
+2015-11-29 09:30:01	2020-11-29 09:30:00	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_timestamp
+                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:timestamp1:timestamp, 2:timestamp2:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: timestamp1 (type: timestamp)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: timestamp1 (type: timestamp)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:timestamp
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:timestamp
+                    Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: timestamp2 (type: timestamp)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, timestamp1:timestamp, timestamp2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 2
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col1:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col1 (type: timestamp)
+                outputColumnNames: _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1]
+                Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: timestamp, _col2: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorTimestampCountDistinct]
+                      functionInputExpressions: [col 0:timestamp]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1]
+                      orderExpressions: [col 0:timestamp]
+                      outputColumns: [2, 0, 1]
+                      outputTypes: [bigint, timestamp, timestamp]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: timestamp), _col2 (type: timestamp)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1]
+                    Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: timestamp)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: timestamp)
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkMultiKeyOperator
+                          keyColumns: 1:timestamp
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 2:bigint, 0:timestamp
+                      Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: timestamp)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: a
+                reduceColumnSortOrder: +
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:bigint, VALUE._col2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: timestamp), KEY.reducesinkkey0 (type: timestamp)
+                outputColumnNames: _col0, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 2, 0]
+                Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: timestamp, _col3: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  PTF Vectorization:
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorTimestampCountDistinct]
+                      functionInputExpressions: [col 0:timestamp]
+                      functionNames: [count]
+                      keyInputColumns: [0]
+                      native: true
+                      nonKeyInputColumns: [1, 2]
+                      orderExpressions: [col 0:timestamp]
+                      outputColumns: [3, 1, 2, 0]
+                      outputTypes: [bigint, bigint, timestamp, timestamp]
+                      streamingColumns: []
+                  Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: timestamp), _col3 (type: timestamp), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [2, 0, 1, 3]
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: timestamp)
+                      null sort order: z
+                      sort order: +
+                      Reduce Sink Vectorization:
+                          className: VectorReduceSinkObjectHashOperator
+                          keyColumns: 2:timestamp
+                          native: true
+                          nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          valueColumns: 0:timestamp, 1:bigint, 3:bigint
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: timestamp), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:timestamp, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col0 (type: timestamp), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+2015-11-29 09:30:00	2020-11-29 09:30:00	1	1
+2015-11-29 09:30:01	2020-11-29 09:30:00	1	1
+PREHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on another column, non-vectorized ptf: expecting 2 for distinct_timestamp1_over_timestamp2, 1 for distinct_timestamp2_over_timestamp1 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_timestamp
+                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:timestamp1:timestamp, 2:timestamp2:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: timestamp2 (type: timestamp)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: timestamp2 (type: timestamp)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 2:timestamp
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 1:timestamp
+                    Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: timestamp1 (type: timestamp)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, timestamp1:timestamp, timestamp2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col1 (type: timestamp), KEY.reducesinkkey0 (type: timestamp)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: timestamp, _col2: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: timestamp), _col2 (type: timestamp)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: timestamp)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: timestamp)
+                      Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col2 (type: timestamp)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: timestamp), VALUE._col2 (type: timestamp)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: timestamp, _col3: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS FIRST
+                        partition by: _col2
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: timestamp), _col3 (type: timestamp), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: timestamp)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: timestamp), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:timestamp, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col0 (type: timestamp), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp2) as distinct_timestamp1_over_timestamp2,
+    count(distinct timestamp2) over(partition by timestamp1) as distinct_timestamp2_over_timestamp1
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+2015-11-29 09:30:00	2020-11-29 09:30:00	2	1
+2015-11-29 09:30:01	2020-11-29 09:30:00	2	1
+PREHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT "*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+*** Distinct on partitioning column, non-vectorized ptf: expecting 1 for both distinct_timestamp1_over_timestamp1 and distinct_timestamp2_over_timestamp2 ***
+PREHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN VECTORIZATION DETAIL SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: ptf_count_distinct_different_values_timestamp
+                  Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:id:int, 1:timestamp1:timestamp, 2:timestamp2:timestamp, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>]
+                  Reduce Output Operator
+                    key expressions: timestamp1 (type: timestamp)
+                    null sort order: a
+                    sort order: +
+                    Map-reduce partition columns: timestamp1 (type: timestamp)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkMultiKeyOperator
+                        keyColumns: 1:timestamp
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        valueColumns: 2:timestamp
+                    Statistics: Num rows: 2 Data size: 160 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: timestamp2 (type: timestamp)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [1, 2]
+                    dataColumns: id:int, timestamp1:timestamp, timestamp2:timestamp
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col1 (type: timestamp)
+                outputColumnNames: _col1, _col2
+                Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col1: timestamp, _col2: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS FIRST
+                        partition by: _col1
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_0
+                              arguments: _col1
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: count_window_0 (type: bigint), _col1 (type: timestamp), _col2 (type: timestamp)
+                    outputColumnNames: count_window_0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col2 (type: timestamp)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: _col2 (type: timestamp)
+                      Statistics: Num rows: 2 Data size: 696 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: count_window_0 (type: bigint), _col1 (type: timestamp)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                notVectorizedReason: Vectorization of PTF is not enabled (hive.vectorized.execution.ptf.enabled IS false)
+                vectorized: false
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), VALUE._col2 (type: timestamp), KEY.reducesinkkey0 (type: timestamp)
+                outputColumnNames: _col0, _col2, _col3
+                Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: bigint, _col2: timestamp, _col3: timestamp
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col3 ASC NULLS FIRST
+                        partition by: _col3
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: count_window_1
+                              arguments: _col3
+                              name: count
+                              window function: GenericUDAFCountEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isDistinct: true
+                  Statistics: Num rows: 2 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col2 (type: timestamp), _col3 (type: timestamp), _col0 (type: bigint), count_window_1 (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: timestamp)
+                      null sort order: z
+                      sort order: +
+                      Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: timestamp), _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: z
+                reduceColumnSortOrder: +
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:timestamp, VALUE._col0:timestamp, VALUE._col1:bigint, VALUE._col2:bigint
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: timestamp), VALUE._col0 (type: timestamp), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2, 3]
+                Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 2 Data size: 192 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT
+    timestamp1,
+    timestamp2,
+    count(distinct timestamp1) over(partition by timestamp1) as distinct_timestamp1_over_timestamp1,
+    count(distinct timestamp2) over(partition by timestamp2) as distinct_timestamp2_over_timestamp2
+FROM ptf_count_distinct_different_values_timestamp
+ORDER BY timestamp1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@ptf_count_distinct_different_values_timestamp
+#### A masked pattern was here ####
+2015-11-29 09:30:00	2020-11-29 09:30:00	1	1
+2015-11-29 09:30:01	2020-11-29 09:30:00	1	1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implements vectorized count(distinct txt1) over(partition by txt1), so a distinct count. Currently, this is not supported, and silently falls back to non-distinct which leads to wrong result.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Qtests are included.
