### PR TITLE
HIVE-24444: compactor.Cleaner should not set state 'mark cleaned' if there are obsolete files in the FS

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1333,7 +1333,7 @@ public class AcidUtils {
    * @return the state of the directory
    * @throws IOException on filesystem errors
    */
-  public static Directory getAcidState(FileSystem fileSystem, Path candidateDirectory, Configuration conf,
+  private static Directory getAcidState(FileSystem fileSystem, Path candidateDirectory, Configuration conf,
       ValidWriteIdList writeIdList, Ref<Boolean> useFileIds, boolean ignoreEmptyFiles, Map<Path,
       HdfsDirSnapshot> dirSnapshots) throws IOException {
     ValidTxnList validTxnList = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1333,7 +1333,7 @@ public class AcidUtils {
    * @return the state of the directory
    * @throws IOException on filesystem errors
    */
-  private static Directory getAcidState(FileSystem fileSystem, Path candidateDirectory, Configuration conf,
+  public static Directory getAcidState(FileSystem fileSystem, Path candidateDirectory, Configuration conf,
       ValidWriteIdList writeIdList, Ref<Boolean> useFileIds, boolean ignoreEmptyFiles, Map<Path,
       HdfsDirSnapshot> dirSnapshots) throws IOException {
     ValidTxnList validTxnList = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -316,7 +316,7 @@ public class Cleaner extends MetaStoreCompactorThread {
     }
     // Check if there will be more obsolete directories to clean when possible. We will only mark cleaned when this
     // number reaches 0.
-    return getNumEventuallyObsoleteDirs(location, dirSnapshots) == 0;
+    return getNumEventuallyObsoleteDirs(location, dirSnapshots, fs) == 0;
   }
 
   /**
@@ -324,8 +324,10 @@ public class Cleaner extends MetaStoreCompactorThread {
    * we can see if the Cleaner has further work to do in this table/partition directory that it hasn't been able to
    * finish, e.g. because of an open transaction at the time of compaction.
    * We do this by assuming that there are no open transactions anywhere and then calling getAcidState. If there are
-   * obsolete directories, then the Cleaner has more work to do.
+   * obsolete/aborted directories, then the Cleaner has more work to do. Eventually.
    * @param location location of table
+   * @param dirSnapshots snapshot of table/partition directory
+   * @param fileSystem
    * @return number of dirs left for the cleaner to clean – eventually
    * @throws IOException
    */
@@ -339,6 +341,6 @@ public class Cleaner extends MetaStoreCompactorThread {
     Path locPath = new Path(location);
     AcidUtils.Directory dir = AcidUtils.getAcidState(fileSystem, locPath, conf, validWriteIdList,
         Ref.from(false), false, dirSnapshots);
-    return dir.getObsolete().size();
+    return dir.getObsolete().size() + dir.getAbortedDirectories().size();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -329,14 +329,15 @@ public class Cleaner extends MetaStoreCompactorThread {
    * @return number of dirs left for the cleaner to clean – eventually
    * @throws IOException
    */
-  private int getNumEventuallyObsoleteDirs(String location, Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots)
+  private int getNumEventuallyObsoleteDirs(String location, Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots,
+      FileSystem fileSystem)
       throws IOException {
     ValidTxnList validTxnList = new ValidReadTxnList();
     //save it so that getAcidState() sees it
     conf.set(ValidTxnList.VALID_TXNS_KEY, validTxnList.writeToString());
     ValidReaderWriteIdList validWriteIdList = new ValidReaderWriteIdList();
     Path locPath = new Path(location);
-    AcidUtils.Directory dir = AcidUtils.getAcidState(locPath.getFileSystem(conf), locPath, conf, validWriteIdList,
+    AcidUtils.Directory dir = AcidUtils.getAcidState(fileSystem, locPath, conf, validWriteIdList,
         Ref.from(false), false, dirSnapshots);
     return dir.getObsolete().size();
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -272,7 +272,8 @@ public class Cleaner extends MetaStoreCompactorThread {
   private boolean removeFiles(String location, ValidWriteIdList writeIdList, CompactionInfo ci)
       throws IOException, NoSuchObjectException, MetaException {
     Path locPath = new Path(location);
-    Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots = null;
+    FileSystem fs = locPath.getFileSystem(conf);
+    Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots = AcidUtils.getHdfsDirSnapshots(fs, locPath);
     AcidUtils.Directory dir = AcidUtils.getAcidState(locPath.getFileSystem(conf), locPath, conf, writeIdList, Ref.from(
         false), false, dirSnapshots);
     List<Path> obsoleteDirs = dir.getObsolete();
@@ -304,7 +305,6 @@ public class Cleaner extends MetaStoreCompactorThread {
     LOG.info(idWatermark(ci) + " About to remove " + filesToDelete.size() +
          " obsolete directories from " + location + ". " + extraDebugInfo.toString());
 
-    FileSystem fs = filesToDelete.get(0).getFileSystem(conf);
     Database db = getMSForConf(conf).getDatabase(getDefaultCatalog(conf), ci.dbname);
 
     for (Path dead : filesToDelete) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -53,7 +53,6 @@ import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -273,9 +272,8 @@ public class Cleaner extends MetaStoreCompactorThread {
       throws IOException, NoSuchObjectException, MetaException {
     Path locPath = new Path(location);
     FileSystem fs = locPath.getFileSystem(conf);
-    Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots = AcidUtils.getHdfsDirSnapshots(fs, locPath);
-    AcidUtils.Directory dir = AcidUtils.getAcidState(locPath.getFileSystem(conf), locPath, conf, writeIdList, Ref.from(
-        false), false, dirSnapshots);
+    AcidUtils.Directory dir = AcidUtils.getAcidState(fs, locPath, conf, writeIdList, Ref.from(
+        false), false);
     List<Path> obsoleteDirs = dir.getObsolete();
     /**
      * add anything in 'dir'  that only has data from aborted transactions - no one should be
@@ -316,7 +314,7 @@ public class Cleaner extends MetaStoreCompactorThread {
     }
     // Check if there will be more obsolete directories to clean when possible. We will only mark cleaned when this
     // number reaches 0.
-    return getNumEventuallyObsoleteDirs(location, dirSnapshots, fs) == 0;
+    return getNumEventuallyObsoleteDirs(location, fs) == 0;
   }
 
   /**
@@ -326,21 +324,18 @@ public class Cleaner extends MetaStoreCompactorThread {
    * We do this by assuming that there are no open transactions anywhere and then calling getAcidState. If there are
    * obsolete/aborted directories, then the Cleaner has more work to do. Eventually.
    * @param location location of table
-   * @param dirSnapshots snapshot of table/partition directory
    * @param fileSystem
    * @return number of dirs left for the cleaner to clean – eventually
    * @throws IOException
    */
-  private int getNumEventuallyObsoleteDirs(String location, Map<Path, AcidUtils.HdfsDirSnapshot> dirSnapshots,
-      FileSystem fileSystem)
-      throws IOException {
+  private int getNumEventuallyObsoleteDirs(String location, FileSystem fileSystem) throws IOException {
     ValidTxnList validTxnList = new ValidReadTxnList();
     //save it so that getAcidState() sees it
     conf.set(ValidTxnList.VALID_TXNS_KEY, validTxnList.writeToString());
     ValidReaderWriteIdList validWriteIdList = new ValidReaderWriteIdList();
     Path locPath = new Path(location);
     AcidUtils.Directory dir = AcidUtils.getAcidState(fileSystem, locPath, conf, validWriteIdList,
-        Ref.from(false), false, dirSnapshots);
+        Ref.from(false), false);
     return dir.getObsolete().size();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -341,6 +341,6 @@ public class Cleaner extends MetaStoreCompactorThread {
     Path locPath = new Path(location);
     AcidUtils.Directory dir = AcidUtils.getAcidState(fileSystem, locPath, conf, validWriteIdList,
         Ref.from(false), false, dirSnapshots);
-    return dir.getObsolete().size() + dir.getAbortedDirectories().size();
+    return dir.getObsolete().size();
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCleaner.java
@@ -573,7 +573,7 @@ public class TestCleaner extends CompactorTest {
     List<Path> paths = getDirectories(conf, t, null);
     Assert.assertEquals(8, paths.size());
     Collections.sort(paths);
-    Assert.assertEquals("base_0000025_v0000026", paths.get(0).getName());
+    Assert.assertEquals("base_0000025_v0000027", paths.get(0).getName());
     Assert.assertEquals("base_0000029_v0000032", paths.get(1).getName());
     Assert.assertEquals("base_20", paths.get(2).getName());
     Assert.assertEquals("delta_0000021_0000022", paths.get(3).getName());


### PR DESCRIPTION
### What changes were proposed in this pull request?

### Why are the changes needed?

### Does this PR introduce _any_ user-facing change?

See HIVE-24444

### How was this patch tested?
Unit test
