### PR TITLE
HIVE-24548: CompactionHeartbeater leaks metastore connection

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -281,10 +281,11 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
     }
     @Override
     public void run() {
+      IMetaStoreClient msc = null;
       try {
         // We need to create our own metastore client since the thrifts clients
         // are not thread safe.
-        IMetaStoreClient msc = HiveMetaStoreUtils.getHiveMetastoreClient(conf);
+        msc = HiveMetaStoreUtils.getHiveMetastoreClient(conf);
         LOG.debug("Heartbeating compaction transaction id {} for table: {}", compactionTxn, tableName);
         while(!stop.get()) {
           msc.heartbeat(compactionTxn.getTxnId(), 0);
@@ -292,6 +293,10 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         }
       } catch (Exception e) {
         LOG.error("Error while heartbeating txn {} in {}, error: ", compactionTxn, Thread.currentThread().getName(), e.getMessage());
+      } finally {
+        if (msc != null) {
+          msc.close();
+        }
       }
     }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
Close metastore connection when CompactionHeartbeater is destoyed


### Why are the changes needed?



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?

