### PR TITLE
HIVE-24541: add config option for default storage handler class

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1992,8 +1992,9 @@ public class HiveConf extends Configuration {
         "created with format specified by hive.default.fileformat. Leaving this null will result in using hive.default.fileformat \n" +
         "for all tables."),
     HIVEDEFAULTSTORAGEHANDLER("hive.default.storage.handler.class", "",
-        "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... LOCATION ...' command will " +
-        "be equivalent to 'CREATE TABLE ... STORED BY [DEFAULT_HANDLER] LOCATION ...'. Users can explicitly override it by CREATE TABLE ... STORED BY [HANDLER]"),
+        "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... STORED AS ... LOCATION ...' command will " +
+        "be equivalent to 'CREATE TABLE ... STORED BY [default.storage.handler.class] LOCATION ...'. Any STORED AS clauses will be ignored, given that STORED BY and STORED AS are " +
+        "incompatible within the same command. Users can explicitly override the default class by issuing 'CREATE TABLE ... STORED BY [overriding.storage.handler.class] ...'"),
     HIVEQUERYRESULTFILEFORMAT("hive.query.result.fileformat", ResultFileFormat.SEQUENCEFILE.toString(),
         new StringSet(ResultFileFormat.getValidSet()),
         "Default file format for storing result of the query."),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1991,6 +1991,9 @@ public class HiveConf extends Configuration {
         "Default file format for CREATE TABLE statement applied to managed tables only. External tables will be \n" +
         "created with format specified by hive.default.fileformat. Leaving this null will result in using hive.default.fileformat \n" +
         "for all tables."),
+    HIVEDEFAULTSTORAGEHANDLER("hive.default.storage.handler.class", "",
+        "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... LOCATION ...' command will " +
+        "be equivalent to 'CREATE TABLE ... STORED BY [DEFAULT_HANDLER] LOCATION ...'. Users can explicitly override it by CREATE TABLE ... STORED BY [HANDLER]"),
     HIVEQUERYRESULTFILEFORMAT("hive.query.result.fileformat", ResultFileFormat.SEQUENCEFILE.toString(),
         new StringSet(ResultFileFormat.getValidSet()),
         "Default file format for storing result of the query."),

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1991,7 +1991,7 @@ public class HiveConf extends Configuration {
         "Default file format for CREATE TABLE statement applied to managed tables only. External tables will be \n" +
         "created with format specified by hive.default.fileformat. Leaving this null will result in using hive.default.fileformat \n" +
         "for all tables."),
