### PR TITLE
HIVE-24399: Optimize Deserializer creation

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Table.java
@@ -241,7 +241,7 @@ public class Table implements Serializable {
           "at least one column must be specified for the table");
     }
     if (!isView()) {
-      if (null == getDeserializerFromMetaStore(false)) {
+      if (null == getDeserializer(false)) {
         throw new HiveException("must specify a non-null serDe");
       }
       if (null == getInputFormatClass()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7714,15 +7714,15 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         } else {
           tableDescriptor = PlanUtils.getDefaultTableDesc(qb.getDirectoryDesc(), cols, colTypes);
         }
-        // We need a specific rowObjectInspector in this case
-        try {
-          specificRowObjectInspector =
-              (StructObjectInspector) tableDescriptor.getDeserializer(conf).getObjectInspector();
-        } catch (Exception e) {
-          throw new SemanticException(e.getMessage(), e);
-        }
       } else {
         tableDescriptor = PlanUtils.getTableDesc(tblDesc, cols, colTypes);
+      }
+      // We need a specific rowObjectInspector in this case
+      try {
+        specificRowObjectInspector =
+            (StructObjectInspector) tableDescriptor.getDeserializer(conf).getObjectInspector();
+      } catch (Exception e) {
+        throw new SemanticException(e.getMessage(), e);
       }
 
       boolean isDfsDir = (destType == QBMetaData.DEST_DFS_FILE);


### PR DESCRIPTION
### What changes were proposed in this pull request?
- `Table.checkValidity` should use `getDeserializer` instead of `getDeserializerFromMetaStore`. This will use the cached version of the Deserializer so it will prevent creating a new one.
- `SemanticAnalyzer.genConversionSelectOperator` should get a `Deserializer` as an input parameter, since we already has that at hand
- When we are generating the FileSinkPlan on an destination table, we should reuse the table deserializer to get the columns whenever it is possible

### Why are the changes needed?
To speed up query planning

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests
