### PR TITLE
HIVE-24478: Subquery GroupBy with Distinct SemanticException: Invalid column reference

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1835,6 +1835,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         qbp.setHavingExprForClause(ctx_1.dest, ast);
         qbp.addAggregationExprsForClause(ctx_1.dest,
             doPhase1GetAggregationsFromSelect(ast, qb, ctx_1.dest));
+        // Clause might also refer to aggregations with distinct
+        qbp.setDistinctFuncExprsForClause(ctx_1.dest,
+            doPhase1GetDistinctFuncExprs(qbp.getAggregationExprsForClause(ctx_1.dest)));
         break;
 
       case HiveParser.KW_WINDOW:

--- a/ql/src/test/queries/clientpositive/groupby_having_distinct.q
+++ b/ql/src/test/queries/clientpositive/groupby_having_distinct.q
@@ -1,0 +1,35 @@
+DROP TABLE tmp_src1;
+
+CREATE TABLE tmp_src1(
+  `npp` string,
+  `nsoc` string) stored as orc;
+
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273111');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273112');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273221');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273222');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392331');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392334');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273444');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273441');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273554');
+INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273555');
+
+EXPLAIN CBO
+SELECT `min_nsoc`
+FROM
+     (SELECT `npp`,
+             MIN(`nsoc`) AS `min_nsoc`,
+             COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+      FROM tmp_src1
+      GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0;
+
+SELECT `min_nsoc`
+FROM
+    (SELECT `npp`,
+            MIN(`nsoc`) AS `min_nsoc`,
+            COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+     FROM tmp_src1
+     GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0;

--- a/ql/src/test/results/clientpositive/llap/groupby_having_distinct.q.out
+++ b/ql/src/test/results/clientpositive/llap/groupby_having_distinct.q.out
@@ -1,0 +1,173 @@
+PREHOOK: query: DROP TABLE tmp_src1
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE tmp_src1
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE tmp_src1(
+  `npp` string,
+  `nsoc` string) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: CREATE TABLE tmp_src1(
+  `npp` string,
+  `nsoc` string) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tmp_src1
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273111')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273111')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273112')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000CG61','7273112')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273221')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273221')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273222')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000EL62','7273222')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392331')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392331')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392334')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000OGH3','9392334')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273444')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273444')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273441')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000Q7V4','7273441')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273554')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273554')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273555')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tmp_src1
+POSTHOOK: query: INSERT INTO tmp_src1 (npp,nsoc) VALUES ('1-1000WA85','7273555')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tmp_src1
+POSTHOOK: Lineage: tmp_src1.npp SCRIPT []
+POSTHOOK: Lineage: tmp_src1.nsoc SCRIPT []
+PREHOOK: query: EXPLAIN CBO
+SELECT `min_nsoc`
+FROM
+     (SELECT `npp`,
+             MIN(`nsoc`) AS `min_nsoc`,
+             COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+      FROM tmp_src1
+      GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tmp_src1
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT `min_nsoc`
+FROM
+     (SELECT `npp`,
+             MIN(`nsoc`) AS `min_nsoc`,
+             COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+      FROM tmp_src1
+      GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tmp_src1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(min_nsoc=[$1])
+  HiveFilter(condition=[>($2, 0)])
+    HiveAggregate(group=[{0}], agg#0=[min($1)], agg#1=[count(DISTINCT $1)])
+      HiveTableScan(table=[[default, tmp_src1]], table:alias=[tmp_src1])
+
+PREHOOK: query: SELECT `min_nsoc`
+FROM
+    (SELECT `npp`,
+            MIN(`nsoc`) AS `min_nsoc`,
+            COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+     FROM tmp_src1
+     GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tmp_src1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT `min_nsoc`
+FROM
+    (SELECT `npp`,
+            MIN(`nsoc`) AS `min_nsoc`,
+            COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
+     FROM tmp_src1
+     GROUP BY `npp`) `a`
+WHERE `nb_nsoc` > 0
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tmp_src1
+#### A masked pattern was here ####
+7273111
+7273221
+9392331
+7273441
+7273554


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fixing _Having_ with _distinct_ issue in SemanticAnalyzer where _Having_ clause should update both aggregationExpressions and Distinct expressions.


### Why are the changes needed?
There can be cases where the aggregation is on a distinct column as in:
``
SELECT `min_nsoc`
FROM
     (SELECT `npp`,
             MIN(`nsoc`) AS `min_nsoc`,
             COUNT(DISTINCT `nsoc`) AS `nb_nsoc`
      FROM tmp_src1
      GROUP BY `npp`) `a`
WHERE `nb_nsoc` > 0;
``

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added query file: groupby_having_distinct.q