### PR TITLE
HIVE-21588: Remove HBase dependency from hive-metastore

### DIFF
--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -61,20 +61,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-client</artifactId>
-       <exclusions>
-             <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-      </exclusions>
    </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -161,35 +147,6 @@
     <dependency>
       <groupId>org.apache.thrift</groupId>
       <artifactId>libthrift</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.tephra</groupId>
-      <artifactId>tephra-api</artifactId>
-      <version>${tephra.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.tephra</groupId>
-      <artifactId>tephra-core</artifactId>
-      <version>${tephra.version}</version>
-      <exclusions>
-          <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-classic</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>ch.qos.logback</groupId>
-          <artifactId>logback-core</artifactId>
-        </exclusion>
-       <exclusion>
-          <groupId>org.ow2.asm</groupId>
-          <artifactId>asm-all</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>co.cask.tephra</groupId>
-      <artifactId>tephra-hbase-compat-1.0</artifactId>
-      <version>${tephra.version}</version>
     </dependency>
     <!-- test intra-project -->
     <dependency>

--- a/metastore/pom.xml
+++ b/metastore/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-   </dependency>
+    </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
       <artifactId>commons-cli</artifactId>

--- a/packaging/src/main/assembly/bin.xml
+++ b/packaging/src/main/assembly/bin.xml
@@ -45,7 +45,6 @@
         <exclude>org.slf4j:*</exclude>
         <exclude>log4j:*</exclude>
         <exclude>junit:*</exclude>
-        <exclude>co.cask.tephra:*</exclude>
         <exclude>commons-configuration:commons-configuration</exclude>
         <exclude>org.apache.hive:hive-jdbc:*:standalone</exclude>
         <exclude>org.apache.hive:hive-contrib</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -208,7 +208,6 @@
     <felix.version>2.4.0</felix.version>
     <curator.version>4.2.0</curator.version>
     <jsr305.version>3.0.0</jsr305.version>
-    <tephra.version>0.6.0</tephra.version>
     <gson.version>2.2.4</gson.version>
     <jjwt.version>0.10.5</jjwt.version>
     <re2j.version>1.2</re2j.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -821,12 +821,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>it.unimi.dsi</groupId>
-      <artifactId>fastutil</artifactId>
-      <version>6.5.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
     </dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -821,6 +821,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>it.unimi.dsi</groupId>
+      <artifactId>fastutil</artifactId>
+      <version>6.5.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.google.re2j</groupId>
       <artifactId>re2j</artifactId>
     </dependency>

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestWorker.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.txn.compactor;
 
-import it.unimi.dsi.fastutil.booleans.AbstractBooleanBidirectionalIterator;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;


### PR DESCRIPTION
### What changes were proposed in this pull request?

HIVE-17234 has removed HBase metastore from master. But maven dependency have not been removed. We should remove it.

### Why are the changes needed?

Reduce dependency to make Spark dependency more clear:
https://github.com/apache/spark/blob/3ce4ab545bfc28db7df2c559726b887b0c8c33b7/pom.xml#L1997-L2007

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

N/A
