### PR TITLE
HIVE-24514: UpdateMDatabaseURI does not update managed location URI

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -8557,7 +8557,26 @@ public class ObjectStore implements RawStore, Configurable {
             updateLocations.put(locationURI.toString(), dbLoc);
             if (!dryRun) {
               mDB.setLocationUri(dbLoc);
-              if (org.apache.commons.lang3.StringUtils.isNotBlank(mDB.getManagedLocationUri())) {
+            }
+          }
+        }
+
+        // if managed location is set, perform location update for managed location URI as well
+        if (org.apache.commons.lang3.StringUtils.isNotBlank(mDB.getManagedLocationUri())) {
+          URI managedLocationURI = null;
+          String managedLocation = mDB.getManagedLocationUri();
+          try {
+            managedLocationURI = new Path(managedLocation).toUri();
+          } catch (IllegalArgumentException e) {
+            badRecords.add(managedLocation);
+          }
+          if (managedLocationURI == null) {
+            badRecords.add(managedLocation);
+          } else {
+            if (shouldUpdateURI(managedLocationURI, oldLoc)) {
+              String dbLoc = mDB.getManagedLocationUri().replaceAll(oldLoc.toString(), newLoc.toString());
+              updateLocations.put(managedLocationURI.toString(), dbLoc);
+              if (!dryRun) {
                 mDB.setManagedLocationUri(dbLoc);
               }
             }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -8557,6 +8557,9 @@ public class ObjectStore implements RawStore, Configurable {
             updateLocations.put(locationURI.toString(), dbLoc);
             if (!dryRun) {
               mDB.setLocationUri(dbLoc);
+              if (org.apache.commons.lang3.StringUtils.isNotBlank(mDB.getManagedLocationUri())) {
+                mDB.setManagedLocationUri(dbLoc);
+              }
             }
           }
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
When FS Root is updated using metatool, if the DB has managed location defined, 
updateMDatabaseURI API should update the managed location as well. Currently it only updates location uri.

### Why are the changes needed?
Hive metatool is used for cases where NN changes and the metastore fs root has to be updated. When updating the fs root using metatool, if the databases have MANAGEDLOCATION explicitly defined the tool misses to update the fs root of the managed location. 

### Does this PR introduce _any_ user-facing change?
Fixes user facing bug for specific fs root change scenario.

### How was this patch tested?
Manually in test cluster which has ability to Update FS Root. 