### PR TITLE
HIVE-24397 : Add the projection specification to the table request object and add placeholders in ObjectStore.java

### DIFF
--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/listener/DummyRawStoreFailEvent.java
@@ -383,6 +383,12 @@ public class DummyRawStoreFailEvent implements RawStore, Configurable {
   }
 
   @Override
+  public List<Table> getTableObjectsByName(String catName, String dbName, List<String> tableNames,
+          GetProjectionsSpec projectionSpec) throws MetaException, UnknownDBException {
+    return objectStore.getTableObjectsByName(catName, dbName, tableNames, projectionSpec);
+  }
+
+  @Override
   public List<String> getAllTables(String catName, String dbName) throws MetaException {
     return objectStore.getAllTables(catName, dbName);
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -30853,6 +30853,11 @@ void GetTablesRequest::__set_processorIdentifier(const std::string& val) {
   this->processorIdentifier = val;
 __isset.processorIdentifier = true;
 }
+
+void GetTablesRequest::__set_projectionSpec(const GetProjectionsSpec& val) {
+  this->projectionSpec = val;
+__isset.projectionSpec = true;
+}
 std::ostream& operator<<(std::ostream& out, const GetTablesRequest& obj)
 {
   obj.printTo(out);
@@ -30954,6 +30959,14 @@ uint32_t GetTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->projectionSpec.read(iprot);
+          this->__isset.projectionSpec = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -31018,6 +31031,11 @@ uint32_t GetTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeString(this->processorIdentifier);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.projectionSpec) {
+    xfer += oprot->writeFieldBegin("projectionSpec", ::apache::thrift::protocol::T_STRUCT, 7);
+    xfer += this->projectionSpec.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -31031,6 +31049,7 @@ void swap(GetTablesRequest &a, GetTablesRequest &b) {
   swap(a.catName, b.catName);
   swap(a.processorCapabilities, b.processorCapabilities);
   swap(a.processorIdentifier, b.processorIdentifier);
+  swap(a.projectionSpec, b.projectionSpec);
   swap(a.__isset, b.__isset);
 }
 
@@ -31041,6 +31060,7 @@ GetTablesRequest::GetTablesRequest(const GetTablesRequest& other1156) {
   catName = other1156.catName;
   processorCapabilities = other1156.processorCapabilities;
   processorIdentifier = other1156.processorIdentifier;
+  projectionSpec = other1156.projectionSpec;
   __isset = other1156.__isset;
 }
 GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1157) {
@@ -31050,6 +31070,7 @@ GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1157)
   catName = other1157.catName;
   processorCapabilities = other1157.processorCapabilities;
   processorIdentifier = other1157.processorIdentifier;
+  projectionSpec = other1157.projectionSpec;
   __isset = other1157.__isset;
   return *this;
 }
