### PR TITLE
HIVE-24392: Add table id and getFileMetadata to GetPartitionsByNamesRequest

### DIFF
--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -18662,6 +18662,16 @@ void GetPartitionsByNamesRequest::__set_validWriteIdList(const std::string& val)
   this->validWriteIdList = val;
 __isset.validWriteIdList = true;
 }
+
+void GetPartitionsByNamesRequest::__set_getFileMetadata(const bool val) {
+  this->getFileMetadata = val;
+__isset.getFileMetadata = true;
+}
+
+void GetPartitionsByNamesRequest::__set_id(const int64_t val) {
+  this->id = val;
+__isset.id = true;
+}
 std::ostream& operator<<(std::ostream& out, const GetPartitionsByNamesRequest& obj)
 {
   obj.printTo(out);
@@ -18780,6 +18790,22 @@ uint32_t GetPartitionsByNamesRequest::read(::apache::thrift::protocol::TProtocol
           xfer += iprot->skip(ftype);
         }
         break;
+      case 9:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->getFileMetadata);
+          this->__isset.getFileMetadata = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 10:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->id);
+          this->__isset.id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -18855,6 +18881,16 @@ uint32_t GetPartitionsByNamesRequest::write(::apache::thrift::protocol::TProtoco
     xfer += oprot->writeString(this->validWriteIdList);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.getFileMetadata) {
+    xfer += oprot->writeFieldBegin("getFileMetadata", ::apache::thrift::protocol::T_BOOL, 9);
+    xfer += oprot->writeBool(this->getFileMetadata);
+    xfer += oprot->writeFieldEnd();
+  }
+  if (this->__isset.id) {
+    xfer += oprot->writeFieldBegin("id", ::apache::thrift::protocol::T_I64, 10);
+    xfer += oprot->writeI64(this->id);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -18870,6 +18906,8 @@ void swap(GetPartitionsByNamesRequest &a, GetPartitionsByNamesRequest &b) {
   swap(a.processorIdentifier, b.processorIdentifier);
   swap(a.engine, b.engine);
   swap(a.validWriteIdList, b.validWriteIdList);
+  swap(a.getFileMetadata, b.getFileMetadata);
+  swap(a.id, b.id);
   swap(a.__isset, b.__isset);
 }
 
@@ -18882,6 +18920,8 @@ GetPartitionsByNamesRequest::GetPartitionsByNamesRequest(const GetPartitionsByNa
   processorIdentifier = other714.processorIdentifier;
   engine = other714.engine;
   validWriteIdList = other714.validWriteIdList;
+  getFileMetadata = other714.getFileMetadata;
+  id = other714.id;
   __isset = other714.__isset;
 }
 GetPartitionsByNamesRequest& GetPartitionsByNamesRequest::operator=(const GetPartitionsByNamesRequest& other715) {
@@ -18893,6 +18933,8 @@ GetPartitionsByNamesRequest& GetPartitionsByNamesRequest::operator=(const GetPar
   processorIdentifier = other715.processorIdentifier;
   engine = other715.engine;
   validWriteIdList = other715.validWriteIdList;
+  getFileMetadata = other715.getFileMetadata;
+  id = other715.id;
   __isset = other715.__isset;
   return *this;
 }
@@ -18907,6 +18949,8 @@ void GetPartitionsByNamesRequest::printTo(std::ostream& out) const {
   out << ", " << "processorIdentifier="; (__isset.processorIdentifier ? (out << to_string(processorIdentifier)) : (out << "<null>"));
   out << ", " << "engine="; (__isset.engine ? (out << to_string(engine)) : (out << "<null>"));
   out << ", " << "validWriteIdList="; (__isset.validWriteIdList ? (out << to_string(validWriteIdList)) : (out << "<null>"));
+  out << ", " << "getFileMetadata="; (__isset.getFileMetadata ? (out << to_string(getFileMetadata)) : (out << "<null>"));
+  out << ", " << "id="; (__isset.id ? (out << to_string(id)) : (out << "<null>"));
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -7163,13 +7163,15 @@ void swap(PartitionValuesResponse &a, PartitionValuesResponse &b);
 std::ostream& operator<<(std::ostream& out, const PartitionValuesResponse& obj);
 
 typedef struct _GetPartitionsByNamesRequest__isset {
-  _GetPartitionsByNamesRequest__isset() : names(false), get_col_stats(false), processorCapabilities(false), processorIdentifier(false), engine(false), validWriteIdList(false) {}
+  _GetPartitionsByNamesRequest__isset() : names(false), get_col_stats(false), processorCapabilities(false), processorIdentifier(false), engine(false), validWriteIdList(false), getFileMetadata(false), id(true) {}
   bool names :1;
   bool get_col_stats :1;
   bool processorCapabilities :1;
   bool processorIdentifier :1;
   bool engine :1;
   bool validWriteIdList :1;
+  bool getFileMetadata :1;
+  bool id :1;
 } _GetPartitionsByNamesRequest__isset;
 
 class GetPartitionsByNamesRequest : public virtual ::apache::thrift::TBase {
@@ -7177,7 +7179,7 @@ class GetPartitionsByNamesRequest : public virtual ::apache::thrift::TBase {
 
   GetPartitionsByNamesRequest(const GetPartitionsByNamesRequest&);
   GetPartitionsByNamesRequest& operator=(const GetPartitionsByNamesRequest&);
-  GetPartitionsByNamesRequest() : db_name(), tbl_name(), get_col_stats(0), processorIdentifier(), engine(), validWriteIdList() {
+  GetPartitionsByNamesRequest() : db_name(), tbl_name(), get_col_stats(0), processorIdentifier(), engine(), validWriteIdList(), getFileMetadata(0), id(-1LL) {
   }
 
   virtual ~GetPartitionsByNamesRequest() noexcept;
@@ -7189,6 +7191,8 @@ class GetPartitionsByNamesRequest : public virtual ::apache::thrift::TBase {
   std::string processorIdentifier;
   std::string engine;
   std::string validWriteIdList;
+  bool getFileMetadata;
+  int64_t id;
 
   _GetPartitionsByNamesRequest__isset __isset;
 
@@ -7207,6 +7211,10 @@ class GetPartitionsByNamesRequest : public virtual ::apache::thrift::TBase {
   void __set_engine(const std::string& val);
 
   void __set_validWriteIdList(const std::string& val);
+
+  void __set_getFileMetadata(const bool val);
+
+  void __set_id(const int64_t val);
 
   bool operator == (const GetPartitionsByNamesRequest & rhs) const
   {
@@ -7237,6 +7245,14 @@ class GetPartitionsByNamesRequest : public virtual ::apache::thrift::TBase {
     if (__isset.validWriteIdList != rhs.__isset.validWriteIdList)
       return false;
     else if (__isset.validWriteIdList && !(validWriteIdList == rhs.validWriteIdList))
+      return false;
+    if (__isset.getFileMetadata != rhs.__isset.getFileMetadata)
+      return false;
+    else if (__isset.getFileMetadata && !(getFileMetadata == rhs.getFileMetadata))
+      return false;
+    if (__isset.id != rhs.__isset.id)
+      return false;
+    else if (__isset.id && !(id == rhs.id))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetPartitionsByNamesRequest.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField PROCESSOR_IDENTIFIER_FIELD_DESC = new org.apache.thrift.protocol.TField("processorIdentifier", org.apache.thrift.protocol.TType.STRING, (short)6);
   private static final org.apache.thrift.protocol.TField ENGINE_FIELD_DESC = new org.apache.thrift.protocol.TField("engine", org.apache.thrift.protocol.TType.STRING, (short)7);
   private static final org.apache.thrift.protocol.TField VALID_WRITE_ID_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("validWriteIdList", org.apache.thrift.protocol.TType.STRING, (short)8);
+  private static final org.apache.thrift.protocol.TField GET_FILE_METADATA_FIELD_DESC = new org.apache.thrift.protocol.TField("getFileMetadata", org.apache.thrift.protocol.TType.BOOL, (short)9);
+  private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("id", org.apache.thrift.protocol.TType.I64, (short)10);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new GetPartitionsByNamesRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new GetPartitionsByNamesRequestTupleSchemeFactory();
@@ -31,6 +33,8 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String processorIdentifier; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String engine; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String validWriteIdList; // optional
+  private boolean getFileMetadata; // optional
+  private long id; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -41,7 +45,9 @@ package org.apache.hadoop.hive.metastore.api;
     PROCESSOR_CAPABILITIES((short)5, "processorCapabilities"),
     PROCESSOR_IDENTIFIER((short)6, "processorIdentifier"),
     ENGINE((short)7, "engine"),
-    VALID_WRITE_ID_LIST((short)8, "validWriteIdList");
+    VALID_WRITE_ID_LIST((short)8, "validWriteIdList"),
+    GET_FILE_METADATA((short)9, "getFileMetadata"),
+    ID((short)10, "id");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -73,6 +79,10 @@ package org.apache.hadoop.hive.metastore.api;
           return ENGINE;
         case 8: // VALID_WRITE_ID_LIST
           return VALID_WRITE_ID_LIST;
+        case 9: // GET_FILE_METADATA
+          return GET_FILE_METADATA;
+        case 10: // ID
+          return ID;
         default:
           return null;
       }
@@ -115,8 +125,10 @@ package org.apache.hadoop.hive.metastore.api;
 
   // isset id assignments
   private static final int __GET_COL_STATS_ISSET_ID = 0;
+  private static final int __GETFILEMETADATA_ISSET_ID = 1;
+  private static final int __ID_ISSET_ID = 2;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.NAMES,_Fields.GET_COL_STATS,_Fields.PROCESSOR_CAPABILITIES,_Fields.PROCESSOR_IDENTIFIER,_Fields.ENGINE,_Fields.VALID_WRITE_ID_LIST};
+  private static final _Fields optionals[] = {_Fields.NAMES,_Fields.GET_COL_STATS,_Fields.PROCESSOR_CAPABILITIES,_Fields.PROCESSOR_IDENTIFIER,_Fields.ENGINE,_Fields.VALID_WRITE_ID_LIST,_Fields.GET_FILE_METADATA,_Fields.ID};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -138,11 +150,17 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.VALID_WRITE_ID_LIST, new org.apache.thrift.meta_data.FieldMetaData("validWriteIdList", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.GET_FILE_METADATA, new org.apache.thrift.meta_data.FieldMetaData("getFileMetadata", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.ID, new org.apache.thrift.meta_data.FieldMetaData("id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(GetPartitionsByNamesRequest.class, metaDataMap);
   }
 
   public GetPartitionsByNamesRequest() {
+    this.id = -1L;
+
   }
 
   public GetPartitionsByNamesRequest(
@@ -183,6 +201,8 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetValidWriteIdList()) {
       this.validWriteIdList = other.validWriteIdList;
     }
+    this.getFileMetadata = other.getFileMetadata;
+    this.id = other.id;
   }
 
   public GetPartitionsByNamesRequest deepCopy() {
@@ -200,6 +220,10 @@ package org.apache.hadoop.hive.metastore.api;
     this.processorIdentifier = null;
     this.engine = null;
     this.validWriteIdList = null;
+    setGetFileMetadataIsSet(false);
+    this.getFileMetadata = false;
+    this.id = -1L;
+
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -424,6 +448,50 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  public boolean isGetFileMetadata() {
+    return this.getFileMetadata;
+  }
+
+  public void setGetFileMetadata(boolean getFileMetadata) {
+    this.getFileMetadata = getFileMetadata;
+    setGetFileMetadataIsSet(true);
+  }
+
+  public void unsetGetFileMetadata() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __GETFILEMETADATA_ISSET_ID);
+  }
+
+  /** Returns true if field getFileMetadata is set (has been assigned a value) and false otherwise */
+  public boolean isSetGetFileMetadata() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __GETFILEMETADATA_ISSET_ID);
+  }
+
+  public void setGetFileMetadataIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __GETFILEMETADATA_ISSET_ID, value);
+  }
+
+  public long getId() {
+    return this.id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+    setIdIsSet(true);
+  }
+
+  public void unsetId() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  /** Returns true if field id is set (has been assigned a value) and false otherwise */
+  public boolean isSetId() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  public void setIdIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __ID_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -490,6 +558,22 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case GET_FILE_METADATA:
+      if (value == null) {
+        unsetGetFileMetadata();
+      } else {
+        setGetFileMetadata((java.lang.Boolean)value);
+      }
+      break;
+
+    case ID:
+      if (value == null) {
+        unsetId();
+      } else {
+        setId((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -520,6 +604,12 @@ package org.apache.hadoop.hive.metastore.api;
     case VALID_WRITE_ID_LIST:
       return getValidWriteIdList();
 
+    case GET_FILE_METADATA:
+      return isGetFileMetadata();
+
+    case ID:
+      return getId();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -547,6 +637,10 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetEngine();
     case VALID_WRITE_ID_LIST:
       return isSetValidWriteIdList();
+    case GET_FILE_METADATA:
+      return isSetGetFileMetadata();
+    case ID:
+      return isSetId();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -638,6 +732,24 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_getFileMetadata = true && this.isSetGetFileMetadata();
+    boolean that_present_getFileMetadata = true && that.isSetGetFileMetadata();
+    if (this_present_getFileMetadata || that_present_getFileMetadata) {
+      if (!(this_present_getFileMetadata && that_present_getFileMetadata))
+        return false;
+      if (this.getFileMetadata != that.getFileMetadata)
+        return false;
+    }
+
+    boolean this_present_id = true && this.isSetId();
+    boolean that_present_id = true && that.isSetId();
+    if (this_present_id || that_present_id) {
+      if (!(this_present_id && that_present_id))
+        return false;
+      if (this.id != that.id)
+        return false;
+    }
+
     return true;
   }
 
@@ -676,6 +788,14 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetValidWriteIdList()) ? 131071 : 524287);
     if (isSetValidWriteIdList())
       hashCode = hashCode * 8191 + validWriteIdList.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetGetFileMetadata()) ? 131071 : 524287);
+    if (isSetGetFileMetadata())
+      hashCode = hashCode * 8191 + ((getFileMetadata) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetId()) ? 131071 : 524287);
+    if (isSetId())
+      hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(id);
 
     return hashCode;
   }
