### PR TITLE
HIVE-24353: performance: do not throw exceptions when parsing dates

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
+++ b/common/src/java/org/apache/hadoop/hive/common/type/TimestampTZUtil.java
@@ -34,6 +34,7 @@ import java.time.format.DateTimeParseException;
 import java.time.format.TextStyle;
 import java.time.temporal.ChronoField;
 import java.time.temporal.TemporalAccessor;
+import java.time.temporal.TemporalQueries;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -71,33 +72,24 @@ public class TimestampTZUtil {
   public static TimestampTZ parse(String s, ZoneId defaultTimeZone) {
     // need to handle offset with single digital hour, see JDK-8066806
     s = handleSingleDigitHourOffset(s);
-    ZonedDateTime zonedDateTime;
-    try {
-      zonedDateTime = ZonedDateTime.parse(s, FORMATTER);
-    } catch (DateTimeParseException e) {
-      // try to be more tolerant
-      // if the input is invalid instead of incomplete, we'll hit exception here again
-      TemporalAccessor accessor = FORMATTER.parse(s);
-      // LocalDate must be present
-      LocalDate localDate = LocalDate.from(accessor);
-      LocalTime localTime;
-      ZoneId zoneId;
-      try {
-        localTime = LocalTime.from(accessor);
-      } catch (DateTimeException e1) {
-        localTime = DEFAULT_LOCAL_TIME;
-      }
-      try {
-        zoneId = ZoneId.from(accessor);
-      } catch (DateTimeException e2) {
-        if (defaultTimeZone == null) {
-          throw new DateTimeException("Time Zone not available");
-        }
-        zoneId = defaultTimeZone;
-      }
-      zonedDateTime = ZonedDateTime.of(localDate, localTime, zoneId);
+    TemporalAccessor accessor = FORMATTER.parse(s);
+
+    LocalDate localDate = accessor.query(TemporalQueries.localDate());
+
+    LocalTime localTime = accessor.query(TemporalQueries.localTime());
+    if (localTime == null) {
+      localTime = DEFAULT_LOCAL_TIME;
     }
 
+    ZoneId zoneId = accessor.query(TemporalQueries.zone());
+    if (zoneId == null) {
+      zoneId = defaultTimeZone;
+      if (zoneId == null) {
+        throw new DateTimeException("Time Zone not available");
+      }
+    }
+
+    ZonedDateTime zonedDateTime = ZonedDateTime.of(localDate, localTime, zoneId);
     if (defaultTimeZone == null) {
       return new TimestampTZ(zonedDateTime);
     }

--- a/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
+++ b/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
@@ -18,12 +18,14 @@
 
 package org.apache.hadoop.hive.common.type;
 
+import com.google.common.base.Stopwatch;
 import org.junit.Assert;
 import org.junit.Test;
 
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 public class TestTimestampTZ {
   @Test
@@ -82,6 +84,18 @@ public class TestTimestampTZ {
     TimestampTZUtil.parse("2017-11-08GMT");
     TimestampTZUtil.parse("2017-10-11 GMT+8:00");
     TimestampTZUtil.parse("2017-05-08 07:45:00-3:00");
+  }
+
+  @Test
+  public void testPerformance() {
+    for (int i = 0; i < 100; i++) {
+      TimestampTZUtil.parse("2017-01-01 13:33:00", ZoneId.of("UTC"));
+    }
+    Stopwatch sw = Stopwatch.createStarted();
+    for (int i = 0; i < 10000; i++) {
+      TimestampTZUtil.parse("2017-01-01 13:33:00", ZoneId.of("UTC"));
+    }
+    System.out.println(sw.elapsed(TimeUnit.MILLISECONDS));
   }
 
   @Test

--- a/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
+++ b/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
@@ -18,15 +18,12 @@
 
 package org.apache.hadoop.hive.common.type;
 
-import com.google.common.base.Stopwatch;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 
 public class TestTimestampTZ {
   @Test
@@ -85,19 +82,6 @@ public class TestTimestampTZ {
     TimestampTZUtil.parse("2017-11-08GMT");
     TimestampTZUtil.parse("2017-10-11 GMT+8:00");
     TimestampTZUtil.parse("2017-05-08 07:45:00-3:00");
-  }
-
-  @Test
-  public void testPerformance() {
-    // Warm up the jvm before measuring.
-    for (int i = 0; i < 100; i++) {
-      TimestampTZUtil.parse("2017-01-01 13:33:00", ZoneId.of("UTC"));
-    }
-    Stopwatch sw = Stopwatch.createStarted();
-    for (int i = 0; i < 10000; i++) {
-      TimestampTZUtil.parse(LocalDate.of(2020, 11, 10).minusDays(i).toString(), ZoneId.of("UTC"));
-    }
-    System.out.println(sw.elapsed(TimeUnit.MILLISECONDS));
   }
 
   @Test

--- a/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
+++ b/common/src/test/org/apache/hadoop/hive/common/type/TestTimestampTZ.java
@@ -22,6 +22,7 @@ import com.google.common.base.Stopwatch;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.format.DateTimeParseException;
 import java.util.TimeZone;
@@ -88,12 +89,13 @@ public class TestTimestampTZ {
 
   @Test
   public void testPerformance() {
+    // Warm up the jvm before measuring.
     for (int i = 0; i < 100; i++) {
       TimestampTZUtil.parse("2017-01-01 13:33:00", ZoneId.of("UTC"));
     }
     Stopwatch sw = Stopwatch.createStarted();
     for (int i = 0; i < 10000; i++) {
-      TimestampTZUtil.parse("2017-01-01 13:33:00", ZoneId.of("UTC"));
+      TimestampTZUtil.parse(LocalDate.of(2020, 11, 10).minusDays(i).toString(), ZoneId.of("UTC"));
     }
     System.out.println(sw.elapsed(TimeUnit.MILLISECONDS));
   }


### PR DESCRIPTION
This resolves https://issues.apache.org/jira/browse/HIVE-24353

### What changes were proposed in this pull request?
Change timestampTZ parsing from using convenience methods that throw exceptions to a chain of queries against the parsed temporalAccessor. 

### Why are the changes needed?
This improves the performance for timestamp parsing. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Existing tests are covering all branches already. 
One test was added, but it has no assertions. 