### PR TITLE
HIVE-24458: Add a method to provide a non-normalized ExpressionTree

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,7 +192,7 @@
     <stax.version>1.0.1</stax.version>
     <slf4j.version>1.7.30</slf4j.version>
     <ST4.version>4.0.4</ST4.version>
-    <storage-api.version>2.7.0-SNAPSHOT</storage-api.version>
+    <storage-api.version>2.7.3-SNAPSHOT</storage-api.version>
     <tez.version>0.10.0</tez.version>
     <super-csv.version>2.2.0</super-csv.version>
     <spark.version>2.4.5</spark.version>

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader.Columniz
 import org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader.SortMergedDeleteEventRegistry;
 
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentImpl;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory;
@@ -471,7 +472,8 @@ public class TestVectorizedOrcAcidRowBatchReader {
           " leaf-4 = (LESS_THAN_EQUALS bucket 536936448)," +
           " leaf-5 = (LESS_THAN_EQUALS rowId 2)," +
           " expr = (and (not leaf-0) (not leaf-1) " +
-          "(not leaf-2) leaf-3 leaf-4 leaf-5)", sarg.toString());
+          "(not leaf-2) leaf-3 leaf-4 leaf-5)",
+          ((SearchArgumentImpl) sarg).toOldString());
     }
     else {
       assertEquals(new OrcRawRecordMerger.KeyInterval(null, null), keyInterval);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestConvertAstToSearchArg.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestConvertAstToSearchArg.java
@@ -636,7 +636,7 @@ public class TestConvertAstToSearchArg {
         " (not leaf-4) leaf-5 leaf-6 leaf-7)" +
         " (or leaf-0 (not leaf-1) leaf-2 (not leaf-3)" +
         " (not leaf-4) leaf-5 leaf-6 leaf-8))",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
   }
@@ -890,7 +890,7 @@ public class TestConvertAstToSearchArg {
     assertEquals(4L, leaf.getLiteral());
 
     assertEquals("(or leaf-0 (not leaf-1) (not leaf-2) leaf-3)",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
     assertEquals(TruthValue.NO,
@@ -1322,7 +1322,7 @@ public class TestConvertAstToSearchArg {
     assertEquals("smith", leaf.getLiteral());
 
     assertEquals("(and leaf-0 leaf-1 leaf-2)",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
   }
@@ -1551,7 +1551,7 @@ public class TestConvertAstToSearchArg {
     assertEquals(50L, leaf.getLiteralList().get(1));
 
     assertEquals("(and (not leaf-0) leaf-1 leaf-2)",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
     assertEquals(TruthValue.YES,
@@ -1804,7 +1804,7 @@ public class TestConvertAstToSearchArg {
     assertEquals("first_name", leaves.get(0).getColumnName());
 
     assertEquals("leaf-0",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
   }
@@ -2375,7 +2375,7 @@ public class TestConvertAstToSearchArg {
         " (or leaf-0 leaf-1 leaf-7 leaf-8)" +
         " (or leaf-0 leaf-4 leaf-7 leaf-8)" +
         " (or leaf-0 leaf-5 leaf-7 leaf-8))",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
   }
 
   @Test
@@ -2716,7 +2716,7 @@ public class TestConvertAstToSearchArg {
     assertEquals(10L, leaves.get(0).getLiteral());
 
     assertEquals("(and (not leaf-0) (not leaf-0))",
-        sarg.getExpression().toString());
+        sarg.getExpression().toOldString());
     assertNoSharedNodes(sarg.getExpression(),
         Sets.<ExpressionTree>newIdentityHashSet());
     assertEquals(TruthValue.NO, sarg.evaluate(values(TruthValue.YES)));
@@ -2749,7 +2749,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.TIMESTAMP, leaf.getType());
@@ -2768,7 +2768,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.DATE, leaf.getType());
@@ -2788,7 +2788,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.DECIMAL, leaf.getType());
@@ -2808,7 +2808,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.STRING, leaf.getType());
@@ -2828,7 +2828,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.STRING, leaf.getType());
@@ -2847,7 +2847,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.LONG, leaf.getType());
@@ -2868,7 +2868,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("(and leaf-0 leaf-1)", sarg.getExpression().toString());
+    assertEquals("(and leaf-0 leaf-1)", sarg.getExpression().toOldString());
     assertEquals(2, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.BOOLEAN, leaf.getType());
@@ -2890,7 +2890,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.FLOAT, leaf.getType());
@@ -2909,7 +2909,7 @@ public class TestConvertAstToSearchArg {
     SearchArgument sarg =
         new ConvertAstToSearchArg(conf, SerializationUtilities.deserializeExpression(serialAst))
             .buildSearchArgument();
-    assertEquals("leaf-0", sarg.getExpression().toString());
+    assertEquals("leaf-0", sarg.getExpression().toOldString());
     assertEquals(1, sarg.getLeaves().size());
     PredicateLeaf leaf = sarg.getLeaves().get(0);
     assertEquals(PredicateLeaf.Type.FLOAT, leaf.getType());

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
@@ -62,8 +62,12 @@ public class TestSearchArgumentImpl {
     return new ExpressionTree(ExpressionTree.Operator.OR, arg);
   }
 
-  private ExpressionTree leaf(int leaf) {
-    return new ExpressionTree(leaf);
+  private static ExpressionTree leaf(int id) {
+    PredicateLeafImpl result = new PredicateLeafImpl(PredicateLeaf.Operator.EQUALS,
+        PredicateLeaf.Type.LONG,
+        "x", (long) id, null);
+    result.setId(id);
+    return new ExpressionTree(result);
   }
 
   private ExpressionTree constant(TruthValue val) {
@@ -85,100 +89,101 @@ public class TestSearchArgumentImpl {
   @Test
   public void testNotPushdown() throws Exception {
     assertEquals("leaf-1", SearchArgumentImpl.BuilderImpl.pushDownNot(leaf(1))
-        .toString());
+        .toOldString());
     assertEquals("(not leaf-1)",
-        SearchArgumentImpl.BuilderImpl.pushDownNot(not(leaf(1))).toString());
+        SearchArgumentImpl.BuilderImpl.pushDownNot(not(leaf(1))).toOldString());
     assertEquals("leaf-1",
         SearchArgumentImpl.BuilderImpl.pushDownNot(not(not(leaf(1))))
-            .toString());
+            .toOldString());
     assertEquals("(not leaf-1)",
         SearchArgumentImpl.BuilderImpl.pushDownNot(not(not(not(leaf(1))))).
-            toString());
+            toOldString());
     assertEquals("(or leaf-1 (not leaf-2))",
         SearchArgumentImpl.BuilderImpl.pushDownNot(not(and(not(leaf(1)),
-            leaf(2)))).toString());
+            leaf(2)))).toOldString());
     assertEquals("(and (not leaf-1) leaf-2)",
         SearchArgumentImpl.BuilderImpl.pushDownNot(not(or(leaf(1),
-            not(leaf(2))))).toString());
+            not(leaf(2))))).toOldString());
     assertEquals("(or (or (not leaf-1) leaf-2) leaf-3)",
         SearchArgumentImpl.BuilderImpl.pushDownNot(or(not(and(leaf(1),
                 not(leaf(2)))),
-            not(not(leaf(3))))).toString());
+            not(not(leaf(3))))).toOldString());
     assertEquals("NO", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.YES))).toString());