@@ -764,6 +884,26 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetValidWriteIdList()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.validWriteIdList, other.validWriteIdList);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetGetFileMetadata()).compareTo(other.isSetGetFileMetadata());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetGetFileMetadata()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.getFileMetadata, other.getFileMetadata);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetId()).compareTo(other.isSetId());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetId()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.id, other.id);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -858,6 +998,18 @@ package org.apache.hadoop.hive.metastore.api;
       } else {
         sb.append(this.validWriteIdList);
       }
+      first = false;
+    }
+    if (isSetGetFileMetadata()) {
+      if (!first) sb.append(", ");
+      sb.append("getFileMetadata:");
+      sb.append(this.getFileMetadata);
+      first = false;
+    }
+    if (isSetId()) {
+      if (!first) sb.append(", ");
+      sb.append("id:");
+      sb.append(this.id);
       first = false;
     }
     sb.append(")");
@@ -997,6 +1149,22 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 9: // GET_FILE_METADATA
+            if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+              struct.getFileMetadata = iprot.readBool();
+              struct.setGetFileMetadataIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
+          case 10: // ID
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.id = iprot.readI64();
+              struct.setIdIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1074,6 +1242,16 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.isSetGetFileMetadata()) {
+        oprot.writeFieldBegin(GET_FILE_METADATA_FIELD_DESC);
+        oprot.writeBool(struct.getFileMetadata);
+        oprot.writeFieldEnd();
+      }
+      if (struct.isSetId()) {
+        oprot.writeFieldBegin(ID_FIELD_DESC);
+        oprot.writeI64(struct.id);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1112,7 +1290,13 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValidWriteIdList()) {
         optionals.set(5);
       }
