### PR TITLE
HIVE-24430: DiskRangeInfo should make use of DiskRangeList

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedTreeReaderFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedTreeReaderFactory.java
@@ -33,7 +33,6 @@ import org.apache.orc.CompressionCodec;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.impl.InStream;
 import org.apache.orc.impl.PositionProvider;
-import org.apache.orc.impl.SettableUncompressedStream;
 import org.apache.orc.impl.TreeReaderFactory;
 import org.apache.orc.OrcProto;
 import org.slf4j.Logger;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/SettableUncompressedStream.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/SettableUncompressedStream.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.orc.encoded;
+
+import org.apache.hadoop.hive.common.DiskRangeInfo;
+import org.apache.hadoop.hive.common.io.DiskRangeList;
+import org.apache.orc.impl.InStream;
+
+public class SettableUncompressedStream extends InStream.UncompressedStream {
+
+  public SettableUncompressedStream(String name, DiskRangeList input, long length) {
+    super(name, input, 0, length);
+    setOffset(input);
+  }
+
+  public void setBuffers(DiskRangeInfo diskRangeList) {
+    setCurrent(diskRangeList.getDiskRanges(), true);
+    reset(diskRangeList.getDiskRanges());
+    setOffset(diskRangeList.getDiskRanges());
+  }
+
+  private void setOffset(DiskRangeList list) {
+    currentOffset = list.listSize() > 1 ? list.next.getOffset() : 0;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
@@ -21,13 +21,10 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 
 import org.apache.hadoop.hive.common.DiskRangeInfo;
-import org.apache.hadoop.hive.common.io.DiskRange;
+import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.common.io.encoded.EncodedColumnBatch.ColumnStreamData;
 import org.apache.hadoop.hive.common.io.encoded.MemoryBuffer;
-import org.apache.orc.impl.SettableUncompressedStream;
 import org.apache.orc.impl.BufferChunk;
-
-import com.google.common.collect.Lists;
 
 /**
  * Stream utility.
@@ -43,7 +40,7 @@ public class StreamUtils {
    * @throws IOException
    */
   public static SettableUncompressedStream createSettableUncompressedStream(String streamName,
-      ColumnStreamData streamBuffer) throws IOException {
+      ColumnStreamData streamBuffer) {
     if (streamBuffer == null) {
       return null;
     }
@@ -53,7 +50,7 @@ public class StreamUtils {
       return new SettableUncompressedStream(streamName, diskRangeInfo.getDiskRanges(),
           diskRangeInfo.getTotalLength());
     } else {
-      return new SettableUncompressedStream(streamName, Lists.<DiskRange>newArrayList(), 0);
+      return new SettableUncompressedStream(streamName, new DiskRangeList(0,0), 0);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.common.DiskRangeInfo;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.common.io.encoded.EncodedColumnBatch.ColumnStreamData;
 import org.apache.hadoop.hive.common.io.encoded.MemoryBuffer;
+import org.apache.orc.impl.SettableUncompressedStream;
 import org.apache.orc.impl.BufferChunk;
 
 /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/StreamUtils.java
@@ -24,7 +24,6 @@ import org.apache.hadoop.hive.common.DiskRangeInfo;
 import org.apache.hadoop.hive.common.io.DiskRangeList;
 import org.apache.hadoop.hive.common.io.encoded.EncodedColumnBatch.ColumnStreamData;
 import org.apache.hadoop.hive.common.io.encoded.MemoryBuffer;
-import org.apache.orc.impl.SettableUncompressedStream;
 import org.apache.orc.impl.BufferChunk;
 
 /**

--- a/storage-api/src/java/org/apache/hadoop/hive/common/DiskRangeInfo.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/DiskRangeInfo.java
@@ -17,20 +17,18 @@
  */
 package org.apache.hadoop.hive.common;
 
-import java.util.ArrayList;
-import java.util.List;
+import org.apache.hadoop.hive.common.io.DiskRangeList;
 
-import org.apache.hadoop.hive.common.io.DiskRange;
 
 /**
  * Disk range information class containing disk ranges and total length.
  */
 public class DiskRangeInfo {
-  List<DiskRange> diskRanges; // TODO: use DiskRangeList instead
-  long totalLength;
+
+  private DiskRangeList diskRanges = null;
+  private long totalLength;
 
   public DiskRangeInfo(int indexBaseOffset) {
-    this.diskRanges = new ArrayList<>();
     // Some data is missing from the stream for PPD uncompressed read (because index offset is
     // relative to the entire stream and we only read part of stream if RGs are filtered; unlike
     // with compressed data where PPD only filters CBs, so we always get full CB, and index offset
@@ -42,12 +40,16 @@ public class DiskRangeInfo {
     this.totalLength = indexBaseOffset;
   }
 
-  public void addDiskRange(DiskRange diskRange) {
-    diskRanges.add(diskRange);
+  public void addDiskRange(DiskRangeList diskRange) {
+    if (diskRanges == null) {
+      diskRanges = diskRange;
+    } else {
+      diskRanges.insertAfter(diskRange);
+    }
     totalLength += diskRange.getLength();
   }
 
-  public List<DiskRange> getDiskRanges() {
+  public DiskRangeList getDiskRanges() {
     return diskRanges;
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Change DiskRangeInfo to use DiskRangeList instead of DiskRange


### Why are the changes needed?
Transition to ORC 1.6 where DiskRangeList is the main class used.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests