### PR TITLE
HIVE-24497: Node heartbeats from LLAP Daemon to the client are not ma…

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
@@ -14,6 +14,7 @@
 
 package org.apache.hadoop.hive.llap.daemon.impl;
 
+import org.apache.hadoop.hive.llap.LlapUtil;
 import org.apache.hadoop.hive.llap.protocol.LlapTaskUmbilicalProtocol.BooleanArray;
 import org.apache.hadoop.hive.llap.protocol.LlapTaskUmbilicalProtocol.TezAttemptArray;
 
@@ -192,9 +193,9 @@ public class AMReporter extends AbstractService {
     }
   }
 
-  public AMNodeInfo registerTask(String amLocation, int port, String umbilicalUser,
-      Token<JobTokenIdentifier> jobToken, QueryIdentifier queryIdentifier,
-      TezTaskAttemptID attemptId, boolean isGuaranteed) {
+  public AMNodeInfo registerTask(boolean externalClientRequest, String amLocation, int port, String umbilicalUser,
+                                 Token<JobTokenIdentifier> jobToken, QueryIdentifier queryIdentifier,
+                                 TezTaskAttemptID attemptId, boolean isGuaranteed) {
     if (LOG.isTraceEnabled()) {
       LOG.trace(
           "Registering for heartbeat: {}, queryIdentifier={}, attemptId={}",
@@ -214,6 +215,7 @@ public class AMReporter extends AbstractService {
       if (amNodeInfo == null) {
         amNodeInfo = new AMNodeInfo(amNodeId, umbilicalUser, jobToken, queryIdentifier, retryPolicy,
           retryTimeout, socketFactory, conf);
+        amNodeInfo.setIsExtCliRequest(externalClientRequest);
         amNodeInfoPerQuery.put(amNodeId, amNodeInfo);
         // Add to the queue only the first time this is registered, and on
         // subsequent instances when it's taken off the queue.
@@ -410,8 +412,15 @@ public class AMReporter extends AbstractService {
         BooleanArray guaranteed = new BooleanArray();
         guaranteed.set(tasks.guaranteed.toArray(new BooleanWritable[tasks.guaranteed.size()]));
 
-        amNodeInfo.getUmbilical().nodeHeartbeat(new Text(nodeId.getHostname()),
-            new Text(daemonId.getUniqueNodeIdInCluster()), nodeId.getPort(), aw, guaranteed);
+        if (LlapUtil.isCloudDeployment(conf) && amNodeInfo.isExtCliRequest()) {
+          String hostname = amNodeInfo.amNodeId.getHostname();
+          int externalClientCloudRpcPort = amNodeInfo.amNodeId.getPort();
+          amNodeInfo.getUmbilical().nodeHeartbeat(new Text(hostname),
+                  new Text(daemonId.getUniqueNodeIdInCluster()), externalClientCloudRpcPort, aw, guaranteed);
+        } else {
+          amNodeInfo.getUmbilical().nodeHeartbeat(new Text(nodeId.getHostname()),
+                  new Text(daemonId.getUniqueNodeIdInCluster()), nodeId.getPort(), aw, guaranteed);
+        }
       } catch (IOException e) {
         QueryIdentifier currentQueryIdentifier = amNodeInfo.getQueryIdentifier();
         amNodeInfo.setAmFailed(true);
@@ -470,6 +479,7 @@ public class AMReporter extends AbstractService {
     private LlapTaskUmbilicalProtocol umbilical;
     private long nextHeartbeatTime;
     private final AtomicBoolean isDone = new AtomicBoolean(false);
+    private final AtomicBoolean isExtCliRequest = new AtomicBoolean(false);
 
 
     public AMNodeInfo(LlapNodeId amNodeId, String umbilicalUser,
@@ -539,6 +549,14 @@ public class AMReporter extends AbstractService {
 
     boolean isDone() {
       return isDone.get();
+    }
+
+    void setIsExtCliRequest(boolean val) {
+      isExtCliRequest.set(val);
+    }
+
+    boolean isExtCliRequest() {
+      return isExtCliRequest.get();
     }
 
     /**

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/AMReporter.java
@@ -215,7 +215,7 @@ public class AMReporter extends AbstractService {
       if (amNodeInfo == null) {
         amNodeInfo = new AMNodeInfo(amNodeId, umbilicalUser, jobToken, queryIdentifier, retryPolicy,
           retryTimeout, socketFactory, conf);
-        amNodeInfo.setIsExtCliRequest(externalClientRequest);
+        amNodeInfo.setIsExternalClientRequest(externalClientRequest);
         amNodeInfoPerQuery.put(amNodeId, amNodeInfo);
         // Add to the queue only the first time this is registered, and on
         // subsequent instances when it's taken off the queue.
@@ -412,7 +412,7 @@ public class AMReporter extends AbstractService {
         BooleanArray guaranteed = new BooleanArray();
         guaranteed.set(tasks.guaranteed.toArray(new BooleanWritable[tasks.guaranteed.size()]));
 
-        if (LlapUtil.isCloudDeployment(conf) && amNodeInfo.isExtCliRequest()) {
+        if (LlapUtil.isCloudDeployment(conf) && amNodeInfo.isExternalClientRequest()) {
           String hostname = amNodeInfo.amNodeId.getHostname();
           int externalClientCloudRpcPort = amNodeInfo.amNodeId.getPort();
           amNodeInfo.getUmbilical().nodeHeartbeat(new Text(hostname),
@@ -479,7 +479,7 @@ public class AMReporter extends AbstractService {
     private LlapTaskUmbilicalProtocol umbilical;
     private long nextHeartbeatTime;
     private final AtomicBoolean isDone = new AtomicBoolean(false);
-    private final AtomicBoolean isExtCliRequest = new AtomicBoolean(false);
+    private final AtomicBoolean isExternalClientRequest = new AtomicBoolean(false);
 
 
     public AMNodeInfo(LlapNodeId amNodeId, String umbilicalUser,
@@ -551,12 +551,12 @@ public class AMReporter extends AbstractService {
       return isDone.get();
     }
 
-    void setIsExtCliRequest(boolean val) {
-      isExtCliRequest.set(val);
+    void setIsExternalClientRequest(boolean val) {
+      isExternalClientRequest.set(val);
     }
 
-    boolean isExtCliRequest() {
-      return isExtCliRequest.get();
+    boolean isExternalClientRequest() {
+      return isExternalClientRequest.get();
     }
 
     /**

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskRunnerCallable.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskRunnerCallable.java
@@ -160,7 +160,7 @@ public class TaskRunnerCallable extends CallableWithNdc<TaskRunner2Result> {
     this.amReporter = amReporter;
     // Register with the AMReporter when the callable is setup. Unregister once it starts running.
     if (amReporter != null && jobToken != null) {
-      this.amNodeInfo = amReporter.registerTask(request.getAmHost(), request.getAmPort(),
+      this.amNodeInfo = amReporter.registerTask(request.getIsExternalClientRequest(), request.getAmHost(), request.getAmPort(),
           vertex.getTokenIdentifier(), jobToken, fragmentInfo.getQueryInfo().getQueryIdentifier(),
           attemptId, isGuaranteed);
     } else {

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestAMReporter.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestAMReporter.java
@@ -71,9 +71,9 @@ public class TestAMReporter {
     String am2Location = "am2";
     String umbilicalUser = "user";
     QueryIdentifier queryId = new QueryIdentifier("app", 0);
-    amReporter.registerTask(am1Location, am1Port, umbilicalUser, null, queryId,
+    amReporter.registerTask(false,am1Location, am1Port, umbilicalUser, null, queryId,
       mock(TezTaskAttemptID.class), false);
-    amReporter.registerTask(am2Location, am2Port, umbilicalUser, null, queryId,
+    amReporter.registerTask(false,am2Location, am2Port, umbilicalUser, null, queryId,
       mock(TezTaskAttemptID.class), false);
 
     Thread.currentThread().sleep(2000);


### PR DESCRIPTION
…tching leading to timeout in cloud deplyoment

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Node heartbeat contains info about all the tasks that were submitted to that LLAP Daemon. In cloud deployment, the client is not able to match this heartbeats due to differences in hostname and port resulting in timeout as see below with the following log .

20/07/24 03:27:03 INFO ext.LlapTaskUmbilicalExternalClient: No tasks found for heartbeat from hostname executor-host-0.executor-host-0.cluster.local, port 25000

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
