### PR TITLE
HIVE-24249: Create View fails if a materialized view exists with the same query

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1921,7 +1921,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
       // due to data freshness)
       if (conf.getBoolVar(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING) &&
               !getQB().isMaterializedView() && !ctx.isLoadingMaterializedView() && !getQB().isCTAS() &&
-               getQB().hasTableDefined()) {
+               getQB().hasTableDefined() &&
+              !forViewCreation) {
         calcitePreCboPlan = applyMaterializedViewRewriting(planner,
             calcitePreCboPlan, mdProvider.getMetadataProvider(), executorProvider);
       }

--- a/ql/src/test/queries/clientpositive/create_view_when_mv_exists.q
+++ b/ql/src/test/queries/clientpositive/create_view_when_mv_exists.q
@@ -1,0 +1,23 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true');
+
+insert into t1(col0) values (1),(3),(10),(NULL);
+
+create materialized view mv1 as
+select * from t1 where col0 > 2;
+
+explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10;
+
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10;
+
+explain cbo
+select * from v1;
+
+select * from v1;

--- a/ql/src/test/results/clientpositive/llap/create_view_when_mv_exists.q.out
+++ b/ql/src/test/results/clientpositive/llap/create_view_when_mv_exists.q.out
@@ -1,0 +1,97 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1(col0) values (1),(3),(10),(NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(col0) values (1),(3),(10),(NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.col0 SCRIPT []
+PREHOOK: query: create materialized view mv1 as
+select * from t1 where col0 > 2
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mv1
+POSTHOOK: query: create materialized view mv1 as
+select * from t1 where col0 > 2
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mv1
+PREHOOK: query: explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@v1
+POSTHOOK: query: explain cbo
+create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@v1
+CBO PLAN:
+HiveProject($f0=[CAST(10):INTEGER])
+  HiveFilter(condition=[=($0, 10)])
+    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10
+PREHOOK: type: CREATEVIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@v1
+POSTHOOK: query: create view v1 as
+select sub.* from (select * from t1 where col0 > 2) sub
+where sub.col0 = 10
+POSTHOOK: type: CREATEVIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@v1
+POSTHOOK: Lineage: v1.col0 SIMPLE []
+PREHOOK: query: explain cbo
+select * from v1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv1
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@v1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from v1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv1
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@v1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject($f0=[CAST(10):INTEGER])
+  HiveFilter(condition=[=(10, $0)])
+    HiveTableScan(table=[[default, mv1]], table:alias=[default.mv1])
+
+PREHOOK: query: select * from v1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mv1
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@v1
+#### A masked pattern was here ####
+POSTHOOK: query: select * from v1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mv1
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@v1
+#### A masked pattern was here ####
+10


### PR DESCRIPTION
### What changes were proposed in this pull request?
Disable materialized view rewrite at view creation.

### Why are the changes needed?
Hive doesn't support view creation when one of the source tables is a materialized view. When the `create view` command is executed the select statement is compiled and the optimizer applies materialized view rewrites if any suitable materialized view exists. A successful rewrite leads to Exception:
```
org.apache.hadoop.hive.ql.parse.SemanticException: View definition references materialized view default.mv1
```
See the jira for full stacktrace.

### Does this PR introduce _any_ user-facing change?
Users can create views even if its query is matching with an existing materialized view query. No SemanticException should be thrown because of that.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=create_view_when_mv_exists.q -pl itests/qtest -Pitests
```