### PR TITLE
HIVE-24534 HIVE-24646: Strict checks between decimal/characters & bigint/doubles

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1772,7 +1772,8 @@ public class HiveConf extends Configuration {
     HIVE_STRICT_CHECKS_TYPE_SAFETY("hive.strict.checks.type.safety", true,
         "Enabling strict type safety checks disallows the following:\n" +
         "  Comparing bigints and strings/(var)chars.\n" +
-        "  Comparing bigints and doubles."),
+        "  Comparing bigints and doubles.\n" +
+        "  Comparing decimals and strings/(var)chars."),
     HIVE_STRICT_CHECKS_CARTESIAN("hive.strict.checks.cartesian.product", false,
         "Enabling strict Cartesian join checks disallows the following:\n" +
         "  Cartesian product (cross join)."),

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -406,5 +406,9 @@
   <name>hive.strict.timestamp.conversion</name>
   <value>false</value>
 </property>
+<property>
+  <name>hive.strict.checks.type.safety</name>
+  <value>false</value>
+</property>
 
 </configuration>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -406,9 +406,5 @@
   <name>hive.strict.timestamp.conversion</name>
   <value>false</value>
 </property>
-<property>
-  <name>hive.strict.checks.type.safety</name>
-  <value>false</value>
-</property>
 
 </configuration>

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -19,21 +19,17 @@
 package org.apache.hadoop.hive.ql.parse.type;
 
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Stack;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -102,15 +98,6 @@ public class TypeCheckProcFactory<T> {
   static final HashMap<Integer, String> SPECIAL_UNARY_OPERATOR_TEXT_MAP;
   static final HashMap<Integer, String> CONVERSION_FUNCTION_TEXT_MAP;
   static final HashSet<Integer> WINDOWING_TOKENS;
-  private static final Set<Set<PrimitiveObjectInspector.PrimitiveCategory>> DECIMAL_CHARACTER_CATEGORIES =
-      ImmutableSet.<Set<PrimitiveObjectInspector.PrimitiveCategory>>builder()
-          .add(EnumSet.of(
-              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.CHAR))
-          .add(EnumSet.of(
-              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.VARCHAR))
-          .add(EnumSet.of(
-              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.STRING))
-          .build();
   
   static {
     SPECIAL_UNARY_OPERATOR_TEXT_MAP = new HashMap<>();
@@ -794,30 +781,6 @@ public class TypeCheckProcFactory<T> {
       return getDefaultExprProcessor().getFuncExprNodeDescWithUdfData(baseType, tableFieldTypeInfo, column);
     }
 
-    private boolean unSafeCompareWithBigInt(TypeInfo otherTypeInfo, TypeInfo bigintCandidate) {
-      Set<PrimitiveObjectInspector.PrimitiveCategory> unsafeConventionTyps = Sets.newHashSet(
-          PrimitiveObjectInspector.PrimitiveCategory.STRING,
-          PrimitiveObjectInspector.PrimitiveCategory.VARCHAR,
-          PrimitiveObjectInspector.PrimitiveCategory.CHAR);
-
-      if (bigintCandidate.equals(TypeInfoFactory.longTypeInfo) && otherTypeInfo instanceof PrimitiveTypeInfo) {
-        PrimitiveObjectInspector.PrimitiveCategory pCategory =
-            ((PrimitiveTypeInfo)otherTypeInfo).getPrimitiveCategory();
-        return unsafeConventionTyps.contains(pCategory);
-      }
-      return false;
-    }
-    
-    private boolean isDecimalCharacterComparison(TypeInfo type1, TypeInfo type2) {
-      if(type1 instanceof PrimitiveTypeInfo && type2 instanceof PrimitiveTypeInfo) {
-        PrimitiveTypeInfo pt1 = (PrimitiveTypeInfo) type1;
-        PrimitiveTypeInfo pt2 = (PrimitiveTypeInfo) type2;
-        return DECIMAL_CHARACTER_CATEGORIES
-            .contains(EnumSet.of(pt1.getPrimitiveCategory(), pt2.getPrimitiveCategory()));
-      }
-      return false;
-    }
-
     protected void validateUDF(ASTNode expr, boolean isFunction, TypeCheckCtx ctx, FunctionInfo fi,
         List<T> children) throws SemanticException {
       // Check if a bigint is implicitely cast to a double as part of a comparison
@@ -831,28 +794,14 @@ public class TypeCheckProcFactory<T> {
 
         LogHelper console = new LogHelper(LOG);
 
-        // For now, if a bigint is going to be cast to a double throw an error or warning
-        if (unSafeCompareWithBigInt(oiTypeInfo0, oiTypeInfo1) || unSafeCompareWithBigInt(oiTypeInfo1, oiTypeInfo0)) {
+        if (TypeInfoUtils.isConversionLossy(oiTypeInfo0, oiTypeInfo1)) {
           String error = StrictChecks.checkTypeSafety(conf);
           if (error != null) {
             throw new UDFArgumentException(error);
           }
-          // To  make the error output be consistency, get the other side type name that comparing with biginit.
-          String type = oiTypeInfo0.getTypeName();
-          if (!oiTypeInfo1.equals(TypeInfoFactory.longTypeInfo)) {
-            type = oiTypeInfo1.getTypeName();
-          }
-          console.printError("WARNING: Comparing a bigint and a " + type + " may result in a loss of precision.");
-        } else if ((oiTypeInfo0.equals(TypeInfoFactory.doubleTypeInfo) && oiTypeInfo1.equals(TypeInfoFactory.longTypeInfo)) ||
-            (oiTypeInfo0.equals(TypeInfoFactory.longTypeInfo) && oiTypeInfo1.equals(TypeInfoFactory.doubleTypeInfo))) {
-          console.printError("WARNING: Comparing a bigint and a double may result in a loss of precision.");
-        } else if (isDecimalCharacterComparison(oiTypeInfo0, oiTypeInfo1)) {
-          String error = StrictChecks.checkTypeSafety(conf);
-          if (error != null) {
-            throw new UDFArgumentException(error);
-          }
-          console.printError("WARNING: Comparing " + oiTypeInfo0.getTypeName() + " and " + oiTypeInfo1.getTypeName()
-              + " may result in loss of precision.");
+          String tName0 = oiTypeInfo0.getTypeName();
+          String tName1 = oiTypeInfo1.getTypeName();
+          console.printError("WARNING: Comparing " + tName0 + " and " + tName1 + " may result in loss of information.");
         }
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.parse.type;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ListMultimap;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -101,7 +102,16 @@ public class TypeCheckProcFactory<T> {
   static final HashMap<Integer, String> SPECIAL_UNARY_OPERATOR_TEXT_MAP;
   static final HashMap<Integer, String> CONVERSION_FUNCTION_TEXT_MAP;
   static final HashSet<Integer> WINDOWING_TOKENS;
-
+  private static final Set<Set<PrimitiveObjectInspector.PrimitiveCategory>> DECIMAL_CHARACTER_CATEGORIES =
+      ImmutableSet.<Set<PrimitiveObjectInspector.PrimitiveCategory>>builder()
+          .add(EnumSet.of(
+              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.CHAR))
+          .add(EnumSet.of(
+              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.VARCHAR))
+          .add(EnumSet.of(
+              PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.STRING))
+          .build();
+  
   static {
     SPECIAL_UNARY_OPERATOR_TEXT_MAP = new HashMap<>();
     SPECIAL_UNARY_OPERATOR_TEXT_MAP.put(HiveParser.PLUS, "positive");
@@ -800,16 +810,10 @@ public class TypeCheckProcFactory<T> {
     
     private boolean isDecimalCharacterComparison(TypeInfo type1, TypeInfo type2) {
       if(type1 instanceof PrimitiveTypeInfo && type2 instanceof PrimitiveTypeInfo) {
-        Set<Set<PrimitiveObjectInspector.PrimitiveCategory>> comparisons = new HashSet<>(3);
-        comparisons.add(EnumSet.of(
-            PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.CHAR));
-        comparisons.add(EnumSet.of(
-            PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.VARCHAR));
-        comparisons.add(EnumSet.of(
-            PrimitiveObjectInspector.PrimitiveCategory.DECIMAL, PrimitiveObjectInspector.PrimitiveCategory.STRING));
         PrimitiveTypeInfo pt1 = (PrimitiveTypeInfo) type1;
         PrimitiveTypeInfo pt2 = (PrimitiveTypeInfo) type2;
-        return comparisons.contains(EnumSet.of(pt1.getPrimitiveCategory(), pt2.getPrimitiveCategory()));
+        return DECIMAL_CHARACTER_CATEGORIES
+            .contains(EnumSet.of(pt1.getPrimitiveCategory(), pt2.getPrimitiveCategory()));
       }
       return false;
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestDecimalStringValidation.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestDecimalStringValidation.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.parse.type;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.exec.FunctionInfo;
+import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
+import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * Test strict type checks for comparison operations between decimal and strings. 
+ *
+ * {@link org.apache.hadoop.hive.conf.HiveConf.ConfVars#HIVE_STRICT_CHECKS_TYPE_SAFETY}
+ */
+@RunWith(Parameterized.class)
+public class TestDecimalStringValidation {
+
+  private static class FunctionCall {
+    private final ExprNodeDesc expL;
+    private final ExprNodeDesc expR;
+    private final FunctionInfo function;
+
+    public FunctionCall(ExprNodeDesc expL, ExprNodeDesc expR, FunctionInfo function) {
+      this.expL = expL;
+      this.expR = expR;
+      this.function = function;
+    }
+
+    @Override
+    public String toString() {
+      return function.getDisplayName() + "(" + expL + "," + expR + ")";
+    }
+  }
+
+  private final FunctionCall call;
+
+  public TestDecimalStringValidation(FunctionCall call) {
+    this.call = call;
+  }
+
+  @Parameterized.Parameters(name = "{index}: {0}")
+  public static Collection<FunctionCall> params() throws Exception {
+    ExprNodeDesc[] characterExps =
+        new ExprNodeDesc[] { new ExprNodeColumnDesc(TypeInfoFactory.varcharTypeInfo, "varchar_col", null, false),
+            new ExprNodeColumnDesc(TypeInfoFactory.charTypeInfo, "char_col", null, false),
+            new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, "string_col", null, false),
+            new ExprNodeConstantDesc(TypeInfoFactory.varcharTypeInfo, "123.3"),
+            new ExprNodeConstantDesc(TypeInfoFactory.charTypeInfo, "123.3"),
+            new ExprNodeConstantDesc(TypeInfoFactory.stringTypeInfo, "123.3"), };
+    ExprNodeDesc[] numericExps =
+        new ExprNodeDesc[] { new ExprNodeColumnDesc(TypeInfoFactory.decimalTypeInfo, "decimal_col", null, false),
+            new ExprNodeConstantDesc(TypeInfoFactory.decimalTypeInfo, 123.3), };
+    FunctionInfo[] functions =
+        new FunctionInfo[] { 
+            FunctionRegistry.getFunctionInfo("="),
+            FunctionRegistry.getFunctionInfo("<"),
+            FunctionRegistry.getFunctionInfo(">"),
+            FunctionRegistry.getFunctionInfo("<>"),
+            FunctionRegistry.getFunctionInfo("<="),
+            FunctionRegistry.getFunctionInfo(">="),
+            FunctionRegistry.getFunctionInfo("<=>") };
+    Collection<FunctionCall> input = new ArrayList<>();
+    for (ExprNodeDesc chrExp : characterExps) {
+      for (ExprNodeDesc numExp : numericExps) {
+        for (FunctionInfo function : functions) {
+          input.add(new FunctionCall(chrExp, numExp, function));
+          input.add(new FunctionCall(numExp, chrExp, function));
+        }
+      }
+    }
+    return input;
+  }
+
+  @Test
+  public void testValidationDecimalWithCharacterFailsWhenStrictChecksEnabled() {
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY, true);
+    try {
+      validateCall(conf);
+      Assert.fail("Validation of " + call + " should fail");
+    } catch (Exception e) {
+      Assert.assertEquals(HiveConf.StrictChecks.checkTypeSafety(conf), e.getMessage());
+    }
+  }
+
+  @Test
+  public void testValidationDecimalWithCharacterSucceedsWhenStrictChecksDisabled() throws SemanticException {
+    HiveConf conf = new HiveConf();
+    conf.setBoolVar(HiveConf.ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY, false);
+    validateCall(conf);
+  }
+
+  private void validateCall(HiveConf conf) throws SemanticException {
+    SessionState.start(conf);
+    TypeCheckCtx ctx = new TypeCheckCtx(null);
+    ExprNodeTypeCheck.getExprNodeDefaultExprProcessor()
+        .validateUDF(null, false, ctx, call.function, Arrays.asList(call.expL, call.expR));
+  }
+
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestDecimalStringValidation.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/parse/type/TestDecimalStringValidation.java
@@ -68,18 +68,17 @@ public class TestDecimalStringValidation {
 
   @Parameterized.Parameters(name = "{index}: {0}")
   public static Collection<FunctionCall> params() throws Exception {
-    ExprNodeDesc[] characterExps =
-        new ExprNodeDesc[] { new ExprNodeColumnDesc(TypeInfoFactory.varcharTypeInfo, "varchar_col", null, false),
+    ExprNodeDesc[] characterExps = new ExprNodeDesc[] { 
+            new ExprNodeColumnDesc(TypeInfoFactory.varcharTypeInfo, "varchar_col", null, false),
             new ExprNodeColumnDesc(TypeInfoFactory.charTypeInfo, "char_col", null, false),
             new ExprNodeColumnDesc(TypeInfoFactory.stringTypeInfo, "string_col", null, false),
             new ExprNodeConstantDesc(TypeInfoFactory.varcharTypeInfo, "123.3"),
             new ExprNodeConstantDesc(TypeInfoFactory.charTypeInfo, "123.3"),
             new ExprNodeConstantDesc(TypeInfoFactory.stringTypeInfo, "123.3"), };
-    ExprNodeDesc[] numericExps =
-        new ExprNodeDesc[] { new ExprNodeColumnDesc(TypeInfoFactory.decimalTypeInfo, "decimal_col", null, false),
+    ExprNodeDesc[] numericExps = new ExprNodeDesc[] { 
+            new ExprNodeColumnDesc(TypeInfoFactory.decimalTypeInfo, "decimal_col", null, false),
             new ExprNodeConstantDesc(TypeInfoFactory.decimalTypeInfo, 123.3), };
-    FunctionInfo[] functions =
-        new FunctionInfo[] { 
+    FunctionInfo[] functions = new FunctionInfo[] { 
             FunctionRegistry.getFunctionInfo("="),
             FunctionRegistry.getFunctionInfo("<"),
             FunctionRegistry.getFunctionInfo(">"),

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_char_00.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_char_00.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table chrtbl (charcol char(5));
+select * from chrtbl where charcol = 123.2;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_char_01.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_char_01.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (chrcol char(5), deccol decimal(4,1));
+select * from tbl where deccol = chrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_string_00.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_string_00.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table strtbl (strcol string);
+select * from strtbl where strcol = 123.3;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_string_01.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_string_01.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table dectbl (deccol decimal(4,1));
+select * from dectbl where deccol = '123.3';

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_string_02.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_string_02.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (strcol string, deccol decimal(4,1));
+select * from tbl where deccol = strcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_00.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_00.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table chrtbl (varcharcol varchar(5));
+select * from chrtbl where varcharcol = 123.2;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_01.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_01.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol = varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_02.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_02.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol < varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_03.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_03.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol > varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_04.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_04.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol >= varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_05.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_05.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol <= varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_06.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_06.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol <> varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_07.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_07.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol is distinct from varchrcol;

--- a/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_08.q
+++ b/ql/src/test/queries/clientnegative/strict_type_decimal_varchar_08.q
@@ -1,0 +1,3 @@
+set hive.strict.checks.type.safety=true;
+create table tbl (varchrcol varchar(5), deccol decimal(4,1));
+select * from tbl where deccol is not distinct from varchrcol;

--- a/ql/src/test/queries/clientpositive/compare_double_bigint_2.q
+++ b/ql/src/test/queries/clientpositive/compare_double_bigint_2.q
@@ -2,7 +2,7 @@
 set hive.strict.checks.bucketing=false;
 
 reset hive.mapred.mode;
-set hive.strict.checks.type.safety=true;
+set hive.strict.checks.type.safety=false;
 
 -- This should fail until we fix the issue with precision when casting a bigint to a double
 

--- a/ql/src/test/queries/clientpositive/dec_str.q
+++ b/ql/src/test/queries/clientpositive/dec_str.q
@@ -1,3 +1,4 @@
+set hive.strict.checks.type.safety=false;
 create table t1 (a decimal (3,1));
 explain select * from t1 where a = '22.3';
 explain select * from t1 where a = '2.3';

--- a/ql/src/test/queries/clientpositive/ops_comparison.q
+++ b/ql/src/test/queries/clientpositive/ops_comparison.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 select 1.0 < 2.0 from src limit 1;
 select 2.0 < 2.0 from src limit 1;

--- a/ql/src/test/queries/clientpositive/orc_ppd_decimal.q
+++ b/ql/src/test/queries/clientpositive/orc_ppd_decimal.q
@@ -4,6 +4,7 @@ SET hive.vectorized.execution.enabled=false;
 SET hive.input.format=org.apache.hadoop.hive.ql.io.HiveInputFormat;
 SET mapred.min.split.size=1000;
 SET mapred.max.split.size=5000;
+SET hive.strict.checks.type.safety=false;
 
 create table newtypesorc_n5(c char(10), v varchar(10), d decimal(5,3), da date) stored as orc tblproperties("orc.stripe.size"="16777216"); 
 

--- a/ql/src/test/queries/clientpositive/parquet_ppd_decimal.q
+++ b/ql/src/test/queries/clientpositive/parquet_ppd_decimal.q
@@ -7,6 +7,7 @@ SET hive.input.format=org.apache.hadoop.hive.ql.io.HiveInputFormat;
 SET mapred.min.split.size=1000;
 SET mapred.max.split.size=5000;
 set hive.llap.cache.allow.synthetic.fileid=true;
+set hive.strict.checks.type.safety=false;
 
 create table newtypestbl_n5(c char(10), v varchar(10), d decimal(5,3), da date) stored as parquet;
 

--- a/ql/src/test/queries/clientpositive/sketches_materialized_view_ntile.q
+++ b/ql/src/test/queries/clientpositive/sketches_materialized_view_ntile.q
@@ -1,5 +1,6 @@
 --! qt:transactional
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/sketches_materialized_view_rank.q
+++ b/ql/src/test/queries/clientpositive/sketches_materialized_view_rank.q
@@ -1,5 +1,6 @@
 --! qt:transactional
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/sketches_rewrite_ntile.q
+++ b/ql/src/test/queries/clientpositive/sketches_rewrite_ntile.q
@@ -1,4 +1,5 @@
 --! qt:transactional
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/sketches_rewrite_ntile_partition_by.q
+++ b/ql/src/test/queries/clientpositive/sketches_rewrite_ntile_partition_by.q
@@ -1,4 +1,5 @@
 --! qt:transactional
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/sketches_rewrite_rank.q
+++ b/ql/src/test/queries/clientpositive/sketches_rewrite_rank.q
@@ -1,5 +1,5 @@
 --! qt:transactional
-
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/sketches_rewrite_rank_partition_by.q
+++ b/ql/src/test/queries/clientpositive/sketches_rewrite_rank_partition_by.q
@@ -1,4 +1,5 @@
 --! qt:transactional
+set hive.strict.checks.type.safety=false;
 
 create table sketch_input (id int, category char(1))
 STORED AS ORC

--- a/ql/src/test/queries/clientpositive/vectorization_parquet_ppd_decimal.q
+++ b/ql/src/test/queries/clientpositive/vectorization_parquet_ppd_decimal.q
@@ -2,6 +2,7 @@
 --! qt:dataset:src
 set hive.vectorized.execution.enabled=true;
 set hive.test.vectorized.execution.enabled.override=enable;
+set hive.strict.checks.type.safety=false;
 
 SET hive.input.format=org.apache.hadoop.hive.ql.io.HiveInputFormat;
 SET mapred.min.split.size=1000;

--- a/ql/src/test/results/clientnegative/strict_type_decimal_char_00.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_char_00.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table chrtbl (charcol char(5))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@chrtbl
+POSTHOOK: query: create table chrtbl (charcol char(5))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@chrtbl
+FAILED: SemanticException [Error 10014]: Line 2:27 Wrong arguments '123.2': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_char_01.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_char_01.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (chrcol char(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (chrcol char(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'chrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_string_00.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_string_00.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table strtbl (strcol string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@strtbl
+POSTHOOK: query: create table strtbl (strcol string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@strtbl
+FAILED: SemanticException [Error 10014]: Line 2:27 Wrong arguments '123.3': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_string_01.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_string_01.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table dectbl (deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dectbl
+POSTHOOK: query: create table dectbl (deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dectbl
+FAILED: SemanticException [Error 10014]: Line 2:27 Wrong arguments ''123.3'': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_string_02.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_string_02.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (strcol string, deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (strcol string, deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'strcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_00.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_00.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table chrtbl (varcharcol varchar(5))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@chrtbl
+POSTHOOK: query: create table chrtbl (varcharcol varchar(5))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@chrtbl
+FAILED: SemanticException [Error 10014]: Line 2:27 Wrong arguments '123.2': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_01.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_01.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_02.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_02.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_03.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_03.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_04.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_04.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_05.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_05.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_06.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_06.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_07.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_07.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientnegative/strict_type_decimal_varchar_08.q.out
+++ b/ql/src/test/results/clientnegative/strict_type_decimal_varchar_08.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl
+POSTHOOK: query: create table tbl (varchrcol varchar(5), deccol decimal(4,1))
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl
+FAILED: SemanticException [Error 10014]: Line 2:24 Wrong arguments 'varchrcol': Unsafe compares between different types are disabled for safety reasons. If you know what you are doing, please set hive.strict.checks.type.safety to false and make sure that hive.mapred.mode is not set to 'strict' to proceed. Note that you may get errors or incorrect results if you make a mistake while using some of the unsafe features.

--- a/ql/src/test/results/clientpositive/llap/avrotblsjoin.q.out
+++ b/ql/src/test/results/clientpositive/llap/avrotblsjoin.q.out
@@ -71,9 +71,9 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@table1_1
 POSTHOOK: Lineage: table1_1.col1 SCRIPT []
 POSTHOOK: Lineage: table1_1.col2 SCRIPT []
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing string and bigint may result in loss of information.
+WARNING: Comparing string and bigint may result in loss of information.
+WARNING: Comparing bigint and string may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select table1_n1.col1, table1_1.* from table1_n1 join table1_1 on table1_n1.col1=table1_1.col1 where table1_1.col1="1"
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/compare_double_bigint_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/compare_double_bigint_2.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: select * from src where cast(1 as bigint) = cast(1.0 as double) limit 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
+++ b/ql/src/test/results/clientpositive/llap/correlationoptimizer8.q.out
@@ -1031,8 +1031,8 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing string and bigint may result in loss of information.
+WARNING: Comparing string and bigint may result in loss of information.
 PREHOOK: query: EXPLAIN
 SELECT subq1.key, subq1.value, x.key, x.value
 FROM 

--- a/ql/src/test/results/clientpositive/llap/dec_str.q.out
+++ b/ql/src/test/results/clientpositive/llap/dec_str.q.out
@@ -6,7 +6,7 @@ POSTHOOK: query: create table t1 (a decimal (3,1))
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
-WARNING: Comparing decimal(3,1) and string may result in loss of precision.
+WARNING: Comparing decimal(3,1) and string may result in loss of information.
 PREHOOK: query: explain select * from t1 where a = '22.3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -33,7 +33,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
-WARNING: Comparing decimal(3,1) and string may result in loss of precision.
+WARNING: Comparing decimal(3,1) and string may result in loss of information.
 PREHOOK: query: explain select * from t1 where a = '2.3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -60,7 +60,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
-WARNING: Comparing decimal(3,1) and string may result in loss of precision.
+WARNING: Comparing decimal(3,1) and string may result in loss of information.
 PREHOOK: query: explain select * from t1 where a = '213.223'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -87,7 +87,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
-WARNING: Comparing decimal(3,1) and string may result in loss of precision.
+WARNING: Comparing decimal(3,1) and string may result in loss of information.
 PREHOOK: query: explain select * from t1 where a = ''
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -106,7 +106,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing decimal(3,1) and string may result in loss of precision.
+WARNING: Comparing decimal(3,1) and string may result in loss of information.
 PREHOOK: query: explain select * from t1 where a = 'ab'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1

--- a/ql/src/test/results/clientpositive/llap/dec_str.q.out
+++ b/ql/src/test/results/clientpositive/llap/dec_str.q.out
@@ -6,6 +6,7 @@ POSTHOOK: query: create table t1 (a decimal (3,1))
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
+WARNING: Comparing decimal(3,1) and string may result in loss of precision.
 PREHOOK: query: explain select * from t1 where a = '22.3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -32,6 +33,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
+WARNING: Comparing decimal(3,1) and string may result in loss of precision.
 PREHOOK: query: explain select * from t1 where a = '2.3'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -58,6 +60,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
+WARNING: Comparing decimal(3,1) and string may result in loss of precision.
 PREHOOK: query: explain select * from t1 where a = '213.223'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -84,6 +87,7 @@ STAGE PLANS:
               outputColumnNames: _col0
               ListSink
 
+WARNING: Comparing decimal(3,1) and string may result in loss of precision.
 PREHOOK: query: explain select * from t1 where a = ''
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -102,6 +106,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
+WARNING: Comparing decimal(3,1) and string may result in loss of precision.
 PREHOOK: query: explain select * from t1 where a = 'ab'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1

--- a/ql/src/test/results/clientpositive/llap/filter_join_breaktask2.q.out
+++ b/ql/src/test/results/clientpositive/llap/filter_join_breaktask2.q.out
@@ -230,8 +230,8 @@ POSTHOOK: Input: default@t4_n8
 POSTHOOK: Input: default@t4_n8@ds=2010-04-17
 #### A masked pattern was here ####
 4	1	1	8	4	5	1	0	9	U	2	2	0	2	1	1	J	C	A	U	2	s	2	NULL	NULL	NULL	NULL	NULL	NULL	1	j	S	6	NULL	1	2	J	g	1	e	2	1	2	U	P	p	3	0	0	0	1	1	1	0	0	0	6	2	j	NULL	NULL	NULL	NULL	NULL	NULL	5	NULL	NULL	j	2	2	1	2	2	1	1	1	1	1	1	1	1	32	NULL	2010-04-17
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing string and bigint may result in loss of information.
+WARNING: Comparing string and bigint may result in loss of information.
 PREHOOK: query: SELECT a.c1 as a_c1, b.c1 b_c1, d.c0 as d_c0
 FROM T1_n85 a JOIN T2_n53 b 
        ON (a.c1 = b.c1 AND a.ds='2010-04-17' AND b.ds='2010-04-17')

--- a/ql/src/test/results/clientpositive/llap/infer_bucket_sort_map_operators.q.out
+++ b/ql/src/test/results/clientpositive/llap/infer_bucket_sort_map_operators.q.out
@@ -210,8 +210,8 @@ Bucket Columns:     	[]
 Sort Columns:       	[]                  	 
 Storage Desc Params:	 	 
 	serialization.format	1                   
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: EXPLAIN INSERT OVERWRITE TABLE test_table_out_n0 PARTITION (part = '1') 
 SELECT a.key, a.value FROM (
 	SELECT key, count(*) AS value FROM test_table1_n14 GROUP BY key

--- a/ql/src/test/results/clientpositive/llap/infer_const_type.q.out
+++ b/ql/src/test/results/clientpositive/llap/infer_const_type.q.out
@@ -29,7 +29,7 @@ POSTHOOK: Input: default@infertypes
 127	32767	12345	-12345	906.0	-307.0	1234
 126	32767	12345	-12345	906.0	-307.0	1234
 126	32767	12345	-12345	906.0	-307.0	1.57
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: EXPLAIN SELECT * FROM infertypes WHERE
   ti  = '127' AND
   si  = 32767 AND
@@ -70,7 +70,7 @@ STAGE PLANS:
               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
               ListSink
 
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: SELECT * FROM infertypes WHERE
   ti  = '127' AND
   si  = 32767 AND
@@ -94,7 +94,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@infertypes
 #### A masked pattern was here ####
 127	32767	12345	-12345	906.0	-307.0	1234
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: EXPLAIN SELECT * FROM infertypes WHERE
   ti  = '128' OR
   si  = 32768 OR
@@ -125,7 +125,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: SELECT * FROM infertypes WHERE
   ti  = '128' OR
   si  = 32768 OR
@@ -193,7 +193,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@infertypes
 #### A masked pattern was here ####
 127	32767	12345	-12345	906.0	-307.0	1234
-WARNING: Comparing string and decimal(3,2) may result in loss of precision.
+WARNING: Comparing string and decimal(3,2) may result in loss of information.
 PREHOOK: query: EXPLAIN SELECT * FROM infertypes WHERE
   ti < '127.0' AND
   i > '100.0' AND
@@ -226,7 +226,7 @@ STAGE PLANS:
               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
               ListSink
 
-WARNING: Comparing string and decimal(3,2) may result in loss of precision.
+WARNING: Comparing string and decimal(3,2) may result in loss of information.
 PREHOOK: query: SELECT * FROM infertypes WHERE
   ti < '127.0' AND
   i > '100.0' AND

--- a/ql/src/test/results/clientpositive/llap/infer_const_type.q.out
+++ b/ql/src/test/results/clientpositive/llap/infer_const_type.q.out
@@ -193,6 +193,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@infertypes
 #### A masked pattern was here ####
 127	32767	12345	-12345	906.0	-307.0	1234
+WARNING: Comparing string and decimal(3,2) may result in loss of precision.
 PREHOOK: query: EXPLAIN SELECT * FROM infertypes WHERE
   ti < '127.0' AND
   i > '100.0' AND
@@ -225,6 +226,7 @@ STAGE PLANS:
               outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
               ListSink
 
+WARNING: Comparing string and decimal(3,2) may result in loss of precision.
 PREHOOK: query: SELECT * FROM infertypes WHERE
   ti < '127.0' AND
   i > '100.0' AND

--- a/ql/src/test/results/clientpositive/llap/join_literals.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_literals.q.out
@@ -1,5 +1,5 @@
-WARNING: Comparing a bigint and a string may result in a loss of precision.
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing string and bigint may result in loss of information.
+WARNING: Comparing string and bigint may result in loss of information.
 PREHOOK: query: SELECT COUNT(*) FROM src a JOIN src b ON a.key = b.key AND a.key = 0L
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -27,7 +27,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 9
-WARNING: Comparing string and decimal(1,0) may result in loss of precision.
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: SELECT COUNT(*) FROM src a JOIN src b ON a.key = b.key AND a.key = 0BD
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/join_literals.q.out
+++ b/ql/src/test/results/clientpositive/llap/join_literals.q.out
@@ -27,6 +27,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 9
+WARNING: Comparing string and decimal(1,0) may result in loss of precision.
 PREHOOK: query: SELECT COUNT(*) FROM src a JOIN src b ON a.key = b.key AND a.key = 0BD
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/ops_comparison.q.out
+++ b/ql/src/test/results/clientpositive/llap/ops_comparison.q.out
@@ -34,6 +34,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' < 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -43,6 +44,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing decimal(1,0) and string may result in loss of information.
 PREHOOK: query: select 1.0 < 'NaN' from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -52,6 +54,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 true
+WARNING: Comparing decimal(1,0) and string may result in loss of information.
 PREHOOK: query: select 1.0 > 'NaN' from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -61,6 +64,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' > 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -88,6 +92,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' = 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -97,6 +102,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing decimal(1,0) and string may result in loss of information.
 PREHOOK: query: select 1.0 = 'NaN' from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -106,6 +112,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 false
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' = 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -124,6 +131,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 true
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' <> 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -133,6 +141,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 true
+WARNING: Comparing decimal(1,0) and string may result in loss of information.
 PREHOOK: query: select 1.0 <> 'NaN' from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
@@ -142,6 +151,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####
 true
+WARNING: Comparing string and decimal(1,0) may result in loss of information.
 PREHOOK: query: select 'NaN' <> 2.0 from src limit 1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src

--- a/ql/src/test/results/clientpositive/llap/orc_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_ppd_decimal.q.out
@@ -36,7 +36,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -46,7 +46,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -92,7 +92,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 334427804500
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -102,7 +102,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 334427804500
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -148,7 +148,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -158,7 +158,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -222,7 +222,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 81475875500
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<='11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -232,7 +232,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 81475875500
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<='11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5

--- a/ql/src/test/results/clientpositive/llap/orc_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_ppd_decimal.q.out
@@ -36,6 +36,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -45,6 +46,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -90,6 +92,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 334427804500
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -99,6 +102,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 334427804500
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -144,6 +148,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -153,6 +158,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 -252951929000
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -216,6 +222,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 81475875500
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<='11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5
@@ -225,6 +232,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypesorc_n5
 #### A masked pattern was here ####
 81475875500
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select sum(hash(*)) from newtypesorc_n5 where d<='11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypesorc_n5

--- a/ql/src/test/results/clientpositive/llap/parquet_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_ppd_decimal.q.out
@@ -54,7 +54,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -73,7 +73,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -144,7 +144,7 @@ POSTHOOK: query: select * from newtypestbl_n5 where d!=0.22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypestbl_n5
 #### A masked pattern was here ####
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -153,7 +153,7 @@ POSTHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypestbl_n5
 #### A masked pattern was here ####
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -214,7 +214,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -233,7 +233,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -360,7 +360,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -379,7 +379,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n5 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5

--- a/ql/src/test/results/clientpositive/llap/parquet_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_ppd_decimal.q.out
@@ -54,6 +54,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -72,6 +73,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -142,6 +144,7 @@ POSTHOOK: query: select * from newtypestbl_n5 where d!=0.22
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypestbl_n5
 #### A masked pattern was here ####
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -150,6 +153,7 @@ POSTHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@newtypestbl_n5
 #### A masked pattern was here ####
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -210,6 +214,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -228,6 +233,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -354,6 +360,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5
@@ -372,6 +379,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n5 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n5

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_0.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_0.q.out
@@ -958,7 +958,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@alltypesparquet
 #### A masked pattern was here ####
 -4.303895780321011	1163.8972588605056	1163.8972588605056	1164.0241556397098	34.11593848717203	34.11593848717203	34.11593848717203	34.11779822379677
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION EXPRESSION
 SELECT AVG(cbigint),
        (-(AVG(cbigint))),
@@ -1137,7 +1137,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint),
        (-(AVG(cbigint))),
        (-6432 + AVG(cbigint)),

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_3.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION EXPRESSION
 SELECT STDDEV_SAMP(csmallint),
        (STDDEV_SAMP(csmallint) - 10.175),
@@ -173,7 +173,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT STDDEV_SAMP(csmallint),
        (STDDEV_SAMP(csmallint) - 10.175),
        STDDEV_POP(ctinyint),

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_limit.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization SELECT cbigint, cdouble FROM alltypesparquet WHERE cbigint < cdouble AND cint > 0 ORDER BY cbigint, cdouble LIMIT 7
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet
@@ -88,7 +88,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT cbigint, cdouble FROM alltypesparquet WHERE cbigint < cdouble AND cint > 0 ORDER BY cbigint, cdouble LIMIT 7
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_not.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_not.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint),
        (-(AVG(cbigint))),
        (-6432 + AVG(cbigint)),

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_offset_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_offset_limit.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization SELECT cbigint, cdouble FROM alltypesparquet WHERE cbigint < cdouble and cint > 0 limit 3,2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet
@@ -62,7 +62,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT cbigint, cdouble FROM alltypesparquet WHERE cbigint < cdouble and cint > 0 limit 3,2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet

--- a/ql/src/test/results/clientpositive/llap/parquet_vectorization_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_vectorization_pushdown.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization SELECT AVG(cbigint) FROM alltypesparquet WHERE cbigint < cdouble
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet
@@ -90,7 +90,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint) FROM alltypesparquet WHERE cbigint < cdouble
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesparquet

--- a/ql/src/test/results/clientpositive/llap/partition_coltype_literals.q.out
+++ b/ql/src/test/results/clientpositive/llap/partition_coltype_literals.q.out
@@ -235,7 +235,7 @@ POSTHOOK: Input: default@partcoltypenum
 POSTHOOK: Input: default@partcoltypenum@tint=110/sint=22000/bint=330000000000
 #### A masked pattern was here ####
 30
-WARNING: Comparing a bigint and a string may result in a loss of precision.
+WARNING: Comparing bigint and string may result in loss of information.
 PREHOOK: query: select count(1) from partcoltypenum where tint=110Y and sint=22000 and bint='330000000000'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partcoltypenum

--- a/ql/src/test/results/clientpositive/llap/partition_wise_fileformat2.q.out
+++ b/ql/src/test/results/clientpositive/llap/partition_wise_fileformat2.q.out
@@ -123,31 +123,6 @@ POSTHOOK: Input: default@partition_test_partitioned@dt=102
 		100
 		100
 		100
-238	val_238	102
-		102
-311	val_311	102
-	val_27	102
-	val_165	102
-	val_409	102
-255	val_255	102
-278	val_278	102
-98	val_98	102
-	val_484	102
-	val_265	102
-	val_193	102
-401	val_401	102
-150	val_150	102
-273	val_273	102
-224		102
-369		102
-66	val_66	102
-128		102
-213	val_213	102
-146	val_146	102
-406	val_406	102
-		102
-		102
-		102
 238	val_238	101
 		101
 311	val_311	101
@@ -173,6 +148,31 @@ POSTHOOK: Input: default@partition_test_partitioned@dt=102
 		101
 		101
 		101
+238	val_238	102
+		102
+311	val_311	102
+	val_27	102
+	val_165	102
+	val_409	102
+255	val_255	102
+278	val_278	102
+98	val_98	102
+	val_484	102
+	val_265	102
+	val_193	102
+401	val_401	102
+150	val_150	102
+273	val_273	102
+224		102
+369		102
+66	val_66	102
+128		102
+213	val_213	102
+146	val_146	102
+406	val_406	102
+		102
+		102
+		102
 PREHOOK: query: explain select *, BLOCK__OFFSET__INSIDE__FILE from partition_test_partitioned where dt >=100 and dt <= 102
 PREHOOK: type: QUERY
 PREHOOK: Input: default@partition_test_partitioned
@@ -244,31 +244,6 @@ POSTHOOK: Input: default@partition_test_partitioned@dt=102
 		100
 		100
 		100
-238	val_238	102
-		102
-311	val_311	102
-	val_27	102
-	val_165	102
-	val_409	102
-255	val_255	102
-278	val_278	102
-98	val_98	102
-	val_484	102
-	val_265	102
-	val_193	102
-401	val_401	102
-150	val_150	102
-273	val_273	102
-224		102
-369		102
-66	val_66	102
-128		102
-213	val_213	102
-146	val_146	102
-406	val_406	102
-		102
-		102
-		102
 238	val_238	101
 		101
 311	val_311	101
@@ -294,3 +269,28 @@ POSTHOOK: Input: default@partition_test_partitioned@dt=102
 		101
 		101
 		101
+238	val_238	102
+		102
+311	val_311	102
+	val_27	102
+	val_165	102
+	val_409	102
+255	val_255	102
+278	val_278	102
+98	val_98	102
+	val_484	102
+	val_265	102
+	val_193	102
+401	val_401	102
+150	val_150	102
+273	val_273	102
+224		102
+369		102
+66	val_66	102
+128		102
+213	val_213	102
+146	val_146	102
+406	val_406	102
+		102
+		102
+		102

--- a/ql/src/test/results/clientpositive/llap/sketches_materialized_view_ntile.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_materialized_view_ntile.q.out
@@ -36,7 +36,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@sketch_input
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mv_1
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; mv matching', id, ntile(4) over (order by id) from sketch_input order by id
@@ -165,7 +165,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; mv matching', id, ntile(4) over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -338,7 +338,7 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@sketch_input
 POSTHOOK: Lineage: sketch_input.category SCRIPT []
 POSTHOOK: Lineage: sketch_input.id SCRIPT []
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; no mv matching', id, ntile(4) over (order by id) from sketch_input order by id
@@ -458,7 +458,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; no mv matching', id, ntile(4) over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -711,7 +711,7 @@ POSTHOOK: Input: default@sketch_input
 POSTHOOK: Output: default@mv_1
 POSTHOOK: Lineage: mv_1._c1 EXPRESSION [(sketch_input)sketch_input.FieldSchema(name:id, type:int, comment:null), (mv_1)default.mv_1.FieldSchema(name:_c1, type:binary, comment:null), ]
 POSTHOOK: Lineage: mv_1.category EXPRESSION [(sketch_input)sketch_input.FieldSchema(name:category, type:char(1), comment:null), (mv_1)default.mv_1.FieldSchema(name:category, type:char(1), comment:null), ]
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; mv matching', id, ntile(4) over (order by id) from sketch_input order by id
@@ -840,7 +840,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; mv matching', id, ntile(4) over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -896,7 +896,7 @@ rewrite; mv matching	14	4
 rewrite; mv matching	14	4
 rewrite; mv matching	15	4
 rewrite; mv matching	15	4
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain
 select 'rewrite; mv matching', category, id, ntile(4) over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
@@ -997,7 +997,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: select 'rewrite; mv matching', category, id, ntile(4) over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mv_1

--- a/ql/src/test/results/clientpositive/llap/sketches_materialized_view_rank.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_materialized_view_rank.q.out
@@ -36,7 +36,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@sketch_input
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mv_1
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; mv matching', id, rank() over (order by id) from sketch_input order by id
@@ -165,7 +165,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; mv matching', id, rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -338,7 +338,7 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@sketch_input
 POSTHOOK: Lineage: sketch_input.category SCRIPT []
 POSTHOOK: Lineage: sketch_input.id SCRIPT []
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; no mv matching', id, rank() over (order by id) from sketch_input order by id
@@ -458,7 +458,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; no mv matching', id, rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -711,7 +711,7 @@ POSTHOOK: Input: default@sketch_input
 POSTHOOK: Output: default@mv_1
 POSTHOOK: Lineage: mv_1._c1 EXPRESSION [(sketch_input)sketch_input.FieldSchema(name:id, type:int, comment:null), (mv_1)default.mv_1.FieldSchema(name:_c1, type:binary, comment:null), ]
 POSTHOOK: Lineage: mv_1.category EXPRESSION [(sketch_input)sketch_input.FieldSchema(name:category, type:char(1), comment:null), (mv_1)default.mv_1.FieldSchema(name:category, type:char(1), comment:null), ]
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select 'rewrite; mv matching', id, rank() over (order by id) from sketch_input order by id
@@ -840,7 +840,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select 'rewrite; mv matching', id, rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -896,7 +896,7 @@ rewrite; mv matching	14	41
 rewrite; mv matching	14	41
 rewrite; mv matching	15	43
 rewrite; mv matching	15	43
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain
 select 'rewrite; mv matching', category, id, rank() over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
@@ -1001,7 +1001,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: select 'rewrite; mv matching', category, id, rank() over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mv_1

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile.q.out
@@ -65,7 +65,7 @@ POSTHOOK: Input: default@sketch_input
 13	4	4
 14	4	4
 15	4	4
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',ntile(4) over (order by id) from sketch_input order by id
@@ -185,7 +185,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',ntile(4) over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -227,7 +227,7 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@sketch_input
 POSTHOOK: Lineage: sketch_input.category SCRIPT []
 POSTHOOK: Lineage: sketch_input.id EXPRESSION []
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',ntile(4) over (order by id nulls first) from sketch_input order by id nulls first
@@ -347,7 +347,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',ntile(4) over (order by id nulls first) from sketch_input order by id nulls first
 PREHOOK: type: QUERY
@@ -381,7 +381,7 @@ NULL	rewrite	1
 13	rewrite	4
 14	rewrite	4
 15	rewrite	4
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',ntile(4) over (order by id nulls last) from sketch_input order by id nulls last
@@ -501,7 +501,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',ntile(4) over (order by id nulls last) from sketch_input order by id nulls last
 PREHOOK: type: QUERY
@@ -535,7 +535,7 @@ POSTHOOK: Input: default@sketch_input
 15	rewrite	4
 NULL	rewrite	4
 NULL	rewrite	4
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,ntile(4) over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile_partition_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_ntile_partition_by.q.out
@@ -100,7 +100,7 @@ POSTHOOK: Input: default@sketch_input
 13	b	3	3
 14	b	4	4
 15	b	4	4
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain
 select id,'rewrite',ntile(4) over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
@@ -220,7 +220,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: select id,'rewrite',ntile(4) over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@sketch_input

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank.q.out
@@ -65,7 +65,7 @@ POSTHOOK: Input: default@sketch_input
 13	20	20
 14	21	21
 15	22	22
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',rank() over (order by id) from sketch_input order by id
@@ -185,7 +185,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -217,7 +217,7 @@ POSTHOOK: Input: default@sketch_input
 13	rewrite	20
 14	rewrite	21
 15	rewrite	22
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',count(id) over ()*rank() over (order by id) from sketch_input order by id
@@ -372,7 +372,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[21][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',count(id) over ()*rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY
@@ -414,7 +414,7 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@sketch_input
 POSTHOOK: Lineage: sketch_input.category SCRIPT []
 POSTHOOK: Lineage: sketch_input.id EXPRESSION []
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',rank() over (order by id nulls first) from sketch_input order by id nulls first
@@ -534,7 +534,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',rank() over (order by id nulls first) from sketch_input order by id nulls first
 PREHOOK: type: QUERY
@@ -568,7 +568,7 @@ NULL	rewrite	1
 13	rewrite	20
 14	rewrite	21
 15	rewrite	22
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
 select id,'rewrite',rank() over (order by id nulls last) from sketch_input order by id nulls last
@@ -688,7 +688,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[17][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,'rewrite',rank() over (order by id nulls last) from sketch_input order by id nulls last
 PREHOOK: type: QUERY
@@ -722,7 +722,7 @@ POSTHOOK: Input: default@sketch_input
 15	rewrite	22
 NULL	rewrite	22
 NULL	rewrite	22
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: select id,rank() over (order by id) from sketch_input order by id
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank_partition_by.q.out
+++ b/ql/src/test/results/clientpositive/llap/sketches_rewrite_rank_partition_by.q.out
@@ -66,7 +66,7 @@ POSTHOOK: Input: default@sketch_input
 13	b	9	9
 14	b	10	10
 15	b	11	11
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain
 select id,'rewrite',rank() over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
@@ -190,7 +190,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: select id,'rewrite',rank() over (partition by category order by id) from sketch_input order by category,id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@sketch_input

--- a/ql/src/test/results/clientpositive/llap/tez_smb_reduce_side.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_smb_reduce_side.q.out
@@ -1022,4 +1022,4 @@ POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
 1
-300
+200

--- a/ql/src/test/results/clientpositive/llap/tez_smb_reduce_side.q.out
+++ b/ql/src/test/results/clientpositive/llap/tez_smb_reduce_side.q.out
@@ -1022,4 +1022,4 @@ POSTHOOK: Input: default@t1
 POSTHOOK: Input: default@t2
 #### A masked pattern was here ####
 1
-200
+300

--- a/ql/src/test/results/clientpositive/llap/vectorization_0.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_0.q.out
@@ -1003,7 +1003,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@alltypesorc
 #### A masked pattern was here ####
 -4.303895780321011	1163.8972588605056	1163.8972588605056	1164.0241556397098	34.11593848717203	34.11593848717203	34.11593848717203	34.11779822379677
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION DETAIL
 SELECT AVG(cbigint),
        (-(AVG(cbigint))),
@@ -1197,7 +1197,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint),
        (-(AVG(cbigint))),
        (-6432 + AVG(cbigint)),

--- a/ql/src/test/results/clientpositive/llap/vectorization_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_3.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION DETAIL
 SELECT STDDEV_SAMP(csmallint),
        (STDDEV_SAMP(csmallint) - 10.175),
@@ -188,7 +188,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT STDDEV_SAMP(csmallint),
        (STDDEV_SAMP(csmallint) - 10.175),
        STDDEV_POP(ctinyint),

--- a/ql/src/test/results/clientpositive/llap/vectorization_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_limit.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization
 SELECT cbigint, cdouble FROM alltypesorc WHERE cbigint < cdouble and cint > 0 order by cbigint, cdouble limit 7
 PREHOOK: type: QUERY
@@ -90,7 +90,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT cbigint, cdouble FROM alltypesorc WHERE cbigint < cdouble and cint > 0 order by cbigint, cdouble limit 7
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesorc

--- a/ql/src/test/results/clientpositive/llap/vectorization_not.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_not.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint),
        (-(AVG(cbigint))),
        (-6432 + AVG(cbigint)),

--- a/ql/src/test/results/clientpositive/llap/vectorization_offset_limit.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_offset_limit.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization SELECT cbigint, cdouble FROM alltypesorc WHERE cbigint < cdouble and cint > 0 limit 3,2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesorc
@@ -62,7 +62,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT cbigint, cdouble FROM alltypesorc WHERE cbigint < cdouble and cint > 0 limit 3,2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesorc

--- a/ql/src/test/results/clientpositive/llap/vectorization_parquet_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_parquet_ppd_decimal.q.out
@@ -54,6 +54,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -67,6 +68,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -132,6 +134,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -145,6 +148,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -210,6 +214,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -223,6 +228,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -324,6 +330,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -342,6 +349,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
+WARNING: Comparing decimal(5,3) and string may result in loss of precision.
 PREHOOK: query: select * from newtypestbl_n1 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1

--- a/ql/src/test/results/clientpositive/llap/vectorization_parquet_ppd_decimal.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_parquet_ppd_decimal.q.out
@@ -54,7 +54,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -68,7 +68,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -134,7 +134,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -148,7 +148,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d!='0.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -214,7 +214,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -228,7 +228,7 @@ apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
 apple     	bee	0.220	1970-02-20
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d<'11.22'
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -330,7 +330,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1
@@ -349,7 +349,7 @@ hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
 hello     	world	11.220	1970-02-27
-WARNING: Comparing decimal(5,3) and string may result in loss of precision.
+WARNING: Comparing decimal(5,3) and string may result in loss of information.
 PREHOOK: query: select * from newtypestbl_n1 where d<='11.22' sort by c
 PREHOOK: type: QUERY
 PREHOOK: Input: default@newtypestbl_n1

--- a/ql/src/test/results/clientpositive/llap/vectorization_pushdown.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_pushdown.q.out
@@ -1,4 +1,4 @@
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: explain vectorization SELECT AVG(cbigint) FROM alltypesorc WHERE cbigint < cdouble
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesorc
@@ -90,7 +90,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(cbigint) FROM alltypesorc WHERE cbigint < cdouble
 PREHOOK: type: QUERY
 PREHOOK: Input: default@alltypesorc

--- a/ql/src/test/results/clientpositive/llap/vectorization_short_regress.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorization_short_regress.q.out
@@ -795,7 +795,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@alltypesorc
 #### A masked pattern was here ####
 2.5109214708344376E18	-2.5109214708344376E18	5.0218429416688753E18	2780	75.198	62	2.5109214708344402E18	2.5109214708344376E18	-1.0	2780	-2780	9460.675803068356	-2.5109214708344376E18	-2118360	1072872630	-2118298	-2.5109214697615652E18	185935.34910862715	0	758	-1.733509234828496	-3728
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION EXPRESSION
 SELECT AVG(ctinyint),
        (AVG(ctinyint) + 6981),
@@ -966,7 +966,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing bigint and double may result in loss of information.
 PREHOOK: query: SELECT AVG(ctinyint),
        (AVG(ctinyint) + 6981),
        ((AVG(ctinyint) + 6981) + AVG(ctinyint)),
@@ -1592,7 +1592,7 @@ POSTHOOK: Input: default@alltypesorc
 #### A masked pattern was here ####
 -462839731	988888	ss	false	-51.0	NULL	NULL	NULL	Lml5J2QBU77	false	-468.04059812638036	44.210	468.04059812638036	10.175	51.0	-102.0	-102.0	NULL	NULL	-988888	417.04059812638036	NULL	3569	NULL	NULL
 -635141101	-89010	ss	false	-51.0	NULL	NULL	NULL	rVWAj4N1MCg8Scyp7wj2C	true	7135.6151106617235	-69.746	-7135.6151106617235	10.175	51.0	-102.0	-102.0	NULL	NULL	89010	-7186.6151106617235	NULL	3569	NULL	NULL
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing double and bigint may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION EXPRESSION
 SELECT   cint,
          cstring1,
@@ -1778,7 +1778,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing double and bigint may result in loss of information.
 PREHOOK: query: SELECT   cint,
          cstring1,
          cboolean2,
@@ -2489,7 +2489,7 @@ POSTHOOK: Input: default@alltypesorc
 -84	-9	NULL	0.016535714	NULL	NULL	9	0.0	-9	1	89011
 -89	-14	NULL	0.015606742	NULL	NULL	14	0.0	-14	1	89011
 -95	-20	NULL	0.014621053	NULL	NULL	20	0.0	-20	1	89011
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing double and bigint may result in loss of information.
 PREHOOK: query: EXPLAIN VECTORIZATION EXPRESSION
 SELECT   cdouble,
          VAR_SAMP(cdouble),
@@ -2704,7 +2704,7 @@ STAGE PLANS:
       Processor Tree:
         ListSink
 
-WARNING: Comparing a bigint and a double may result in a loss of precision.
+WARNING: Comparing double and bigint may result in loss of information.
 PREHOOK: query: SELECT   cdouble,
          VAR_SAMP(cdouble),
          (2563.58 * VAR_SAMP(cdouble)),

--- a/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/typeinfo/TypeInfoUtils.java
@@ -24,12 +24,15 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.HiveVarchar;
 import org.apache.hadoop.hive.serde.serdeConstants;
@@ -883,6 +886,33 @@ public final class TypeInfoUtils {
     }
 
     return true;
+  }
+
+  private static final Set<Set<PrimitiveCategory>> LOSSY_TYPE_CONVERSIONS =
+      ImmutableSet.<Set<PrimitiveCategory>>builder()
+          .add(EnumSet.of(PrimitiveCategory.DECIMAL, PrimitiveCategory.CHAR))
+          .add(EnumSet.of(PrimitiveCategory.DECIMAL, PrimitiveCategory.VARCHAR))
+          .add(EnumSet.of(PrimitiveCategory.DECIMAL, PrimitiveCategory.STRING))
+          .add(EnumSet.of(PrimitiveCategory.DOUBLE, PrimitiveCategory.LONG))
+          .add(EnumSet.of(PrimitiveCategory.LONG, PrimitiveCategory.CHAR))
+          .add(EnumSet.of(PrimitiveCategory.LONG, PrimitiveCategory.VARCHAR))
+          .add(EnumSet.of(PrimitiveCategory.LONG, PrimitiveCategory.STRING))
+          .build();
+
+  /**
+   * Returns true if the conversion between the types is lossy (i.e., it can lead to loss of information), and false
+   * otherwise.
+   * TODO Not all cases are covered 
+   * Note that the method does not imply anything about the coercibility of types; use 
+   * {@link #isConversionRequiredForComparison(TypeInfo, TypeInfo)} to determine if a conversion is possible.
+   */
+  public static boolean isConversionLossy(TypeInfo t1, TypeInfo t2) {
+    if (t1 instanceof PrimitiveTypeInfo && t2 instanceof PrimitiveTypeInfo) {
+      PrimitiveTypeInfo pt1 = (PrimitiveTypeInfo) t1;
+      PrimitiveTypeInfo pt2 = (PrimitiveTypeInfo) t2;
+      return LOSSY_TYPE_CONVERSIONS.contains(EnumSet.of(pt1.getPrimitiveCategory(), pt2.getPrimitiveCategory()));
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Throw an error when `hive.strict.checks.type.safety=true` and the query contains comparison between decimals and character or bigint and double types.

### Why are the changes needed?
To fail-fast and avoid unexpected query results. Examples in HIVE-24534.
Strict type checks between bigint and double types was implemented before but due to a bug it was not throwing an error but just a warning.

### Does this PR introduce _any_ user-facing change?
Queries relying on comparisons between decimal and character  or  bigint and double types will fail.

### How was this patch tested?
`mvn clean test -Dtest=TestNegativeCliDriver -Dqfile_regex="strict_type_decimal.*" -Dtest.output.overwrite`
`mvn test -Dtest=TestDecimalStringValidation`