### PR TITLE
HIVE-24504: VectorFileSinkArrowOperator does not serialize complex types correctly

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestSerializer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestSerializer.java
@@ -28,7 +28,7 @@ import java.util.List;
 
 public class TestSerializer {
   @Test
-  public void testEmptyArray() {
+  public void testEmptyList() {
     List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString("array<tinyint>");
     List<String> fieldNames = Arrays.asList(new String[]{"a"});
     Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
@@ -67,6 +67,33 @@ public class TestSerializer {
     Assert.assertEquals(
         "Schema<a: Struct<b: List<$data$: Int(8, true)>, c: List<$data$: Struct<keys: Utf8, values: Utf8>>, " +
             "d: Struct<e: List<$data$: Int(8, true)>, f: List<$data$: Struct<keys: Utf8, values: Utf8>>>>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+
+  @Test
+  public void testEmptyComplexMap() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(
+        "map<array<tinyint>,struct<b:array<tinyint>,c:map<string,string>>>");
+    List<String> fieldNames = Arrays.asList(new String[] { "a" });
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals(
+        "Schema<a: List<$data$: Struct<keys: List<$data$: Int(8, true)>, values: " +
+            "Struct<b: List<$data$: Int(8, true)>, c: List<$data$: Struct<keys: Utf8, values: Utf8>>>>>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+
+  @Test
+  public void testEmptyComplexList() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString("struct<b:array<array<tinyint>>," +
+        "c:array<map<string,string>>,d:array<struct<e:array<tinyint>,f:map<string,string>>>>");
+    List<String> fieldNames = Arrays.asList(new String[] { "a" });
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals(
+        "Schema<a: Struct<b: List<$data$: List<$data$: Int(8, true)>>, c: List<$data$: List<$data$: " +
+            "Struct<keys: Utf8, values: Utf8>>>, d: List<$data$: Struct<e: List<$data$: Int(8, true)>, " +
+            "f: List<$data$: Struct<keys: Utf8, values: Utf8>>>>>>",
         writable.getVectorSchemaRoot().getSchema().toString());
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestSerializer.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestSerializer.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.arrow;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class TestSerializer {
+  @Test
+  public void testEmptyArray() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString("array<tinyint>");
+    List<String> fieldNames = Arrays.asList(new String[]{"a"});
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals("Schema<a: List<$data$: Int(8, true)>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+
+  @Test
+  public void testEmptyStruct() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString("struct<b:int,c:string>");
+    List<String> fieldNames = Arrays.asList(new String[] { "a" });
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals("Schema<a: Struct<b: Int(32, true), c: Utf8>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+
+  @Test
+  public void testEmptyMap() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString("map<string,string>");
+    List<String> fieldNames = Arrays.asList(new String[] { "a" });
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals("Schema<a: List<$data$: Struct<keys: Utf8, values: Utf8>>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+
+  @Test
+  public void testEmptyComplexStruct() {
+    List<TypeInfo> typeInfos = TypeInfoUtils.getTypeInfosFromTypeString(
+        "struct<b:array<tinyint>,c:map<string,string>,d:struct<e:array<tinyint>,f:map<string,string>>>");
+    List<String> fieldNames = Arrays.asList(new String[] { "a" });
+    Serializer converter = new Serializer(new HiveConf(), "attemptId", typeInfos, fieldNames);
+    ArrowWrapperWritable writable = converter.emptyBatch();
+    Assert.assertEquals(
+        "Schema<a: Struct<b: List<$data$: Int(8, true)>, c: List<$data$: Struct<keys: Utf8, values: Utf8>>, " +
+            "d: Struct<e: List<$data$: Int(8, true)>, f: List<$data$: Struct<keys: Utf8, values: Utf8>>>>>",
+        writable.getVectorSchemaRoot().getSchema().toString());
+  }
+}


### PR DESCRIPTION

### What changes were proposed in this pull request?
Use an empty batch to generate the schema for the empty results

### Why are the changes needed?
Clients expect the full schema even for empty results

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit and other test