### PR TITLE
HIVE-24552: Possible HMS connections leak or accumulation in loadDyna…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2942,6 +2942,9 @@ private void constructOneLBLocationMap(FileStatus fSta,
                   + " isAcid=" + isAcid + ", "
                   + " resetStatistics=" + resetStatistics, e);
           throw e;
+        } finally {
+          // get(conf).getMSC can be called in this task, Close the HMS connection right after use, do not wait for finalizer to close it.
+          closeCurrent();
         }
       });
     }


### PR DESCRIPTION
…micPartitions

Close the HMS connection in the tasks of loadDynamicPartitions. Not wait for finalizer to close it.
In the task, there is a possible calling path:
loadPartitionInternal->addWriteNotificationLog->addWriteNotificationLog(6 params)->get(conf).getSynchronizedMSC()....
This get(conf) will create a threadlocal object Hive, and getSynch... will create a metastore connection for it.
Need to close this connection before this task returns. 

### Why are the changes needed?
To fix too many opened connections issue.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Run related to load dynamic partitions unit tests. 