### PR TITLE
HIVE-24337: Cache delete delta files in LLAP cache

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4605,7 +4605,7 @@ public class HiveConf extends Configuration {
          "notifications are received by the daemon. Sweep phase of proactive eviction will only do the cache policy " +
          "cleanup in this case. This can increase cache hit ratio but might scale bad in a workload that generates " +
          "many proactive eviction events."),
-    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "none", new StringSet("none", "metadata", "all"),
+    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "all", new StringSet("none", "metadata", "all"),
          "When set to 'all' queries that use LLAP IO for execution will also access delete delta files via " +
          "LLAP IO layer and thus they will be fully cached. When set to 'metadata', only the tail of delete deltas " +
          "will be cached. If set to 'none', only the base files and insert deltas will be channeled through LLAP, " +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4605,7 +4605,7 @@ public class HiveConf extends Configuration {
          "notifications are received by the daemon. Sweep phase of proactive eviction will only do the cache policy " +
          "cleanup in this case. This can increase cache hit ratio but might scale bad in a workload that generates " +
          "many proactive eviction events."),
-    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "metadata", new StringSet("none", "metadata", "all"),
+    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "none", new StringSet("none", "metadata", "all"),
          "When set to 'all' queries that use LLAP IO for execution will also access delete delta files via " +
          "LLAP IO layer and thus they will be fully cached. When set to 'metadata', only the tail of delete deltas " +
          "will be cached. If set to 'none', only the base files and insert deltas will be channeled through LLAP, " +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4605,6 +4605,11 @@ public class HiveConf extends Configuration {
          "notifications are received by the daemon. Sweep phase of proactive eviction will only do the cache policy " +
          "cleanup in this case. This can increase cache hit ratio but might scale bad in a workload that generates " +
          "many proactive eviction events."),
+    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", true, "When turned on, " +
+         "queries that use LLAP IO for execution will also access delete delta files via LLAP IO layer and thus they " +
+         "will be cached. If turned off, only the base files and insert deltas will be channeled through LLAP, while " +
+         "delete deltas will be accessed directly from their configured FS without caching them. " +
+         "This feature only works with ColumnizedDeleteEventRegistry, SortMergedDeleteEventRegistry is not supported."),
     LLAP_IO_SHARE_OBJECT_POOLS("hive.llap.io.share.object.pools", false,
         "Whether to used shared object pools in LLAP IO. A safety flag."),
     LLAP_AUTO_ALLOW_UBER("hive.llap.auto.allow.uber", false,

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4605,10 +4605,11 @@ public class HiveConf extends Configuration {
          "notifications are received by the daemon. Sweep phase of proactive eviction will only do the cache policy " +
          "cleanup in this case. This can increase cache hit ratio but might scale bad in a workload that generates " +
          "many proactive eviction events."),
-    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", true, "When turned on, " +
-         "queries that use LLAP IO for execution will also access delete delta files via LLAP IO layer and thus they " +
-         "will be cached. If turned off, only the base files and insert deltas will be channeled through LLAP, while " +
-         "delete deltas will be accessed directly from their configured FS without caching them. " +
+    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "all", new StringSet("none", "metadata", "all"),
+         "When set to 'all' queries that use LLAP IO for execution will also access delete delta files via " +
+         "LLAP IO layer and thus they will be fully cached. When set to 'metadata', only the tail of delete deltas " +
+         "will be cached. If set to 'none', only the base files and insert deltas will be channeled through LLAP, " +
+         "while delete deltas will be accessed directly from their configured FS without caching them. " +
          "This feature only works with ColumnizedDeleteEventRegistry, SortMergedDeleteEventRegistry is not supported."),
     LLAP_IO_SHARE_OBJECT_POOLS("hive.llap.io.share.object.pools", false,
         "Whether to used shared object pools in LLAP IO. A safety flag."),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -4605,7 +4605,7 @@ public class HiveConf extends Configuration {
          "notifications are received by the daemon. Sweep phase of proactive eviction will only do the cache policy " +
          "cleanup in this case. This can increase cache hit ratio but might scale bad in a workload that generates " +
          "many proactive eviction events."),
