### PR TITLE
HIVE-24489: TPC-DS dockerized tests fail due to stale entries in MIN_HISTORY_LEVEL metastore table

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
@@ -29,7 +29,7 @@ import java.io.UncheckedIOException;
 public class PostgresTPCDS extends Postgres {
   @Override
   public String getDockerImageName() {
-    return "zabetak/postgres-tpcds-metastore:1.2";
+    return "zabetak/postgres-tpcds-metastore:1.3";
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Update docker metastore version to zabetak/postgres-tpcds-metastore:1.3
on which some cleanup was performed to remove stale entries in various
tables including MIN_HISTORY_LEVEL.

See https://github.com/zabetak/hive-postgres-metastore/commit/04be88888bd2e9400d7ae604a4112aaa4531dd36

### Why are the changes needed?
To fix test failures while running `TestTezTPCDS30TBPerfCliDriver` tests. More details in the JIRA.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn test -Dtest=TestTezTPCDS30TBPerfCliDriver`