### PR TITLE
HIVE-24562: Deflake TestHivePrivilegeObjectOwnerNameAndType

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/security/authorization/plugin/TestHivePrivilegeObjectOwnerNameAndType.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
 import org.apache.hadoop.hive.ql.security.HiveAuthenticationProvider;
@@ -77,6 +78,7 @@ public class TestHivePrivilegeObjectOwnerNameAndType {
     conf.setVar(ConfVars.HIVE_TXN_MANAGER, DbTxnManager.class.getName());
     conf.setVar(ConfVars.HIVEMAPREDMODE, "nonstrict");
 
+    TestTxnDbUtil.prepDb(conf);
     SessionState.start(conf);
     driver = new Driver(conf);
     runCmd("create table " + TABLE_NAME + " (i int, j int, k string) partitioned by (city string, `date` string) ");


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change modifies the test TestHivePrivilegeObjectOwnerNameAndType in the hope that it will reduce the intermittent failures that I saw on my unrelated PR. The full trace of the failure is available in the JIRA.

### Why are the changes needed?
Deflake the test.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the modified test locally.