### PR TITLE
HIVE-24488: Make tests using docker more comfortable

### DIFF
--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
@@ -64,8 +64,6 @@ public abstract class DatabaseRule extends ExternalResource {
   }
 
   public final String getContainerHostAddress() {
-    //xport HIVE_TEST_DOCKER_HOST=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' `hostname`)
-
     String hostAddress = System.getenv("HIVE_TEST_DOCKER_HOST");
     LOG.info("addr:{}", hostAddress);
     if (hostAddress != null) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
@@ -57,7 +57,23 @@ public abstract class DatabaseRule extends ExternalResource {
 
   public abstract String getJdbcDriver();
 
-  public abstract String getJdbcUrl();
+  public abstract String getJdbcUrl(String hostAddress);
+
+  public final String getJdbcUrl() {
+    return getJdbcUrl(getContainerHostAddress());
+  }
+
+  public final String getContainerHostAddress() {
+    //xport HIVE_TEST_DOCKER_HOST=$(docker inspect -f '{{range.NetworkSettings.Networks}}{{.Gateway}}{{end}}' `hostname`)
+
+    String hostAddress = System.getenv("HIVE_TEST_DOCKER_HOST");
+    LOG.info("addr:{}", hostAddress);
+    if (hostAddress != null) {
+      return hostAddress;
+    } else {
+      return "localhost";
+    }
+  }
 
   private boolean verbose;
 
@@ -79,7 +95,11 @@ public abstract class DatabaseRule extends ExternalResource {
    *
    * @return URL
    */
-  public abstract String getInitialJdbcUrl();
+  public abstract String getInitialJdbcUrl(String hostAddress);
+
+  public final String getInitialJdbcUrl() {
+    return getJdbcUrl(getContainerHostAddress());
+  }
 
   /**
    * Determine if the docker container is ready to use.

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
@@ -124,16 +124,14 @@ public abstract class DatabaseRule extends ExternalResource {
 
   @Override
   public void before() throws Exception { //runDockerContainer
-    if (runCmdAndPrintStreams(buildRmCmd(), 600) != 0) {
-      throw new RuntimeException("Unable to remove docker container");
-    }
+    runCmdAndPrintStreams(buildRmCmd(), 600);
     if (runCmdAndPrintStreams(buildRunCmd(), 600) != 0) {
       throw new RuntimeException("Unable to start docker container");
     }
     long startTime = System.currentTimeMillis();
     ProcessResults pr;
     do {
-      Thread.sleep(5000);
+      Thread.sleep(1000);
       pr = runCmd(buildLogCmd(), 5);
       if (pr.rc != 0) {
         throw new RuntimeException("Failed to get docker logs");
@@ -162,8 +160,14 @@ public abstract class DatabaseRule extends ExternalResource {
     }
   }
 
-  protected String getDockerContainerName(){
-    return String.format("metastore-test-%s-install", getDbType());
+  protected String getDockerContainerName() {
+    String suffix = System.getenv("HIVE_TEST_DOCKER_CONTAINER_SUFFIX");
+    if (suffix == null) {
+      suffix = "";
+    } else {
+      suffix = "-" + suffix;
+    }
+    return String.format("metastore-test-%s-install%s", getDbType(), suffix);
   }
 
   private ProcessResults runCmd(String[] cmd, long secondsToWait)

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
@@ -107,6 +107,9 @@ public abstract class DatabaseRule extends ExternalResource {
 
   @Override
   public void before() throws Exception { //runDockerContainer
+    if (runCmdAndPrintStreams(buildRmCmd(), 600) != 0) {
+      throw new RuntimeException("Unable to remove docker container");
+    }
     if (runCmdAndPrintStreams(buildRunCmd(), 600) != 0) {
       throw new RuntimeException("Unable to start docker container");
     }
@@ -134,9 +137,6 @@ public abstract class DatabaseRule extends ExternalResource {
       return;
     }
     try {
-      if (runCmdAndPrintStreams(buildStopCmd(), 600) != 0) {
-        throw new RuntimeException("Unable to stop docker container");
-      }
       if (runCmdAndPrintStreams(buildRmCmd(), 600) != 0) {
         throw new RuntimeException("Unable to remove docker container");
       }
@@ -179,6 +179,7 @@ public abstract class DatabaseRule extends ExternalResource {
     List<String> cmd = new ArrayList<>(4 + getDockerAdditionalArgs().length);
     cmd.add("docker");
     cmd.add("run");
+    cmd.add("--rm");
     cmd.add("--name");
     cmd.add(getDockerContainerName());
     cmd.addAll(Arrays.asList(getDockerAdditionalArgs()));
@@ -186,18 +187,12 @@ public abstract class DatabaseRule extends ExternalResource {
     return cmd.toArray(new String[cmd.size()]);
   }
 
-  private String[] buildStopCmd() {
-    return buildArray(
-        "docker",
-        "stop",
-        getDockerContainerName()
-    );
-  }
-
   private String[] buildRmCmd() {
     return buildArray(
         "docker",
         "rm",
+        "-f",
+        "-v",
         getDockerContainerName()
     );
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/DatabaseRule.java
@@ -65,7 +65,6 @@ public abstract class DatabaseRule extends ExternalResource {
 
   public final String getContainerHostAddress() {
     String hostAddress = System.getenv("HIVE_TEST_DOCKER_HOST");
-    LOG.info("addr:{}", hostAddress);
     if (hostAddress != null) {
       return hostAddress;
     } else {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Derby.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Derby.java
@@ -66,13 +66,13 @@ public class Derby extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl() {
+  public String getJdbcUrl(String hostAddress) {
     return String.format("jdbc:derby:memory:%s/%s;create=true", System.getProperty("test.tmp.dir"),
         getDb());
   }
 
   @Override
-  public String getInitialJdbcUrl() {
+  public String getInitialJdbcUrl(String hostAddress) {
     return String.format("jdbc:derby:memory:%s/%s;create=true", System.getProperty("test.tmp.dir"),
         getDb());
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mssql.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mssql.java
@@ -62,13 +62,13 @@ public class Mssql extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl() {
-    return "jdbc:sqlserver://localhost:1433;DatabaseName=" + HIVE_DB + ";";
+  public String getJdbcUrl(String hostAddress) {
+    return "jdbc:sqlserver://" + hostAddress + ":1433;DatabaseName=" + HIVE_DB + ";";
   }
 
   @Override
-  public String getInitialJdbcUrl() {
-    return "jdbc:sqlserver://localhost:1433";
+  public String getInitialJdbcUrl(String hostAddress) {
+    return "jdbc:sqlserver://" + hostAddress + ":1433";
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mysql.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Mysql.java
@@ -53,13 +53,13 @@ public class Mysql extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl() {
-    return "jdbc:mysql://localhost:3306/" + HIVE_DB;
+  public String getJdbcUrl(String hostAddress) {
+    return "jdbc:mysql://" + hostAddress + ":3306/" + HIVE_DB;
   }
 
   @Override
-  public String getInitialJdbcUrl() {
-    return "jdbc:mysql://localhost:3306/?allowPublicKeyRetrieval=true";
+  public String getInitialJdbcUrl(String hostAddress) {
+    return "jdbc:mysql://" + hostAddress + ":3306/?allowPublicKeyRetrieval=true";
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Oracle.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Oracle.java
@@ -57,13 +57,13 @@ public class Oracle extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl() {
-    return "jdbc:oracle:thin:@//localhost:1521/xe";
+  public String getJdbcUrl(String hostAddress) {
+    return "jdbc:oracle:thin:@//" + hostAddress + ":1521/xe";
   }
 
   @Override
-  public String getInitialJdbcUrl() {
-    return "jdbc:oracle:thin:@//localhost:1521/xe";
+  public String getInitialJdbcUrl(String hostAddress) {
+    return "jdbc:oracle:thin:@//" + hostAddress + ":1521/xe";
   }
 
   @Override

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
@@ -61,20 +61,20 @@ public class Postgres extends DatabaseRule {
   }
 
   @Override
-  public String getJdbcUrl() {
-    return "jdbc:postgresql://localhost:5432/" + HIVE_DB;
+  public String getJdbcUrl(String hostAddress) {
+    return "jdbc:postgresql://" + hostAddress + ":5432/" + HIVE_DB;
   }
 
   @Override
-  public String getInitialJdbcUrl() {
-    return "jdbc:postgresql://localhost:5432/postgres";
+  public String getInitialJdbcUrl(String hostAddress) {
+    return "jdbc:postgresql://" + hostAddress + ":5432/postgres";
   }
 
   @Override
   public boolean isContainerReady(String logOutput) {
     if (logOutput.contains("PostgreSQL init process complete; ready for start up")) {
       try (Socket socket = new Socket()) {
-        socket.connect(new InetSocketAddress("localhost", 5432), 1000);
+        socket.connect(new InetSocketAddress(getContainerHostAddress(), 5432), 1000);
         return true;
       } catch (IOException e) {
         LOG.info("cant connect to postgres; {}", e.getMessage());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/Postgres.java
@@ -21,10 +21,15 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * JUnit TestRule for Postgres.
  */
 public class Postgres extends DatabaseRule {
+  private static final Logger LOG = LoggerFactory.getLogger(Postgres.class);
+
   @Override
   public String getDockerImageName() {
     return "postgres:9.3";
@@ -72,6 +77,7 @@ public class Postgres extends DatabaseRule {
         socket.connect(new InetSocketAddress("localhost", 5432), 1000);
         return true;
       } catch (IOException e) {
+        LOG.info("cant connect to postgres; {}", e.getMessage());
         return false;
       }
     }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/dbinstall/rules/PostgresTPCDS.java
@@ -33,8 +33,8 @@ public class PostgresTPCDS extends Postgres {
   }
 
   @Override
-  public String getJdbcUrl() {
-    return "jdbc:postgresql://localhost:5432/metastore";
+  public String getJdbcUrl(String hostAddress) {
+    return "jdbc:postgresql://" + hostAddress + ":5432/metastore";
   }
 
   @Override


### PR DESCRIPTION
bugfixes:
* force remove the container prior to starting the test
* also remove the volume on deletion (tpcds30tb left a ~600M garbage volume behind on each run)

additions:
* add option to enable specifying the docker host address (enables to run them from hive-dev-box containers)
* container name suffix support (needed to possibly run multiple instance of the same test at the same time)


