### PR TITLE
HIVE-18728: Secure webHCat with SSL

### DIFF
--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/AppConfig.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/AppConfig.java
@@ -110,7 +110,12 @@ public class AppConfig extends Configuration {
   public static final String MAPPER_MEMORY_MB    = "templeton.mapper.memory.mb";
   public static final String MR_AM_MEMORY_MB     = "templeton.mr.am.memory.mb";
   public static final String TEMPLETON_JOBSLIST_ORDER = "templeton.jobs.listorder";
-
+  public static final String USE_SSL = "templeton.use.ssl";
+  public static final String KEY_STORE_PATH = "templeton.keystore.path";
+  public static final String KEY_STORE_PASSWORD = "templeton.keystore.password";
+  public static final String SSL_PROTOCOL_BLACKLIST = "templeton.ssl.protocol.blacklist";
+  public static final String HOST = "templeton.host";
+  
   /*
    * These parameters controls the maximum number of concurrent job submit/status/list
    * operations in templeton service. If more number of concurrent requests comes then
@@ -191,8 +196,7 @@ public class AppConfig extends Configuration {
   public static final String HADOOP_END_INTERVAL_NAME = "job.end.retry.interval";
   public static final String HADOOP_END_RETRY_NAME    = "job.end.retry.attempts";
   public static final String HADOOP_END_URL_NAME      = "job.end.notification.url";
-  public static final String HADOOP_SPECULATIVE_NAME
-    = "mapred.map.tasks.speculative.execution";
+  public static final String HADOOP_SPECULATIVE_NAME = "mapred.map.tasks.speculative.execution";
   public static final String HADOOP_CHILD_JAVA_OPTS = "mapred.child.java.opts";
   public static final String HADOOP_MAP_MEMORY_MB = "mapreduce.map.memory.mb";
   public static final String HADOOP_MR_AM_JAVA_OPTS = "yarn.app.mapreduce.am.command-opts";
@@ -215,9 +219,9 @@ public class AppConfig extends Configuration {
   }
 
   private void init() {
-    for (Map.Entry<String, String> e : System.getenv().entrySet())
+    for (Map.Entry<String, String> e : System.getenv().entrySet()) {
       set("env." + e.getKey(), e.getValue());
-
+    }
     String templetonDir = getTempletonDir();
     for (String fname : TEMPLETON_CONF_FILENAMES) {
       logConfigLoadAttempt(templetonDir + File.separator + fname);
@@ -309,8 +313,7 @@ public class AppConfig extends Configuration {
     if (requestedOrder != null) {
       try {
         return JobsListOrder.valueOf(requestedOrder.toLowerCase());
-      }
-      catch(IllegalArgumentException ex) {
+      } catch(IllegalArgumentException ex) {
         LOG.warn("Ignoring setting " + TEMPLETON_JOBSLIST_ORDER + " configured with in-correct value " + requestedOrder);
       }
     }

--- a/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Main.java
+++ b/hcatalog/webhcat/svr/src/main/java/org/apache/hive/hcatalog/templeton/Main.java
@@ -21,12 +21,18 @@ package org.apache.hive.hcatalog.templeton;
 import com.sun.jersey.api.core.PackagesResourceConfig;
 import com.sun.jersey.spi.container.servlet.ServletContainer;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +56,11 @@ import org.eclipse.jetty.server.handler.HandlerList;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LowResourceMonitor;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.slf4j.bridge.SLF4JBridgeHandler;
 
@@ -74,6 +85,10 @@ public class Main {
   private static final Logger LOG = LoggerFactory.getLogger(Main.class);
 
   public static final int DEFAULT_PORT = 8080;
+  public static final String DEFAULT_HOST = "0.0.0.0";
+  public static final String DEFAULT_KEY_STORE_PATH = "";
+  public static final String DEFAULT_KEY_STORE_PASSWORD = "";
+  public static final String DEFAULT_SSL_PROTOCOL_BLACKLIST = "SSLv2,SSLv3";
   private Server server;
 
   private static volatile AppConfig conf;
@@ -231,6 +246,13 @@ public class Main {
     // Add any redirects
     addRedirects(server);
 
+    // Set handling for low resource conditions.
+    final LowResourceMonitor low = new LowResourceMonitor(server);
+    low.setLowResourcesIdleTimeout(10000);
+    server.addBean(low);
+
+    server.addConnector(createChannelConnector());
+    
     // Start the server
     server.start();
     this.server = server;
@@ -252,6 +274,35 @@ public class Main {
     return xsrfFilter;
   }
 
+  /**
+   Create a channel connector for "http/https" requests.
+   */
+
+  private Connector createChannelConnector() {
+    ServerConnector connector;
+    final HttpConfiguration httpConf = new HttpConfiguration();
+    httpConf.setRequestHeaderSize(1024 * 64);
+    final HttpConnectionFactory http = new HttpConnectionFactory(httpConf);
+
+    if (conf.getBoolean(AppConfig.USE_SSL, false)) {
+      LOG.info("Using SSL for templeton.");
+      SslContextFactory sslContextFactory = new SslContextFactory();
+      sslContextFactory.setKeyStorePath(conf.get(AppConfig.KEY_STORE_PATH, DEFAULT_KEY_STORE_PATH));
+      sslContextFactory.setKeyStorePassword(conf.get(AppConfig.KEY_STORE_PASSWORD, DEFAULT_KEY_STORE_PASSWORD));
+      Set<String> excludedSSLProtocols = Sets.newHashSet(Splitter.on(",").trimResults().omitEmptyStrings()
+              .split(Objects.toString(conf.get(AppConfig.SSL_PROTOCOL_BLACKLIST, DEFAULT_SSL_PROTOCOL_BLACKLIST), "")));
+      sslContextFactory.addExcludeProtocols(excludedSSLProtocols.toArray(new String[excludedSSLProtocols.size()]));
+      connector = new ServerConnector(server, sslContextFactory, http);
+    } else {
+      connector = new ServerConnector(server, http);
+    }
+
+    connector.setReuseAddress(true);
+    connector.setHost(conf.get(AppConfig.HOST, DEFAULT_HOST));
+    connector.setPort(conf.getInt(AppConfig.PORT, DEFAULT_PORT));
+    return connector;
+  }
+  
   // Configure the AuthFilter with the Kerberos params iff security
   // is enabled.
   public FilterHolder makeAuthFilter() throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Adds templeton configuration options for enabling TLS

### Why are the changes needed?
Allows more secure connections to WebHCat

The code for this change has been sitting around since 2018. Targeting has moved from 3.0 to 3.1 to now 3.2, I figure moving it over to Github will help get this in.

### Does this PR introduce _any_ user-facing change?
Yes, added configuration options and docs should be updated. The update to the docs has already been made in the original ticket, need someone with editing permissions to do so.

### How was this patch tested?
No tests were added, but you can verify this with a simple curl command.
curl -k 'https://<user>:<password>@<host>:50111/templeton/v1/status'

Any guidance on adding a test for this would be appreciated.