-    HIVEDEFAULTSTORAGEHANDLER("hive.default.storage.handler.class", "",
+    HIVE_DEFAULT_STORAGE_HANDLER("hive.default.storage.handler.class", "",
         "Default storage handler class for CREATE TABLE statements. If this is set to a valid class, a 'CREATE TABLE ... STORED AS ... LOCATION ...' command will " +
         "be equivalent to 'CREATE TABLE ... STORED BY [default.storage.handler.class] LOCATION ...'. Any STORED AS clauses will be ignored, given that STORED BY and STORED AS are " +
         "incompatible within the same command. Users can explicitly override the default class by issuing 'CREATE TABLE ... STORED BY [overriding.storage.handler.class] ...'"),

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -208,6 +208,7 @@ mr.query.files=\
   bucketmapjoin_negative2.q,\
   bucketmapjoin_negative3.q,\
   cbo_rp_auto_join1.q,\
+  default_storage_handler.q,\
   explain_rearrange.q,\
   f_is_null.q,\
   hook_context_cs.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13391,6 +13391,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // set storage handler if default handler is provided in config
     String defaultStorageHandler = HiveConf.getVar(conf, HIVEDEFAULTSTORAGEHANDLER);
     if (defaultStorageHandler != null && !defaultStorageHandler.isEmpty()) {
+      LOG.info("Default storage handler class detected in config. Using storage handler class if exists: '{}'",
+          defaultStorageHandler);
       storageFormat.setStorageHandler(defaultStorageHandler);
       isUserStorageFormat = true;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.parse;
 
 import static java.util.Objects.nonNull;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONCONVERT;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEDEFAULTSTORAGEHANDLER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVESTATSDBCLASS;
 import static org.apache.hadoop.hive.ql.optimizer.calcite.translator.ASTConverter.NON_FK_FILTERED;
 
@@ -13386,6 +13387,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     LOG.info("Creating table " + dbDotTab + " position=" + ast.getCharPositionInLine());
     int numCh = ast.getChildCount();
+
+    // set storage handler if default handler is provided in config
+    String defaultStorageHandler = HiveConf.getVar(conf, HIVEDEFAULTSTORAGEHANDLER);
+    if (defaultStorageHandler != null && !defaultStorageHandler.isEmpty()) {
+      storageFormat.setStorageHandler(defaultStorageHandler);
+      isUserStorageFormat = true;
+    }
 
     /*
      * Check the 1st-level children and do simple semantic checks: 1) CTLT and

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hive.ql.parse;
 
 import static java.util.Objects.nonNull;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.DYNAMICPARTITIONCONVERT;
-import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVEDEFAULTSTORAGEHANDLER;
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_DEFAULT_STORAGE_HANDLER;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVESTATSDBCLASS;
 import static org.apache.hadoop.hive.ql.optimizer.calcite.translator.ASTConverter.NON_FK_FILTERED;
 
@@ -13389,7 +13389,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     int numCh = ast.getChildCount();
 
     // set storage handler if default handler is provided in config
-    String defaultStorageHandler = HiveConf.getVar(conf, HIVEDEFAULTSTORAGEHANDLER);
+    String defaultStorageHandler = HiveConf.getVar(conf, HIVE_DEFAULT_STORAGE_HANDLER);
     if (defaultStorageHandler != null && !defaultStorageHandler.isEmpty()) {
       LOG.info("Default storage handler class detected in config. Using storage handler class if exists: '{}'",
           defaultStorageHandler);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -69,6 +69,11 @@ public class StorageFormat {
       }
       break;
     case HiveParser.TOK_FILEFORMAT_GENERIC:
+      if (storageHandler != null) {
+        // We can get here if a default storage handler is set in the config, but the DDL contains a STORED AS clause.
+        // In this case, we opt to ignore the STORED AS.
+        break;
+      }
       ASTNode grandChild = (ASTNode)child.getChild(0);
       String name = (grandChild == null ? "" : grandChild.getText()).trim().toUpperCase();
       processStorageFormat(name);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -27,9 +27,14 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.StorageFormatDescriptor;
 import org.apache.hadoop.hive.ql.io.StorageFormatFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class StorageFormat {
+
+  private static final Logger LOG = LoggerFactory.getLogger(StorageFormat.class);
   private static final StorageFormatFactory storageFormatFactory = new StorageFormatFactory();
+
   private final Configuration conf;
   private String inputFormat;
   private String outputFormat;
@@ -73,6 +78,8 @@ public class StorageFormat {
         // Under normal circumstances, we should not get here (since STORED BY and STORED AS are incompatible within the
         // same command). Only scenario we can end up here is if a default storage handler class is set in the config.
         // In this case, we opt to ignore the STORED AS clause.
+        LOG.info("'STORED AS' clause will be ignored, since a default storage handler class is already set: '{}'",
+            storageHandler);
         break;
       }
       ASTNode grandChild = (ASTNode)child.getChild(0);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -157,4 +157,8 @@ public class StorageFormat {
   public Map<String, String> getSerdeProps() {
     return serdeProps;
   }
+
+  public void setStorageHandler(String storageHandlerClass) throws SemanticException {
+    storageHandler = ensureClassExists(storageHandlerClass);
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -70,8 +70,9 @@ public class StorageFormat {
       break;
     case HiveParser.TOK_FILEFORMAT_GENERIC:
       if (storageHandler != null) {
-        // We can get here if a default storage handler is set in the config, but the DDL contains a STORED AS clause.
-        // In this case, we opt to ignore the STORED AS.
+        // Under normal circumstances, we should not get here (since STORED BY and STORED AS are incompatible within the
+        // same command). Only scenario we can end up here is if a default storage handler class is set in the config.
+        // In this case, we opt to ignore the STORED AS clause.
         break;
       }
       ASTNode grandChild = (ASTNode)child.getChild(0);

--- a/ql/src/test/queries/clientpositive/default_storage_handler.q
+++ b/ql/src/test/queries/clientpositive/default_storage_handler.q
@@ -1,0 +1,25 @@
+-- Set a default storage handler class
+SET hive.default.storage.handler.class=org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler;
+
+CREATE EXTERNAL TABLE test_tbl_with_default(a string, b int);
+
+DESCRIBE FORMATTED test_tbl_with_default;
+
+-- Default storage handler is set, but overridden explicitly in the create table command
+SET hive.default.storage.handler.class=org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler;
+
+CREATE EXTERNAL TABLE test_tbl_overridden(DB_ID bigint, NAME STRING)
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+"hive.sql.database.type" = "METASTORE",
+"hive.sql.query" = "SELECT DB_ID, NAME FROM DBS"
+);
+
+DESCRIBE FORMATTED test_tbl_overridden;
+
+-- Unset default storage handler prop
+SET hive.default.storage.handler.class=;
+
+CREATE EXTERNAL TABLE test_tbl_no_default(a string, b int) STORED AS ORC;
+
+DESCRIBE FORMATTED test_tbl_no_default;

--- a/ql/src/test/queries/clientpositive/default_storage_handler.q
+++ b/ql/src/test/queries/clientpositive/default_storage_handler.q
@@ -5,6 +5,14 @@ CREATE EXTERNAL TABLE test_tbl_with_default(a string, b int);
 
 DESCRIBE FORMATTED test_tbl_with_default;
 
+-- Set a default storage handler class,
+-- create table command contains a STORED AS clause to be ignored
+SET hive.default.storage.handler.class=org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler;
+
+CREATE EXTERNAL TABLE test_tbl_with_default_orc(a string, b int) STORED AS ORC;
+
+DESCRIBE FORMATTED test_tbl_with_default_orc;
+
 -- Default storage handler is set, but overridden explicitly in the create table command
 SET hive.default.storage.handler.class=org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler;
 

--- a/ql/src/test/results/clientpositive/default_storage_handler.q.out
+++ b/ql/src/test/results/clientpositive/default_storage_handler.q.out
@@ -52,6 +52,60 @@ Bucket Columns:     	[]
 Sort Columns:       	[]                  	 
 Storage Desc Params:	 	 
 	serialization.format	1                   
+PREHOOK: query: CREATE EXTERNAL TABLE test_tbl_with_default_orc(a string, b int) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_tbl_with_default_orc
+POSTHOOK: query: CREATE EXTERNAL TABLE test_tbl_with_default_orc(a string, b int) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_tbl_with_default_orc
+PREHOOK: query: DESCRIBE FORMATTED test_tbl_with_default_orc
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_tbl_with_default_orc
+POSTHOOK: query: DESCRIBE FORMATTED test_tbl_with_default_orc
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_tbl_with_default_orc
+# col_name            	data_type           	comment             
+facility            	string              	from deserializer   
+severity            	string              	from deserializer   
+version             	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+hostname            	string              	from deserializer   
+app_name            	string              	from deserializer   
+proc_id             	string              	from deserializer   
+msg_id              	string              	from deserializer   
+structured_data     	map<string,string>  	from deserializer   
+msg                 	binary              	from deserializer   
+unmatched           	binary              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"app_name\":\"true\",\"facility\":\"true\",\"hostname\":\"true\",\"msg\":\"true\",\"msg_id\":\"true\",\"proc_id\":\"true\",\"severity\":\"true\",\"structured_data\":\"true\",\"ts\":\"true\",\"unmatched\":\"true\",\"version\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	storage_handler     	org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.log.syslog.SyslogSerDe	 
+InputFormat:        	null                	 
+OutputFormat:       	null                	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
 PREHOOK: query: CREATE EXTERNAL TABLE test_tbl_overridden(DB_ID bigint, NAME STRING)
 STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
 TBLPROPERTIES (

--- a/ql/src/test/results/clientpositive/default_storage_handler.q.out
+++ b/ql/src/test/results/clientpositive/default_storage_handler.q.out
@@ -1,0 +1,155 @@
+PREHOOK: query: CREATE EXTERNAL TABLE test_tbl_with_default(a string, b int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_tbl_with_default
+POSTHOOK: query: CREATE EXTERNAL TABLE test_tbl_with_default(a string, b int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_tbl_with_default
+PREHOOK: query: DESCRIBE FORMATTED test_tbl_with_default
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_tbl_with_default
+POSTHOOK: query: DESCRIBE FORMATTED test_tbl_with_default
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_tbl_with_default
+# col_name            	data_type           	comment             
+facility            	string              	from deserializer   
+severity            	string              	from deserializer   
+version             	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+hostname            	string              	from deserializer   
+app_name            	string              	from deserializer   
+proc_id             	string              	from deserializer   
+msg_id              	string              	from deserializer   
+structured_data     	map<string,string>  	from deserializer   
+msg                 	binary              	from deserializer   
+unmatched           	binary              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"app_name\":\"true\",\"facility\":\"true\",\"hostname\":\"true\",\"msg\":\"true\",\"msg_id\":\"true\",\"proc_id\":\"true\",\"severity\":\"true\",\"structured_data\":\"true\",\"ts\":\"true\",\"unmatched\":\"true\",\"version\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	storage_handler     	org.apache.hadoop.hive.ql.log.syslog.SyslogStorageHandler
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.log.syslog.SyslogSerDe	 
+InputFormat:        	null                	 
+OutputFormat:       	null                	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: CREATE EXTERNAL TABLE test_tbl_overridden(DB_ID bigint, NAME STRING)
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+"hive.sql.database.type" = "METASTORE",
+"hive.sql.query" = "SELECT DB_ID, NAME FROM DBS"
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_tbl_overridden
+POSTHOOK: query: CREATE EXTERNAL TABLE test_tbl_overridden(DB_ID bigint, NAME STRING)
+STORED BY 'org.apache.hive.storage.jdbc.JdbcStorageHandler'
+TBLPROPERTIES (
+"hive.sql.database.type" = "METASTORE",
+"hive.sql.query" = "SELECT DB_ID, NAME FROM DBS"
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_tbl_overridden
+PREHOOK: query: DESCRIBE FORMATTED test_tbl_overridden
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_tbl_overridden
+POSTHOOK: query: DESCRIBE FORMATTED test_tbl_overridden
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_tbl_overridden
+# col_name            	data_type           	comment             
+db_id               	bigint              	from deserializer   
+name                	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"db_id\":\"true\",\"name\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	hive.sql.database.type	METASTORE           
+	hive.sql.query      	SELECT DB_ID, NAME FROM DBS
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	storage_handler     	org.apache.hive.storage.jdbc.JdbcStorageHandler
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hive.storage.jdbc.JdbcSerDe	 
+InputFormat:        	null                	 
+OutputFormat:       	null                	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: CREATE EXTERNAL TABLE test_tbl_no_default(a string, b int) STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_tbl_no_default
+POSTHOOK: query: CREATE EXTERNAL TABLE test_tbl_no_default(a string, b int) STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_tbl_no_default
+PREHOOK: query: DESCRIBE FORMATTED test_tbl_no_default
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_tbl_no_default
+POSTHOOK: query: DESCRIBE FORMATTED test_tbl_no_default
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_tbl_no_default
+# col_name            	data_type           	comment             
+a                   	string              	                    
+b                   	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"a\":\"true\",\"b\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	totalSize           	0                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.ql.io.orc.OrcSerde	 
+InputFormat:        	org.apache.hadoop.hive.ql.io.orc.OrcInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new config option to set a default storage handler class. If this config is set to a valid, existing class, the storage handler class won't have to be explicitly provided in the create table statement with the `STORED BY `clause, but will be 'inserted' under the hood.

For example, if `hive.default.storage.handler.class=org.apache.iceberg.mr.hive.HiveIcebergStorageHandler` is set,
then the command `CREATE TABLE abc (a int, b string) LOCATION ...` will be equivalent to 
`CREATE TABLE abc (a int, b string) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' LOCATION ...`

### Why are the changes needed?
In order to use existing create table commands for new table formats, such as Iceberg, without modification.

### Does this PR introduce _any_ user-facing change?
new config option settable via beeline/hive-site

### How was this patch tested?
q tests + manually with local run