+        not(constant(TruthValue.YES))).toOldString());
     assertEquals("YES", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.NO))).toString());
+        not(constant(TruthValue.NO))).toOldString());
     assertEquals("NULL", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.NULL))).toString());
+        not(constant(TruthValue.NULL))).toOldString());
     assertEquals("YES_NO", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.YES_NO))).toString());
+        not(constant(TruthValue.YES_NO))).toOldString());
     assertEquals("YES_NULL", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.NO_NULL))).toString());
+        not(constant(TruthValue.NO_NULL))).toOldString());
     assertEquals("NO_NULL", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.YES_NULL))).toString());
+        not(constant(TruthValue.YES_NULL))).toOldString());
     assertEquals("YES_NO_NULL", SearchArgumentImpl.BuilderImpl.pushDownNot(
-        not(constant(TruthValue.YES_NO_NULL))).toString());
+        not(constant(TruthValue.YES_NO_NULL))).toOldString());
   }
 
   @Test
   public void testFlatten() throws Exception {
-    assertEquals("leaf-1", SearchArgumentImpl.BuilderImpl.flatten(leaf(1)).toString());
+    PredicateLeafImpl leaf1 = new PredicateLeafImpl();
+    assertEquals("leaf-1", SearchArgumentImpl.BuilderImpl.flatten(leaf(1)).toOldString());
     assertEquals("NO",
         SearchArgumentImpl.BuilderImpl.flatten(constant(TruthValue.NO)).toString());
     assertEquals("(not (not leaf-1))",
-        SearchArgumentImpl.BuilderImpl.flatten(not(not(leaf(1)))).toString());
+        SearchArgumentImpl.BuilderImpl.flatten(not(not(leaf(1)))).toOldString());
     assertEquals("(and leaf-1 leaf-2)",
-        SearchArgumentImpl.BuilderImpl.flatten(and(leaf(1), leaf(2))).toString());
+        SearchArgumentImpl.BuilderImpl.flatten(and(leaf(1), leaf(2))).toOldString());
     assertEquals("(and (or leaf-1 leaf-2) leaf-3)",
         SearchArgumentImpl.BuilderImpl.flatten(and(or(leaf(1), leaf(2)), leaf(3))
-        ).toString());
+        ).toOldString());
     assertEquals("(and leaf-1 leaf-2 leaf-3 leaf-4)",
         SearchArgumentImpl.BuilderImpl.flatten(and(and(leaf(1), leaf(2)),
-            and(leaf(3), leaf(4)))).toString());
+            and(leaf(3), leaf(4)))).toOldString());
     assertEquals("(or leaf-1 leaf-2 leaf-3 leaf-4)",
         SearchArgumentImpl.BuilderImpl.flatten(or(leaf(1), or(leaf(2), or(leaf(3),
-            leaf(4))))).toString());
+            leaf(4))))).toOldString());
     assertEquals("(or leaf-1 leaf-2 leaf-3 leaf-4)",
         SearchArgumentImpl.BuilderImpl.flatten(or(or(or(leaf(1), leaf(2)), leaf(3)),
-            leaf(4))).toString());
+            leaf(4))).toOldString());
     assertEquals("(or leaf-1 leaf-2 leaf-3 leaf-4 leaf-5 leaf-6)",
         SearchArgumentImpl.BuilderImpl.flatten(or(or(leaf(1), or(leaf(2), leaf(3))),
-            or(or(leaf(4), leaf(5)), leaf(6)))).toString());
+            or(or(leaf(4), leaf(5)), leaf(6)))).toOldString());
     assertEquals("(and (not leaf-1) leaf-2 (not leaf-3) leaf-4 (not leaf-5) leaf-6)",
         SearchArgumentImpl.BuilderImpl.flatten(and(and(not(leaf(1)), and(leaf(2),
                 not(leaf(3)))), and(and(leaf(4), not(leaf(5))), leaf(6)))
-        ).toString());
+        ).toOldString());
     assertEquals("(not (and leaf-1 leaf-2 leaf-3))",
         SearchArgumentImpl.BuilderImpl.flatten(not(and(leaf(1), and(leaf(2), leaf(3))))
-        ).toString());
+        ).toOldString());
   }
 
   @Test
   public void testFoldMaybe() throws Exception {
     assertEquals("(and leaf-1)",
         SearchArgumentImpl.BuilderImpl.foldMaybe(and(leaf(1),
-            constant(TruthValue.YES_NO_NULL))).toString());
+            constant(TruthValue.YES_NO_NULL))).toOldString());
     assertEquals("(and leaf-1 leaf-2)",
         SearchArgumentImpl.BuilderImpl.foldMaybe(and(leaf(1),
-            constant(TruthValue.YES_NO_NULL), leaf(2))).toString());
+            constant(TruthValue.YES_NO_NULL), leaf(2))).toOldString());
     assertEquals("(and leaf-1 leaf-2)",
         SearchArgumentImpl.BuilderImpl.
             foldMaybe(and(constant(TruthValue.YES_NO_NULL),
-                leaf(1), leaf(2), constant(TruthValue.YES_NO_NULL))).toString());
+                leaf(1), leaf(2), constant(TruthValue.YES_NO_NULL))).toOldString());
     assertEquals("YES_NO_NULL",
         SearchArgumentImpl.BuilderImpl.
             foldMaybe(and(constant(TruthValue.YES_NO_NULL),
-                constant(TruthValue.YES_NO_NULL))).toString());
+                constant(TruthValue.YES_NO_NULL))).toOldString());
     assertEquals("YES_NO_NULL",
         SearchArgumentImpl.BuilderImpl.
             foldMaybe(or(leaf(1),
-                constant(TruthValue.YES_NO_NULL))).toString());
+                constant(TruthValue.YES_NO_NULL))).toOldString());
     assertEquals("(or leaf-1 (and leaf-2))",
         SearchArgumentImpl.BuilderImpl.foldMaybe(or(leaf(1),
-            and(leaf(2), constant(TruthValue.YES_NO_NULL)))).toString());
+            and(leaf(2), constant(TruthValue.YES_NO_NULL)))).toOldString());
     assertEquals("(and leaf-1)",
         SearchArgumentImpl.BuilderImpl.foldMaybe(and(or(leaf(2),
-            constant(TruthValue.YES_NO_NULL)), leaf(1))).toString());
+            constant(TruthValue.YES_NO_NULL)), leaf(1))).toOldString());
     assertEquals("(and leaf-100)", SearchArgumentImpl.BuilderImpl.foldMaybe(
         SearchArgumentImpl.BuilderImpl.convertToCNF(and(leaf(100),
             or(and(leaf(0), leaf(1)),
@@ -189,30 +194,30 @@ public class TestSearchArgumentImpl {
                 and(leaf(10), leaf(11)),
                 and(leaf(12), leaf(13)),
                 and(leaf(14), leaf(15)),
-                and(leaf(16), leaf(17)))))).toString());
+                and(leaf(16), leaf(17)))))).toOldString());
   }
 
   @Test
   public void testCNF() throws Exception {
     assertEquals("leaf-1", SearchArgumentImpl.BuilderImpl.convertToCNF(leaf(1)).
-        toString());
+        toOldString());
     assertEquals("NO", SearchArgumentImpl.BuilderImpl.convertToCNF(
         constant(TruthValue.NO)).toString());
     assertEquals("(not leaf-1)", SearchArgumentImpl.BuilderImpl.convertToCNF(
-        not(leaf(1))).toString());
+        not(leaf(1))).toOldString());
     assertEquals("(and leaf-1 leaf-2)", SearchArgumentImpl.BuilderImpl.
         convertToCNF(
-            and(leaf(1), leaf(2))).toString());
+            and(leaf(1), leaf(2))).toOldString());
     assertEquals("(or (not leaf-1) leaf-2)", SearchArgumentImpl.BuilderImpl.
         convertToCNF(
-            or(not(leaf(1)), leaf(2))).toString());
+            or(not(leaf(1)), leaf(2))).toOldString());
     assertEquals("(and (or leaf-1 leaf-2) (not leaf-3))",
         SearchArgumentImpl.BuilderImpl.convertToCNF(
-            and(or(leaf(1), leaf(2)), not(leaf(3)))).toString());
+            and(or(leaf(1), leaf(2)), not(leaf(3)))).toOldString());
     assertEquals("(and (or leaf-1 leaf-3) (or leaf-2 leaf-3)" +
         " (or leaf-1 leaf-4) (or leaf-2 leaf-4))",
         SearchArgumentImpl.BuilderImpl.convertToCNF(
-            or(and(leaf(1), leaf(2)), and(leaf(3), leaf(4)))).toString());
+            or(and(leaf(1), leaf(2)), and(leaf(3), leaf(4)))).toOldString());
     assertEquals("(and" +
         " (or leaf-1 leaf-5) (or leaf-2 leaf-5)" +
         " (or leaf-3 leaf-5) (or leaf-4 leaf-5)" +
@@ -220,7 +225,7 @@ public class TestSearchArgumentImpl {
         " (or leaf-3 leaf-6) (or leaf-4 leaf-6))",
         SearchArgumentImpl.BuilderImpl.convertToCNF(
             or(and(leaf(1), leaf(2), leaf(3), leaf(4)),
-                and(leaf(5), leaf(6)))).toString());
+                and(leaf(5), leaf(6)))).toOldString());
     assertEquals("(and" +
         " (or leaf-5 leaf-6 (not leaf-7) leaf-1 leaf-3)" +
         " (or leaf-5 leaf-6 (not leaf-7) leaf-2 leaf-3)" +
@@ -230,7 +235,7 @@ public class TestSearchArgumentImpl {
             or(and(leaf(1), leaf(2)),
                 and(leaf(3), leaf(4)),
                 or(leaf(5), leaf(6)),
-                not(leaf(7)))).toString());
+                not(leaf(7)))).toOldString());
     assertEquals("(and" +
         " (or leaf-8 leaf-0 leaf-3 leaf-6)" +
         " (or leaf-8 leaf-1 leaf-3 leaf-6)" +
@@ -254,7 +259,7 @@ public class TestSearchArgumentImpl {
                 leaf(2)),
             and(leaf(3), leaf(4), leaf(5)),
             and(leaf(6), leaf(7)),
-            leaf(8))).toString());
+            leaf(8))).toOldString());
     assertEquals("YES_NO_NULL", SearchArgumentImpl.BuilderImpl.
         convertToCNF(or(and(leaf(0), leaf(1)),
             and(leaf(2), leaf(3)),
@@ -275,7 +280,7 @@ public class TestSearchArgumentImpl {
                 and(leaf(10), leaf(11)),
                 and(leaf(12), leaf(13)),
                 and(leaf(14), leaf(15)),
-                and(leaf(16), leaf(17))))).toString());
+                and(leaf(16), leaf(17))))).toOldString());
     assertNoSharedNodes(SearchArgumentImpl.BuilderImpl.
         convertToCNF(or(and(leaf(0), leaf(1), leaf(2)),
             and(leaf(3), leaf(4), leaf(5)),
@@ -300,7 +305,7 @@ public class TestSearchArgumentImpl {
 
   @Test
   public void testBuilder() throws Exception {
-    SearchArgument sarg =
+    SearchArgumentImpl sarg = (SearchArgumentImpl)
         SearchArgumentFactory.newBuilder()
             .startAnd()
             .lessThan("x", PredicateLeaf.Type.LONG, 10L)
@@ -311,8 +316,8 @@ public class TestSearchArgumentImpl {
     assertEquals("leaf-0 = (LESS_THAN x 10), " +
         "leaf-1 = (LESS_THAN_EQUALS y hi), " +
         "leaf-2 = (EQUALS z 1.0), " +
-        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toString());
-    sarg = SearchArgumentFactory.newBuilder()
+        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toOldString());
+    sarg = (SearchArgumentImpl) SearchArgumentFactory.newBuilder()
         .startNot()
         .startOr()
         .isNull("x", PredicateLeaf.Type.LONG)
@@ -326,12 +331,13 @@ public class TestSearchArgumentImpl {
         "leaf-1 = (BETWEEN y 10 20), " +
         "leaf-2 = (IN z 1 2 3), " +
         "leaf-3 = (NULL_SAFE_EQUALS a stinger), " +
-        "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))", sarg.toString());
+        "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
+        sarg.toOldString());
   }
 
   @Test
   public void testBuilderComplexTypes() throws Exception {
-    SearchArgument sarg =
+    SearchArgumentImpl sarg = (SearchArgumentImpl)
         SearchArgumentFactory.newBuilder()
             .startAnd()
             .lessThan("x", PredicateLeaf.Type.DATE,
@@ -344,9 +350,9 @@ public class TestSearchArgumentImpl {
     assertEquals("leaf-0 = (LESS_THAN x 1970-01-11), " +
         "leaf-1 = (LESS_THAN_EQUALS y hi        ), " +
         "leaf-2 = (EQUALS z 1), " +
-        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toString());
+        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toOldString());
 
-    sarg = SearchArgumentFactory.newBuilder()
+    sarg = (SearchArgumentImpl) SearchArgumentFactory.newBuilder()
         .startNot()
         .startOr()
         .isNull("x", PredicateLeaf.Type.LONG)
@@ -363,12 +369,12 @@ public class TestSearchArgumentImpl {
         "leaf-2 = (IN z 1 2 3), " +
         "leaf-3 = (NULL_SAFE_EQUALS a stinger), " +
         "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
-        sarg.toString());
+        sarg.toOldString());
   }
 
   @Test
   public void testBuilderComplexTypes2() throws Exception {
-    SearchArgument sarg =
+    SearchArgumentImpl sarg = (SearchArgumentImpl)
         SearchArgumentFactory.newBuilder()
             .startAnd()
             .lessThan("x", PredicateLeaf.Type.DATE, Date.valueOf("2005-3-12"))
@@ -381,9 +387,9 @@ public class TestSearchArgumentImpl {
     assertEquals("leaf-0 = (LESS_THAN x 2005-03-12), " +
         "leaf-1 = (LESS_THAN_EQUALS y hi        ), " +
         "leaf-2 = (EQUALS z 1), " +
-        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toString());
+        "expr = (and leaf-0 leaf-1 leaf-2)", sarg.toOldString());
 
-    sarg = SearchArgumentFactory.newBuilder()
+    sarg = (SearchArgumentImpl) SearchArgumentFactory.newBuilder()
         .startNot()
         .startOr()
         .isNull("x", PredicateLeaf.Type.LONG)
@@ -400,12 +406,12 @@ public class TestSearchArgumentImpl {
         "leaf-2 = (IN z 1 2 3), " +
         "leaf-3 = (NULL_SAFE_EQUALS a stinger), " +
         "expr = (and (not leaf-0) (not leaf-1) (not leaf-2) (not leaf-3))",
-        sarg.toString());
+        sarg.toOldString());
   }
 
   @Test
   public void testBuilderFloat() throws Exception {
-    SearchArgument sarg =
+    SearchArgumentImpl sarg = (SearchArgumentImpl)
         SearchArgumentFactory.newBuilder()
             .startAnd()
             .lessThan("x", PredicateLeaf.Type.LONG, 22L)
@@ -421,7 +427,7 @@ public class TestSearchArgumentImpl {
         "leaf-2 = (LESS_THAN_EQUALS y hi        ), " +
         "leaf-3 = (EQUALS z 0.22), " +
         "leaf-4 = (EQUALS z1 0.22), " +
-        "expr = (and leaf-0 leaf-1 leaf-2 leaf-3 leaf-4)", sarg.toString());
+        "expr = (and leaf-0 leaf-1 leaf-2 leaf-3 leaf-4)", sarg.toOldString());
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
@@ -126,7 +126,6 @@ public class TestSearchArgumentImpl {
 
   @Test
   public void testFlatten() throws Exception {
-    PredicateLeafImpl leaf1 = new PredicateLeafImpl();
     assertEquals("leaf-1", SearchArgumentImpl.BuilderImpl.flatten(leaf(1)).toOldString());
     assertEquals("NO",
         SearchArgumentImpl.BuilderImpl.flatten(constant(TruthValue.NO)).toString());

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -98,7 +98,7 @@
     <sqlline.version>1.9.0</sqlline.version>
     <jline.version>2.14.6</jline.version>
     <ST4.version>4.0.4</ST4.version>
-    <storage-api.version>2.7.0-SNAPSHOT</storage-api.version>
+    <storage-api.version>2.7.3-SNAPSHOT</storage-api.version>
     <beanutils.version>1.9.4</beanutils.version>
     <hamcrest.version>1.3</hamcrest.version>
     <curator.version>4.2.0</curator.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -24,7 +24,7 @@
 
   <groupId>org.apache.hive</groupId>
   <artifactId>hive-storage-api</artifactId>
-  <version>2.7.0-SNAPSHOT</version>
+  <version>2.7.3-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>Hive Storage API</name>
 

--- a/storage-api/src/java/org/apache/hadoop/hive/common/io/CacheTag.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/io/CacheTag.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
  * Comes in 3 flavours to optimize for minimal memory overhead:
  * - TableCacheTag for tables without partitions: DB/table level
  * - SinglePartitionCacheTag for tables with 1 partition level: DB/table/1st_partition
- * - MultiPartitionCacheTag for tables with >1 partition levels:
+ * - MultiPartitionCacheTag for tables with &gt; 1 partition levels:
  *     DB/table/1st_partition/.../nth_partition .
  */
 public abstract class CacheTag implements Comparable<CacheTag> {

--- a/storage-api/src/java/org/apache/hadoop/hive/common/type/CalendarUtils.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/common/type/CalendarUtils.java
@@ -32,7 +32,7 @@ import java.util.concurrent.TimeUnit;
  * the epoch offset rather than holding the instant in time constant and change
  * the string representation.
  *
- * These utilities will be fast for the common case (> 1582 AD), but slow for
+ * These utilities will be fast for the common case (&gt; 1582 AD), but slow for
  * old dates.
  */
 public class CalendarUtils {

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
@@ -31,7 +31,7 @@ public class ExpressionTree {
   public enum Operator {OR, AND, NOT, LEAF, CONSTANT}
   private final Operator operator;
   private final List<ExpressionTree> children;
-  private final SearchArgumentImpl.PredicateLeafImpl leaf;
+  private final PredicateLeaf leaf;
   private final SearchArgument.TruthValue constant;
 
   ExpressionTree() {
@@ -43,7 +43,7 @@ public class ExpressionTree {
 
   ExpressionTree(Operator op, ExpressionTree... kids) {
     operator = op;
-    children = new ArrayList<ExpressionTree>();
+    children = new ArrayList<>();
     leaf = null;
     this.constant = null;
     Collections.addAll(children, kids);
@@ -68,7 +68,7 @@ public class ExpressionTree {
     if (other.children == null) {
       this.children = null;
     } else {
-      this.children = new ArrayList<ExpressionTree>();
+      this.children = new ArrayList<>();
       for(ExpressionTree child: other.children) {
         children.add(new ExpressionTree(child));
       }

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
@@ -49,7 +49,7 @@ public class ExpressionTree {
     Collections.addAll(children, kids);
   }
 
-  ExpressionTree(SearchArgumentImpl.PredicateLeafImpl leaf) {
+  ExpressionTree(PredicateLeaf leaf) {
     operator = Operator.LEAF;
     children = null;
     this.leaf = leaf;

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/ExpressionTree.java
@@ -31,25 +31,25 @@ public class ExpressionTree {
   public enum Operator {OR, AND, NOT, LEAF, CONSTANT}
   private final Operator operator;
   private final List<ExpressionTree> children;
-  private int leaf;
+  private final SearchArgumentImpl.PredicateLeafImpl leaf;
   private final SearchArgument.TruthValue constant;
 
   ExpressionTree() {
     operator = null;
     children = null;
-    leaf = 0;
+    leaf = null;
     constant = null;
   }
 
   ExpressionTree(Operator op, ExpressionTree... kids) {
     operator = op;
     children = new ArrayList<ExpressionTree>();
-    leaf = -1;
+    leaf = null;
     this.constant = null;
     Collections.addAll(children, kids);
   }
 
-  ExpressionTree(int leaf) {
+  ExpressionTree(SearchArgumentImpl.PredicateLeafImpl leaf) {
     operator = Operator.LEAF;
     children = null;
     this.leaf = leaf;
@@ -59,7 +59,7 @@ public class ExpressionTree {
   ExpressionTree(SearchArgument.TruthValue constant) {
     operator = Operator.CONSTANT;
     children = null;
-    this.leaf = -1;
+    this.leaf = null;
     this.constant = constant;
   }
 
@@ -94,7 +94,7 @@ public class ExpressionTree {
       case NOT:
         return children.get(0).evaluate(leaves).not();
       case LEAF:
-        return leaves[leaf];
+        return leaves[leaf.getId()];
       case CONSTANT:
         return constant;
       default:
@@ -102,39 +102,57 @@ public class ExpressionTree {
     }
   }
 
+  private void buildString(boolean useLeafIds, StringBuilder output) {
+    switch (operator) {
+      case OR:
+        output.append("(or");
+        for(ExpressionTree child: children) {
+          output.append(' ');
+          child.buildString(useLeafIds, output);
+        }
+        output.append(')');
+        break;
+      case AND:
+        output.append("(and");
+        for(ExpressionTree child: children) {
+          output.append(' ');
+          child.buildString(useLeafIds, output);
+        }
+        output.append(')');
+        break;
+      case NOT:
+        output.append("(not ");
+        children.get(0).buildString(useLeafIds, output);
+        output.append(')');
+        break;
+      case LEAF:
+        output.append("leaf-");
+        if (useLeafIds) {
+          output.append(leaf.getId());
+        } else {
+          output.append(leaf);
+        }
+        break;
+      case CONSTANT:
+        output.append(constant);
+        break;
+    }
+  }
+
   @Override
   public String toString() {
     StringBuilder buffer = new StringBuilder();
-    switch (operator) {
-      case OR:
-        buffer.append("(or");
-        for(ExpressionTree child: children) {
-          buffer.append(' ');
-          buffer.append(child.toString());
-        }
-        buffer.append(')');
-        break;
-      case AND:
-        buffer.append("(and");
-        for(ExpressionTree child: children) {
-          buffer.append(' ');
-          buffer.append(child.toString());
-        }
-        buffer.append(')');
-        break;
-      case NOT:
-        buffer.append("(not ");
-        buffer.append(children.get(0));
-        buffer.append(')');
-        break;
-      case LEAF:
-        buffer.append("leaf-");
-        buffer.append(leaf);
-        break;
-      case CONSTANT:
-        buffer.append(constant);
-        break;
-    }
+    buildString(false, buffer);
+    return buffer.toString();
+  }
+
+  /**
+   * Generate the old string for the old test cases.
+   * @return the expression as a string using the leaf ids
+   */
+  public String toOldString() {
+    StringBuilder buffer = new StringBuilder();
+    buildString(true, buffer);
     return buffer.toString();
   }
 
@@ -151,10 +169,10 @@ public class ExpressionTree {
   }
 
   public int getLeaf() {
-    return leaf;
+    return leaf.getId();
   }
 
-  public void setLeaf(int leaf) {
-    this.leaf = leaf;
+  public PredicateLeaf getPredicateLeaf() {
+    return leaf;
   }
 }

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/PredicateLeaf.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/PredicateLeaf.java
@@ -99,4 +99,11 @@ public interface PredicateLeaf {
    *
    */
   public List<Object> getLiteralList();
+
+  /**
+   * Get the id of the leaf.
+   * The ids are assigned sequentially from 0.
+   * @return the offset in the list returned from {@link SearchArgument#getLeaves}
+   */
+  int getId();
 }

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
@@ -157,8 +157,9 @@ public interface SearchArgument {
   public List<PredicateLeaf> getLeaves();
 
   /**
-   * Get the expression tree. This should only needed for file formats that
-   * need to translate the expression to an internal form.
+   * Get the expression tree normalized into conjunctive normal form.
+   * This should only needed for file formats that need to translate
+   * the expression to an internal form.
    */
   public ExpressionTree getExpression();
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
@@ -163,6 +163,11 @@ public interface SearchArgument {
   public ExpressionTree getExpression();
 
   /**
+   * Get the expression tree without the
+   */
+  public ExpressionTree getUnexpandedExpression();
+
+  /**
    * Evaluate the entire predicate based on the values for the leaf predicates.
    * @param leaves the value of each leaf predicate
    * @return the value of hte entire predicate

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgument.java
@@ -163,9 +163,11 @@ public interface SearchArgument {
   public ExpressionTree getExpression();
 
   /**
-   * Get the expression tree without the
+   * Get the expression tree without the normalization to conjunctive normal
+   * form. It will still have the negations pushed to the leaves, but it
+   * won't have the potentially exponential expansion.
    */
-  public ExpressionTree getUnexpandedExpression();
+  public ExpressionTree getCompactExpression();
 
   /**
    * Evaluate the entire predicate based on the values for the leaf predicates.

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
@@ -291,7 +291,7 @@ public final class SearchArgumentImpl implements SearchArgument {
 
     private final Deque<ExpressionTree> currentTree =
         new ArrayDeque<>();
-    private final Map<PredicateLeafImpl, PredicateLeafImpl> leaves =
+    private final Map<PredicateLeaf, PredicateLeaf> leaves =
         new HashMap<>();
     private final ExpressionTree root =
         new ExpressionTree(ExpressionTree.Operator.AND);
@@ -338,8 +338,8 @@ public final class SearchArgumentImpl implements SearchArgument {
       return this;
     }
 
-    private PredicateLeafImpl addLeaf(PredicateLeafImpl leaf) {
-      PredicateLeafImpl result = leaves.get(leaf);
+    private PredicateLeaf addLeaf(PredicateLeaf leaf) {
+      PredicateLeaf result = leaves.get(leaf);
       if (result == null) {
         leaves.put(leaf, leaf);
         return leaf;

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
@@ -249,7 +249,7 @@ public final class SearchArgumentImpl implements SearchArgument {
   }
 
   @Override
-  public ExpressionTree getUnexpandedExpression() {
+  public ExpressionTree getCompactExpression() {
     return unexpandedExpression;
   }
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
@@ -130,6 +130,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       return literalList;
     }
 
+    @Override
     public int getId() {
       return id;
     }
@@ -214,14 +215,14 @@ public final class SearchArgumentImpl implements SearchArgument {
   }
 
   private final List<PredicateLeaf> leaves;
-  private final ExpressionTree expression;
-  private final ExpressionTree unexpandedExpression;
+  private final ExpressionTree normalizedExpression;
+  private final ExpressionTree compactExpression;
 
-  SearchArgumentImpl(ExpressionTree expression,
-                     ExpressionTree unexpandedExpression,
+  SearchArgumentImpl(ExpressionTree normalizedExpression,
+                     ExpressionTree compactExpression,
                      List<PredicateLeaf> leaves) {
-    this.expression = expression;
-    this.unexpandedExpression = unexpandedExpression;
+    this.normalizedExpression = normalizedExpression;
+    this.compactExpression = compactExpression;
     this.leaves = leaves;
   }
 
@@ -229,8 +230,8 @@ public final class SearchArgumentImpl implements SearchArgument {
   @SuppressWarnings("unused")
   SearchArgumentImpl() {
         leaves = null;
-        expression = null;
-        unexpandedExpression = null;
+        normalizedExpression = null;
+        compactExpression = null;
   }
 
   @Override
@@ -240,22 +241,23 @@ public final class SearchArgumentImpl implements SearchArgument {
 
   @Override
   public TruthValue evaluate(TruthValue[] leaves) {
-    return expression == null ? TruthValue.YES : expression.evaluate(leaves);
+    return normalizedExpression == null ? TruthValue.YES
+        : normalizedExpression.evaluate(leaves);
   }
 
   @Override
   public ExpressionTree getExpression() {
-    return expression;
+    return normalizedExpression;
   }
 
   @Override
   public ExpressionTree getCompactExpression() {
-    return unexpandedExpression;
+    return compactExpression;
   }
 
   @Override
   public String toString() {
-    return expression.toString();
+    return normalizedExpression.toString();
   }
 
   /**
@@ -272,7 +274,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       buffer.append(", ");
     }
     buffer.append("expr = ");
-    buffer.append(expression.toOldString());
+    buffer.append(normalizedExpression.toOldString());
     return buffer.toString();
   }
 

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentImpl.java
@@ -18,19 +18,14 @@
 
 package org.apache.hadoop.hive.ql.io.sarg;
 
-import java.sql.Timestamp;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.NoDynamicValuesException;
@@ -51,6 +46,7 @@ public final class SearchArgumentImpl implements SearchArgument {
     private String columnName;
     private final Object literal;
     private final List<Object> literalList;
+    private int id;
 
     // Used by kryo
     @SuppressWarnings("unused")
@@ -60,6 +56,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       columnName = null;
       literal = null;
       literalList = null;
+      id = -1;
     }
 
     public PredicateLeafImpl(Operator operator,
@@ -79,6 +76,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       this.type = type;
       this.columnName = columnName;
       this.literal = literal;
+      this.id = -1;
       checkLiteralType(literal, type, conf);
       this.literalList = literalList;
       if (literalList != null) {
@@ -115,7 +113,7 @@ public final class SearchArgumentImpl implements SearchArgument {
     @Override
     public List<Object> getLiteralList() {
       if (literalList != null && literalList.size() > 0 && literalList.get(0) instanceof LiteralDelegate) {
-        List<Object> newLiteraList = new ArrayList<Object>();
+        List<Object> newLiteraList = new ArrayList<>();
         try {
           for (Object litertalObj : literalList) {
             Object literal = ((LiteralDelegate) litertalObj).getLiteral();
@@ -130,6 +128,14 @@ public final class SearchArgumentImpl implements SearchArgument {
         return newLiteraList;
       }
       return literalList;
+    }
+
+    public int getId() {
+      return id;
+    }
+
+    public void setId(int newId) {
+      id = newId;
     }
 
     @Override
@@ -209,9 +215,13 @@ public final class SearchArgumentImpl implements SearchArgument {
 
   private final List<PredicateLeaf> leaves;
   private final ExpressionTree expression;
+  private final ExpressionTree unexpandedExpression;
 
-  SearchArgumentImpl(ExpressionTree expression, List<PredicateLeaf> leaves) {
+  SearchArgumentImpl(ExpressionTree expression,
+                     ExpressionTree unexpandedExpression,
+                     List<PredicateLeaf> leaves) {
     this.expression = expression;
+    this.unexpandedExpression = unexpandedExpression;
     this.leaves = leaves;
   }
 
@@ -220,6 +230,7 @@ public final class SearchArgumentImpl implements SearchArgument {
   SearchArgumentImpl() {
         leaves = null;
         expression = null;
+        unexpandedExpression = null;
   }
 
   @Override
@@ -238,9 +249,22 @@ public final class SearchArgumentImpl implements SearchArgument {
   }
 
   @Override
+  public ExpressionTree getUnexpandedExpression() {
+    return unexpandedExpression;
+  }
+
+  @Override
   public String toString() {
+    return expression.toString();
+  }
+
+  /**
+   * Generate the backwards compatible string for test cases
+   * @return the sarg using the old string
+   */
+  public String toOldString() {
     StringBuilder buffer = new StringBuilder();
-    for(int i=0; i < leaves.size(); ++i) {
+    for(int i=0; leaves != null && i < leaves.size(); ++i) {
       buffer.append("leaf-");
       buffer.append(i);
       buffer.append(" = ");
@@ -248,7 +272,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       buffer.append(", ");
     }
     buffer.append("expr = ");
-    buffer.append(expression);
+    buffer.append(expression.toOldString());
     return buffer.toString();
   }
 
@@ -264,9 +288,9 @@ public final class SearchArgumentImpl implements SearchArgument {
     private static final int CNF_COMBINATIONS_THRESHOLD = 256;
 
     private final Deque<ExpressionTree> currentTree =
-        new ArrayDeque<ExpressionTree>();
-    private final Map<PredicateLeaf, Integer> leaves =
-        new HashMap<PredicateLeaf, Integer>();
+        new ArrayDeque<>();
+    private final Map<PredicateLeafImpl, PredicateLeafImpl> leaves =
+        new HashMap<>();
     private final ExpressionTree root =
         new ExpressionTree(ExpressionTree.Operator.AND);
     {
@@ -312,12 +336,11 @@ public final class SearchArgumentImpl implements SearchArgument {
       return this;
     }
 
-    private int addLeaf(PredicateLeaf leaf) {
-      Integer result = leaves.get(leaf);
+    private PredicateLeafImpl addLeaf(PredicateLeafImpl leaf) {
+      PredicateLeafImpl result = leaves.get(leaf);
       if (result == null) {
-        int id = leaves.size();
-        leaves.put(leaf, id);
-        return id;
+        leaves.put(leaf, leaf);
+        return leaf;
       } else {
         return result;
       }
@@ -330,7 +353,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null || literal == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.LESS_THAN,
                 type, column, literal, null, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -345,7 +368,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null || literal == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.LESS_THAN_EQUALS,
                 type, column, literal, null, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -360,7 +383,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null || literal == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.EQUALS,
                 type, column, literal, null, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -375,7 +398,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null || literal == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.NULL_SAFE_EQUALS,
                 type, column, literal, null, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -394,10 +417,9 @@ public final class SearchArgumentImpl implements SearchArgument {
           throw new IllegalArgumentException("Can't create in expression with "
               + "no arguments");
         }
-        List<Object> argList = new ArrayList<Object>();
-        argList.addAll(Arrays.asList(literal));
+        List<Object> argList = new ArrayList<>(Arrays.asList(literal));
 
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.IN,
                 type, column, null, argList, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -411,7 +433,7 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.IS_NULL,
                 type, column, null, null, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -426,10 +448,10 @@ public final class SearchArgumentImpl implements SearchArgument {
       if (column == null || lower == null || upper == null) {
         parent.getChildren().add(new ExpressionTree(TruthValue.YES_NO_NULL));
       } else {
-        List<Object> argList = new ArrayList<Object>();
+        List<Object> argList = new ArrayList<>();
         argList.add(lower);
         argList.add(upper);
-        PredicateLeaf leaf =
+        PredicateLeafImpl leaf =
             new PredicateLeafImpl(PredicateLeaf.Operator.BETWEEN,
                 type, column, null, argList, conf);
         parent.getChildren().add(new ExpressionTree(addLeaf(leaf)));
@@ -448,54 +470,21 @@ public final class SearchArgumentImpl implements SearchArgument {
      * Recursively explore the tree to find the leaves that are still reachable
      * after optimizations.
      * @param tree the node to check next
-     * @param next the next available leaf id
-     * @param leafReorder
-     * @return the next available leaf id
+     * @param leaves the list of leaves that were found
      */
-    static int compactLeaves(ExpressionTree tree, int next, int[] leafReorder) {
+    static void compactLeaves(ExpressionTree tree,
+                              List<PredicateLeaf> leaves) {
       if (tree.getOperator() == ExpressionTree.Operator.LEAF) {
-        int oldLeaf = tree.getLeaf();
-        if (leafReorder[oldLeaf] == -1) {
-          leafReorder[oldLeaf] = next++;
+        PredicateLeafImpl newLeaf = (PredicateLeafImpl) tree.getPredicateLeaf();
+        if (newLeaf.getId() == -1) {
+          newLeaf.setId(leaves.size());
+          leaves.add(newLeaf);
         }
       } else if (tree.getChildren() != null){
         for(ExpressionTree child: tree.getChildren()) {
-          next = compactLeaves(child, next, leafReorder);
+          compactLeaves(child, leaves);
         }
       }
-      return next;
-    }
-
-    /**
-     * Rewrite expression tree to update the leaves.
-     * @param root the root of the tree to fix
-     * @param leafReorder a map from old leaf ids to new leaf ids
-     * @return the fixed root
-     */
-    static ExpressionTree rewriteLeaves(ExpressionTree root,
-                              int[] leafReorder) {
-      // The leaves could be shared in the tree. Use Set to remove the duplicates.
-      Set<ExpressionTree> leaves = new HashSet<ExpressionTree>();
-      Queue<ExpressionTree> nodes = new LinkedList<ExpressionTree>();
-      nodes.add(root);
-
-      while(!nodes.isEmpty()) {
-        ExpressionTree node = nodes.remove();
-        if (node.getOperator() == ExpressionTree.Operator.LEAF) {
-          leaves.add(node);
-        } else {
-          if (node.getChildren() != null){
-            nodes.addAll(node.getChildren());
-          }
-        }
-      }
-
-      // Update the leaf in place
-      for(ExpressionTree leaf : leaves) {
-        leaf.setLeaf(leafReorder[leaf.getLeaf()]);
-      }
-
-      return root;
     }
 
     @Override
@@ -504,28 +493,18 @@ public final class SearchArgumentImpl implements SearchArgument {
         throw new IllegalArgumentException("Failed to end " +
             currentTree.size() + " operations.");
       }
+      ExpressionTree optimized = optimize(root);
+      ExpressionTree expanded = convertToCNF(new ExpressionTree(optimized));
+      expanded = flatten(expanded);
+      List<PredicateLeaf> finalLeaves = new ArrayList<>(leaves.size());
+      compactLeaves(expanded, finalLeaves);
+      return new SearchArgumentImpl(expanded, optimized, finalLeaves);
+    }
+
+    static ExpressionTree optimize(ExpressionTree root) {
       ExpressionTree optimized = pushDownNot(root);
       optimized = foldMaybe(optimized);
-      optimized = flatten(optimized);
-      optimized = convertToCNF(optimized);
-      optimized = flatten(optimized);
-      int leafReorder[] = new int[leaves.size()];
-      Arrays.fill(leafReorder, -1);
-      int newLeafCount = compactLeaves(optimized, 0, leafReorder);
-      optimized = rewriteLeaves(optimized, leafReorder);
-      ArrayList<PredicateLeaf> leafList = new ArrayList<>(newLeafCount);
-      // expand list to correct size
-      for(int i=0; i < newLeafCount; ++i) {
-        leafList.add(null);
-      }
-      // build the new list
-      for(Map.Entry<PredicateLeaf, Integer> elem: leaves.entrySet()) {
-        int newLoc = leafReorder[elem.getValue()];
-        if (newLoc != -1) {
-          leafList.set(newLoc, elem.getKey());
-        }
-      }
-      return new SearchArgumentImpl(optimized, leafList);
+      return flatten(optimized);
     }
 
     /**
@@ -669,7 +648,7 @@ public final class SearchArgumentImpl implements SearchArgument {
           or.getChildren().add(kid);
         }
       } else {
-        List<ExpressionTree> work = new ArrayList<ExpressionTree>(result);
+        List<ExpressionTree> work = new ArrayList<>(result);
         result.clear();
         for(ExpressionTree kid: kids) {
           for(ExpressionTree or: work) {
@@ -701,17 +680,15 @@ public final class SearchArgumentImpl implements SearchArgument {
         }
         if (root.getOperator() == ExpressionTree.Operator.OR) {
           // a list of leaves that weren't under AND expressions
-          List<ExpressionTree> nonAndList = new ArrayList<ExpressionTree>();
+          List<ExpressionTree> nonAndList = new ArrayList<>();
           // a list of AND expressions that we need to distribute
-          List<ExpressionTree> andList = new ArrayList<ExpressionTree>();
+          List<ExpressionTree> andList = new ArrayList<>();
           for(ExpressionTree child: root.getChildren()) {
             if (child.getOperator() == ExpressionTree.Operator.AND) {
               andList.add(child);
             } else if (child.getOperator() == ExpressionTree.Operator.OR) {
               // pull apart the kids of the OR expression
-              for(ExpressionTree grandkid: child.getChildren()) {
-                nonAndList.add(grandkid);
-              }
+              nonAndList.addAll(child.getChildren());
             } else {
               nonAndList.add(child);
             }

--- a/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentFactoryTest.java
+++ b/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentFactoryTest.java
@@ -1,0 +1,160 @@
+package org.apache.hadoop.hive.ql.io.sarg;
+
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class SearchArgumentFactoryTest {
+
+  private final Configuration conf = new Configuration();
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testNormalize() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .build();
+
+    Assert.assertEquals("(and "
+                        + "(or leaf-(IN f1 1 6) leaf-(IN f1 3 4)) "
+                        + "(or leaf-(IN f2 a c) leaf-(IN f1 3 4)) "
+                        + "(or leaf-(IN f1 1 6) leaf-(IN f2 c e)) "
+                        + "(or leaf-(IN f2 a c) leaf-(IN f2 c e)))",
+                        sArg.getExpression().toString());
+
+    Assert.assertEquals("(or "
+                        + "(and leaf-(IN f1 1 6) leaf-(IN f2 a c)) "
+                        + "(and leaf-(IN f1 3 4) leaf-(IN f2 c e)))",
+                        sArg.getUnexpandedExpression().toString());
+  }
+
+  @Test
+  public void testNormalizeNested() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder()
+      .startAnd()
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 5L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "d")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 5L)
+      .in("f2", PredicateLeaf.Type.STRING, "b", "e")
+      .end()
+      .end()
+      .end()
+      .build();
+
+    Assert.assertEquals("(and "
+                        + "(or leaf-(IN f1 1 6) leaf-(IN f1 3 4)) "
+                        + "(or leaf-(IN f2 a c) leaf-(IN f1 3 4)) "
+                        + "(or leaf-(IN f1 1 6) leaf-(IN f2 c e)) "
+                        + "(or leaf-(IN f2 a c) leaf-(IN f2 c e)) "
+                        + "(or leaf-(IN f1 1 5) leaf-(IN f1 3 5)) "
+                        + "(or leaf-(IN f2 a d) leaf-(IN f1 3 5)) "
+                        + "(or leaf-(IN f1 1 5) leaf-(IN f2 b e)) "
+                        + "(or leaf-(IN f2 a d) leaf-(IN f2 b e)))",
+                        sArg.getExpression().toString());
+    Assert.assertEquals("(and "
+                        + "(or "
+                        + "(and leaf-(IN f1 1 6) leaf-(IN f2 a c)) "
+                        + "(and leaf-(IN f1 3 4) leaf-(IN f2 c e))) "
+                        + "(or "
+                        + "(and leaf-(IN f1 1 5) leaf-(IN f2 a d)) "
+                        + "(and leaf-(IN f1 3 5) leaf-(IN f2 b e))))",
+                        sArg.getUnexpandedExpression().toString());
+  }
+
+  @Test
+  public void testNoNormalize() {
+    SearchArgument sArg = SearchArgumentFactory.newBuilder(conf)
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .build();
+
+    ExpressionTree unexpanded = sArg.getUnexpandedExpression();
+    Assert.assertEquals(ExpressionTree.Operator.OR, unexpanded.getOperator());
+    Assert.assertEquals(2, unexpanded.getChildren().size());
+    for (ExpressionTree child : unexpanded.getChildren()) {
+      Assert.assertEquals(ExpressionTree.Operator.AND, child.getOperator());
+      Assert.assertEquals(2, child.getChildren().size());
+      for (ExpressionTree gChild : child.getChildren()) {
+        Assert.assertEquals(ExpressionTree.Operator.LEAF, gChild.getOperator());
+      }
+    }
+  }
+
+  @Test
+  public void testNoNormalizeNormalize() {
+    SearchArgument nnSArg = SearchArgumentFactory.newBuilder(conf)
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .end()
+      .build();
+
+    Assert.assertEquals("(and (or leaf-(IN f1 1 6) leaf-(IN f1 3 4))" +
+        " (or leaf-(IN f2 a c) leaf-(IN f1 3 4))" +
+        " (or leaf-(IN f1 1 6) leaf-(IN f2 c e))" +
+        " (or leaf-(IN f2 a c) leaf-(IN f2 c e)))",
+        nnSArg.getExpression().toString());
+    Assert.assertEquals("(or (and leaf-(IN f1 1 6) leaf-(IN f2 a c))" +
+            " (and leaf-(IN f1 3 4) leaf-(IN f2 c e)))",
+        nnSArg.getUnexpandedExpression().toString());
+  }
+
+  @Test
+  public void testNoNormalizeValidations() {
+    conf.setBoolean("sarg.normalize", false);
+    thrown.expectMessage("Failed to end");
+    thrown.expect(IllegalArgumentException.class);
+    SearchArgumentFactory.newBuilder(conf)
+      .startOr()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 1L, 6L)
+      .in("f2", PredicateLeaf.Type.STRING, "a", "c")
+      .end()
+      .startAnd()
+      .in("f1", PredicateLeaf.Type.LONG, 3L, 4L)
+      .in("f2", PredicateLeaf.Type.STRING, "c", "e")
+      .end()
+      .build();
+  }
+}

--- a/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentFactoryTest.java
+++ b/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/SearchArgumentFactoryTest.java
@@ -38,7 +38,7 @@ public class SearchArgumentFactoryTest {
     Assert.assertEquals("(or "
                         + "(and leaf-(IN f1 1 6) leaf-(IN f2 a c)) "
                         + "(and leaf-(IN f1 3 4) leaf-(IN f2 c e)))",
-                        sArg.getUnexpandedExpression().toString());
+                        sArg.getCompactExpression().toString());
   }
 
   @Test
@@ -85,7 +85,7 @@ public class SearchArgumentFactoryTest {
                         + "(or "
                         + "(and leaf-(IN f1 1 5) leaf-(IN f2 a d)) "
                         + "(and leaf-(IN f1 3 5) leaf-(IN f2 b e))))",
-                        sArg.getUnexpandedExpression().toString());
+                        sArg.getCompactExpression().toString());
   }
 
   @Test
@@ -103,7 +103,7 @@ public class SearchArgumentFactoryTest {
       .end()
       .build();
 
-    ExpressionTree unexpanded = sArg.getUnexpandedExpression();
+    ExpressionTree unexpanded = sArg.getCompactExpression();
     Assert.assertEquals(ExpressionTree.Operator.OR, unexpanded.getOperator());
     Assert.assertEquals(2, unexpanded.getChildren().size());
     for (ExpressionTree child : unexpanded.getChildren()) {
@@ -137,7 +137,7 @@ public class SearchArgumentFactoryTest {
         nnSArg.getExpression().toString());
     Assert.assertEquals("(or (and leaf-(IN f1 1 6) leaf-(IN f2 a c))" +
             " (and leaf-(IN f1 3 4) leaf-(IN f2 c e)))",
-        nnSArg.getUnexpandedExpression().toString());
+        nnSArg.getCompactExpression().toString());
   }
 
   @Test

--- a/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentFactory.java
+++ b/storage-api/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentFactory.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.io.sarg;
 
 import org.apache.hadoop.conf.Configuration;
@@ -6,7 +24,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
-public class SearchArgumentFactoryTest {
+public class TestSearchArgumentFactory {
 
   private final Configuration conf = new Configuration();
 


### PR DESCRIPTION
This pull request provides a method to get a non-normalized copy of the SArg expression. This can be useful for applications where the smaller non-normalized expression is useful.

I've changed the SArg ExpressionTree leaves to keep a pointer to the PredicateLeafImpl rather than just the id. That makes a lot of things easier, including dealing with keeping the normalized and non-normalized versions in sync with the leaves.

It also changes the format of the toString to be easier to read, but to make the old tests easier to port I've provided a toOldString method that generates the old string.