### PR TITLE
HIVE-24556: Optimize DefaultGraphWalker for case with no grandchild

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultGraphWalker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lib/DefaultGraphWalker.java
@@ -164,9 +164,20 @@ public class DefaultGraphWalker implements SemanticGraphWalker {
 
       // Add a single child and restart the loop
       for (Node childNode : node.getChildren()) {
-        if (!getDispatchedList().contains(childNode)) {
-          opStack.push(childNode);
+        // skip if already dispatched
+        if (getDispatchedList().contains(childNode)) {
+          continue;
+        }
+
+        boolean hasChildren = childNode.getChildren() != null;
+        opStack.push(childNode);
+        if (hasChildren) {
+          // exit loop to process child's children
           break;
+        } else { // no children - safe to dispatch in-line
+          dispatch(childNode, opStack);
+          opQueue.add(childNode);
+          opStack.pop();
         }
       }
     } // end while


### PR DESCRIPTION
Change-Id: I9390db2b356b7f36f906b2ab3214e4975984108a

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request? Add an optimization to DefaultGraphWalker for when node has no grandchildren. This helps in cases such as a large IN clause with constant strings - otherwise it would ping pong back and forth between the top loop and the children loop (each time re-iterating the children to find a new unprocessed one). There is likely other opportunities for optimization here but this is enough for my case and I hesitate including other possible fixes without a use case or need (especially since this code is well used). 
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed? Large IN clause case compilation went from 30 minutes to under 10 seconds.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change? Better perf?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
