### PR TITLE
HIVE-24485: Make the slow-start behavior tunable

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -509,7 +509,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE:
-      setupAutoReducerParallelism(edgeProp, w);
+      setupAutoReducerParallelism(edgeProp, w, vConf);
       // fall through
 
     default:
@@ -553,7 +553,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE: {
-      setupAutoReducerParallelism(edgeProp, w);
+      setupAutoReducerParallelism(edgeProp, w, vConf);
       break;
     }
     case CUSTOM_SIMPLE_EDGE: {
@@ -1654,7 +1654,7 @@ public class DagUtils {
     return instance;
   }
 
-  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v)
+  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v, Configuration conf)
     throws IOException {
     if (edgeProp.isAutoReduce()) {
       Configuration pluginConf = new Configuration(false);
@@ -1667,6 +1667,16 @@ public class DagUtils {
       pluginConf.setLong(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_DESIRED_TASK_INPUT_SIZE,
           edgeProp.getInputSizePerReducer());
+      pluginConf.setFloat(
+          ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
+          conf.getFloat(
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT));
+      pluginConf.setFloat(
+          ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
+          conf.getFloat(
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
+              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT));
       UserPayload payload = TezUtils.createUserPayloadFromConf(pluginConf);
       desc.setUserPayload(payload);
       v.setVertexManagerPlugin(desc);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -509,7 +509,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE:
-      setupAutoReducerParallelism(edgeProp, w, vConf);
+      setupAutoReducerParallelism(edgeProp, w);
       // fall through
 
     default:
@@ -553,7 +553,7 @@ public class DagUtils {
       break;
 
     case SIMPLE_EDGE: {
-      setupAutoReducerParallelism(edgeProp, w, vConf);
+      setupAutoReducerParallelism(edgeProp, w);
       break;
     }
     case CUSTOM_SIMPLE_EDGE: {
@@ -1654,7 +1654,7 @@ public class DagUtils {
     return instance;
   }
 
-  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v, Configuration conf)
+  private void setupAutoReducerParallelism(TezEdgeProperty edgeProp, Vertex v)
     throws IOException {
     if (edgeProp.isAutoReduce()) {
       Configuration pluginConf = new Configuration(false);
@@ -1669,14 +1669,10 @@ public class DagUtils {
           edgeProp.getInputSizePerReducer());
       pluginConf.setFloat(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
-          conf.getFloat(
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION,
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT));
+          edgeProp.getSlowStartMinSrcFraction());
       pluginConf.setFloat(
           ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
-          conf.getFloat(
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION,
-              ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT));
+          edgeProp.getSlowStartMaxSrcFraction());
       UserPayload payload = TezUtils.createUserPayloadFromConf(pluginConf);
       desc.setUserPayload(payload);
       v.setVertexManagerPlugin(desc);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezWork.java
@@ -462,6 +462,7 @@ public class GenTezWork implements SemanticNodeProcessor {
           if (rWork.isAutoReduceParallelism()) {
             edgeProp =
                 new TezEdgeProperty(context.conf, edgeType, true, rWork.isSlowStart(),
+                    rWork.getSlowStartMinSrcFraction(), rWork.getSlowStartMaxSrcFraction(),
                     rWork.getMinReduceTasks(), rWork.getMaxReduceTasks(), bytesPerReducer);
           } else {
             edgeProp = new TezEdgeProperty(edgeType);

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ReduceWork.java
@@ -84,6 +84,12 @@ public class ReduceWork extends BaseWork {
   // boolean that says whether to slow start or not
   private boolean isSlowStart = true;
 
+  // the first task can be scheduled after this fraction of source tasks complete
+  private float slowStartMinSrcFraction;
+
+  // all tasks can be scheduled after this fraction of source tasks complete
+  private float slowStartMaxSrcFraction;
+
   // for auto reduce parallelism - minimum reducers requested
   private int minReduceTasks;
 
@@ -219,6 +225,22 @@ public class ReduceWork extends BaseWork {
 
   public void setSlowStart(boolean isSlowStart) {
     this.isSlowStart = isSlowStart;
+  }
+
+  public void setSlowStartMinSrcFraction(float slowStartMinSrcFraction) {
+    this.slowStartMinSrcFraction = slowStartMinSrcFraction;
+  }
+
+  public float getSlowStartMinSrcFraction() {
+    return slowStartMinSrcFraction;
+  }
+
+  public void setSlowStartMaxSrcFraction(float slowStartMaxSrcFraction) {
+    this.slowStartMaxSrcFraction = slowStartMaxSrcFraction;
+  }
+
+  public float getSlowStartMaxSrcFraction() {
+    return slowStartMaxSrcFraction;
   }
 
   // ReducerTraits.UNIFORM

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TezEdgeProperty.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TezEdgeProperty.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.plan;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.tez.dag.library.vertexmanager.ShuffleVertexManager;
 
 public class TezEdgeProperty {
 
@@ -38,6 +39,8 @@ public class TezEdgeProperty {
 
   private boolean isAutoReduce;
   private boolean isSlowStart = true;
+  private float slowStartMinSrcFraction = ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MIN_SRC_FRACTION_DEFAULT;
+  private float slowStartMaxSrcFraction = ShuffleVertexManager.TEZ_SHUFFLE_VERTEX_MANAGER_MAX_SRC_FRACTION_DEFAULT;
   private int minReducer;
   private int maxReducer;
   private long inputSizePerReducer;
@@ -51,10 +54,13 @@ public class TezEdgeProperty {
   }
 
   public TezEdgeProperty(HiveConf hiveConf, EdgeType edgeType, boolean isAutoReduce,
-      boolean isSlowStart, int minReducer, int maxReducer, long bytesPerReducer) {
+      boolean isSlowStart, float slowStartMinSrcFraction, float slowStartMaxSrcFraction,
+      int minReducer, int maxReducer, long bytesPerReducer) {
     this(hiveConf, edgeType, -1);
     setAutoReduce(hiveConf, isAutoReduce, minReducer, maxReducer, bytesPerReducer);
     this.isSlowStart = isSlowStart;
+    this.slowStartMinSrcFraction = slowStartMinSrcFraction;
+    this.slowStartMaxSrcFraction = slowStartMaxSrcFraction;
   }
 
   public void setAutoReduce(HiveConf hiveConf, boolean isAutoReduce, int minReducer,
@@ -100,6 +106,14 @@ public class TezEdgeProperty {
 
   public boolean isSlowStart() {
     return isSlowStart;
+  }
+
+  public float getSlowStartMinSrcFraction() {
+    return slowStartMinSrcFraction;
+  }
+
+  public float getSlowStartMaxSrcFraction() {
+    return slowStartMaxSrcFraction;
   }
 
   public void setSlowStart(boolean slowStart) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Make it possible to apply `tez.shuffle-vertex-manager.min-src-fraction` and `tez.shuffle-vertex-manager.max-src-fraction` even if auto reducer parallelism is enabled.

https://issues.apache.org/jira/browse/HIVE-24485

### Why are the changes needed?
With this PR, we can tweak the trade-off between timing to start and accuracy of estimation.
Tez can gather more samples with higher fractions while it delays the start of the next vertex.

### Does this PR introduce _any_ user-facing change?
Users who are configuring `tez.shuffle-vertex-manager.{min,max}-src-fraction` or `mapreduce.job.reduce.slowstart.completedmaps`, the alternative of `tez.shuffle-vertex-manager.min-src-fraction`, can face the change of behavior when they enable auto reducer parallelism.

https://github.com/apache/tez/blob/dadc09f5a44c1cb61af00efecb3d27b92c92aa8f/tez-mapreduce/src/main/java/org/apache/tez/mapreduce/hadoop/DeprecatedKeys.java#L123

### How was this patch tested?
No test cases will be added because `Vertex#VertexManagerPluginDescriptor` is invisible from the outside of a Tez package.
We can check the change by running a job and then checking the Tez log.

```
beeline -e '
SET hive.tez.auto.reducer.parallelism=true;
SET hive.tez.min.partition.factor=1.0; -- enforce auto-parallelism
SET tez.shuffle-vertex-manager.min-src-fraction=0.55;
SET tez.shuffle-vertex-manager.max-src-fraction=0.95;
CREATE TABLE mofu (name string);
INSERT INTO mofu (name) VALUES ('12345');
SELECT name, count(*) FROM mofu GROUP BY name;
'
```

```
2020-12-04 16:10:47,170 [INFO] [Dispatcher thread {Central}] |vertexmanager.ShuffleVertexManagerBase|: Settings minFrac: 0.55 maxFrac: 0.95 auto: true desiredTaskIput: 256000000
```