-    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "all", new StringSet("none", "metadata", "all"),
+    LLAP_IO_CACHE_DELETEDELTAS("hive.llap.io.cache.deletedeltas", "metadata", new StringSet("none", "metadata", "all"),
          "When set to 'all' queries that use LLAP IO for execution will also access delete delta files via " +
          "LLAP IO layer and thus they will be fully cached. When set to 'metadata', only the tail of delete deltas " +
          "will be cached. If set to 'none', only the base files and insert deltas will be channeled through LLAP, " +

--- a/llap-client/src/java/org/apache/hadoop/hive/llap/io/api/LlapIo.java
+++ b/llap-client/src/java/org/apache/hadoop/hive/llap/io/api/LlapIo.java
@@ -19,14 +19,18 @@
 package org.apache.hadoop.hive.llap.io.api;
 
 import java.io.IOException;
+import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.io.CacheTag;
 import org.apache.hadoop.hive.llap.daemon.rpc.LlapDaemonProtocolProtos;
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
 import org.apache.orc.impl.OrcTail;
 
 import javax.annotation.Nullable;
@@ -65,4 +69,22 @@ public interface LlapIo<T> {
   long evictEntity(LlapDaemonProtocolProtos.EvictEntityRequestProto protoRequest);
 
   void initCacheOnlyInputFormat(InputFormat<?, ?> inputFormat);
+
+  /**
+   * Creates an LLAP record reader for a given file, by creating a split from this file, and passing it into a new
+   * LLAP record reader. May return null when attempting with unsupported schema evolution between reader and file
+   * schemas.
+   * Useful if a file is read multiple times as LLAP will cache it. Should be used for rather smaller files.
+   * @param fileKey - file ID, if null it will be determined during read but for additional performance cost
+   * @param path - path for the file to read
+   * @param tag - cache tag associated with this file (required for LLAP administrative purposes)
+   * @param tableIncludedCols - list of column #'s to be read from the file
+   * @param conf - job conf for this read. Schema serialized herein should be aligned with tableIncludedCols
+   * @param offset - required offset to start reading from
+   * @param length - required reading length
+   * @return
+   * @throws IOException
+   */
+  RecordReader<NullWritable, VectorizedRowBatch> llapVectorizedOrcReaderForPath(Object fileKey, Path path, CacheTag tag,
+      List<Integer> tableIncludedCols, JobConf conf, long offset, long length) throws IOException;
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapInputFormat.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapInputFormat.java
@@ -101,7 +101,7 @@ public class LlapInputFormat implements InputFormat<NullWritable, VectorizedRowB
 
     FileSplit fileSplit = (FileSplit) split;
     reporter.setStatus(fileSplit.toString());
-    FileSystem splitFileSystem = fileSplit.getPath().getFileSystem(job);
+
     try {
       // At this entry point, we are going to assume that these are logical table columns.
       // Perhaps we should go thru the code and clean this up to be more explicit; for now, we

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapIoImpl.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapIoImpl.java
@@ -74,16 +74,21 @@ import org.apache.hadoop.hive.llap.metrics.LlapDaemonIOMetrics;
 import org.apache.hadoop.hive.llap.metrics.MetricsUtils;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.io.LlapCacheOnlyInputFormatInterface;
+import org.apache.hadoop.hive.ql.io.orc.OrcSplit;
 import org.apache.hadoop.hive.ql.io.orc.encoded.IoTrace;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.serde2.Deserializer;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.InputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.metrics2.util.MBeans;
 import org.apache.hive.common.util.FixedSizedObjectPool;
 import org.apache.orc.impl.OrcTail;
 
 
+import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
@@ -387,5 +392,32 @@ public class LlapIoImpl implements LlapIo<VectorizedRowBatch>, LlapIoDebugDump {
   public OrcTail getOrcTailFromCache(Path path, Configuration jobConf, CacheTag tag, Object fileKey)
       throws IOException {
     return OrcEncodedDataReader.getOrcTailForPath(path, jobConf, tag, daemonConf, (MetadataCache) fileMetadataCache, fileKey);
+  }
+
+  @Override
+  public RecordReader<NullWritable, VectorizedRowBatch> llapVectorizedOrcReaderForPath(Object fileKey, Path path, CacheTag tag, List<Integer> tableIncludedCols,
+      JobConf conf, long offset, long length) throws IOException {
+
+    OrcTail tail = getOrcTailFromCache(path, conf, tag, fileKey);
+    OrcSplit split = new OrcSplit(path, fileKey, offset, length, (String[]) null, tail, false, false,
+        Lists.newArrayList(), 0, length, path.getParent(), null);
+    try {
+      LlapRecordReader rr = LlapRecordReader.create(conf, split, tableIncludedCols, "localhost", orcCvp,
+          executor, null, null, null, daemonConf);
+
+      // May happen when attempting with unsupported schema evolution between reader and file schemas
+      if (rr == null) {
+        return null;
+      }
+
+      // This needs to be cleared as no partition values should be added to the result batches as constants.
+      rr.setPartitionValues(null);
+
+      // Triggers the IO thread pool to pick up this read job
+      rr.start();
+      return rr;
+    } catch (HiveException e) {
+      throw new IOException(e);
+    }
   }
 }

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapRecordReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/api/impl/LlapRecordReader.java
@@ -87,7 +87,7 @@ class LlapRecordReader implements RecordReader<NullWritable, VectorizedRowBatch>
   private final boolean isVectorized;
   private final boolean probeDecodeEnabled;
   private VectorizedOrcAcidRowBatchReader acidReader;
-  private final Object[] partitionValues;
+  private Object[] partitionValues;
 
   private final ArrayBlockingQueue<Object> queue;
   private final AtomicReference<Throwable> pendingError = new AtomicReference<>(null);
@@ -608,7 +608,10 @@ class LlapRecordReader implements RecordReader<NullWritable, VectorizedRowBatch>
     return 0.0f;
   }
 
-  
+  void setPartitionValues(Object[] partitionValues) {
+    this.partitionValues = partitionValues;
+  }
+
   /** This class encapsulates include-related logic for LLAP readers. It is not actually specific
    *  to LLAP IO but in LLAP IO in particular, I want to encapsulate all this mess for now until
    *  we have smth better like Schema Evolution v2. This can also hypothetically encapsulate

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidInputFormat.java
@@ -346,14 +346,13 @@ public interface AcidInputFormat<KEY extends WritableComparable, VALUE>
       }
     }
 
-    public Object getFileId(Path deltaDirectory, int bucketId, Configuration conf) {
+    public Object getFileId(Path deltaFile, int bucketId, Configuration conf) {
       boolean forceSynthetic = !HiveConf.getBoolVar(conf, HiveConf.ConfVars.LLAP_IO_USE_FILEID_PATH);
       if (fileId != null && !forceSynthetic) {
         return fileId;
       }
       // Calculate the synthetic fileid
-      Path realPath = getPath(deltaDirectory, bucketId);
-      return new SyntheticFileId(realPath, length, modTime);
+      return new SyntheticFileId(deltaFile, length, modTime);
     }
 
     public Path getPath(Path deltaDirectory, int bucketId) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/sarg/ConvertAstToSearchArg.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/sarg/ConvertAstToSearchArg.java
@@ -65,6 +65,10 @@ import com.google.common.cache.CacheBuilder;
 
 public class ConvertAstToSearchArg {
   private static final Logger LOG = LoggerFactory.getLogger(ConvertAstToSearchArg.class);
+
+  private static final int KRYO_OUTPUT_BUFFER_SIZE = 4 * 1024;
+  private static final int KRYO_OUTPUT_BUFFER_MAX_SIZE = 10 * 1024 * 1024;
+
   private final SearchArgument.Builder builder;
   private final Configuration conf;
 
@@ -574,7 +578,7 @@ public class ConvertAstToSearchArg {
   }
 
   public static String sargToKryo(SearchArgument sarg) {
-    Output out = new Output(4 * 1024, 10 * 1024 * 1024);
+    Output out = new Output(KRYO_OUTPUT_BUFFER_SIZE, KRYO_OUTPUT_BUFFER_MAX_SIZE);
     kryo.get().writeObject(out, sarg);
     out.close();
     return Base64.encodeBase64String(out.toBytes());

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/sarg/ConvertAstToSearchArg.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/sarg/ConvertAstToSearchArg.java
@@ -59,6 +59,7 @@ import org.slf4j.LoggerFactory;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -570,6 +571,13 @@ public class ConvertAstToSearchArg {
 
   public static boolean canCreateFromConf(Configuration conf) {
     return conf.get(TableScanDesc.FILTER_EXPR_CONF_STR) != null || conf.get(SARG_PUSHDOWN) != null;
+  }
+
+  public static String sargToKryo(SearchArgument sarg) {
+    Output out = new Output(4 * 1024, 10 * 1024 * 1024);
+    kryo.get().writeObject(out, sarg);
+    out.close();
+    return Base64.encodeBase64String(out.toBytes());
   }
 
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.io.orc;
 
+import static org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg.sargToKryo;
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -46,7 +47,6 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.TreeSet;
 
-import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -135,19 +135,9 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.esotericsoftware.kryo.Kryo;
-import com.esotericsoftware.kryo.io.Output;
-
 @SuppressWarnings({ "deprecation", "unchecked", "rawtypes" })
 public class TestInputOutputFormat {
   private static final Logger LOG = LoggerFactory.getLogger(TestInputOutputFormat.class);
-
-  public static String toKryo(SearchArgument sarg) {
-    Output out = new Output(4 * 1024, 10 * 1024 * 1024);
-    new Kryo().writeObject(out, sarg);
-    out.close();
-    return Base64.encodeBase64String(out.toBytes());
-  }
 
   Path workDir = new Path(System.getProperty("test.tmp.dir","target/tmp"));
   static final int MILLIS_IN_DAY = 1000 * 60 * 60 * 24;
@@ -2674,7 +2664,7 @@ public class TestInputOutputFormat {
     types.add(builder.build());
     SearchArgument isNull = SearchArgumentFactory.newBuilder()
         .startAnd().isNull("cost", PredicateLeaf.Type.LONG).end().build();
-    conf.set(ConvertAstToSearchArg.SARG_PUSHDOWN, toKryo(isNull));
+    conf.set(ConvertAstToSearchArg.SARG_PUSHDOWN, sargToKryo(isNull));
     conf.set(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR,
         "url,cost");
     options.include(new boolean[]{true, true, false, true, false});
@@ -2722,7 +2712,7 @@ public class TestInputOutputFormat {
             .lessThan("z", PredicateLeaf.Type.LONG, Long.valueOf(0))
             .end()
             .build();
-    conf.set("sarg.pushdown", toKryo(sarg));
+    conf.set("sarg.pushdown", sargToKryo(sarg));
     conf.set("hive.io.file.readcolumn.names", "z,r");
     serde.initialize(conf, properties, null);
     inspector = (StructObjectInspector) serde.getObjectInspector();
@@ -2756,7 +2746,7 @@ public class TestInputOutputFormat {
             .lessThan("z", PredicateLeaf.Type.STRING, new String("foo"))
             .end()
             .build();
-    conf.set("sarg.pushdown", toKryo(sarg));
+    conf.set("sarg.pushdown", sargToKryo(sarg));
     conf.set("hive.io.file.readcolumn.names", "z");
     properties.setProperty("columns", "z");
     properties.setProperty("columns.types", "string");

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/sarg/TestSearchArgumentImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.io.sarg;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg.sargToKryo;
 
 import com.google.common.collect.Sets;
 
@@ -438,7 +439,7 @@ public class TestSearchArgumentImpl {
         .end()
         .build();
 
-    String serializedSarg = TestInputOutputFormat.toKryo(sarg);
+    String serializedSarg = sargToKryo(sarg);
     SearchArgument sarg2 = ConvertAstToSearchArg.create(serializedSarg);
 
     Field literalField = PredicateLeafImpl.class.getDeclaredField("literal");


### PR DESCRIPTION
Changes:
- Added new method in LLAP IO API so that a cached LLAP record reader can be created for arbitrary files
- Made ColumnizedDeleteEventRegistry make use of this when LLAP is available and the feature is turned on
- Removed some unnecessary / inefficient code parts in LlapInputFormat and AcidInputFormat

Functional testing: existing testing already covers this change:
- TestVectorizedOrcAcidRowBatchReader unit test covers the code paths of this change when the feature is off (no LLAP present)
- TestMiniLlapCliDriver/acid_direct_update_delete.q qtest covers the code paths where LLAP is present and ACID delete deltas are cached into LLAP IO (since the feature flag is by default turned on)

Performance testing: used S3 to see performance gains on a small (6 rows) table read that had ~20 delete events.
- query duration decreased from ~17s to ~7s