-      oprot.writeBitSet(optionals, 6);
+      if (struct.isSetGetFileMetadata()) {
+        optionals.set(6);
+      }
+      if (struct.isSetId()) {
+        optionals.set(7);
+      }
+      oprot.writeBitSet(optionals, 8);
       if (struct.isSetNames()) {
         {
           oprot.writeI32(struct.names.size());
@@ -1143,6 +1327,12 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValidWriteIdList()) {
         oprot.writeString(struct.validWriteIdList);
       }
+      if (struct.isSetGetFileMetadata()) {
+        oprot.writeBool(struct.getFileMetadata);
+      }
+      if (struct.isSetId()) {
+        oprot.writeI64(struct.id);
+      }
     }
 
     @Override
@@ -1152,7 +1342,7 @@ package org.apache.hadoop.hive.metastore.api;
       struct.setDb_nameIsSet(true);
       struct.tbl_name = iprot.readString();
       struct.setTbl_nameIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(6);
+      java.util.BitSet incoming = iprot.readBitSet(8);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list644 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
@@ -1194,6 +1384,14 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(5)) {
         struct.validWriteIdList = iprot.readString();
         struct.setValidWriteIdListIsSet(true);
+      }
+      if (incoming.get(6)) {
+        struct.getFileMetadata = iprot.readBool();
+        struct.setGetFileMetadataIsSet(true);
+      }
+      if (incoming.get(7)) {
+        struct.id = iprot.readI64();
+        struct.setIdIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetPartitionsByNamesRequest.php
@@ -69,6 +69,16 @@ class GetPartitionsByNamesRequest
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        9 => array(
+            'var' => 'getFileMetadata',
+            'isRequired' => false,
+            'type' => TType::BOOL,
+        ),
+        10 => array(
+            'var' => 'id',
+            'isRequired' => false,
+            'type' => TType::I64,
+        ),
     );
 
     /**
@@ -103,6 +113,14 @@ class GetPartitionsByNamesRequest
      * @var string
      */
     public $validWriteIdList = null;
