### PR TITLE
HIVE-24524: LLAP ShuffleHandler: upgrade to netty4

### DIFF
--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -135,6 +135,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/hcatalog/core/pom.xml
+++ b/hcatalog/core/pom.xml
@@ -183,6 +183,12 @@
       <version>${hadoop.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -198,7 +204,11 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
-         </exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -221,16 +231,16 @@
       <version>${hadoop.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
-          <exclusions>
-             <exclusion>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-          </exclusion>
-         </exclusions>
+      <exclusions>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>

--- a/hcatalog/hcatalog-pig-adapter/pom.xml
+++ b/hcatalog/hcatalog-pig-adapter/pom.xml
@@ -133,6 +133,12 @@
       <version>${hadoop.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hive</groupId>

--- a/kryo-registrator/pom.xml
+++ b/kryo-registrator/pom.xml
@@ -59,6 +59,10 @@
           <groupId>net.java.dev.jets3t</groupId>
           <artifactId>jets3t</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
      </exclusions>
     </dependency>
     <dependency>

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -83,11 +83,6 @@
       <artifactId>netty-all</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>${netty3.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
     </dependency>

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -310,6 +310,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-all</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/AsyncTaskCopyLocalJars.java
@@ -63,7 +63,6 @@ class AsyncTaskCopyLocalJars implements Callable<Void> {
         // log4j-1.2-API needed for NDC
         org.apache.log4j.config.Log4j1ConfigurationFactory.class,
         io.netty.util.NetUtil.class, // netty4
-        org.jboss.netty.util.NetUtil.class, //netty3
         org.apache.arrow.vector.types.pojo.ArrowType.class, //arrow-vector
         org.apache.arrow.memory.BaseAllocator.class, //arrow-memory
         org.apache.arrow.flatbuf.Schema.class, //arrow-format

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/shufflehandler/ShuffleHandler.java
@@ -14,19 +14,18 @@
 
 package org.apache.hadoop.hive.llap.shufflehandler;
 
-import static org.jboss.netty.buffer.ChannelBuffers.wrappedBuffer;
-import static org.jboss.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
-import static org.jboss.netty.handler.codec.http.HttpMethod.GET;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.OK;
-import static org.jboss.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
-import static org.jboss.netty.handler.codec.http.HttpVersion.HTTP_1_1;
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
+import static io.netty.handler.codec.http.HttpMethod.GET;
+import static io.netty.handler.codec.http.HttpResponseStatus.BAD_REQUEST;
+import static io.netty.handler.codec.http.HttpResponseStatus.FORBIDDEN;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static io.netty.handler.codec.http.HttpResponseStatus.METHOD_NOT_ALLOWED;
+import static io.netty.handler.codec.http.HttpResponseStatus.NOT_FOUND;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static io.netty.handler.codec.http.HttpResponseStatus.UNAUTHORIZED;
+import static io.netty.handler.codec.http.HttpVersion.HTTP_1_1;
 
-import javax.crypto.SecretKey;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -43,24 +42,14 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Pattern;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Charsets;
-import com.google.common.base.Preconditions;
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
-import com.google.common.cache.RemovalListener;
-import com.google.common.cache.RemovalNotification;
-import com.google.common.cache.Weigher;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import javax.crypto.SecretKey;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.LocalDirAllocator;
 import org.apache.hadoop.fs.Path;
@@ -83,46 +72,58 @@ import org.apache.tez.common.security.JobTokenSecretManager;
 import org.apache.tez.runtime.library.common.security.SecureShuffleUtils;
 import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
 import org.apache.tez.runtime.library.common.sort.impl.TezIndexRecord;
-import org.jboss.netty.bootstrap.ServerBootstrap;
-import org.jboss.netty.buffer.ChannelBuffer;
-import org.jboss.netty.buffer.ChannelBuffers;
-import org.jboss.netty.channel.Channel;
-import org.jboss.netty.channel.ChannelFactory;
-import org.jboss.netty.channel.ChannelFuture;
-import org.jboss.netty.channel.ChannelFutureListener;
-import org.jboss.netty.channel.ChannelHandler;
-import org.jboss.netty.channel.ChannelHandlerContext;
-import org.jboss.netty.channel.ChannelPipeline;
-import org.jboss.netty.channel.ChannelPipelineFactory;
-import org.jboss.netty.channel.ChannelStateEvent;
-import org.jboss.netty.channel.Channels;
-import org.jboss.netty.channel.ExceptionEvent;
-import org.jboss.netty.channel.MessageEvent;
-import org.jboss.netty.channel.SimpleChannelUpstreamHandler;
-import org.jboss.netty.channel.group.ChannelGroup;
-import org.jboss.netty.channel.group.DefaultChannelGroup;
-import org.jboss.netty.channel.socket.nio.NioServerSocketChannelFactory;
-import org.jboss.netty.handler.codec.frame.TooLongFrameException;
-import org.jboss.netty.handler.codec.http.DefaultHttpResponse;
-import org.jboss.netty.handler.codec.http.HttpChunkAggregator;
-import org.jboss.netty.handler.codec.http.HttpHeaders;
-import org.jboss.netty.handler.codec.http.HttpRequest;
-import org.jboss.netty.handler.codec.http.HttpRequestDecoder;
-import org.jboss.netty.handler.codec.http.HttpResponse;
-import org.jboss.netty.handler.codec.http.HttpResponseEncoder;
-import org.jboss.netty.handler.codec.http.HttpResponseStatus;
-import org.jboss.netty.handler.codec.http.QueryStringDecoder;
-import org.jboss.netty.handler.timeout.IdleState;
-import org.jboss.netty.handler.timeout.IdleStateAwareChannelHandler;
-import org.jboss.netty.handler.timeout.IdleStateEvent;
-import org.jboss.netty.handler.timeout.IdleStateHandler;
-import org.jboss.netty.handler.ssl.SslHandler;
-import org.jboss.netty.handler.stream.ChunkedWriteHandler;
-import org.jboss.netty.util.CharsetUtil;
-import org.jboss.netty.util.HashedWheelTimer;
-import org.jboss.netty.util.Timer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.base.Preconditions;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.cache.RemovalListener;
+import com.google.common.cache.RemovalNotification;
+import com.google.common.cache.Weigher;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler.Sharable;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.group.ChannelGroup;
+import io.netty.channel.group.DefaultChannelGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.TooLongFrameException;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.DefaultHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpRequestDecoder;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseEncoder;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.QueryStringDecoder;
+import io.netty.handler.ssl.SslHandler;
+import io.netty.handler.stream.ChunkedWriteHandler;
+import io.netty.handler.timeout.IdleState;
+import io.netty.handler.timeout.IdleStateEvent;
+import io.netty.handler.timeout.IdleStateHandler;
+import io.netty.util.CharsetUtil;
 import io.netty.util.NetUtil;
+import io.netty.util.concurrent.GlobalEventExecutor;
 
 public class ShuffleHandler implements AttemptRegistrationListener {
 
@@ -150,10 +151,15 @@ public class ShuffleHandler implements AttemptRegistrationListener {
       Pattern.CASE_INSENSITIVE);
 
   private int port;
-  private final ChannelFactory selector;
-  private final ChannelGroup accepted = new DefaultChannelGroup();
-  protected HttpPipelineFactory pipelineFact;
+  private NioEventLoopGroup bossGroup;
+  private NioEventLoopGroup workerGroup;
+  private final ChannelGroup accepted = new DefaultChannelGroup(GlobalEventExecutor.INSTANCE);
   private final int sslFileBufferSize;
+
+  // pipeline items
+  private Shuffle SHUFFLE;
+  private SSLFactory sslFactory;
+
   private final Configuration conf;
   private final String[] localDirs;
   private final DirWatcher dirWatcher;
@@ -226,7 +232,6 @@ public class ShuffleHandler implements AttemptRegistrationListener {
   final boolean connectionKeepAliveEnabled;
   final int connectionKeepAliveTimeOut;
   final int mapOutputMetaInfoCacheSize;
-  Timer timer;
   private final LocalDirAllocator lDirAlloc =
       new LocalDirAllocator(SHUFFLE_HANDLER_LOCAL_DIRS);
   private final Shuffle shuffle;
@@ -260,7 +265,8 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     }
   }
 
-  private ShuffleHandler(Configuration conf) {
+  @VisibleForTesting
+  ShuffleHandler(Configuration conf) {
     this.conf = conf;
     manageOsCache = conf.getBoolean(SHUFFLE_MANAGE_OS_CACHE,
         DEFAULT_SHUFFLE_MANAGE_OS_CACHE);
@@ -287,17 +293,23 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     shuffleTransferToAllowed = conf.getBoolean(SHUFFLE_TRANSFERTO_ALLOWED,
         DEFAULT_SHUFFLE_TRANSFERTO_ALLOWED);
 
-    ThreadFactory bossFactory = new ThreadFactoryBuilder()
-        .setNameFormat("ShuffleHandler Netty Boss #%d")
-        .build();
-    ThreadFactory workerFactory = new ThreadFactoryBuilder()
-        .setNameFormat("ShuffleHandler Netty Worker #%d")
-        .build();
+    final String BOSS_THREAD_NAME_PREFIX = "ShuffleHandler Netty Boss #";
+    AtomicInteger bossThreadCounter = new AtomicInteger(0);
+    bossGroup = new NioEventLoopGroup(maxShuffleThreads, new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable r) {
+        return new Thread(r, BOSS_THREAD_NAME_PREFIX + bossThreadCounter.incrementAndGet());
+      }
+    });
 
-    selector = new NioServerSocketChannelFactory(
-        Executors.newCachedThreadPool(bossFactory),
-        Executors.newCachedThreadPool(workerFactory),
-        maxShuffleThreads);
+    final String WORKER_THREAD_NAME_PREFIX = "ShuffleHandler Netty Worker #";
+    AtomicInteger workerThreadCounter = new AtomicInteger(0);
+    workerGroup = new NioEventLoopGroup(maxShuffleThreads, new ThreadFactory() {
+      @Override
+      public Thread newThread(Runnable r) {
+        return new Thread(r, WORKER_THREAD_NAME_PREFIX + workerThreadCounter.incrementAndGet());
+      }
+    });
 
     sslFileBufferSize = conf.getInt(SUFFLE_SSL_FILE_BUFFER_SIZE_KEY,
         DEFAULT_SUFFLE_SSL_FILE_BUFFER_SIZE);
@@ -339,27 +351,60 @@ public class ShuffleHandler implements AttemptRegistrationListener {
 
 
   public void start() throws Exception {
-    ServerBootstrap bootstrap = new ServerBootstrap(selector);
-    // Timer is shared across entire factory and must be released separately
-    timer = new HashedWheelTimer();
-    try {
-      pipelineFact = new HttpPipelineFactory(conf, timer);
-    } catch (Exception ex) {
-      throw new RuntimeException(ex);
-    }
-    bootstrap.setPipelineFactory(pipelineFact);
-    bootstrap.setOption("backlog", NetUtil.SOMAXCONN);
+    ServerBootstrap bootstrap = new ServerBootstrap()
+        .channel(NioServerSocketChannel.class)
+        .group(bossGroup, workerGroup)
+        .localAddress(port)
+        .option(ChannelOption.SO_BACKLOG, NetUtil.SOMAXCONN)
+        .childOption(ChannelOption.SO_KEEPALIVE, true);
+    initPipeline(bootstrap, conf);
+
     port = conf.getInt(SHUFFLE_PORT_CONFIG_KEY, DEFAULT_SHUFFLE_PORT);
-    Channel ch = bootstrap.bind(new InetSocketAddress(port));
+    Channel ch = bootstrap.bind().sync().channel();
     accepted.add(ch);
-    port = ((InetSocketAddress)ch.getLocalAddress()).getPort();
+    port = ((InetSocketAddress)ch.localAddress()).getPort();
     conf.set(SHUFFLE_PORT_CONFIG_KEY, Integer.toString(port));
-    pipelineFact.SHUFFLE.setPort(port);
+    SHUFFLE.setPort(port);
     if (dirWatcher != null) {
       dirWatcher.start();
     }
-    LOG.info("LlapShuffleHandler" + " listening on port " + port + " (SOMAXCONN: " + bootstrap.getOption("backlog")
-      + ")");
+    LOG.info("LlapShuffleHandler listening on port {} (SOMAXCONN: {})", port, NetUtil.SOMAXCONN);
+  }
+
+  private void initPipeline(ServerBootstrap bootstrap, Configuration conf) throws Exception {
+    SHUFFLE = getShuffle(conf);
+    // TODO Setup SSL Shuffle
+    //  if (conf.getBoolean(MRConfig.SHUFFLE_SSL_ENABLED_KEY,
+    //                      MRConfig.SHUFFLE_SSL_ENABLED_DEFAULT)) {
+    //    LOG.info("Encrypted shuffle is enabled.");
+    //    sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
+    //    sslFactory.init();
+    //  }
+
+    ChannelInitializer<NioSocketChannel> channelInitializer =
+        new ChannelInitializer<NioSocketChannel>() {
+          @Override
+      public void initChannel(NioSocketChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+        if (sslFactory != null) {
+          pipeline.addLast("ssl", new SslHandler(sslFactory.createSSLEngine()));
+        }
+        pipeline.addLast("decoder", new HttpRequestDecoder());
+        pipeline.addLast("aggregator", new HttpObjectAggregator(1 << 16));
+        pipeline.addLast("encoder", new HttpResponseEncoder());
+        pipeline.addLast("chunking", new ChunkedWriteHandler());
+        pipeline.addLast("shuffle", SHUFFLE);
+        pipeline.addLast("idle", new IdleStateHandler(0, connectionKeepAliveTimeOut, 0));
+        pipeline.addLast(TIMEOUT_HANDLER, new TimeoutHandler());
+      }
+    };
+    bootstrap.childHandler(channelInitializer);
+  }
+
+  private void destroyPipeline() {
+    if (sslFactory != null) {
+      sslFactory.destroy();
+    }
   }
 
   public static void initializeAndStart(Configuration conf) throws Exception {
@@ -389,9 +434,11 @@ public class ShuffleHandler implements AttemptRegistrationListener {
    */
   public static ByteBuffer serializeMetaData(int port) throws IOException {
     //TODO these bytes should be versioned
-    DataOutputBuffer port_dob = new DataOutputBuffer();
-    port_dob.writeInt(port);
-    return ByteBuffer.wrap(port_dob.getData(), 0, port_dob.getLength());
+    DataOutputBuffer portDob = new DataOutputBuffer();
+    portDob.writeInt(port);
+    ByteBuffer buf = ByteBuffer.wrap(portDob.getData(), 0, portDob.getLength());
+    portDob.close();
+    return buf;
   }
 
   /**
@@ -515,20 +562,16 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     }
   }
 
-
   protected void stop() throws Exception {
     accepted.close().awaitUninterruptibly(10, TimeUnit.SECONDS);
-    if (selector != null) {
-      ServerBootstrap bootstrap = new ServerBootstrap(selector);
-      bootstrap.releaseExternalResources();
+    if (bossGroup != null) {
+      bossGroup.shutdownGracefully();
     }
-    if (pipelineFact != null) {
-      pipelineFact.destroy();
+    if (workerGroup != null) {
+      workerGroup.shutdownGracefully();
     }
-    if (timer != null) {
-      // Release this shared timer resource
-      timer.stop();
-    }
+    destroyPipeline();
+
     if (dirWatcher != null) {
       dirWatcher.stop();
     }
@@ -569,7 +612,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     userRsrc.remove(appIdString);
   }
 
-  private static class TimeoutHandler extends IdleStateAwareChannelHandler {
+  static class TimeoutHandler extends ChannelDuplexHandler {
 
     private boolean enabledTimeout;
 
@@ -578,59 +621,18 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     }
 
     @Override
-    public void channelIdle(ChannelHandlerContext ctx, IdleStateEvent e) {
-      if (e.getState() == IdleState.WRITER_IDLE && enabledTimeout) {
-        e.getChannel().close();
+    public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+      if (evt instanceof IdleStateEvent) {
+        IdleStateEvent e = (IdleStateEvent) evt;
+        if (e.state() == IdleState.WRITER_IDLE && enabledTimeout) {
+          ctx.channel().close();
+        }
       }
     }
   }
 
-  class HttpPipelineFactory implements ChannelPipelineFactory {
-
-    final Shuffle SHUFFLE;
-    private SSLFactory sslFactory;
-    private final ChannelHandler idleStateHandler;
-
-    public HttpPipelineFactory(Configuration conf, Timer timer) throws Exception {
-      SHUFFLE = getShuffle(conf);
-      // TODO Setup SSL Shuffle
-//      if (conf.getBoolean(MRConfig.SHUFFLE_SSL_ENABLED_KEY,
-//                          MRConfig.SHUFFLE_SSL_ENABLED_DEFAULT)) {
-//        LOG.info("Encrypted shuffle is enabled.");
-//        sslFactory = new SSLFactory(SSLFactory.Mode.SERVER, conf);
-//        sslFactory.init();
-//      }
-      this.idleStateHandler = new IdleStateHandler(timer, 0, connectionKeepAliveTimeOut, 0);
-    }
-
-    public void destroy() {
-      if (sslFactory != null) {
-        sslFactory.destroy();
-      }
-    }
-
-    @Override
-    public ChannelPipeline getPipeline() throws Exception {
-      ChannelPipeline pipeline = Channels.pipeline();
-      if (sslFactory != null) {
-        pipeline.addLast("ssl", new SslHandler(sslFactory.createSSLEngine()));
-      }
-      pipeline.addLast("decoder", new HttpRequestDecoder());
-      pipeline.addLast("aggregator", new HttpChunkAggregator(1 << 16));
-      pipeline.addLast("encoder", new HttpResponseEncoder());
-      pipeline.addLast("chunking", new ChunkedWriteHandler());
-      pipeline.addLast("shuffle", SHUFFLE);
-      pipeline.addLast("idle", idleStateHandler);
-      pipeline.addLast(TIMEOUT_HANDLER, new TimeoutHandler());
-      return pipeline;
-      // TODO factor security manager into pipeline
-      // TODO factor out encode/decode to permit binary shuffle
-      // TODO factor out decode of index to permit alt. models
-    }
-
-  }
-
-  class Shuffle extends SimpleChannelUpstreamHandler {
+  @Sharable
+  class Shuffle extends ChannelInboundHandlerAdapter {
 
     private final Configuration conf;
     // TODO Change the indexCache to be a guava loading cache, rather than a custom implementation.
@@ -704,24 +706,30 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     }
 
     @Override
-    public void channelOpen(ChannelHandlerContext ctx, ChannelStateEvent evt) 
+    public void channelActive(ChannelHandlerContext ctx)
         throws Exception {
       if ((maxShuffleConnections > 0) && (accepted.size() >= maxShuffleConnections)) {
         LOG.info(String.format("Current number of shuffle connections (%d) is " + 
             "greater than or equal to the max allowed shuffle connections (%d)", 
             accepted.size(), maxShuffleConnections));
-        evt.getChannel().close();
+        ctx.channel().close();
         return;
       }
-      accepted.add(evt.getChannel());
-      super.channelOpen(ctx, evt);
+      accepted.add(ctx.channel());
+      super.channelActive(ctx);
      
     }
 
     @Override
-    public void messageReceived(ChannelHandlerContext ctx, MessageEvent evt)
+    public void channelRead(ChannelHandlerContext ctx, Object message)
         throws Exception {
-      HttpRequest request = (HttpRequest) evt.getMessage();
+      FullHttpRequest request = (FullHttpRequest) message;
+      handleRequest(ctx, request);
+      request.release();
+    }
+
+    private void handleRequest(ChannelHandlerContext ctx, FullHttpRequest request)
+        throws IOException {
       if (request.getMethod() != GET) {
           sendError(ctx, METHOD_NOT_ALLOWED);
           return;
@@ -733,8 +741,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
               request.headers().get(ShuffleHeader.HTTP_HEADER_VERSION))) {
         sendError(ctx, "Incompatible shuffle request version", BAD_REQUEST);
       }
-      final Map<String,List<String>> q =
-        new QueryStringDecoder(request.getUri()).getParameters();
+      final Map<String, List<String>> q = new QueryStringDecoder(request.uri()).parameters();
       final List<String> keepAliveList = q.get("keepAlive");
       boolean keepAliveParam = false;
       if (keepAliveList != null && keepAliveList.size() == 1) {
@@ -749,7 +756,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
       final List<String> jobQ = q.get("job");
       final List<String> dagIdQ = q.get("dag");
       if (LOG.isDebugEnabled()) {
-        LOG.debug("RECV: " + request.getUri() +
+        LOG.debug("RECV: " + request.uri() +
             "\n  mapId: " + mapIds +
             "\n  reduceId: " + reduceQ +
             "\n  jobId: " + jobQ +
@@ -779,7 +786,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
         sendError(ctx, "Bad job parameter", BAD_REQUEST);
         return;
       }
-      final String reqUri = request.getUri();
+      final String reqUri = request.uri();
       if (null == reqUri) {
         // TODO? add upstream?
         sendError(ctx, FORBIDDEN);
@@ -797,16 +804,17 @@ public class ShuffleHandler implements AttemptRegistrationListener {
 
       Map<String, MapOutputInfo> mapOutputInfoMap =
           new HashMap<String, MapOutputInfo>();
-      Channel ch = evt.getChannel();
-
+      Channel ch = ctx.channel();
       // In case of KeepAlive, ensure that timeout handler does not close connection until entire
       // response is written (i.e, response headers + mapOutput).
-      ChannelPipeline pipeline = ch.getPipeline();
+      ChannelPipeline pipeline = ch.pipeline();
       TimeoutHandler timeoutHandler = (TimeoutHandler)pipeline.get(TIMEOUT_HANDLER);
       timeoutHandler.setEnabledTimeout(false);
 
       String user = userRsrc.get(jobId);
-
+      if (keepAliveParam || connectionKeepAliveEnabled){
+        pipeline.replace(pipeline.get("encoder"), "encoder", new HttpResponseEncoder());
+      }
       try {
         populateHeaders(mapIds, jobId, dagId, user, reduceId,
             response, keepAliveParam, mapOutputInfoMap);
@@ -824,7 +832,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
         sendError(ctx, errorMessage, INTERNAL_SERVER_ERROR);
         return;
       }
-      ch.write(response);
+      ch.writeAndFlush(response);
       // TODO refactor the following into the pipeline
       ChannelFuture lastMap = null;
       for (String mapId : mapIds) {
@@ -858,7 +866,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
           public void operationComplete(ChannelFuture future) throws Exception {
             if (!future.isSuccess()) {
               // On error close the channel.
-              future.getChannel().close();
+              future.channel().close();
               return;
             }
             // Entire response is written out. Safe to enable timeout handling.
@@ -1011,7 +1019,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
         new ShuffleHeader(mapId, info.getPartLength(), info.getRawLength(), reduce);
       final DataOutputBuffer dob = new DataOutputBuffer();
       header.write(dob);
-      ch.write(wrappedBuffer(dob.getData(), 0, dob.getLength()));
+      ch.writeAndFlush(wrappedBuffer(dob.getData(), 0, dob.getLength()));
       final File spillfile =
           new File(mapOutputInfo.mapOutputFileName.toString());
       RandomAccessFile spill;
@@ -1022,7 +1030,7 @@ public class ShuffleHandler implements AttemptRegistrationListener {
         return null;
       }
       ChannelFuture writeFuture;
-      if (ch.getPipeline().get(SslHandler.class) == null) {
+      if (ch.pipeline().get(SslHandler.class) == null) {
         boolean canEvictAfterTransfer = true;
         if (!shouldAlwaysEvictOsCache) {
           canEvictAfterTransfer = (reduce > 0); // e.g broadcast data
@@ -1031,25 +1039,14 @@ public class ShuffleHandler implements AttemptRegistrationListener {
             info.getStartOffset(), info.getPartLength(), manageOsCache, readaheadLength,
             readaheadPool, spillfile.getAbsolutePath(), 
             shuffleBufferSize, shuffleTransferToAllowed, canEvictAfterTransfer);
-        writeFuture = ch.write(partition);
-        writeFuture.addListener(new ChannelFutureListener() {
-            // TODO error handling; distinguish IO/connection failures,
-            //      attribute to appropriate spill output
-          @Override
-          public void operationComplete(ChannelFuture future) {
-            if (future.isSuccess()) {
-              partition.transferSuccessful();
-            }
-            partition.releaseExternalResources();
-          }
-        });
+        writeFuture = ch.writeAndFlush(partition);
       } else {
         // HTTPS cannot be done with zero copy.
         final FadvisedChunkedFile chunk = new FadvisedChunkedFile(spill,
             info.getStartOffset(), info.getPartLength(), sslFileBufferSize,
             manageOsCache, readaheadLength, readaheadPool,
             spillfile.getAbsolutePath());
-        writeFuture = ch.write(chunk);
+        writeFuture = ch.writeAndFlush(chunk);
       }
       return writeFuture;
     }
@@ -1059,42 +1056,46 @@ public class ShuffleHandler implements AttemptRegistrationListener {
     }
 
     protected void sendError(ChannelHandlerContext ctx, String message, HttpResponseStatus status) {
-      HttpResponse response = new DefaultHttpResponse(HTTP_1_1, status);
+      FullHttpResponse response = new DefaultFullHttpResponse(HTTP_1_1, status);
       sendError(ctx, message, response);
+      response.release();
     }
 
-    protected void sendError(ChannelHandlerContext ctx, String message, HttpResponse response) {
-      sendError(ctx, ChannelBuffers.copiedBuffer(message, CharsetUtil.UTF_8), response);
+    protected void sendError(ChannelHandlerContext ctx, String message, FullHttpResponse response) {
+      sendError(ctx, Unpooled.copiedBuffer(message, CharsetUtil.UTF_8), response);
     }
 
     private void sendFakeShuffleHeaderWithError(ChannelHandlerContext ctx, String message,
         HttpResponse response) throws IOException {
+      FullHttpResponse fullResponse =
+          new DefaultFullHttpResponse(response.getProtocolVersion(), response.getStatus());
+      fullResponse.headers().set(response.headers());
+
       ShuffleHeader header = new ShuffleHeader(message, -1, -1, -1);
       DataOutputBuffer out = new DataOutputBuffer();
       header.write(out);
 
-      sendError(ctx, wrappedBuffer(out.getData(), 0, out.getLength()), response);
+      sendError(ctx, wrappedBuffer(out.getData(), 0, out.getLength()), fullResponse);
+      fullResponse.release();
     }
 
-    protected void sendError(ChannelHandlerContext ctx, ChannelBuffer content,
-        HttpResponse response) {
+    protected void sendError(ChannelHandlerContext ctx, ByteBuf content,
+        FullHttpResponse response) {
       response.headers().set(CONTENT_TYPE, "text/plain; charset=UTF-8");
       // Put shuffle version into http header
       response.headers().add(ShuffleHeader.HTTP_HEADER_NAME,
           ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
       response.headers().add(ShuffleHeader.HTTP_HEADER_VERSION,
           ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
-      response.setContent(content);
+      response.content().writeBytes(content);
 
       // Close the connection as soon as the error message is sent.
-      ctx.getChannel().write(response).addListener(ChannelFutureListener.CLOSE);
+      ctx.channel().writeAndFlush(response).addListener(ChannelFutureListener.CLOSE);
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext ctx, ExceptionEvent e)
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause)
         throws Exception {
-      Channel ch = e.getChannel();
-      Throwable cause = e.getCause();
       if (cause instanceof TooLongFrameException) {
         sendError(ctx, BAD_REQUEST);
         return;
@@ -1111,8 +1112,8 @@ public class ShuffleHandler implements AttemptRegistrationListener {
       }
 
       LOG.error("Shuffle error: ", cause);
-      if (ch.isConnected()) {
-        LOG.error("Shuffle error " + e);
+      if (ctx.channel().isActive()) {
+        LOG.error("Shuffle error", cause);
         sendError(ctx, INTERNAL_SERVER_ERROR);
       }
     }

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/shufflehandler/TestShuffleHandler.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/shufflehandler/TestShuffleHandler.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.llap.shufflehandler;
+
+import static io.netty.buffer.Unpooled.wrappedBuffer;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.SocketAddress;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.tez.runtime.library.common.shuffle.orderedgrouped.ShuffleHeader;
+import org.junit.Assert;
+import org.junit.Test;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+public class TestShuffleHandler {
+
+  private static final File TEST_DIR =
+      new File(System.getProperty("test.build.data"), TestShuffleHandler.class.getName())
+          .getAbsoluteFile();
+  private static final String HADOOP_TMP_DIR = "hadoop.tmp.dir";
+
+  static class LastSocketAddress {
+    SocketAddress lastAddress;
+
+    void setAddress(SocketAddress lastAddress) {
+      this.lastAddress = lastAddress;
+    }
+
+    SocketAddress getSocketAddres() {
+      return lastAddress;
+    }
+  }
+
+  private static class MockShuffleHandler2
+      extends org.apache.hadoop.hive.llap.shufflehandler.ShuffleHandler {
+    MockShuffleHandler2(Configuration conf) {
+      super(conf);
+    }
+
+    boolean socketKeepAlive = false;
+
+    @Override
+    protected Shuffle getShuffle(final Configuration conf) {
+      return new Shuffle(conf) {
+        @Override
+        protected void verifyRequest(String appid, ChannelHandlerContext ctx, HttpRequest request,
+            HttpResponse response, URL requestUri) throws IOException {
+          SocketChannel channel = (SocketChannel) (ctx.channel());
+          socketKeepAlive = channel.config().isKeepAlive();
+        }
+      };
+    }
+
+    protected boolean isSocketKeepAlive() {
+      return socketKeepAlive;
+    }
+  }
+
+  @Test(timeout = 10000)
+  public void testKeepAlive() throws Exception {
+    final ArrayList<Throwable> failures = new ArrayList<Throwable>(1);
+    Configuration conf = new Configuration();
+    conf.set(HADOOP_TMP_DIR, TEST_DIR.getAbsolutePath());
+    conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, 0);
+    conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
+    // try setting to -ve keep alive timeout.
+    conf.setInt(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_TIME_OUT, -100);
+    final LastSocketAddress lastSocketAddress = new LastSocketAddress();
+
+    ShuffleHandler shuffleHandler = new ShuffleHandler(conf) {
+      @Override
+      protected Shuffle getShuffle(final Configuration conf) {
+        // replace the shuffle handler with one stubbed for testing
+        return new Shuffle(conf) {
+          @Override
+          protected MapOutputInfo getMapOutputInfo(String jobId, int dagId, String mapId,
+              int reduce, String user) throws IOException {
+            return null;
+          }
+
+          @Override
+          protected void verifyRequest(String appid, ChannelHandlerContext ctx,
+              HttpRequest request, HttpResponse response, URL requestUri)
+                  throws IOException {
+          }
+
+          @Override
+          protected void populateHeaders(List<String> mapIds, String jobId, int dagId, String user,
+              int reduce, HttpResponse response, boolean keepAliveParam,
+              Map<String, MapOutputInfo> mapOutputInfoMap) throws IOException {
+            // Send some dummy data (populate content length details)
+            ShuffleHeader header = new ShuffleHeader("attempt_12345_1_m_1_0", 5678, 5678, 1);
+            DataOutputBuffer dob = new DataOutputBuffer();
+            header.write(dob);
+            dob = new DataOutputBuffer();
+            for (int i = 0; i < 100000; ++i) {
+              header.write(dob);
+            }
+
+            long contentLength = dob.getLength();
+            super.setResponseHeaders(response, keepAliveParam, contentLength);
+          }
+
+          @Override
+          protected ChannelFuture sendMapOutput(ChannelHandlerContext ctx, Channel ch, String user,
+              String mapId, int reduce, MapOutputInfo mapOutputInfo) throws IOException {
+            lastSocketAddress.setAddress(ch.remoteAddress());
+
+            // send a shuffle header and a lot of data down the channel
+            // to trigger a broken pipe
+            ShuffleHeader header = new ShuffleHeader("attempt_12345_1_m_1_0", 5678, 5678, 1);
+            DataOutputBuffer dob = new DataOutputBuffer();
+            header.write(dob);
+            ch.writeAndFlush(wrappedBuffer(dob.getData(), 0, dob.getLength()));
+            dob = new DataOutputBuffer();
+            for (int i = 0; i < 100000; ++i) {
+              header.write(dob);
+            }
+            return ch.writeAndFlush(wrappedBuffer(dob.getData(), 0, dob.getLength()));
+          }
+
+          @Override
+          protected void sendError(ChannelHandlerContext ctx, HttpResponseStatus status) {
+            if (failures.size() == 0) {
+              failures.add(new Error());
+              ctx.channel().close();
+            }
+          }
+
+          @Override
+          protected void sendError(ChannelHandlerContext ctx, String message,
+              HttpResponseStatus status) {
+            if (failures.size() == 0) {
+              failures.add(new Error());
+              ctx.channel().close();
+            }
+          }
+        };
+      }
+    };
+
+    shuffleHandler.start();
+
+    String shuffleBaseURL = "http://127.0.0.1:"
+        + conf.get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
+    URL url = new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+        + "map=attempt_12345_1_m_1_0");
+    HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME, ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
+    conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
+        ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
+    conn.connect();
+    DataInputStream input = new DataInputStream(conn.getInputStream());
+    Assert.assertEquals(HttpHeaders.Values.KEEP_ALIVE,
+        conn.getHeaderField(HttpHeaders.Names.CONNECTION));
+    Assert.assertEquals("timeout=1", conn.getHeaderField(HttpHeaders.Values.KEEP_ALIVE));
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    ShuffleHeader header = new ShuffleHeader();
+    header.readFields(input);
+    byte[] buffer = new byte[1024];
+    while (input.read(buffer) != -1) {
+    }
+    SocketAddress firstAddress = lastSocketAddress.getSocketAddres();
+    input.close();
+
+    // For keepAlive via URL
+    url = new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+        + "map=attempt_12345_1_m_1_0&keepAlive=true");
+    conn = (HttpURLConnection) url.openConnection();
+    conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME, ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
+    conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
+        ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
+    conn.connect();
+    input = new DataInputStream(conn.getInputStream());
+    Assert.assertEquals(HttpHeaders.Values.KEEP_ALIVE,
+        conn.getHeaderField(HttpHeaders.Names.CONNECTION));
+    Assert.assertEquals("timeout=1", conn.getHeaderField(HttpHeaders.Values.KEEP_ALIVE));
+    Assert.assertEquals(HttpURLConnection.HTTP_OK, conn.getResponseCode());
+    header = new ShuffleHeader();
+    header.readFields(input);
+    input.close();
+    SocketAddress secondAddress = lastSocketAddress.getSocketAddres();
+    Assert.assertNotNull("Initial shuffle address should not be null", firstAddress);
+    Assert.assertNotNull("Keep-Alive shuffle address should not be null", secondAddress);
+    Assert.assertEquals(
+        "Initial shuffle address and keep-alive shuffle " + "address should be the same",
+        firstAddress, secondAddress);
+  }
+
+  @Test
+  public void testSocketKeepAlive() throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(HADOOP_TMP_DIR, TEST_DIR.getAbsolutePath());
+    conf.setInt(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY, 0);
+    conf.setBoolean(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_ENABLED, true);
+    // try setting to -ve keep alive timeout.
+    conf.setInt(ShuffleHandler.SHUFFLE_CONNECTION_KEEP_ALIVE_TIME_OUT, -100);
+    HttpURLConnection conn = null;
+    MockShuffleHandler2 shuffleHandler = new MockShuffleHandler2(conf);
+    try {
+      shuffleHandler.start();
+
+      String shuffleBaseURL = "http://127.0.0.1:"
+          + conf.get(ShuffleHandler.SHUFFLE_PORT_CONFIG_KEY);
+      URL url = new URL(shuffleBaseURL + "/mapOutput?job=job_12345_1&dag=1&reduce=1&"
+          + "map=attempt_12345_1_m_1_0");
+      conn = (HttpURLConnection) url.openConnection();
+      conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_NAME,
+          ShuffleHeader.DEFAULT_HTTP_HEADER_NAME);
+      conn.setRequestProperty(ShuffleHeader.HTTP_HEADER_VERSION,
+          ShuffleHeader.DEFAULT_HTTP_HEADER_VERSION);
+      conn.connect();
+      conn.getInputStream();
+      Assert.assertTrue("socket should be set KEEP_ALIVE", shuffleHandler.isSocketKeepAlive());
+    } finally {
+      if (conn != null) {
+        conn.disconnect();
+      }
+      shuffleHandler.stop();
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
     <powermock.version>2.0.2</powermock.version>
     <mina.version>2.0.0-M5</mina.version>
     <netty.version>4.1.48.Final</netty.version>
-    <netty3.version>3.10.5.Final</netty3.version>
+    <netty3.version>3.10.5.Final</netty3.version> <!-- used by druid storage handler -->
     <pac4j-saml.version>4.0.3</pac4j-saml.version>
     <paranamer.version>2.8</paranamer.version>
     <parquet.version>1.11.1</parquet.version>
@@ -542,6 +542,10 @@
           <exclusion>
             <groupId>org.mortbay.jetty</groupId>
             <artifactId>servlet-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
         </exclusions>
      </dependency>
@@ -926,6 +930,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-hdfs</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -944,10 +954,14 @@
             <groupId>com.codahale.metrics</groupId>
             <artifactId>metrics-core</artifactId>
           </exclusion>
-            <exclusion>
-              <groupId>io.netty</groupId>
-              <artifactId>netty-all</artifactId>
-            </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-all</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
         </exclusions>
      </dependency>
       <dependency>
@@ -967,6 +981,10 @@
              <groupId>io.netty</groupId>
              <artifactId>netty-all</artifactId>
            </exclusion>
+           <exclusion>
+             <groupId>io.netty</groupId>
+             <artifactId>netty</artifactId>
+           </exclusion>
         </exclusions>
      </dependency>
       <dependency>
@@ -985,6 +1003,10 @@
            <exclusion>
              <groupId>io.netty</groupId>
              <artifactId>netty-all</artifactId>
+           </exclusion>
+           <exclusion>
+             <groupId>io.netty</groupId>
+             <artifactId>netty</artifactId>
            </exclusion>
         </exclusions>
       </dependency>
@@ -1184,6 +1206,12 @@
         <groupId>org.apache.tez</groupId>
         <artifactId>tez-runtime-library</artifactId>
         <version>${tez.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.tez</groupId>
@@ -1199,6 +1227,12 @@
         <groupId>org.apache.tez</groupId>
         <artifactId>tez-mapreduce</artifactId>
         <version>${tez.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.tez</groupId>
@@ -1214,11 +1248,6 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty</artifactId>
-      <version>${netty3.version}</version>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -791,6 +791,10 @@
          <groupId>org.glassfish.jersey.core</groupId>
          <artifactId>*</artifactId>
        </exclusion>
+       <exclusion>
+         <groupId>io.netty</groupId>
+         <artifactId>netty</artifactId>
+        </exclusion>
      </exclusions>
    </dependency>
     <dependency>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -215,6 +215,10 @@
           <groupId>org.eclipse.jetty</groupId>
           <artifactId>jetty-util</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>

--- a/shims/0.23/pom.xml
+++ b/shims/0.23/pom.xml
@@ -77,6 +77,12 @@
       <version>${hadoop.version}</version>
       <classifier>tests</classifier>
       <optional>true</optional>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>
@@ -122,6 +128,10 @@
           <exclusion>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
           </exclusion>
         </exclusions>
   </dependency>

--- a/spark-client/pom.xml
+++ b/spark-client/pom.xml
@@ -100,6 +100,10 @@
           <groupId>com.fasterxml.jackson.module</groupId>
           <artifactId>jackson-module-scala_${scala.binary.version}</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
       </exclusions>
    </dependency>
     <dependency>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -238,6 +238,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-mapreduce-client-core</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hive</groupId>

--- a/upgrade-acid/pre-upgrade/pom.xml
+++ b/upgrade-acid/pre-upgrade/pom.xml
@@ -160,6 +160,10 @@ java.io.IOException: Cannot initialize Cluster. Please check your configuration 
                 <groupId>org.apache.zookeeper</groupId>
                 <artifactId>zookeeper</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>io.netty</groupId>
+                <artifactId>netty</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Upgrade netty3 to netty4 in Shuffle Handler.

### Why are the changes needed?
Netty3 is EOL since 2016.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Tested on cluster, microstrategy workload 100/100 queries passed.
