### PR TITLE
HIVE-24545: jdbc.HiveStatement: Number of rows is greater than Integer.MAX_VALUE

### DIFF
--- a/beeline/src/java/org/apache/hive/beeline/Commands.java
+++ b/beeline/src/java/org/apache/hive/beeline/Commands.java
@@ -1045,7 +1045,7 @@ public class Commands {
             outputFile.fetchFinished();
           }
         } else {
-          int count = stmnt.getUpdateCount();
+          long count = stmnt.getLargeUpdateCount();
           long end = System.currentTimeMillis();
 
           if (showReport()) {

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -588,6 +588,26 @@ public class HiveStatement implements java.sql.Statement {
   }
 
   @Override
+  public long getLargeUpdateCount() throws SQLException {
+    checkConnection("getLargeUpdateCount");
+    /**
+     * Poll on the operation status, till the operation is complete. We want to ensure that since a
+     * client might end up using executeAsync and then call this to check if the query run is
+     * finished.
+     */
+    long numModifiedRows = -1L;
+    TGetOperationStatusResp resp = waitForOperationToComplete();
+    if (resp != null) {
+      numModifiedRows = resp.getNumModifiedRows();
+    }
+    if (numModifiedRows == -1L || numModifiedRows > Long.MAX_VALUE) {
+      LOG.warn("Invalid number of updated rows: {}", numModifiedRows);
+      return -1;
+    }
+    return numModifiedRows;
+  }
+
+  @Override
   public SQLWarning getWarnings() throws SQLException {
     checkConnection("getWarnings");
     return warningChain;


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should use java.sql.getLargeUpdateCount() where it's possible. User-facing case is beeline output.

### Why are the changes needed?
Because this can be confusing for the user on beeline output:
```
20/12/16 01:37:36 [main]: WARN jdbc.HiveStatement: Number of rows is greater than Integer.MAX_VALUE
```

### Does this PR introduce _any_ user-facing change?
Yes, beeline is supposed to return row numbers > Integer.MAX_VALUE properly.

### How was this patch tested?
Not yet tested.
