### PR TITLE
HIVE-24550: Cleanup only transaction information for the current DriverContext

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/TestHiveServer2Acid.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/TestHiveServer2Acid.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.jdbc.miniHS2;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.txn.TxnDbUtil;
+import org.apache.hadoop.hive.ql.exec.UDF;
+import org.apache.hive.jdbc.TestJdbcWithMiniHS2;
+import org.apache.hive.service.cli.CLIServiceClient;
+import org.apache.hive.service.cli.HiveSQLException;
+import org.apache.hive.service.cli.OperationHandle;
+import org.apache.hive.service.cli.OperationState;
+import org.apache.hive.service.cli.OperationStatus;
+import org.apache.hive.service.cli.RowSet;
+import org.apache.hive.service.cli.SessionHandle;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * End to end test with MiniHS2 with ACID enabled.
+ */
+public class TestHiveServer2Acid {
+
+  private static MiniHS2 miniHS2 = null;
+  private static Map<String, String> confOverlay = new HashMap<>();
+
+  @BeforeClass
+  public static void beforeTest() throws Exception {
+    HiveConf conf = new HiveConf();
+    TxnDbUtil.setConfValues(conf);
+    TxnDbUtil.prepDb(conf);
+    miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.TEZ);
+    confOverlay.put(ConfVars.HIVE_SERVER2_ENABLE_DOAS.varname, "false");
+    miniHS2.start(confOverlay);
+  }
+
+  @AfterClass
+  public static void afterTest() throws Exception {
+    miniHS2.stop();
+  }
+
+  public static class SleepMsUDF extends UDF {
+    public Integer evaluate(final Integer value, final Integer ms) {
+      try {
+        Thread.sleep(ms);
+      } catch (InterruptedException e) {
+        // No-op
+      }
+      return value;
+    }
+  }
+
+  /**
+   * Test overlapping async queries in one session.
+   * Since TxnManager is shared in the session this can cause all kind of trouble.
+   * @throws Exception ex
+   */
+  @Test
+  public void testAsyncConcurrent() throws Exception {
+    String tableName = "TestHiveServer2TestConnection";
+    CLIServiceClient serviceClient = miniHS2.getServiceClient();
+    SessionHandle sessHandle = serviceClient.openSession("foo", "bar");
+    serviceClient.executeStatement(sessHandle, "DROP TABLE IF EXISTS " + tableName, confOverlay);
+    serviceClient.executeStatement(sessHandle, "CREATE TABLE " + tableName + " (id INT)", confOverlay);
+    serviceClient.executeStatement(sessHandle, "insert into " + tableName + " values(5)", confOverlay);
+    OperationHandle opHandle =
+        serviceClient.executeStatementAsync(sessHandle, "select * from " + tableName, confOverlay);
+    assertOperationFinished(serviceClient, opHandle);
+    RowSet rowSet = serviceClient.fetchResults(opHandle);
+    serviceClient.executeStatement(sessHandle,
+        "create temporary function sleepMsUDF as '" + TestHiveServer2Acid.SleepMsUDF.class.getName() + "'",
+        confOverlay);
+    // Start a second "slow" query
+    OperationHandle opHandle2 = serviceClient
+        .executeStatementAsync(sessHandle, "select sleepMsUDF(id, 1000), id from " + tableName, confOverlay);
+    // Close the first operation (this will destroy the Driver and TxnManager)
+    serviceClient.closeOperation(opHandle);
+    assertEquals(1, rowSet.numRows());
+    assertOperationFinished(serviceClient, opHandle2);
+    rowSet = serviceClient.fetchResults(opHandle2);
+    assertEquals(1, rowSet.numRows());
+    serviceClient.executeStatement(sessHandle, "DROP TABLE IF EXISTS " + tableName, confOverlay);
+    serviceClient.closeSession(sessHandle);
+  }
+
+  private void assertOperationFinished(CLIServiceClient serviceClient, OperationHandle opHandle)
+      throws InterruptedException, HiveSQLException {
+    OperationState pStatus = OperationState.RUNNING;
+    for (int i = 0; i < 10; i++) {
+      Thread.sleep(100);
+      pStatus = serviceClient.getOperationStatus(opHandle, false).getState();
+      if (pStatus == OperationState.FINISHED) {
+        break;
+      }
+    }
+    assertEquals(OperationState.FINISHED, pStatus);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -881,7 +881,7 @@ public class Driver implements IDriver {
     } finally {
       driverState.unlock();
     }
-    driverTxnHandler.destroy();
+    driverTxnHandler.destroy(driverContext.getQueryState().getQueryId());
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -527,11 +527,15 @@ class DriverTxnHandler {
     release(!hiveLocks.isEmpty());
   }
 
-  void destroy() {
+  void destroy(String queryIdFromDriver) {
+    // We need cleanup transactions, even if we did not acquired locks yet
+    // However TxnManager is bound to session, so wee need to check if it is already handling a new query
     boolean isTxnOpen =
         driverContext != null &&
         driverContext.getTxnManager() != null &&
-        driverContext.getTxnManager().isTxnOpen();
+        driverContext.getTxnManager().isTxnOpen() &&
+        org.apache.commons.lang3.StringUtils.equals(queryIdFromDriver, driverContext.getTxnManager().getQueryid());
+
     release(!hiveLocks.isEmpty() || isTxnOpen);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -246,6 +246,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       tableWriteIds.clear();
       isExplicitTransaction = false;
       startTransactionCount = 0;
+      this.queryId = ctx.getConf().get(HiveConf.ConfVars.HIVEQUERYID.varname);
       LOG.info("Opened " + JavaUtils.txnIdToString(txnId));
       ctx.setHeartbeater(startHeartbeat(delay));
       return txnId;
@@ -481,6 +482,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     stmtId = -1;
     numStatements = 0;
     tableWriteIds.clear();
+    queryId = null;
   }
 
   @Override
@@ -1139,5 +1141,10 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
         }
       }
     }
+  }
+
+  @Override
+  public String getQueryid() {
+    return queryId;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
@@ -436,4 +436,9 @@ class DummyTxnManager extends HiveTxnManagerImpl {
     }
     return locks;
   }
+
+  @Override
+  public String getQueryid() {
+    return null;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
@@ -347,4 +347,10 @@ public interface HiveTxnManager {
       throws LockException;
 
  long getLatestTxnIdInConflict() throws LockException;
+
+ /**
+  * Return the queryId this txnManager is handling
+  * @return
+  */
+ String getQueryid();
 }


### PR DESCRIPTION


### What changes were proposed in this pull request?
Driver should only cleanup transactionmanager if it is still processing the same query.


### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit test.