@@ -31062,6 +31083,7 @@ void GetTablesRequest::printTo(std::ostream& out) const {
   out << ", " << "catName="; (__isset.catName ? (out << to_string(catName)) : (out << "<null>"));
   out << ", " << "processorCapabilities="; (__isset.processorCapabilities ? (out << to_string(processorCapabilities)) : (out << "<null>"));
   out << ", " << "processorIdentifier="; (__isset.processorIdentifier ? (out << to_string(processorIdentifier)) : (out << "<null>"));
+  out << ", " << "projectionSpec="; (__isset.projectionSpec ? (out << to_string(projectionSpec)) : (out << "<null>"));
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -11415,12 +11415,13 @@ void swap(GetTableResult &a, GetTableResult &b);
 std::ostream& operator<<(std::ostream& out, const GetTableResult& obj);
 
 typedef struct _GetTablesRequest__isset {
-  _GetTablesRequest__isset() : tblNames(false), capabilities(false), catName(false), processorCapabilities(false), processorIdentifier(false) {}
+  _GetTablesRequest__isset() : tblNames(false), capabilities(false), catName(false), processorCapabilities(false), processorIdentifier(false), projectionSpec(false) {}
   bool tblNames :1;
   bool capabilities :1;
   bool catName :1;
   bool processorCapabilities :1;
   bool processorIdentifier :1;
+  bool projectionSpec :1;
 } _GetTablesRequest__isset;
 
 class GetTablesRequest : public virtual ::apache::thrift::TBase {
@@ -11438,6 +11439,7 @@ class GetTablesRequest : public virtual ::apache::thrift::TBase {
   std::string catName;
   std::vector<std::string>  processorCapabilities;
   std::string processorIdentifier;
+  GetProjectionsSpec projectionSpec;
 
   _GetTablesRequest__isset __isset;
 
@@ -11452,6 +11454,8 @@ class GetTablesRequest : public virtual ::apache::thrift::TBase {
   void __set_processorCapabilities(const std::vector<std::string> & val);
 
   void __set_processorIdentifier(const std::string& val);
+
+  void __set_projectionSpec(const GetProjectionsSpec& val);
 
   bool operator == (const GetTablesRequest & rhs) const
   {
@@ -11476,6 +11480,10 @@ class GetTablesRequest : public virtual ::apache::thrift::TBase {
     if (__isset.processorIdentifier != rhs.__isset.processorIdentifier)
       return false;
     else if (__isset.processorIdentifier && !(processorIdentifier == rhs.processorIdentifier))
+      return false;
+    if (__isset.projectionSpec != rhs.__isset.projectionSpec)
+      return false;
+    else if (__isset.projectionSpec && !(projectionSpec == rhs.projectionSpec))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/GetTablesRequest.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField CAT_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catName", org.apache.thrift.protocol.TType.STRING, (short)4);
   private static final org.apache.thrift.protocol.TField PROCESSOR_CAPABILITIES_FIELD_DESC = new org.apache.thrift.protocol.TField("processorCapabilities", org.apache.thrift.protocol.TType.LIST, (short)5);
   private static final org.apache.thrift.protocol.TField PROCESSOR_IDENTIFIER_FIELD_DESC = new org.apache.thrift.protocol.TField("processorIdentifier", org.apache.thrift.protocol.TType.STRING, (short)6);
+  private static final org.apache.thrift.protocol.TField PROJECTION_SPEC_FIELD_DESC = new org.apache.thrift.protocol.TField("projectionSpec", org.apache.thrift.protocol.TType.STRUCT, (short)7);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new GetTablesRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new GetTablesRequestTupleSchemeFactory();
@@ -27,6 +28,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String catName; // optional
   private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> processorCapabilities; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String processorIdentifier; // optional
+  private @org.apache.thrift.annotation.Nullable GetProjectionsSpec projectionSpec; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35,7 +37,8 @@ package org.apache.hadoop.hive.metastore.api;
     CAPABILITIES((short)3, "capabilities"),
     CAT_NAME((short)4, "catName"),
     PROCESSOR_CAPABILITIES((short)5, "processorCapabilities"),
-    PROCESSOR_IDENTIFIER((short)6, "processorIdentifier");
+    PROCESSOR_IDENTIFIER((short)6, "processorIdentifier"),
+    PROJECTION_SPEC((short)7, "projectionSpec");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -63,6 +66,8 @@ package org.apache.hadoop.hive.metastore.api;
           return PROCESSOR_CAPABILITIES;
         case 6: // PROCESSOR_IDENTIFIER
           return PROCESSOR_IDENTIFIER;
+        case 7: // PROJECTION_SPEC
+          return PROJECTION_SPEC;
         default:
           return null;
       }
@@ -104,7 +109,7 @@ package org.apache.hadoop.hive.metastore.api;
   }
 
   // isset id assignments
-  private static final _Fields optionals[] = {_Fields.TBL_NAMES,_Fields.CAPABILITIES,_Fields.CAT_NAME,_Fields.PROCESSOR_CAPABILITIES,_Fields.PROCESSOR_IDENTIFIER};
+  private static final _Fields optionals[] = {_Fields.TBL_NAMES,_Fields.CAPABILITIES,_Fields.CAT_NAME,_Fields.PROCESSOR_CAPABILITIES,_Fields.PROCESSOR_IDENTIFIER,_Fields.PROJECTION_SPEC};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -122,6 +127,8 @@ package org.apache.hadoop.hive.metastore.api;
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
     tmpMap.put(_Fields.PROCESSOR_IDENTIFIER, new org.apache.thrift.meta_data.FieldMetaData("processorIdentifier", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.PROJECTION_SPEC, new org.apache.thrift.meta_data.FieldMetaData("projectionSpec", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT        , "GetProjectionsSpec")));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(GetTablesRequest.class, metaDataMap);
   }
@@ -160,6 +167,9 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetProcessorIdentifier()) {
       this.processorIdentifier = other.processorIdentifier;
     }
+    if (other.isSetProjectionSpec()) {
+      this.projectionSpec = new GetProjectionsSpec(other.projectionSpec);
+    }
   }
 
   public GetTablesRequest deepCopy() {
@@ -174,6 +184,7 @@ package org.apache.hadoop.hive.metastore.api;
     this.catName = null;
     this.processorCapabilities = null;
     this.processorIdentifier = null;
+    this.projectionSpec = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -352,6 +363,30 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public GetProjectionsSpec getProjectionSpec() {
+    return this.projectionSpec;
+  }
+
+  public void setProjectionSpec(@org.apache.thrift.annotation.Nullable GetProjectionsSpec projectionSpec) {
+    this.projectionSpec = projectionSpec;
+  }
+
+  public void unsetProjectionSpec() {
+    this.projectionSpec = null;
+  }
+
+  /** Returns true if field projectionSpec is set (has been assigned a value) and false otherwise */
+  public boolean isSetProjectionSpec() {
+    return this.projectionSpec != null;
+  }
+
+  public void setProjectionSpecIsSet(boolean value) {
+    if (!value) {
+      this.projectionSpec = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -402,6 +437,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case PROJECTION_SPEC:
+      if (value == null) {
+        unsetProjectionSpec();
+      } else {
+        setProjectionSpec((GetProjectionsSpec)value);
+      }
+      break;
+
     }
   }
 
@@ -426,6 +469,9 @@ package org.apache.hadoop.hive.metastore.api;
     case PROCESSOR_IDENTIFIER:
       return getProcessorIdentifier();
 
+    case PROJECTION_SPEC:
+      return getProjectionSpec();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -449,6 +495,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetProcessorCapabilities();
     case PROCESSOR_IDENTIFIER:
       return isSetProcessorIdentifier();
+    case PROJECTION_SPEC:
+      return isSetProjectionSpec();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -522,6 +570,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_projectionSpec = true && this.isSetProjectionSpec();
+    boolean that_present_projectionSpec = true && that.isSetProjectionSpec();
+    if (this_present_projectionSpec || that_present_projectionSpec) {
+      if (!(this_present_projectionSpec && that_present_projectionSpec))
+        return false;
+      if (!this.projectionSpec.equals(that.projectionSpec))
+        return false;
+    }
+
     return true;
   }
 
@@ -552,6 +609,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetProcessorIdentifier()) ? 131071 : 524287);
     if (isSetProcessorIdentifier())
       hashCode = hashCode * 8191 + processorIdentifier.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetProjectionSpec()) ? 131071 : 524287);
+    if (isSetProjectionSpec())
+      hashCode = hashCode * 8191 + projectionSpec.hashCode();
 
     return hashCode;
   }
@@ -620,6 +681,16 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetProcessorIdentifier()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.processorIdentifier, other.processorIdentifier);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetProjectionSpec()).compareTo(other.isSetProjectionSpec());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetProjectionSpec()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.projectionSpec, other.projectionSpec);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -699,6 +770,16 @@ package org.apache.hadoop.hive.metastore.api;
         sb.append("null");
       } else {
         sb.append(this.processorIdentifier);
+      }
+      first = false;
+    }
+    if (isSetProjectionSpec()) {
+      if (!first) sb.append(", ");
+      sb.append("projectionSpec:");
+      if (this.projectionSpec == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.projectionSpec);
       }
       first = false;
     }
