### PR TITLE
HIVE-24536. Upgrade ORC to 1.6.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,7 +179,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <postgres.version>42.2.14</postgres.version>
     <opencsv.version>2.3</opencsv.version>
-    <orc.version>1.5.12</orc.version>
+    <orc.version>1.6.6</orc.version>
     <mockito-core.version>3.3.3</mockito-core.version>
     <powermock.version>2.0.2</powermock.version>
     <mina.version>2.0.0-M5</mina.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to upgrade Apache ORC from 1.5.12 to 1.6.6.

### Why are the changes needed?

This will bring the latest bug fixes.

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CI with the existing test cases.