### PR TITLE
HIVE-24501: UpdateInputAccessTimeHook should not update stats

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/UpdateInputAccessTimeHook.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/UpdateInputAccessTimeHook.java
@@ -19,7 +19,9 @@ package org.apache.hadoop.hive.ql.hooks;
 
 import java.util.Set;
 
+import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
@@ -66,7 +68,10 @@ public class UpdateInputAccessTimeHook {
           String tblName = re.getTable().getTableName();
           Table t = db.getTable(dbName, tblName);
           t.setLastAccessTime(lastAccessTime);
-          db.alterTable(dbName + "." + tblName, t, false, null, false);
+          EnvironmentContext ec = new EnvironmentContext();
+          /*we are not modifying any data so stats should be exactly the same*/
+          ec.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
+          db.alterTable(dbName + "." + tblName, t, false, ec, false);
           break;
         }
         case PARTITION: {
@@ -78,7 +83,10 @@ public class UpdateInputAccessTimeHook {
           p.setLastAccessTime(lastAccessTime);
           db.alterPartition(null, dbName, tblName, p, null, false);
           t.setLastAccessTime(lastAccessTime);
-          db.alterTable(dbName + "." + tblName, t, false, null, false);
+          EnvironmentContext ec = new EnvironmentContext();
+          /*we are not modifying any data so stats should be exactly the same*/
+          ec.putToProperties(StatsSetupConst.DO_NOT_UPDATE_STATS, StatsSetupConst.TRUE);
+          db.alterTable(dbName + "." + tblName, t, false, ec, false);
           break;
         }
         default:


### PR DESCRIPTION
### What changes were proposed in this pull request?
When UpdateInputAccessTimeHook is used as pre-hook, any simple queries on transactional table throws exception (full stactrace in https://issues.apache.org/jira/browse/HIVE-24501)
```
org.apache.hadoop.hive.ql.metadata.HiveException(Unable to alter table. Cannot change stats state for a transactional table default.test without providing the transactional write state for verification
```
For updating only access time, the stats of table and partitions does not have to be updated. This PR sets environment context to skip updating the stats.

### Why are the changes needed?
Bug with exception trace in https://issues.apache.org/jira/browse/HIVE-24501


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually on dev cluster.