@@ -821,6 +902,15 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 7: // PROJECTION_SPEC
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+              struct.projectionSpec = new GetProjectionsSpec();
+              struct.projectionSpec.read(iprot);
+              struct.setProjectionSpecIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -888,6 +978,13 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.projectionSpec != null) {
+        if (struct.isSetProjectionSpec()) {
+          oprot.writeFieldBegin(PROJECTION_SPEC_FIELD_DESC);
+          struct.projectionSpec.write(oprot);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -922,7 +1019,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorIdentifier()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetProjectionSpec()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetTblNames()) {
         {
           oprot.writeI32(struct.tblNames.size());
@@ -950,6 +1050,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetProcessorIdentifier()) {
         oprot.writeString(struct.processorIdentifier);
       }
+      if (struct.isSetProjectionSpec()) {
+        struct.projectionSpec.write(oprot);
+      }
     }
 
     @Override
@@ -957,7 +1060,7 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       struct.dbName = iprot.readString();
       struct.setDbNameIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list1010 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
@@ -996,6 +1099,11 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(4)) {
         struct.processorIdentifier = iprot.readString();
         struct.setProcessorIdentifierIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.projectionSpec = new GetProjectionsSpec();
+        struct.projectionSpec.read(iprot);
+        struct.setProjectionSpecIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/GetTablesRequest.php
@@ -60,6 +60,12 @@ class GetTablesRequest
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        7 => array(
+            'var' => 'projectionSpec',
+            'isRequired' => false,
+            'type' => TType::STRUCT,
+            'class' => '\metastore\GetProjectionsSpec',
+        ),
     );
 
     /**
@@ -86,6 +92,10 @@ class GetTablesRequest
      * @var string
      */
     public $processorIdentifier = null;
+    /**
+     * @var \metastore\GetProjectionsSpec
+     */
+    public $projectionSpec = null;
 
     public function __construct($vals = null)
     {
@@ -107,6 +117,9 @@ class GetTablesRequest
             }
             if (isset($vals['processorIdentifier'])) {
                 $this->processorIdentifier = $vals['processorIdentifier'];
+            }
+            if (isset($vals['projectionSpec'])) {
+                $this->projectionSpec = $vals['projectionSpec'];
             }
         }
     }
