### PR TITLE
HIVE-24434: Filter out materialized views for rewriting if plan pattern is not allowed

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
@@ -19,15 +19,18 @@
 package org.apache.hadoop.hive.ql.metadata;
 
 import org.apache.calcite.plan.RelOptMaterialization;
+import org.apache.calcite.plan.RelOptTable;
+import org.apache.calcite.rel.RelNode;
 
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.apache.commons.collections.CollectionUtils.intersection;
 
 /**
- * Wrapper class of {@link RelOptMaterialization} and corresponding flags.
+ * Hive extension of {@link RelOptMaterialization}.
  */
-public class Materialization {
+public class HiveRelOptMaterialization extends RelOptMaterialization {
 
   /**
    * Enumeration of Materialized view query rewrite algorithms.
@@ -43,18 +46,15 @@ public class Materialization {
     CALCITE;
 
     public static final EnumSet<RewriteAlgorithm> ALL = EnumSet.allOf(RewriteAlgorithm.class);
-  }
 
-  private final RelOptMaterialization relOptMaterialization;
+  }
   private final EnumSet<RewriteAlgorithm> scope;
 
-  public Materialization(RelOptMaterialization relOptMaterialization, EnumSet<RewriteAlgorithm> scope) {
-    this.relOptMaterialization = relOptMaterialization;
+  public HiveRelOptMaterialization(RelNode tableRel, RelNode queryRel,
+                                   RelOptTable starRelOptTable, List<String> qualifiedTableName,
+                                   EnumSet<RewriteAlgorithm> scope) {
+    super(tableRel, queryRel, starRelOptTable, qualifiedTableName);
     this.scope = scope;
-  }
-
-  public RelOptMaterialization getRelOptMaterialization() {
-    return relOptMaterialization;
   }
 
   public EnumSet<RewriteAlgorithm> getScope() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Materialization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Materialization.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.metadata;
 
 import org.apache.calcite.plan.RelOptMaterialization;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Materialization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Materialization.java
@@ -1,0 +1,54 @@
+package org.apache.hadoop.hive.ql.metadata;
+
+import org.apache.calcite.plan.RelOptMaterialization;
+
+import java.util.EnumSet;
+
+import static org.apache.commons.collections.CollectionUtils.intersection;
+
+/**
+ * Wrapper class of {@link RelOptMaterialization} and corresponding flags.
+ */
+public class Materialization {
+
+  /**
+   * Enumeration of Materialized view query rewrite algorithms.
+   */
+  public enum RewriteAlgorithm {
+    /**
+     * Query sql text is compared to stored materialized view definition sql texts.
+     */
+    TEXT,
+    /**
+     * Use rewriting algorithm provided by Calcite.
+     */
+    CALCITE;
+
+    public static final EnumSet<RewriteAlgorithm> ALL = EnumSet.allOf(RewriteAlgorithm.class);
+  }
+
+  private final RelOptMaterialization relOptMaterialization;
+  private final EnumSet<RewriteAlgorithm> scope;
+
+  public Materialization(RelOptMaterialization relOptMaterialization, EnumSet<RewriteAlgorithm> scope) {
+    this.relOptMaterialization = relOptMaterialization;
+    this.scope = scope;
+  }
+
+  public RelOptMaterialization getRelOptMaterialization() {
+    return relOptMaterialization;
+  }
+
+  public EnumSet<RewriteAlgorithm> getScope() {
+    return scope;
+  }
+
+  /**
+   * Is this materialized view applicable to the specified scope.
+   * @param scope Set of algorithms
+   * @return true if applicable false otherwise
+   */
+  public boolean isSupported(EnumSet<RewriteAlgorithm> scope) {
+    return !intersection(this.scope, scope).isEmpty();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
@@ -18,13 +18,11 @@
 
 package org.apache.hadoop.hive.ql.metadata;
 
-import org.apache.calcite.plan.RelOptMaterialization;
 import org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -35,8 +33,8 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 
 /**
- * Collection for storing {@link RelOptMaterialization}s.
- * RelOptMaterialization can be lookup by
+ * Collection for storing {@link Materialization}s.
+ * Materialization can be lookup by
  * - the Materialized View fully qualified name
  * - query text.
  * This implementation contains two {@link ConcurrentHashMap} one for name based and one for query text based lookup.
@@ -48,18 +46,18 @@ public class MaterializedViewsCache {
   private static final Logger LOG = LoggerFactory.getLogger(MaterializedViewsCache.class);
 
   // Key is the database name. Value a map from the qualified name to the view object.
-  private final ConcurrentMap<String, ConcurrentMap<String, RelOptMaterialization>> materializedViews =
+  private final ConcurrentMap<String, ConcurrentMap<String, Materialization>> materializedViews =
           new ConcurrentHashMap<>();
   // Map for looking up materialization by view query text
-  private final Map<String, List<RelOptMaterialization>> sqlToMaterializedView = new ConcurrentHashMap<>();
+  private final Map<String, List<Materialization>> sqlToMaterializedView = new ConcurrentHashMap<>();
 
 
-  public void putIfAbsent(Table materializedViewTable, RelOptMaterialization materialization) {
-    ConcurrentMap<String, RelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
+  public void putIfAbsent(Table materializedViewTable, Materialization materialization) {
+    ConcurrentMap<String, Materialization> dbMap = ensureDbMap(materializedViewTable);
 
     // You store the materialized view
-    dbMap.compute(materializedViewTable.getTableName(), (mvTableName, relOptMaterialization) -> {
-      List<RelOptMaterialization> materializationList = sqlToMaterializedView.computeIfAbsent(
+    dbMap.compute(materializedViewTable.getTableName(), (mvTableName, aMaterialization) -> {
+      List<Materialization> materializationList = sqlToMaterializedView.computeIfAbsent(
               materializedViewTable.getViewExpandedText(), s -> new ArrayList<>());
       materializationList.add(materialization);
       return materialization;
@@ -69,12 +67,12 @@ public class MaterializedViewsCache {
             materializedViewTable.getDbName(), materializedViewTable.getTableName());
   }
 
-  private ConcurrentMap<String, RelOptMaterialization> ensureDbMap(Table materializedViewTable) {
+  private ConcurrentMap<String, Materialization> ensureDbMap(Table materializedViewTable) {
     // We are going to create the map for each view in the given database
-    ConcurrentMap<String, RelOptMaterialization> dbMap =
-            new ConcurrentHashMap<String, RelOptMaterialization>();
+    ConcurrentMap<String, Materialization> dbMap =
+            new ConcurrentHashMap<String, Materialization>();
     // If we are caching the MV, we include it in the cache
-    final ConcurrentMap<String, RelOptMaterialization> prevDbMap = materializedViews.putIfAbsent(
+    final ConcurrentMap<String, Materialization> prevDbMap = materializedViews.putIfAbsent(
             materializedViewTable.getDbName(), dbMap);
     if (prevDbMap != null) {
       dbMap = prevDbMap;
@@ -83,11 +81,11 @@ public class MaterializedViewsCache {
   }
 
   public void refresh(
-          Table oldMaterializedViewTable, Table materializedViewTable, RelOptMaterialization newMaterialization) {
-    ConcurrentMap<String, RelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
+          Table oldMaterializedViewTable, Table materializedViewTable, Materialization newMaterialization) {
+    ConcurrentMap<String, Materialization> dbMap = ensureDbMap(materializedViewTable);
 
     dbMap.compute(materializedViewTable.getTableName(), (mvTableName, existingMaterialization) -> {
-      List<RelOptMaterialization> optMaterializationList = sqlToMaterializedView.computeIfAbsent(
+      List<Materialization> optMaterializationList = sqlToMaterializedView.computeIfAbsent(
               materializedViewTable.getViewExpandedText(), s -> new ArrayList<>());
 
       if (existingMaterialization == null) {
@@ -95,7 +93,8 @@ public class MaterializedViewsCache {
         optMaterializationList.add(newMaterialization);
         return newMaterialization;
       }
-      Table existingMaterializedViewTable = HiveMaterializedViewUtils.extractTable(existingMaterialization);
+      Table existingMaterializedViewTable = HiveMaterializedViewUtils.extractTable(
+              existingMaterialization.getRelOptMaterialization());
       if (existingMaterializedViewTable.equals(oldMaterializedViewTable)) {
         // If the old version is the same, we replace it
         optMaterializationList.remove(existingMaterialization);
@@ -112,13 +111,14 @@ public class MaterializedViewsCache {
   }
 
   public void remove(Table materializedViewTable) {
-    ConcurrentMap<String, RelOptMaterialization> dbMap = materializedViews.get(materializedViewTable.getDbName());
+    ConcurrentMap<String, Materialization> dbMap = materializedViews.get(materializedViewTable.getDbName());
     if (dbMap != null) {
       // Delete only if the create time for the input materialized view table and the table
       // in the map match. Otherwise, keep the one in the map.
       dbMap.computeIfPresent(materializedViewTable.getTableName(), (mvTableName, oldMaterialization) -> {
-        if (HiveMaterializedViewUtils.extractTable(oldMaterialization).equals(materializedViewTable)) {
-          List<RelOptMaterialization> materializationList =
+        if (HiveMaterializedViewUtils.extractTable(
+                oldMaterialization.getRelOptMaterialization()).equals(materializedViewTable)) {
+          List<Materialization> materializationList =
                   sqlToMaterializedView.get(materializedViewTable.getViewExpandedText());
           materializationList.remove(oldMaterialization);
           return null;
@@ -132,12 +132,13 @@ public class MaterializedViewsCache {
   }
 
   public void remove(String dbName, String tableName) {
-    ConcurrentMap<String, RelOptMaterialization> dbMap = materializedViews.get(dbName);
+    ConcurrentMap<String, Materialization> dbMap = materializedViews.get(dbName);
     if (dbMap != null) {
-      dbMap.computeIfPresent(tableName, (mvTableName, relOptMaterialization) -> {
-        String queryText = HiveMaterializedViewUtils.extractTable(relOptMaterialization).getViewExpandedText();
-        List<RelOptMaterialization> materializationList = sqlToMaterializedView.get(queryText);
-        materializationList.remove(relOptMaterialization);
+      dbMap.computeIfPresent(tableName, (mvTableName, materialization) -> {
+        String queryText = HiveMaterializedViewUtils.extractTable(
+                materialization.getRelOptMaterialization()).getViewExpandedText();
+        List<Materialization> materializationList = sqlToMaterializedView.get(queryText);
+        materializationList.remove(materialization);
         return null;
       });
 
@@ -145,13 +146,13 @@ public class MaterializedViewsCache {
     }
   }
 
-  public List<RelOptMaterialization> values() {
-    List<RelOptMaterialization> result = new ArrayList<>();
+  public List<Materialization> values() {
+    List<Materialization> result = new ArrayList<>();
     materializedViews.forEach((dbName, mvs) -> result.addAll(mvs.values()));
     return unmodifiableList(result);
   }
 
-  RelOptMaterialization get(String dbName, String viewName) {
+  Materialization get(String dbName, String viewName) {
     if (materializedViews.get(dbName) != null) {
       LOG.debug("Found materialized view {}.{} in registry", dbName, viewName);
       return materializedViews.get(dbName).get(viewName);
@@ -160,8 +161,8 @@ public class MaterializedViewsCache {
     return null;
   }
 
-  public List<RelOptMaterialization> get(String querySql) {
-    List<RelOptMaterialization> relOptMaterializationList = sqlToMaterializedView.get(querySql);
+  public List<Materialization> get(String querySql) {
+    List<Materialization> relOptMaterializationList = sqlToMaterializedView.get(querySql);
     if (relOptMaterializationList == null) {
       LOG.trace("No materialized view with query text '{}' found in registry.", querySql);
       LOG.debug("No materialized view with similar query text found in registry.");

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveMaterializedViewUtils.java
@@ -53,6 +53,7 @@ import org.apache.hadoop.hive.metastore.api.CreationMetadata;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveRelOptMaterialization;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
@@ -171,8 +172,8 @@ public class HiveMaterializedViewUtils {
    * Method to enrich the materialization query contained in the input with
    * its invalidation.
    */
-  public static RelOptMaterialization augmentMaterializationWithTimeInformation(
-      RelOptMaterialization materialization, String validTxnsList,
+  public static HiveRelOptMaterialization augmentMaterializationWithTimeInformation(
+      HiveRelOptMaterialization materialization, String validTxnsList,
       ValidTxnWriteIdList materializationTxnList) throws LockException {
     // Extract tables used by the query which will in turn be used to generate
     // the corresponding txn write ids
@@ -197,8 +198,8 @@ public class HiveMaterializedViewUtils {
         augmentMaterializationProgram.build());
     augmentMaterializationPlanner.setRoot(materialization.queryRel);
     final RelNode modifiedQueryRel = augmentMaterializationPlanner.findBestExp();
-    return new RelOptMaterialization(materialization.tableRel, modifiedQueryRel,
-        null, materialization.qualifiedTableName);
+    return new HiveRelOptMaterialization(materialization.tableRel, modifiedQueryRel,
+        null, materialization.qualifiedTableName, materialization.getScope());
   }
 
   /**
@@ -209,7 +210,8 @@ public class HiveMaterializedViewUtils {
    * values. The view scan will consist of the scan over the materialization followed by a
    * filter on the grouping id value corresponding to that grouping set.
    */
-  public static List<RelOptMaterialization> deriveGroupingSetsMaterializedViews(RelOptMaterialization materialization) {
+  public static List<HiveRelOptMaterialization> deriveGroupingSetsMaterializedViews(
+      HiveRelOptMaterialization materialization) {
     final RelNode query = materialization.queryRel;
     final Project project;
     final Aggregate aggregate;
@@ -258,7 +260,7 @@ public class HiveMaterializedViewUtils {
       }
     }
     // Create multiple materializations
-    final List<RelOptMaterialization> materializationList = new ArrayList<>();
+    final List<HiveRelOptMaterialization> materializationList = new ArrayList<>();
     final RelBuilder builder = HiveRelFactories.HIVE_BUILDER.create(aggregate.getCluster(), null);
     final RexBuilder rexBuilder = aggregate.getCluster().getRexBuilder();
     final List<AggregateCall> aggregateCalls = new ArrayList<>(aggregate.getAggCallList());
@@ -317,9 +319,9 @@ public class HiveMaterializedViewUtils {
       final RelNode newTableRel = builder.build();
       final Table scanTable = extractTable(materialization);
       materializationList.add(
-          new RelOptMaterialization(newTableRel, newQueryRel, null,
+          new HiveRelOptMaterialization(newTableRel, newQueryRel, null,
               ImmutableList.of(scanTable.getDbName(), scanTable.getTableName(),
-                  "#" + materializationList.size())));
+                  "#" + materializationList.size()), materialization.getScope()));
     }
     return materializationList;
   }
@@ -337,7 +339,8 @@ public class HiveMaterializedViewUtils {
     return value;
   }
 
-  public static RelOptMaterialization copyMaterializationToNewCluster(RelOptCluster optCluster, RelOptMaterialization materialization) {
+  public static RelOptMaterialization copyMaterializationToNewCluster(
+      RelOptCluster optCluster, RelOptMaterialization materialization) {
     final RelNode viewScan = materialization.tableRel;
     final RelNode newViewScan = HiveMaterializedViewUtils.copyNodeNewCluster(
             optCluster, viewScan);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
@@ -1,0 +1,34 @@
+package org.apache.hadoop.hive.ql.parse;
+
+import org.apache.calcite.rel.RelNode;
+
+/**
+ * Wrapper of Calcite plan.
+ */
+public class CBOPlan {
+  private final RelNode plan;
+  private final String invalidAutomaticRewritingMaterializationReason;
+
+  public CBOPlan(RelNode plan, String invalidAutomaticRewritingMaterializationReason) {
+    this.plan = plan;
+    this.invalidAutomaticRewritingMaterializationReason = invalidAutomaticRewritingMaterializationReason;
+  }
+
+  /**
+   * Root node of plan.
+   * @return Root {@link RelNode}
+   */
+  public RelNode getPlan() {
+    return plan;
+  }
+
+  /**
+   * Returns an error message if this plan can not be a definition of a Materialized view which is an input of
+   * Calcite based materialized view query rewrite.
+   * null or empty string otherwise.
+   * @return
+   */
+  public String getInvalidAutomaticRewritingMaterializationReason() {
+    return invalidAutomaticRewritingMaterializationReason;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
@@ -43,8 +43,8 @@ public class CBOPlan {
   /**
    * Returns an error message if this plan can not be a definition of a Materialized view which is an input of
    * Calcite based materialized view query rewrite.
-   * null or empty string otherwise.
-   * @return
+   * Null or empty string otherwise.
+   * @return String contains error message or null.
    */
   public String getInvalidAutomaticRewritingMaterializationReason() {
     return invalidAutomaticRewritingMaterializationReason;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CBOPlan.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.hadoop.hive.ql.parse;
 
 import org.apache.calcite.rel.RelNode;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -151,6 +151,7 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveRelOptMaterialization;
 import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.NotNullConstraint;
 import org.apache.hadoop.hive.ql.metadata.PrimaryKeyInfo;
@@ -2199,7 +2200,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
           // We only retrieve the materialization corresponding to the rebuild. In turn,
           // we pass 'true' for the forceMVContentsUpToDate parameter, as we cannot allow the
           // materialization contents to be stale for a rebuild if we want to use it.
-          RelOptMaterialization materialization = db.getMaterializedViewForRebuild(
+          HiveRelOptMaterialization materialization = db.getMaterializedViewForRebuild(
               mvRebuildDbName, mvRebuildName, tablesUsedQuery, getTxnMgr());
           if (materialization != null) {
             materializations.add(materialization);
@@ -2210,9 +2211,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
           // as this is not a rebuild, and we apply the user parameters
           // (HIVE_MATERIALIZED_VIEW_REWRITING_TIME_WINDOW) instead.
           if (useMaterializedViewsRegistry) {
-            materializations = db.getPreprocessedMaterializedViewsFromRegistry(tablesUsedQuery, getTxnMgr());
+            materializations.addAll(db.getPreprocessedMaterializedViewsFromRegistry(tablesUsedQuery, getTxnMgr()));
           } else {
-            materializations = db.getPreprocessedMaterializedViews(tablesUsedQuery, getTxnMgr());
+            materializations.addAll(db.getPreprocessedMaterializedViews(tablesUsedQuery, getTxnMgr()));
           }
         }
         // We need to use the current cluster for the scan operator on views,
@@ -2376,9 +2377,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
       String expandedQueryText = ctx.getTokenRewriteStream()
               .toString(EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM, ast.getTokenStartIndex(), ast.getTokenStopIndex());
       try {
-        List<RelOptMaterialization> relOptMaterializationList = db.getMaterializedViewsBySql(
+        List<HiveRelOptMaterialization> relOptMaterializationList = db.getMaterializedViewsBySql(
                 expandedQueryText, getTablesUsed(calciteGenPlan), getTxnMgr());
-        for (RelOptMaterialization relOptMaterialization : relOptMaterializationList) {
+        for (HiveRelOptMaterialization relOptMaterialization : relOptMaterializationList) {
           try {
             Table hiveTableMD = extractTable(relOptMaterialization);
             if (HiveMaterializedViewUtils.checkPrivilegeForMaterializedViews(singletonList(hiveTableMD))) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -553,13 +553,14 @@ public final class ParseUtils {
       return sb.toString();
     }
 
-  public static RelNode parseQuery(HiveConf conf, String viewQuery)
+  public static CBOPlan parseQuery(HiveConf conf, String viewQuery)
       throws SemanticException, IOException, ParseException {
     final Context ctx = new Context(conf);
     ctx.setIsLoadingMaterializedView(true);
     final ASTNode ast = parse(viewQuery, ctx);
     final CalcitePlanner analyzer = getAnalyzer(conf, ctx);
-    return analyzer.genLogicalPlan(ast);
+    RelNode logicalPlan = analyzer.genLogicalPlan(ast);
+    return new CBOPlan(logicalPlan, analyzer.getInvalidAutomaticRewritingMaterializationReason());
   }
 
   public static List<FieldSchema> parseQueryAndGetSchema(HiveConf conf, String viewQuery)

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_11.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_11.q
@@ -1,0 +1,24 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.materializedview.rewriting.sql=false;
+
+create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true');
+
+create materialized view mat1 as
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2;
+
+-- MV is not used because sql text based is disabled calcite based does not support UNION operator in view definition.
+explain cbo
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2;
+
+explain
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2;
+
+drop materialized view mat1;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_11.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_11.q.out
@@ -1,0 +1,166 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
+PREHOOK: query: create materialized view mat1 as
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+POSTHOOK: query: create materialized view mat1 as
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+PREHOOK: query: explain cbo
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{0}])
+  HiveProject($f0=[$0])
+    HiveUnion(all=[true])
+      HiveProject($f0=[CAST(1):INTEGER])
+        HiveFilter(condition=[=($0, 1)])
+          HiveTableScan(table=[[default, t1]], table:alias=[t1])
+      HiveProject($f0=[CAST(2):INTEGER])
+        HiveFilter(condition=[=($0, 2)])
+          HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+select * from t1 where col0 = 1
+union
+select * from t1 where col0 = 2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Union 2 (CONTAINS)
+        Map 4 <- Union 2 (CONTAINS)
+        Reducer 3 <- Union 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (col0 = 1) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (col0 = 1) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: 1 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        keys: _col0 (type: int)
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 4 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (col0 = 2) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (col0 = 2) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: 2 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        keys: _col0 (type: int)
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Union 2 
+            Vertex: Union 2
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: drop materialized view mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: drop materialized view mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Store the scope of each materialized view in the cache/registry. It specifies whether the MV can be used in both Calcite and Sql text based query rewrites or Sql text based only.
2. Scope value is calculated when the MV definition is parsed during adding the MV to the Registry.

### Why are the changes needed?
Number of Materialized views added to the Calcite based rewrite planner affects query compilation performance. Too much view definition increases the planning time without any benefit. There are plan patterns which are not supported by the planner. MV having such patterns in its definition can be filtered out before even added to the planner.


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_rewrite_11.q -pl itests/qtest -Pitests
```