### PR TITLE
HIVE-24547: Fix acid_vectorization_original

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13070,7 +13070,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     for (ASTNode node : fieldDescList) {
       Map<ASTNode, String> map = translateFieldDesc(node);
       for (Entry<ASTNode, String> entry : map.entrySet()) {
-        unparseTranslator.addTranslation(entry.getKey(), entry.getValue());
+        unparseTranslator.addTranslation(entry.getKey(), entry.getValue().toLowerCase());
       }
     }
 

--- a/ql/src/test/queries/clientpositive/acid_vectorization_original.q
+++ b/ql/src/test/queries/clientpositive/acid_vectorization_original.q
@@ -1,4 +1,3 @@
---! qt:disabled:HIVE-24547
 set hive.mapred.mode=nonstrict;
 set hive.support.concurrency=true;
 set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;


### PR DESCRIPTION
### What changes were proposed in this pull request?
When collecting identifiers to expanded query text Convert replacement text to lower case when adding it to `UnparseTranslator`.

### Why are the changes needed?
Virtual column identifiers like `ROW__ID` are converted to lower case when added to `UnparseTranslator` except when the query contains joins.
```
select o1.ROW__ID r1, o1.* from over10k_orc o1 join over10k_orc o2
on o1.ROW__ID.rowid == o2.ROW__ID.rowid and o1.ROW__ID.writeid == o2.ROW__ID.writeid and o1.ROW__ID.bucketid == o2.ROW__ID.bucketid;

```

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=acid_vectorization_original.q -pl itests/qtest -Pitests
```