@@ -191,6 +204,14 @@ class GetTablesRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 7:
+                    if ($ftype == TType::STRUCT) {
+                        $this->projectionSpec = new \metastore\GetProjectionsSpec();
+                        $xfer += $this->projectionSpec->read($input);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -250,6 +271,14 @@ class GetTablesRequest
         if ($this->processorIdentifier !== null) {
             $xfer += $output->writeFieldBegin('processorIdentifier', TType::STRING, 6);
             $xfer += $output->writeString($this->processorIdentifier);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->projectionSpec !== null) {
+            if (!is_object($this->projectionSpec)) {
+                throw new TProtocolException('Bad type in structure.', TProtocolException::INVALID_DATA);
+            }
+            $xfer += $output->writeFieldBegin('projectionSpec', TType::STRUCT, 7);
+            $xfer += $this->projectionSpec->write($output);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -17700,17 +17700,19 @@ class GetTablesRequest(object):
      - catName
      - processorCapabilities
      - processorIdentifier
+     - projectionSpec
 
     """
 
 
-    def __init__(self, dbName=None, tblNames=None, capabilities=None, catName=None, processorCapabilities=None, processorIdentifier=None,):
+    def __init__(self, dbName=None, tblNames=None, capabilities=None, catName=None, processorCapabilities=None, processorIdentifier=None, projectionSpec=None,):
         self.dbName = dbName
         self.tblNames = tblNames
         self.capabilities = capabilities
         self.catName = catName
         self.processorCapabilities = processorCapabilities
         self.processorIdentifier = processorIdentifier
+        self.projectionSpec = projectionSpec
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -17762,6 +17764,12 @@ class GetTablesRequest(object):
                     self.processorIdentifier = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.STRUCT:
+                    self.projectionSpec = GetProjectionsSpec()
+                    self.projectionSpec.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -17801,6 +17809,10 @@ class GetTablesRequest(object):
         if self.processorIdentifier is not None:
             oprot.writeFieldBegin('processorIdentifier', TType.STRING, 6)
             oprot.writeString(self.processorIdentifier.encode('utf-8') if sys.version_info[0] == 2 else self.processorIdentifier)
+            oprot.writeFieldEnd()
+        if self.projectionSpec is not None:
+            oprot.writeFieldBegin('projectionSpec', TType.STRUCT, 7)
+            self.projectionSpec.write(oprot)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28226,6 +28238,7 @@ GetTablesRequest.thrift_spec = (
     (4, TType.STRING, 'catName', 'UTF8', None, ),  # 4
     (5, TType.LIST, 'processorCapabilities', (TType.STRING, 'UTF8', False), None, ),  # 5
     (6, TType.STRING, 'processorIdentifier', 'UTF8', None, ),  # 6
+    (7, TType.STRUCT, 'projectionSpec', [GetProjectionsSpec, None], None, ),  # 7
 )
 all_structs.append(GetTablesResult)
 GetTablesResult.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -5040,6 +5040,7 @@ class GetTablesRequest
   CATNAME = 4
   PROCESSORCAPABILITIES = 5
   PROCESSORIDENTIFIER = 6
+  PROJECTIONSPEC = 7
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
@@ -5047,7 +5048,8 @@ class GetTablesRequest
     CAPABILITIES => {:type => ::Thrift::Types::STRUCT, :name => 'capabilities', :class => ::ClientCapabilities, :optional => true},
     CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true},
     PROCESSORCAPABILITIES => {:type => ::Thrift::Types::LIST, :name => 'processorCapabilities', :element => {:type => ::Thrift::Types::STRING}, :optional => true},
-    PROCESSORIDENTIFIER => {:type => ::Thrift::Types::STRING, :name => 'processorIdentifier', :optional => true}
+    PROCESSORIDENTIFIER => {:type => ::Thrift::Types::STRING, :name => 'processorIdentifier', :optional => true},
+    PROJECTIONSPEC => {:type => ::Thrift::Types::STRUCT, :name => 'projectionSpec', :class => ::GetProjectionsSpec, :optional => true}
   }
 
   def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2366,6 +2366,20 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   }
 
   @Override
+  public List<Table> getTableObjectsByRequest(GetTablesRequest req) throws TException {
+    if (processorCapabilities != null)
+      req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
+    if (processorIdentifier != null)
+      req.setProcessorIdentifier(processorIdentifier);
+    if (req.getCapabilities() == null) {
+      req.setCapabilities(version);
+    }
+    req.setCapabilities(version);
+    List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
+    return deepCopyTables(FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs));
+  }
+
+  @Override
   public Materialization getMaterializationInvalidationInfo(CreationMetadata cm, String validTxnList)
       throws MetaException, InvalidOperationException, UnknownDBException, TException {
     return client.get_materialization_invalidation_info(cm, validTxnList);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2366,7 +2366,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   }
 
   @Override
-  public List<Table> getTableObjectsByRequest(GetTablesRequest req) throws TException {
+  public GetTablesResult getTables(GetTablesRequest req) throws TException {
     if (processorCapabilities != null)
       req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
     if (processorIdentifier != null)
@@ -2376,7 +2376,8 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     req.setCapabilities(version);
     List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
-    return deepCopyTables(FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs));
+    return new GetTablesResult(deepCopyTables(
+            FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs)));
   }
 
   @Override

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2349,34 +2349,27 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   @Override
   public List<Table> getTableObjectsByName(String dbName, List<String> tableNames)
       throws TException {
-    return getTableObjectsByName(getDefaultCatalog(conf), dbName, tableNames);
+    return getTables(getDefaultCatalog(conf), dbName, tableNames, null);
   }
 
   @Override
   public List<Table> getTableObjectsByName(String catName, String dbName,
                                            List<String> tableNames) throws TException {
+    return getTables(catName, dbName, tableNames, null);
+  }
+
+  @Override
+  public List<Table> getTables(String catName, String dbName, List<String> tableNames,
+      GetProjectionsSpec projectionsSpec) throws TException {
     GetTablesRequest req = new GetTablesRequest(dbName);
     req.setCatName(catName);
     req.setTblNames(tableNames);
     req.setCapabilities(version);
     if (processorCapabilities != null)
       req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
+    req.setProjectionSpec(projectionsSpec);
     List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
     return deepCopyTables(FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs));
-  }
-
-  @Override
-  public GetTablesResult getTables(GetTablesRequest req) throws TException {
-    if (processorCapabilities != null)
-      req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
-    if (processorIdentifier != null)
-      req.setProcessorIdentifier(processorIdentifier);
-    if (req.getCapabilities() == null)
-      req.setCapabilities(version);
-
-    List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
-    return new GetTablesResult(deepCopyTables(
-            FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs)));
   }
 
   @Override

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -2371,10 +2371,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       req.setProcessorCapabilities(new ArrayList<String>(Arrays.asList(processorCapabilities)));
     if (processorIdentifier != null)
       req.setProcessorIdentifier(processorIdentifier);
-    if (req.getCapabilities() == null) {
+    if (req.getCapabilities() == null)
       req.setCapabilities(version);
-    }
-    req.setCapabilities(version);
+
     List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
     return new GetTablesResult(deepCopyTables(
             FilterUtils.filterTablesIfEnabled(isClientFilterEnabled, filterHook, tabs)));

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -733,11 +733,13 @@ public interface IMetaStoreClient {
   List<Table> getTableObjectsByName(String dbName, List<String> tableNames)
       throws MetaException, InvalidOperationException, UnknownDBException, TException;
 
-
   /**
    * Get tables as objects (rather than just fetching their names).  This is more expensive and
    * should only be used if you actually need all the information about the tables.
-   * @param request GetTablesRequest Object.
+   * @param catName catalog name
+   * @param dbName The database the tables are located in.
+   * @param tableNames The names of the tables to fetch.
+   * @param projectionsSpec The subset of columns that need to be fetched as part of the table object.
    * @return A list of objects representing the tables.
    *          Only the tables that can be retrieved from the database are returned.  For example,
    *          if none of the requested tables could be retrieved, an empty list is returned.
@@ -751,7 +753,7 @@ public interface IMetaStoreClient {
    * @throws MetaException
    *          Any other errors
    */
-  GetTablesResult getTables(GetTablesRequest request)
+  List<Table> getTables(String catName, String dbName, List<String> tableNames, GetProjectionsSpec projectionsSpec)
           throws MetaException, InvalidOperationException, UnknownDBException, TException;
 
   /**

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -751,7 +751,7 @@ public interface IMetaStoreClient {
    * @throws MetaException
    *          Any other errors
    */
-  List<Table> getTableObjectsByRequest(GetTablesRequest request)
+  GetTablesResult getTables(GetTablesRequest request)
           throws MetaException, InvalidOperationException, UnknownDBException, TException;
 
   /**

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -733,6 +733,27 @@ public interface IMetaStoreClient {
   List<Table> getTableObjectsByName(String dbName, List<String> tableNames)
       throws MetaException, InvalidOperationException, UnknownDBException, TException;
 
+
+  /**
+   * Get tables as objects (rather than just fetching their names).  This is more expensive and
+   * should only be used if you actually need all the information about the tables.
+   * @param request GetTablesRequest Object.
+   * @return A list of objects representing the tables.
+   *          Only the tables that can be retrieved from the database are returned.  For example,
+   *          if none of the requested tables could be retrieved, an empty list is returned.
+   *          There is no guarantee of ordering of the returned tables.
+   * @throws InvalidOperationException
+   *          The input to this operation is invalid (e.g., the list of tables names is null)
+   * @throws UnknownDBException
+   *          The requested database could not be fetched.
+   * @throws TException
+   *          A thrift communication error occurred
+   * @throws MetaException
+   *          Any other errors
+   */
+  List<Table> getTableObjectsByRequest(GetTablesRequest request)
+          throws MetaException, InvalidOperationException, UnknownDBException, TException;
+
   /**
    * Get tables as objects (rather than just fetching their names).  This is more expensive and
    * should only be used if you actually need all the information about the tables.

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -1952,11 +1952,11 @@ struct GetProjectionsSpec {
    1: list<string> fieldList;
    // SQL-92 compliant regex pattern for param keys to be included
    // _ or % wildcards are supported. '_' represent one character and '%' represents 0 or more characters
-   // Currently this is unsupported.
+   // Currently this is unsupported when fetching tables.
    2: string includeParamKeyPattern;
    // SQL-92 compliant regex pattern for param keys to be excluded
    // _ or % wildcards are supported. '_' represent one character and '%' represents 0 or more characters
-   // Current this is unsupported.
+   // Current this is unsupported  when fetching tables.
    3: string excludeParamKeyPattern;
 }
 

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -1952,9 +1952,11 @@ struct GetProjectionsSpec {
    1: list<string> fieldList;
    // SQL-92 compliant regex pattern for param keys to be included
    // _ or % wildcards are supported. '_' represent one character and '%' represents 0 or more characters
+   // Currently this is unsupported.
    2: string includeParamKeyPattern;
    // SQL-92 compliant regex pattern for param keys to be excluded
    // _ or % wildcards are supported. '_' represent one character and '%' represents 0 or more characters
+   // Current this is unsupported.
    3: string excludeParamKeyPattern;
 }
 

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -1454,7 +1454,8 @@ struct GetTablesRequest {
   3: optional ClientCapabilities capabilities,
   4: optional string catName,
   5: optional list<string> processorCapabilities,
-  6: optional string processorIdentifier
+  6: optional string processorIdentifier,
+  7: optional GetProjectionsSpec projectionSpec
 }
 
 struct GetTablesResult {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -3571,19 +3571,20 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     public List<Table> get_table_objects_by_name(final String dbName, final List<String> tableNames)
         throws MetaException, InvalidOperationException, UnknownDBException {
       String[] parsedDbName = parseDbName(dbName, conf);
-      return getTableObjectsInternal(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], tableNames, null);
+      return getTableObjectsInternal(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], tableNames, null, null);
     }
 
     @Override
     public GetTablesResult get_table_objects_by_name_req(GetTablesRequest req) throws TException {
       String catName = req.isSetCatName() ? req.getCatName() : getDefaultCatalog(conf);
       return new GetTablesResult(getTableObjectsInternal(catName, req.getDbName(),
-          req.getTblNames(), req.getCapabilities()));
+          req.getTblNames(), req.getCapabilities(), req.getProjectionSpec()));
     }
 
     private List<Table> getTableObjectsInternal(String catName, String dbName,
                                                 List<String> tableNames,
-                                                ClientCapabilities capabilities)
+                                                ClientCapabilities capabilities,
+                                                GetProjectionsSpec projectionsSpec)
             throws MetaException, InvalidOperationException, UnknownDBException {
       if (isInTest) {
         assertClientHasCapability(capabilities, ClientCapability.TEST_CAPABILITY,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -3623,11 +3623,11 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         while (startIndex < distinctTableNames.size()) {
           int endIndex = Math.min(startIndex + tableBatchSize, distinctTableNames.size());
           tables.addAll(ms.getTableObjectsByName(catName, dbName, distinctTableNames.subList(
-              startIndex, endIndex)));
+              startIndex, endIndex), projectionsSpec));
           startIndex = endIndex;
         }
         for (Table t : tables) {
-          if (MetaStoreUtils.isInsertOnlyTableParam(t.getParameters())) {
+          if (t.getParameters() != null && MetaStoreUtils.isInsertOnlyTableParam(t.getParameters())) {
             assertClientHasCapability(capabilities, ClientCapability.INSERT_ONLY_TABLES,
                 "insert-only tables", "get_table_req");
           }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -3590,6 +3590,14 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         assertClientHasCapability(capabilities, ClientCapability.TEST_CAPABILITY,
             "Hive tests", "get_table_objects_by_name_req");
       }
+
+      if (projectionsSpec != null) {
+        if (!projectionsSpec.isSetFieldList() && (projectionsSpec.isSetIncludeParamKeyPattern() ||
+                projectionsSpec.isSetExcludeParamKeyPattern())) {
+          throw new InvalidOperationException("Include and Exclude Param key are not supported.");
+        }
+      }
+
       List<Table> tables = new ArrayList<>();
       startMultiTableFunction("get_multi_table", dbName, tableNames);
       Exception ex = null;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -1890,8 +1890,7 @@ public class ObjectStore implements RawStore, Configurable {
 
       if (projectionFields == null) {
         mtables = (List<MTable>) query.execute(db, catName, lowered_tbl_names);
-      }
-      else {
+      } else {
         if (projectionFields.size() > 1) {
           // Execute the query to fetch the partial results.
           List<Object[]> results = (List<Object[]>) query.execute(db, catName, lowered_tbl_names);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -1907,27 +1907,27 @@ public class ObjectStore implements RawStore, Configurable {
           mtables.add(mtable);
         }
       }
+
+      //TODO: Verify
+      // If mtables were null due to an exception, this code will not be hit. However if the pattern did not match in
+      // the query and mtables were null then we can verify if this happened because the DB was not found.
+      if (mtables == null || mtables.isEmpty()) {
+        verifyDBExists(catName, db);
+      } else {
+        for (Iterator iter = mtables.iterator(); iter.hasNext(); ) {
+          Table tbl = convertToTable((MTable) iter.next());
+          // Retrieve creation metadata if needed
+          if (TableType.MATERIALIZED_VIEW.toString().equals(tbl.getTableType())) {
+            tbl.setCreationMetadata(
+                    convertToCreationMetadata(
+                            getCreationMetadata(tbl.getCatName(), tbl.getDbName(), tbl.getTableName())));
+          }
+          tables.add(tbl);
+        }
+      }
       committed = commitTransaction();
     } finally {
       rollbackAndCleanup(committed, query);
-    }
-
-    //TODO: Verify
-    // If mtables were null due to an exception, this code will not be hit. However if the pattern did not match in
-    // the query and mtables were null then we can verify if this happened because the DB was not found.
-    if (mtables == null || mtables.isEmpty()) {
-      verifyDBExists(catName, db);
-    } else {
-      for (Iterator iter = mtables.iterator(); iter.hasNext(); ) {
-        Table tbl = convertToTable((MTable) iter.next());
-        // Retrieve creation metadata if needed
-        if (TableType.MATERIALIZED_VIEW.toString().equals(tbl.getTableType())) {
-          tbl.setCreationMetadata(
-              convertToCreationMetadata(
-                  getCreationMetadata(tbl.getCatName(), tbl.getDbName(), tbl.getTableName())));
-        }
-        tables.add(tbl);
-      }
     }
     return tables;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -1892,6 +1892,12 @@ public class ObjectStore implements RawStore, Configurable {
     return tables;
   }
 
+  @Override
+  public List<Table> getTableObjectsByName(String catName, String db, List<String> tbl_names,
+          GetProjectionsSpec projectionsSpec) throws MetaException, UnknownDBException {
+    return getTableObjectsByName(catName, db, tbl_names, null);
+  }
+
   /** Makes shallow copy of a list to avoid DataNucleus mucking with our objects. */
   private <T> List<T> convertList(List<T> dnList) {
     return (dnList == null) ? null : Lists.newArrayList(dnList);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RawStore.java
@@ -445,6 +445,22 @@ public interface RawStore extends Configurable {
       throws MetaException, UnknownDBException;
 
   /**
+   * @param catName catalog name
+   * @param dbname
+   *        The name of the database from which to retrieve the tables
+   * @param tableNames
+   *        The names of the tables to retrieve.
+   * @param projectionSpec
+   *        Projection Specification containing the columns that need to be returned.
+   * @return A list of the tables retrievable from the database
+   *          whose names are in the list tableNames.
+   *         If there are duplicate names, only one instance of the table will be returned
+   * @throws MetaException failure in querying the RDBMS.
+   */
+  List<Table> getTableObjectsByName(String catName, String dbname, List<String> tableNames,
+                                    GetProjectionsSpec projectionSpec) throws MetaException, UnknownDBException;
+
+  /**
    * Get all tables in a database.
    * @param catName catalog name.
    * @param dbName database name.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/TableFields.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/TableFields.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+import java.util.*;
+
+// This class validates the Table fields and creates a mapping to the JDO Column names. When DirectSQL is implemented
+// this class should be integrated with the PartitionProjectionEvaluator class. The PartitionProjectionEvaluator class
+// should be converted to a tempalte that works for both partition and tables.
+public class TableFields {
+    // this map stores all the single valued fields in the table class and maps them to the corresponding
+    // single-valued fields from the MTable class. This map is used to parse the given table fields.
+    private static final ImmutableMap<String, String> allSingleValuedFields = new ImmutableMap.Builder<String, String>()
+            .put("id", "id")
+            .put("tableName", "tableName")
+            .put("dbName", "database.name")
+            .put("owner", "owner")
+            .put("createTime", "createTime")
+            .put("lastAccessTime", "lastAccessTime")
+            .put("retention", "retention")
+            .put("sd.location", "sd.location")
+            .put("sd.inputFormat", "sd.inputFormat")
+            .put("sd.outputFormat", "sd.outputFormat")
+            .put("sd.compressed", "sd.isCompressed")
+            .put("sd.numBuckets", "sd.numBuckets")
+            .put("sd.serdeInfo.name", "sd.serDeInfo.name")
+            .put("sd.serdeInfo.serializationLib", "sd.serDeInfo.serializationLib")
+            .put("sd.serdeInfo.description", "sd.serDeInfo.description")
+            .put("sd.serdeInfo.serializerClass", "sd.serDeInfo.serializerClass")
+            .put("sd.serdeInfo.deserializerClass", "sd.serDeInfo.deserializerClass")
+            .put("sd.serdeInfo.serdeType", "sd.serDeInfo.serdeType")
+            .put("viewOriginalText", "viewOriginalText")
+            .put("viewExpandedText", "viewExpandedText")
+            .put("rewriteEnabled", "rewriteEnabled")
+            .put("tableType", "tableType")
+            .put("writeId", "writeId")
+            .build();
+
+    private static final ImmutableSet<String> allMultiValuedFields = new ImmutableSet.Builder<String>()
+            .add("values")
+            .add("sd.cols.name")
+            .add("sd.cols.type")
+            .add("sd.cols.comment")
+            .add("sd.serdeInfo.parameters")
+            .add("sd.bucketCols")
+            .add("sd.sortCols.col")
+            .add("sd.sortCols.order")
+            .add("sd.parameters")
+            .add("sd.skewedInfo.skewedColNames")
+            .add("sd.skewedInfo.skewedColValues")
+            .add("sd.skewedInfo.skewedColValueLocationMaps")
+            .add("partitionKeys.name")
+            .add("partitionKeys.type")
+            .add("partitionKeys.comment")
+            .add("parameters")
+            .build();
+
+    private static final ImmutableSet<String> allFields = new ImmutableSet.Builder<String>()
+            .addAll(allSingleValuedFields.keySet())
+            .addAll(allMultiValuedFields)
+            .build();
+
+    private static void validate(Collection<String> projectionFields) throws MetaException {
+        Set<String> verify = new HashSet<>(projectionFields);
+        verify.removeAll(allFields);
+        if (verify.size() > 0) {
+            throw new MetaException("Invalid table fields in the projection spec" + Arrays
+                    .toString(verify.toArray(new String[verify.size()])));
+        }
+    }
+
+    /**
+     * Given a list of table fields, checks if all the fields requested are single-valued. If all
+     * the fields are single-valued returns list of equivalent MTable fieldnames
+     * which can be used in the setResult clause of a JDO query
+     *
+     * @param fields of tableFields in the projection
+     * @return List of JDO field names which can be used in setResult clause
+     * of a JDO query. Returns null if input fields cannot be used in a setResult clause
+     */
+    public static List<String> getMFieldNames(List<String> fields)
+            throws MetaException {
+        // if there are no fields requested, it means all the fields are requested which include
+        // multi-valued fields.
+        if (fields == null || fields.isEmpty()) {
+            return null;
+        }
+        // throw exception if there are invalid field names
+        validate(fields);
+        // else, check if all the fields are single-valued. In case there are multi-valued fields requested
+        // return null since setResult in JDO doesn't support multi-valued fields
+        if (!allSingleValuedFields.keySet().containsAll(fields)) {
+            return null;
+        }
+
+        List<String> jdoFields = new ArrayList<>(fields.size());
+
+        for (String field : fields) {
+            jdoFields.add(allSingleValuedFields.get(field));
+        }
+        return jdoFields;
+    }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -1650,6 +1650,12 @@ public class CachedStore implements RawStore, Configurable {
     return tables;
   }
 
+  @Override
+  public List<Table> getTableObjectsByName(String catName, String db, List<String> tbl_names,
+          GetProjectionsSpec projectionsSpec) throws MetaException, UnknownDBException {
+    return getTableObjectsByName(catName, db, tbl_names, null);
+  }
+
   @Override public List<String> getAllTables(String catName, String dbName) throws MetaException {
     return rawStore.getAllTables(catName, dbName);
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreControlledCommit.java
@@ -351,6 +351,12 @@ public class DummyRawStoreControlledCommit implements RawStore, Configurable {
   }
 
   @Override
+  public List<Table> getTableObjectsByName(String catName, String dbname, List<String> tableNames,
+                                           GetProjectionsSpec projectionSpec) throws MetaException, UnknownDBException {
+    return Collections.emptyList();
+  }
+
+  @Override
   public List<String> getAllTables(String catName, String dbName) throws MetaException {
     return objectStore.getAllTables(catName, dbName);
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/DummyRawStoreForJdoConnection.java
@@ -348,6 +348,13 @@ public class DummyRawStoreForJdoConnection implements RawStore {
   }
 
   @Override
+  public List<Table> getTableObjectsByName(String catName, String dbname, List<String> tableNames,
+          GetProjectionsSpec projectionSpec) throws MetaException, UnknownDBException {
+
+    return Collections.emptyList();
+  }
+
+  @Override
   public List<String> getAllTables(String catName, String dbName) throws MetaException {
 
     return Collections.emptyList();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -1532,19 +1532,6 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
     return fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs));
   }
 
-  /** {@inheritDoc}
-   * @return*/
-  @Override
-  public GetTablesResult getTables(GetTablesRequest req)
-          throws MetaException, InvalidOperationException, UnknownDBException, TException {
-    if (req.getCapabilities() == null) {
-      req.setCapabilities(version);
-    }
-    List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
-    return new GetTablesResult(fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs)));
-  }
-
-
   /** {@inheritDoc} */
   @Override
   public List<ExtendedTableInfo> getTablesExt(String catName, String dbName, String tablePattern,
@@ -3282,6 +3269,13 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   public List<Table> getTableObjectsByName(String catName, String dbName,
                                            List<String> tableNames) throws MetaException,
       InvalidOperationException, UnknownDBException, TException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public List<Table> getTables(String catName, String dbName, List<String> tableNames,
+                                           GetProjectionsSpec projectionsSpec) throws MetaException,
+          InvalidOperationException, UnknownDBException, TException {
     throw new UnsupportedOperationException();
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -1532,15 +1532,16 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
     return fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs));
   }
 
-  /** {@inheritDoc} */
+  /** {@inheritDoc}
+   * @return*/
   @Override
-  public List<Table> getTableObjectsByRequest(GetTablesRequest req)
+  public GetTablesResult getTables(GetTablesRequest req)
           throws MetaException, InvalidOperationException, UnknownDBException, TException {
     if (req.getCapabilities() == null) {
       req.setCapabilities(version);
     }
     List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
-    return fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs));
+    return new GetTablesResult(fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs)));
   }
 
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -1534,6 +1534,18 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
 
   /** {@inheritDoc} */
   @Override
+  public List<Table> getTableObjectsByRequest(GetTablesRequest req)
+          throws MetaException, InvalidOperationException, UnknownDBException, TException {
+    if (req.getCapabilities() == null) {
+      req.setCapabilities(version);
+    }
+    List<Table> tabs = client.get_table_objects_by_name_req(req).getTables();
+    return fastpath ? tabs : deepCopyTables(filterHook.filterTables(tabs));
+  }
+
+
+  /** {@inheritDoc} */
+  @Override
   public List<ExtendedTableInfo> getTablesExt(String catName, String dbName, String tablePattern,
                  int requestedFields, int limit) throws MetaException, TException {
     GetTablesExtRequest req = new GetTablesExtRequest(catName, dbName, tablePattern, requestedFields);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
@@ -307,7 +307,7 @@ public class TestGetPartitionsUsingProjectionAndFilterSpecs {
     Assert.assertNotNull(partitionWithoutSDS);
     Assert.assertEquals(partitionWithoutSDS.size(), origPartitions.size());
     comparePartitionForSingleValuedFields(projectedFields, sharedSD, partitionWithoutSDS, 0);
-  }
+    }
 
   /**
    * Confirms if the partitionWithoutSD object at partitionWithoutSDSIndex index has all the

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
@@ -307,7 +307,7 @@ public class TestGetPartitionsUsingProjectionAndFilterSpecs {
     Assert.assertNotNull(partitionWithoutSDS);
     Assert.assertEquals(partitionWithoutSDS.size(), origPartitions.size());
     comparePartitionForSingleValuedFields(projectedFields, sharedSD, partitionWithoutSDS, 0);
-    }
+  }
 
   /**
    * Confirms if the partitionWithoutSD object at partitionWithoutSDSIndex index has all the

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.metastore.client;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.*;
 import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
@@ -47,7 +47,7 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
  * querying like getting one, or multiple tables, and table name lists.
  */
 @RunWith(Parameterized.class)
-@Category(MetastoreCheckinTest.class)
+@Category(MetastoreUnitTest.class)
 public class TestTablesGetExists extends MetaStoreClientTest {
   private static final String DEFAULT_DATABASE = "default";
   private static final String OTHER_DATABASE = "dummy";
@@ -399,17 +399,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
     List<String> projectedFields = Collections.singletonList("sd.location");
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     projectSpec.setFieldList(projectedFields);
 
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec);
     Assert.assertEquals("Found tables", 2, tables.size());
 
     for(Table table : tables) {
@@ -426,13 +420,7 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(null);
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, null);
 
     Assert.assertEquals("Found tables", 2, tables.size());
   }
@@ -443,15 +431,10 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     projectSpec.setExcludeParamKeyPattern("foo");
 
-    Assert.assertThrows(Exception.class, ()->client.getTables(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec));
   }
 
   @Test
@@ -460,16 +443,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList("Invalid1");
     projectSpec.setFieldList(projectedFields);
 
-    Assert.assertThrows(Exception.class, ()->client.getTables(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec));
   }
 
 
@@ -479,16 +457,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList("Invalid1", "Invalid2");
     projectSpec.setFieldList(projectedFields);
 
-    Assert.assertThrows(Exception.class, ()->client.getTables(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec));
   }
 
   @Test
@@ -497,17 +470,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList();
     projectSpec.setFieldList(projectedFields);
 
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec);
 
     Assert.assertEquals("Found tables", 2, tables.size());
   }
@@ -518,17 +485,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList("dbName", "tableName", "createTime", "lastAccessTime");
     projectSpec.setFieldList(projectedFields);
 
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec);
 
     Assert.assertEquals("Found tables", 2, tables.size());
 
@@ -546,17 +507,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList("sd.serdeInfo.name", "sd.serdeInfo.serializationLib", "sd.serdeInfo.description");
     projectSpec.setFieldList(projectedFields);
 
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec);
 
     Assert.assertEquals("Found tables", 2, tables.size());
 
@@ -577,17 +532,11 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     tableNames.add(testTables[0].getTableName());
     tableNames.add(testTables[1].getTableName());
 
-    GetTablesRequest request = new GetTablesRequest();
-    request.setProjectionSpec(new GetProjectionsSpec());
-    request.setTblNames(tableNames);
-    request.setDbName(DEFAULT_DATABASE);
-
-    GetProjectionsSpec projectSpec = request.getProjectionSpec();
+    GetProjectionsSpec projectSpec = new GetProjectionsSpec();
     List<String> projectedFields = Arrays.asList("sd.cols.name", "sd.serdeInfo.name", "sd.serdeInfo.serializationLib", "sd.serdeInfo.parameters");
     projectSpec.setFieldList(projectedFields);
 
-    GetTablesResult result = client.getTables(request);
-    List<Table> tables = result.getTables();
+    List<Table> tables = client.getTables(null, DEFAULT_DATABASE, tableNames, projectSpec);
 
     Assert.assertEquals("Found tables", 2, tables.size());
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -431,7 +431,9 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     request.setTblNames(tableNames);
     request.setDbName(DEFAULT_DATABASE);
 
-    Assert.assertThrows(Exception.class, ()->client.getTableObjectsByRequest(request));
+    List<Table> tables = client.getTableObjectsByRequest(request);
+
+    Assert.assertEquals("Found tables", 2, tables.size());
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.metastore.client;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.*;
 import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
@@ -47,7 +47,7 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
  * querying like getting one, or multiple tables, and table name lists.
  */
 @RunWith(Parameterized.class)
-@Category(MetastoreUnitTest.class)
+@Category(MetastoreCheckinTest.class)
 public class TestTablesGetExists extends MetaStoreClientTest {
   private static final String DEFAULT_DATABASE = "default";
   private static final String OTHER_DATABASE = "dummy";
@@ -567,6 +567,7 @@ public class TestTablesGetExists extends MetaStoreClientTest {
       Assert.assertFalse(sd.isSetCols());
       Assert.assertTrue(sd.isSetSerdeInfo());
       SerDeInfo serDeInfo = sd.getSerdeInfo();
+      Assert.assertTrue(serDeInfo.isSetSerializationLib());
     }
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.metastore.client;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
 import org.apache.hadoop.hive.metastore.api.*;
 import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
@@ -47,7 +47,7 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
  * querying like getting one, or multiple tables, and table name lists.
  */
 @RunWith(Parameterized.class)
-@Category(MetastoreCheckinTest.class)
+@Category(MetastoreUnitTest.class)
 public class TestTablesGetExists extends MetaStoreClientTest {
   private static final String DEFAULT_DATABASE = "default";
   private static final String OTHER_DATABASE = "dummy";
@@ -408,8 +408,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Collections.singletonList("sd.location");
     projectSpec.setFieldList(projectedFields);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
-
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
     Assert.assertEquals("Found tables", 2, tables.size());
 
     for(Table table : tables) {
@@ -431,7 +431,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     request.setTblNames(tableNames);
     request.setDbName(DEFAULT_DATABASE);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
 
     Assert.assertEquals("Found tables", 2, tables.size());
   }
@@ -450,7 +451,7 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     GetProjectionsSpec projectSpec = request.getProjectionSpec();
     projectSpec.setExcludeParamKeyPattern("foo");
 
-    Assert.assertThrows(Exception.class, ()->client.getTableObjectsByRequest(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(request));
   }
 
   @Test
@@ -468,7 +469,7 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList("Invalid1");
     projectSpec.setFieldList(projectedFields);
 
-    Assert.assertThrows(Exception.class, ()->client.getTableObjectsByRequest(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(request));
   }
 
 
@@ -487,7 +488,7 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList("Invalid1", "Invalid2");
     projectSpec.setFieldList(projectedFields);
 
-    Assert.assertThrows(Exception.class, ()->client.getTableObjectsByRequest(request));
+    Assert.assertThrows(Exception.class, ()->client.getTables(request));
   }
 
   @Test
@@ -505,7 +506,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList();
     projectSpec.setFieldList(projectedFields);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
 
     Assert.assertEquals("Found tables", 2, tables.size());
   }
@@ -525,7 +527,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList("dbName", "tableName", "createTime", "lastAccessTime");
     projectSpec.setFieldList(projectedFields);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
 
     Assert.assertEquals("Found tables", 2, tables.size());
 
@@ -552,7 +555,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList("sd.serdeInfo.name", "sd.serdeInfo.serializationLib", "sd.serdeInfo.description");
     projectSpec.setFieldList(projectedFields);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
 
     Assert.assertEquals("Found tables", 2, tables.size());
 
@@ -581,7 +585,8 @@ public class TestTablesGetExists extends MetaStoreClientTest {
     List<String> projectedFields = Arrays.asList("sd.cols.name", "sd.serdeInfo.name", "sd.serdeInfo.serializationLib", "sd.serdeInfo.parameters");
     projectSpec.setFieldList(projectedFields);
 
-    List<Table> tables = client.getTableObjectsByRequest(request);
+    GetTablesResult result = client.getTables(request);
+    List<Table> tables = result.getTables();
 
     Assert.assertEquals("Found tables", 2, tables.size());
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestTablesGetExists.java
@@ -21,7 +21,7 @@ package org.apache.hadoop.hive.metastore.client;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
-import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
+import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
 import org.apache.hadoop.hive.metastore.api.*;
 import org.apache.hadoop.hive.metastore.client.builder.CatalogBuilder;
 import org.apache.hadoop.hive.metastore.client.builder.DatabaseBuilder;
@@ -47,7 +47,7 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
  * querying like getting one, or multiple tables, and table name lists.
  */
 @RunWith(Parameterized.class)
-@Category(MetastoreUnitTest.class)
+@Category(MetastoreCheckinTest.class)
 public class TestTablesGetExists extends MetaStoreClientTest {
   private static final String DEFAULT_DATABASE = "default";
   private static final String OTHER_DATABASE = "dummy";


### PR DESCRIPTION
HIVE-24397 : Add the projection specification to the table request object and add placeholders in ObjectStore.java

The GetProjectionsSpec object is added to GetTablesRequest. The projection specification are passed down
to the RawStore implementations to enable creating a subset of the columns that are returned.

This patch does not introduce any customer facing changes.
