### PR TITLE
HIVE-24513: Advance write ID during drop constraint

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/drop/AlterTableDropConstraintAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/drop/AlterTableDropConstraintAnalyzer.java
@@ -26,6 +26,8 @@ import org.apache.hadoop.hive.ql.ddl.DDLWork;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableAnalyzer;
 import org.apache.hadoop.hive.ql.ddl.DDLSemanticAnalyzerFactory.DDLType;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.parse.ASTNode;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
@@ -46,5 +48,10 @@ public class AlterTableDropConstraintAnalyzer extends AbstractAlterTableAnalyzer
 
     AlterTableDropConstraintDesc desc = new AlterTableDropConstraintDesc(tableName, null, constraintName);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
+
+    Table table = getTable(tableName);
+    if (AcidUtils.isTransactionalTable(table)) {
+      setAcidDdlDesc(desc);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/drop/AlterTableDropConstraintDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/constraint/drop/AlterTableDropConstraintDesc.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
+import org.apache.hadoop.hive.ql.ddl.DDLDesc.DDLDescWithWriteId;
 import org.apache.hadoop.hive.ql.parse.ReplicationSpec;
 import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.plan.Explain;
@@ -31,12 +32,13 @@ import org.apache.hadoop.hive.ql.plan.Explain.Level;
  * DDL task description for ALTER TABLE ... DROP CONSTRAINT ... commands.
  */
 @Explain(displayName = "Drop Constraint", explainLevels = { Level.USER, Level.DEFAULT, Level.EXTENDED })
-public class AlterTableDropConstraintDesc implements DDLDesc, Serializable {
+public class AlterTableDropConstraintDesc implements DDLDescWithWriteId, Serializable {
   private static final long serialVersionUID = 1L;
 
   private final TableName tableName;
   private final ReplicationSpec replicationSpec;
   private final String constraintName;
+  private Long writeId;
 
   public AlterTableDropConstraintDesc(TableName tableName, ReplicationSpec replicationSpec, String constraintName)
       throws SemanticException  {
@@ -62,4 +64,24 @@ public class AlterTableDropConstraintDesc implements DDLDesc, Serializable {
   public String getConstraintName() {
     return constraintName;
   }
+
+  @Override
+  public String getFullTableName() {
+    return tableName.getNotEmptyDbTable();
+  }
+
+  @Override
+  public void setWriteId(long writeId) {
+    this.writeId = writeId;
+  }
+
+  public Long getWriteId() {
+    return writeId;
+  }
+
+  @Override
+  public boolean mayNeedWriteId() {
+    return true;
+  }
+
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -379,7 +379,7 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
   }
 
   @Test
-  public void testAddConstraintAdvancingWriteIds() throws Exception {
+  public void testAddAndDropConstraintAdvancingWriteIds() throws Exception {
 
     String tableName = "constraints_table";
     hiveConf.setBoolean("hive.stats.autogather", true);
@@ -410,8 +410,25 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     runStatementOnDriver(String.format("alter table %s ADD CONSTRAINT unique1 UNIQUE (a, b) DISABLE", tableName));
     validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
     LOG.info("ValidWriteIds after add constraint unique::"+ validWriteIds);
-    Assert.assertEquals("default.constraints_table:5:9223372036854775807::", validWriteIds); 
-  
+    Assert.assertEquals("default.constraints_table:5:9223372036854775807::", validWriteIds);
+
+    LOG.info("ValidWriteIds before drop constraint::"+ validWriteIds);
+    runStatementOnDriver(String.format("alter table %s  DROP CONSTRAINT a_PK", tableName));
+    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.constraints_table:6:9223372036854775807::", validWriteIds);
+    LOG.info("ValidWriteIds after drop constraint primary key::"+ validWriteIds);
+    runStatementOnDriver(String.format("alter table %s  DROP CONSTRAINT check1", tableName));
+    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.constraints_table:7:9223372036854775807::", validWriteIds);
+    LOG.info("ValidWriteIds after drop constraint check::"+ validWriteIds);
+    runStatementOnDriver(String.format("alter table %s  DROP CONSTRAINT unique1", tableName));
+    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.constraints_table:8:9223372036854775807::", validWriteIds);
+    LOG.info("ValidWriteIds after drop constraint unique::"+ validWriteIds);
+    runStatementOnDriver(String.format("alter table %s CHANGE COLUMN b b STRING", tableName));
+    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.constraints_table:9:9223372036854775807::", validWriteIds);
+
   }
 
   @Test

--- a/ql/src/test/results/clientnegative/drop_invalid_constraint2.q.out
+++ b/ql/src/test/results/clientnegative/drop_invalid_constraint2.q.out
@@ -6,6 +6,4 @@ POSTHOOK: query: CREATE TABLE table2 (a STRING, b STRING, constraint pk1 primary
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@table2
-PREHOOK: query: ALTER TABLE table1 DROP CONSTRAINT pk1
-PREHOOK: type: ALTERTABLE_DROPCONSTRAINT
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. InvalidObjectException(message:The constraint: pk1 does not exist for the associated table: default.table1)
+FAILED: SemanticException [Error 10001]: Table not found default.table1

--- a/ql/src/test/results/clientpositive/llap/default_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/default_constraint.q.out
@@ -1985,7 +1985,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3288                
+	totalSize           	3290                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2062,7 +2062,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3288                
+	totalSize           	3290                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -2140,7 +2140,7 @@ Table Parameters:
 	bucketing_version   	2                   
 #### A masked pattern was here ####
 	numFiles            	3                   
-	totalSize           	3288                
+	totalSize           	3290                
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####


### PR DESCRIPTION
### What changes were proposed in this pull request?
Advance write ID during drop constraint

### Why are the changes needed?
To server consistent metadata from HS2 cache

### Does this PR introduce _any_ user-facing change?
No
### How was this patch tested?
Added new tests