### PR TITLE
HIVE-24539: OrcInputFormat schema generation should respect column delimiter

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -96,6 +96,7 @@ import org.apache.hadoop.hive.ql.metadata.VirtualColumn;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.SerDeStats;
+import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.BaseCharTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
@@ -2675,12 +2676,13 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
   public static TypeDescription getDesiredRowTypeDescr(Configuration conf,
                                                        boolean isAcidRead,
                                                        int dataColumns) {
-
     String columnNameProperty = null;
     String columnTypeProperty = null;
 
     ArrayList<String> schemaEvolutionColumnNames = null;
     ArrayList<TypeDescription> schemaEvolutionTypeDescrs = null;
+    // Make sure we split colNames using the right Delimiter
+    final String columnNameDelimiter = conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA));
 
     boolean haveSchemaEvolutionProperties = false;
     if (isAcidRead || HiveConf.getBoolVar(conf, ConfVars.HIVE_SCHEMA_EVOLUTION) ) {
@@ -2692,7 +2694,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
           (columnNameProperty != null && columnTypeProperty != null);
 
       if (haveSchemaEvolutionProperties) {
-        schemaEvolutionColumnNames = Lists.newArrayList(columnNameProperty.split(","));
+        schemaEvolutionColumnNames = Lists.newArrayList(columnNameProperty.split(columnNameDelimiter));
         if (schemaEvolutionColumnNames.size() == 0) {
           haveSchemaEvolutionProperties = false;
         } else {
@@ -2726,7 +2728,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
         return null;
       }
 
-      schemaEvolutionColumnNames = Lists.newArrayList(columnNameProperty.split(","));
+      schemaEvolutionColumnNames = Lists.newArrayList(columnNameProperty.split(columnNameDelimiter));
       if (schemaEvolutionColumnNames.size() == 0) {
         return null;
       }

--- a/ql/src/test/queries/clientpositive/comma_in_column_name.q
+++ b/ql/src/test/queries/clientpositive/comma_in_column_name.q
@@ -2,13 +2,28 @@ create table test_n4 (`x,y` int);
 
 insert into test_n4 values (1),(2);
 
-select `x,y` from test_n4 where `x,y` >=2 ;
+explain vectorization
+select `x,y` from test_n4 where `x,y` >=2;
+select `x,y` from test_n4 where `x,y` >=2;
 
-drop table test_n4; 
+SET hive.fetch.task.conversion=none;
+explain vectorization
+select `x,y` from test_n4 where `x,y` >=2;
+select `x,y` from test_n4 where `x,y` >=2;
+
+drop table test_n4;
+
+SET hive.fetch.task.conversion=more;
 
 create table test_n4 (`x,y` int) stored as orc;
 
 insert into test_n4 values (1),(2);
 
-select `x,y` from test_n4 where `x,y` <2 ;
+explain vectorization
+select `x,y` from test_n4 where `x,y` <2;
+select `x,y` from test_n4 where `x,y` <2;
 
+SET hive.fetch.task.conversion=none;
+explain vectorization
+select `x,y` from test_n4 where `x,y` <2;
+select `x,y` from test_n4 where `x,y` <2;

--- a/ql/src/test/results/clientpositive/llap/comma_in_column_name.q.out
+++ b/ql/src/test/results/clientpositive/llap/comma_in_column_name.q.out
@@ -15,6 +15,104 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@test_n4
 POSTHOOK: Lineage: test_n4.x,y SCRIPT []
+PREHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` >=2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` >=2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: test_n4
+          filterExpr: (x,y >= 2) (type: boolean)
+          Filter Operator
+            predicate: (x,y >= 2) (type: boolean)
+            Select Operator
+              expressions: x,y (type: int)
+              outputColumnNames: _col0
+              ListSink
+
+PREHOOK: query: select `x,y` from test_n4 where `x,y` >=2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: select `x,y` from test_n4 where `x,y` >=2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+2
+PREHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` >=2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` >=2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: test_n4
+                  filterExpr: (x,y >= 2) (type: boolean)
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (x,y >= 2) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: x,y (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: false
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                enabledConditionsNotMet: Could not enable vectorization due to partition column names size 2 is greater than the number of table column names size 1 IS false
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: select `x,y` from test_n4 where `x,y` >=2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_n4
@@ -49,6 +147,104 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@test_n4
 POSTHOOK: Lineage: test_n4.x,y SCRIPT []
+PREHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` <2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` <2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: test_n4
+          filterExpr: (x,y < 2) (type: boolean)
+          Filter Operator
+            predicate: (x,y < 2) (type: boolean)
+            Select Operator
+              expressions: x,y (type: int)
+              outputColumnNames: _col0
+              ListSink
+
+PREHOOK: query: select `x,y` from test_n4 where `x,y` <2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: select `x,y` from test_n4 where `x,y` <2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+1
+PREHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` <2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization
+select `x,y` from test_n4 where `x,y` <2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_n4
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: test_n4
+                  filterExpr: (x,y < 2) (type: boolean)
+                  Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (x,y < 2) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: x,y (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: false
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                enabledConditionsNotMet: Could not enable vectorization due to partition column names size 2 is greater than the number of table column names size 1 IS false
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: select `x,y` from test_n4 where `x,y` <2
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_n4


### PR DESCRIPTION
### What changes were proposed in this pull request?
OrcInputFormat  getDesiredRowTypeDescr method should use column delimiter to generate column names.

### Why are the changes needed?
Current logic can create wrong names when column names contain commas.


### Does this PR introduce _any_ user-facing change?
no


### How was this patch tested?
q file