### PR TITLE
HIVE-24473 Make Hive buildable with HBase 2.x GA versions

### DIFF
--- a/itests/hcatalog-unit/pom.xml
+++ b/itests/hcatalog-unit/pom.xml
@@ -319,4 +319,24 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <!-- See HIVE-24473 -->
+      <id>gahbase</id>
+      <activation>
+        <property>
+          <name>hbase.version</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-zookeeper</artifactId>
+          <classifier>tests</classifier>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/hbase/ManyMiniCluster.java
+++ b/itests/hcatalog-unit/src/test/java/org/apache/hive/hcatalog/hbase/ManyMiniCluster.java
@@ -254,8 +254,9 @@ public class ManyMiniCluster {
       hbaseDir = hbaseDir.replaceAll("\\\\", "/");
       hbaseRoot = "file:///" + hbaseDir;
 
-      if (hbaseConf == null)
+      if (hbaseConf == null) {
         hbaseConf = HBaseConfiguration.create();
+      }
 
       hbaseConf.set("hbase.rootdir", hbaseRoot);
       hbaseConf.set("hbase.master", "local");
@@ -265,6 +266,7 @@ public class ManyMiniCluster {
       hbaseConf.setInt("hbase.master.info.port", -1);
       hbaseConf.setInt("hbase.regionserver.port", findFreePort());
       hbaseConf.setInt("hbase.regionserver.info.port", -1);
+      hbaseConf.setBoolean("hbase.unsafe.stream.capability.enforce", false);
 
       hbaseCluster = new MiniHBaseCluster(hbaseConf, numRegionServers);
       hbaseConf.set("hbase.master", hbaseCluster.getMaster().getServerName().getHostAndPort());

--- a/itests/util/pom.xml
+++ b/itests/util/pom.xml
@@ -240,4 +240,22 @@
       </exclusions>
     </dependency>
   </dependencies>
+  <profiles>
+    <profile>
+      <!-- See HIVE-24473 -->
+      <id>gahbase</id>
+      <activation>
+        <property>
+          <name>hbase.version</name>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-zookeeper</artifactId>
+          <classifier>tests</classifier>
+        </dependency>
+      </dependencies>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
     <commons-cli.version>1.2</commons-cli.version>
     <commons-codec.version>1.7</commons-codec.version>
     <commons-collections.version>3.2.2</commons-collections.version>
+    <commons-collections4.version>4.1</commons-collections4.version>
     <commons-compress.version>1.19</commons-compress.version>
     <commons-configuration.version>1.10</commons-configuration.version>
     <commons-exec.version>1.1</commons-exec.version>
@@ -342,6 +343,11 @@
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
         <version>${commons-collections.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${commons-collections4.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-io</groupId>
@@ -1001,6 +1007,12 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-mapreduce</artifactId>
+        <version>${hbase.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-zookeeper</artifactId>
+        <classifier>tests</classifier>
         <version>${hbase.version}</version>
       </dependency>
       <dependency>
@@ -1711,6 +1723,14 @@
       <modules>
         <module>itests</module>
       </modules>
+    </profile>
+    <profile>
+      <id>customhbase</id>
+      <activation>
+        <property>
+          <name>hbase.version</name>
+        </property>
+      </activation>
     </profile>
   </profiles>
 </project>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -180,6 +180,10 @@
     </dependency>
     <dependency>
        <groupId>org.apache.commons</groupId>
+       <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>org.apache.commons</groupId>
        <artifactId>commons-lang3</artifactId>
        <version>${commons-lang3.version}</version>
     </dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make Hive buildable with HBase 2.x GA releases that are built for Hadoop 3

### Why are the changes needed?
Currently Hive includes an old pre-relase version of HBase.
Hive should be able to use GA HBase 2.x code.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. Download Hbase 2.2.6 sources
2. Rebuild and install HBase 2.2.6 locally with -Dhadoop.profile=3.0
3. Build and test hive locally:
mvn clean install -DskipTests  -Dhbase.version=2.2.6; 
mvn test -Dhbase.version=2.2.6; 
cd itests; 
mvn clean install -DskipTests  -Dhbase.version=2.2.6;  
mvn test -Dhbase.version=2.2.6

There were some test failures on my system, but they were all present in a control run without the patch.