### PR TITLE
HIVE-24571: Redundant code in SemanticAnalyzer.java file

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -10993,7 +10993,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       ASTNode rewrittenTree;
       // Parse the rewritten query string
       // check if we need to ctx.setCmd(rewrittenQuery);
-      ParseDriver pd = new ParseDriver();
       try {
         rewrittenTree = ParseUtils.parse(rewrittenQuery);
       } catch (ParseException e) {


### PR DESCRIPTION
ParseDriver pd = new ParseDriver() 
This code is redundant code, it is recommended to delete it