+    /**
+     * @var bool
+     */
+    public $getFileMetadata = null;
+    /**
+     * @var int
+     */
+    public $id = -1;
 
     public function __construct($vals = null)
     {
@@ -130,6 +148,12 @@ class GetPartitionsByNamesRequest
             }
             if (isset($vals['validWriteIdList'])) {
                 $this->validWriteIdList = $vals['validWriteIdList'];
+            }
+            if (isset($vals['getFileMetadata'])) {
+                $this->getFileMetadata = $vals['getFileMetadata'];
+            }
+            if (isset($vals['id'])) {
+                $this->id = $vals['id'];
             }
         }
     }
@@ -227,6 +251,20 @@ class GetPartitionsByNamesRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 9:
+                    if ($ftype == TType::BOOL) {
+                        $xfer += $input->readBool($this->getFileMetadata);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
+                case 10:
+                    if ($ftype == TType::I64) {
+                        $xfer += $input->readI64($this->id);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -293,6 +331,16 @@ class GetPartitionsByNamesRequest
         if ($this->validWriteIdList !== null) {
             $xfer += $output->writeFieldBegin('validWriteIdList', TType::STRING, 8);
             $xfer += $output->writeString($this->validWriteIdList);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->getFileMetadata !== null) {
+            $xfer += $output->writeFieldBegin('getFileMetadata', TType::BOOL, 9);
+            $xfer += $output->writeBool($this->getFileMetadata);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->id !== null) {
+            $xfer += $output->writeFieldBegin('id', TType::I64, 10);
+            $xfer += $output->writeI64($this->id);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -10732,11 +10732,13 @@ class GetPartitionsByNamesRequest(object):
      - processorIdentifier
      - engine
      - validWriteIdList
+     - getFileMetadata
+     - id
 
     """
 
 
-    def __init__(self, db_name=None, tbl_name=None, names=None, get_col_stats=None, processorCapabilities=None, processorIdentifier=None, engine=None, validWriteIdList=None,):
+    def __init__(self, db_name=None, tbl_name=None, names=None, get_col_stats=None, processorCapabilities=None, processorIdentifier=None, engine=None, validWriteIdList=None, getFileMetadata=None, id=-1,):
         self.db_name = db_name
         self.tbl_name = tbl_name
         self.names = names
@@ -10745,6 +10747,8 @@ class GetPartitionsByNamesRequest(object):
         self.processorIdentifier = processorIdentifier
         self.engine = engine
         self.validWriteIdList = validWriteIdList
+        self.getFileMetadata = getFileMetadata
+        self.id = id
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -10805,6 +10809,16 @@ class GetPartitionsByNamesRequest(object):
                     self.validWriteIdList = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 9:
+                if ftype == TType.BOOL:
+                    self.getFileMetadata = iprot.readBool()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 10:
+                if ftype == TType.I64:
+                    self.id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -10852,6 +10866,14 @@ class GetPartitionsByNamesRequest(object):
         if self.validWriteIdList is not None:
             oprot.writeFieldBegin('validWriteIdList', TType.STRING, 8)
             oprot.writeString(self.validWriteIdList.encode('utf-8') if sys.version_info[0] == 2 else self.validWriteIdList)
+            oprot.writeFieldEnd()
+        if self.getFileMetadata is not None:
+            oprot.writeFieldBegin('getFileMetadata', TType.BOOL, 9)
+            oprot.writeBool(self.getFileMetadata)
+            oprot.writeFieldEnd()
+        if self.id is not None:
+            oprot.writeFieldBegin('id', TType.I64, 10)
+            oprot.writeI64(self.id)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27667,6 +27689,8 @@ GetPartitionsByNamesRequest.thrift_spec = (
     (6, TType.STRING, 'processorIdentifier', 'UTF8', None, ),  # 6
     (7, TType.STRING, 'engine', 'UTF8', None, ),  # 7
     (8, TType.STRING, 'validWriteIdList', 'UTF8', None, ),  # 8
+    (9, TType.BOOL, 'getFileMetadata', None, None, ),  # 9
+    (10, TType.I64, 'id', None, -1, ),  # 10
 )
 all_structs.append(GetPartitionsByNamesResult)
 GetPartitionsByNamesResult.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -3282,6 +3282,8 @@ class GetPartitionsByNamesRequest
   PROCESSORIDENTIFIER = 6
   ENGINE = 7
   VALIDWRITEIDLIST = 8
+  GETFILEMETADATA = 9
+  ID = 10
 
   FIELDS = {
     DB_NAME => {:type => ::Thrift::Types::STRING, :name => 'db_name'},
@@ -3291,7 +3293,9 @@ class GetPartitionsByNamesRequest
     PROCESSORCAPABILITIES => {:type => ::Thrift::Types::LIST, :name => 'processorCapabilities', :element => {:type => ::Thrift::Types::STRING}, :optional => true},
     PROCESSORIDENTIFIER => {:type => ::Thrift::Types::STRING, :name => 'processorIdentifier', :optional => true},
     ENGINE => {:type => ::Thrift::Types::STRING, :name => 'engine', :optional => true},
-    VALIDWRITEIDLIST => {:type => ::Thrift::Types::STRING, :name => 'validWriteIdList', :optional => true}
+    VALIDWRITEIDLIST => {:type => ::Thrift::Types::STRING, :name => 'validWriteIdList', :optional => true},
+    GETFILEMETADATA => {:type => ::Thrift::Types::BOOL, :name => 'getFileMetadata', :optional => true},
+    ID => {:type => ::Thrift::Types::I64, :name => 'id', :default => -1, :optional => true}
   }
 
   def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -901,7 +901,9 @@ struct GetPartitionsByNamesRequest {
   5: optional list<string> processorCapabilities,
   6: optional string processorIdentifier,
   7: optional string engine,
-  8: optional string validWriteIdList
+  8: optional string validWriteIdList,
+  9: optional bool getFileMetadata,
+  10: optional i64 id=-1 // table id
 }
 
 struct GetPartitionsByNamesResult {


### PR DESCRIPTION
Add two optional entries for thrift structure GetPartitionsByNamesRequest:
1. getFileMetadata
2. id for table ID