### PR TITLE
HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2462,9 +2462,9 @@ public class HiveConf extends Configuration {
     HIVEPPDRECOGNIZETRANSITIVITY("hive.ppd.recognizetransivity", true,
         "Whether to transitively replicate predicate filters over equijoin conditions."),
     HIVEPPD_RECOGNIZE_COLUMN_EQUALITIES("hive.ppd.recognize.column.equalities", true,
-        "When hive.ppd.recognizetransivity is true Whether traverse join branches to discover equal columns based" +
-                " on equijoin keys and try to substitute equal columns to predicates " +
-                "and push down to the other branch."),
+        "Whether we should traverse the join branches to discover transitive propagation opportunities over" +
+                " equijoin conditions. \n" +
+                "Requires hive.ppd.recognizetransivity to be set to true."),
     HIVEPPDREMOVEDUPLICATEFILTERS("hive.ppd.remove.duplicatefilters", true,
         "During query optimization, filters may be pushed down in the operator tree. \n" +
         "If this config is true only pushed down filters remain in the operator tree, \n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2461,6 +2461,10 @@ public class HiveConf extends Configuration {
         "Whether to enable predicate pushdown through windowing"),
     HIVEPPDRECOGNIZETRANSITIVITY("hive.ppd.recognizetransivity", true,
         "Whether to transitively replicate predicate filters over equijoin conditions."),
+    HIVEPPD_RECOGNIZE_COLUMN_EQUALITIES("hive.ppd.recognize.column.equalities", true,
+        "When hive.ppd.recognizetransivity is true Whether traverse join branches to discover equal columns based" +
+                " on equijoin keys and try to substitute equal columns to predicates " +
+                "and push down to the other branch."),
     HIVEPPDREMOVEDUPLICATEFILTERS("hive.ppd.remove.duplicatefilters", true,
         "During query optimization, filters may be pushed down in the operator tree. \n" +
         "If this config is true only pushed down filters remain in the operator tree, \n" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -699,6 +699,8 @@ public final class OpProcFactory {
       List<ExprNodeDesc> targetKeys = target.getConf().getKeyCols();
 
       ExprWalkerInfo rsPreds = owi.getPrunedPreds(target);
+      boolean recogniseColumnEqualities = HiveConf.getBoolVar(owi.getParseContext().getConf(),
+              HiveConf.ConfVars.HIVEPPD_RECOGNIZE_COLUMN_EQUALITIES);
       for (int sourcePos = 0; sourcePos < parentOperators.size(); sourcePos++) {
         ReduceSinkOperator source = (ReduceSinkOperator) parentOperators.get(sourcePos);
         List<ExprNodeDesc> sourceKeys = source.getConf().getKeyCols();
@@ -716,8 +718,7 @@ public final class OpProcFactory {
           }
 
           Set<ExprNodeColumnDesc> columnsInPredicates = null;
-          if (HiveConf.getBoolVar(owi.getParseContext().getConf(),
-                  HiveConf.ConfVars.HIVEPPD_RECOGNIZE_COLUMN_EQUALITIES)) {
+          if (recogniseColumnEqualities) {
             columnsInPredicates = owi.getColumnsInPredicates().get(source);
             if (columnsInPredicates == null) {
               columnsInPredicates = collectColumnsInPredicates(entry.getValue());
@@ -732,8 +733,7 @@ public final class OpProcFactory {
             }
             ExprNodeDesc replaced = ExprNodeDescUtils.replace(backtrack, sourceKeys, targetKeys);
             if (replaced == null) {
-              if (!HiveConf.getBoolVar(owi.getParseContext().getConf(),
-                      HiveConf.ConfVars.HIVEPPD_RECOGNIZE_COLUMN_EQUALITIES)) {
+              if (!recogniseColumnEqualities) {
                 continue;
               }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -768,21 +768,9 @@ public final class OpProcFactory {
       Set<ExprNodeColumnDesc> columnsInPredicates;
       columnsInPredicates = new HashSet<>();
       for (ExprNodeDesc predicate : predicates) {
-        extractColumnExprNodes(predicate, columnsInPredicates);
+        columnsInPredicates.addAll(ExprNodeDescUtils.findAllColumnDescs(predicate));
       }
       return columnsInPredicates;
-    }
-
-    private void extractColumnExprNodes(ExprNodeDesc exprNodeDesc, Set<ExprNodeColumnDesc> result) {
-      if (exprNodeDesc instanceof ExprNodeColumnDesc) {
-        result.add((ExprNodeColumnDesc) exprNodeDesc);
-        return;
-      }
-      if (exprNodeDesc instanceof ExprNodeGenericFuncDesc) {
-        for (ExprNodeDesc child : exprNodeDesc.getChildren()) {
-          extractColumnExprNodes(child, result);
-        }
-      }
     }
 
     private Map<ExprNodeDesc, ExprNodeDesc> searchForEqualities(

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -853,6 +853,7 @@ public final class OpProcFactory {
       }
 
       Map<String, ExprNodeDesc> columnExprMap = operator.getColumnExprMap();
+      // Some operators do not have columnExprMap. Example: FilterOperator.
       if (columnExprMap == null) {
         if (operator.getParentOperators().size() == 1) {
           return searchForEqualities(operator.getParentOperators().get(0), exprNodeDescList);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -811,7 +811,8 @@ public final class OpProcFactory {
       return replaceMap;
     }
 
-    private Map<ExprNodeDesc, String> searchForEqualities(Operator<?> operator, Set<ExprNodeColumnDesc> exprNodeDescSet) {
+    private Map<ExprNodeDesc, String> searchForEqualities(
+            Operator<?> operator, Set<ExprNodeColumnDesc> exprNodeDescSet) {
       if (exprNodeDescSet.isEmpty()) {
         return Collections.emptyMap();
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpProcFactory.java
@@ -733,6 +733,9 @@ public final class OpProcFactory {
                 equalities = searchForEqualities(join, sourcePos, source, columnsInPredicates);
                 owi.getEqualities().put(source, equalities);
               }
+              if (equalities.isEmpty()) {
+                continue;
+              }
 
               ExprNodeDesc newPredicate = replaceColumnExprNodes(predicate, equalities);
               backtrack = ExprNodeDescUtils.backtrack(newPredicate, join, source);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpWalkerInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpWalkerInfo.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.hive.ql.ppd;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
+import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 
 /**
@@ -39,11 +43,15 @@ public class OpWalkerInfo implements NodeProcessorCtx {
     opToPushdownPredMap;
   private final ParseContext pGraphContext;
   private final List<FilterOperator> candidateFilterOps;
+  private final Map<Operator<?>, Set<ExprNodeColumnDesc>> columnsInPredicates;
+  private final Map<Operator<?>, Map<ExprNodeDesc, ExprNodeDesc>> equalities;
 
   public OpWalkerInfo(ParseContext pGraphContext) {
     this.pGraphContext = pGraphContext;
     opToPushdownPredMap = new HashMap<Operator<? extends OperatorDesc>, ExprWalkerInfo>();
     candidateFilterOps = new ArrayList<FilterOperator>();
+    columnsInPredicates = new HashMap<>();
+    equalities = new HashMap<>();
   }
 
   public ExprWalkerInfo getPrunedPreds(Operator<? extends OperatorDesc> op) {
@@ -67,4 +75,11 @@ public class OpWalkerInfo implements NodeProcessorCtx {
     candidateFilterOps.add(fop);
   }
 
+  public Map<Operator<?>, Set<ExprNodeColumnDesc>> getColumnsInPredicates() {
+    return columnsInPredicates;
+  }
+
+  public Map<Operator<?>, Map<ExprNodeDesc, ExprNodeDesc>> getEqualities() {
+    return equalities;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpWalkerInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ppd/OpWalkerInfo.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.hadoop.hive.ql.exec.FilterOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
@@ -43,8 +44,12 @@ public class OpWalkerInfo implements NodeProcessorCtx {
     opToPushdownPredMap;
   private final ParseContext pGraphContext;
   private final List<FilterOperator> candidateFilterOps;
-  private final Map<Operator<?>, Set<ExprNodeColumnDesc>> columnsInPredicates;
-  private final Map<Operator<?>, Map<ExprNodeDesc, ExprNodeDesc>> equalities;
+  // The following two maps required for traversing join branches to discover transitive propagation opportunities
+  // over equijoin conditions:
+  // Contains column expression desc referenced in all predicates associated to ReduceSink operators.
+  private final Map<ReduceSinkOperator, Set<ExprNodeColumnDesc>> columnsInPredicates;
+  // Contains equal column pairs in ReduceSinkOperator row schema.
+  private final Map<ReduceSinkOperator, Map<ExprNodeDesc, ExprNodeDesc>> equalities;
 
   public OpWalkerInfo(ParseContext pGraphContext) {
     this.pGraphContext = pGraphContext;
@@ -75,11 +80,11 @@ public class OpWalkerInfo implements NodeProcessorCtx {
     candidateFilterOps.add(fop);
   }
 
-  public Map<Operator<?>, Set<ExprNodeColumnDesc>> getColumnsInPredicates() {
+  public Map<ReduceSinkOperator, Set<ExprNodeColumnDesc>> getColumnsInPredicates() {
     return columnsInPredicates;
   }
 
-  public Map<Operator<?>, Map<ExprNodeDesc, ExprNodeDesc>> getEqualities() {
+  public Map<ReduceSinkOperator, Map<ExprNodeDesc, ExprNodeDesc>> getEqualities() {
     return equalities;
   }
 }

--- a/ql/src/test/results/clientpositive/llap/dynamic_partition_join_noncbo.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_partition_join_noncbo.q.out
@@ -1055,10 +1055,10 @@ STAGE PLANS:
                     predicate: pli is not null (type: boolean)
                     Statistics: Num rows: 15390381 Data size: 116471238533 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
-                      key expressions: pli (type: bigint), p1 (type: string)
+                      key expressions: pli (type: bigint), 'P30' (type: string)
                       null sort order: zz
                       sort order: ++
-                      Map-reduce partition columns: pli (type: bigint), p1 (type: string)
+                      Map-reduce partition columns: pli (type: bigint), 'P30' (type: string)
                       Statistics: Num rows: 15390381 Data size: 116471238533 Basic stats: COMPLETE Column stats: NONE
                       value expressions: dtpi (type: bigint)
             Execution mode: vectorized, llap

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
@@ -1600,13 +1600,8 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
-<<<<<<< HEAD
                           1 Reducer 5
-                        Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                          1 Map 4
                         Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1615,13 +1610,8 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
-<<<<<<< HEAD
                             1 Map 6
-                          Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                            1 Map 5
                           Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1629,13 +1619,8 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
-<<<<<<< HEAD
                               1 Map 4
-                            Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                              1 Map 6
                             Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1653,11 +1638,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
-<<<<<<< HEAD
-                  filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
-=======
-                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
->>>>>>> update q test
+                  filterExpr: (((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
@@ -1667,19 +1648,7 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-<<<<<<< HEAD
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                       Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: z2
-                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1734,7 +1703,7 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: key (type: string)
-                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -1872,13 +1841,8 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
-<<<<<<< HEAD
                           1 Reducer 5
-                        Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                          1 Map 4
                         Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1887,13 +1851,8 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
-<<<<<<< HEAD
                             1 Map 6
-                          Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                            1 Map 5
                           Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1901,13 +1860,8 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
-<<<<<<< HEAD
                               1 Map 4
-                            Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                              1 Map 6
                             Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1925,11 +1879,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
-<<<<<<< HEAD
-                  filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
-=======
-                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
->>>>>>> update q test
+                  filterExpr: (((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
@@ -1939,19 +1889,7 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-<<<<<<< HEAD
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                       Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: z2
-                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2006,7 +1944,7 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: key (type: string)
-                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/hybridgrace_hashjoin_2.q.out
@@ -1559,10 +1559,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                  filterExpr: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    predicate: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 350 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
@@ -1600,8 +1600,13 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
+<<<<<<< HEAD
                           1 Reducer 5
                         Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                          1 Map 4
+                        Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1610,8 +1615,13 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
+<<<<<<< HEAD
                             1 Map 6
                           Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                            1 Map 5
+                          Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1619,8 +1629,13 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
+<<<<<<< HEAD
                               1 Map 4
                             Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                              1 Map 6
+                            Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1638,17 +1653,33 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
+<<<<<<< HEAD
                   filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
+=======
+                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+>>>>>>> update q test
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (key is not null and (value < 'zzzzzzzz')) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
+<<<<<<< HEAD
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: z2
+                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1800,10 +1831,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                  filterExpr: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    predicate: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 350 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
@@ -1841,8 +1872,13 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
+<<<<<<< HEAD
                           1 Reducer 5
                         Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                          1 Map 4
+                        Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1851,8 +1887,13 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
+<<<<<<< HEAD
                             1 Map 6
                           Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                            1 Map 5
+                          Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1860,8 +1901,13 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
+<<<<<<< HEAD
                               1 Map 4
                             Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                              1 Map 6
+                            Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1879,17 +1925,33 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
+<<<<<<< HEAD
                   filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
+=======
+                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+>>>>>>> update q test
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (key is not null and (value < 'zzzzzzzz')) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
+<<<<<<< HEAD
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: z2
+                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query17.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query17.q.out
@@ -22,10 +22,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
-                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
+                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[198]_col0) AND DynamicValue(RS[198]_col1) and cs_item_sk BETWEEN DynamicValue(RS[198]_col2) AND DynamicValue(RS[198]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[198]_col4))) (type: boolean)
                   Statistics: Num rows: 43005109025 Data size: 1202866239204 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
+                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[198]_col0) AND DynamicValue(RS[198]_col1) and cs_item_sk BETWEEN DynamicValue(RS[198]_col2) AND DynamicValue(RS[198]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[198]_col4))) (type: boolean)
                     Statistics: Num rows: 42899393143 Data size: 1199909333196 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: cs_bill_customer_sk (type: bigint), cs_item_sk (type: bigint), cs_quantity (type: int), cs_sold_date_sk (type: bigint)
@@ -168,10 +168,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 3591605541540 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[208]_col0) AND DynamicValue(RS[208]_col1) and ss_item_sk BETWEEN DynamicValue(RS[208]_col2) AND DynamicValue(RS[208]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[208]_col4) AND DynamicValue(RS[208]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[208]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 3424422808632 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_quantity (type: int), ss_sold_date_sk (type: bigint)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query25.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query25.q.out
@@ -22,10 +22,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
-                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[196]_col0) AND DynamicValue(RS[196]_col1) and cs_item_sk BETWEEN DynamicValue(RS[196]_col2) AND DynamicValue(RS[196]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[196]_col4))) (type: boolean)
+                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
                   Statistics: Num rows: 43005109025 Data size: 5847849100352 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[196]_col0) AND DynamicValue(RS[196]_col1) and cs_item_sk BETWEEN DynamicValue(RS[196]_col2) AND DynamicValue(RS[196]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[196]_col4))) (type: boolean)
+                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
                     Statistics: Num rows: 42899393143 Data size: 5833473819384 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: cs_bill_customer_sk (type: bigint), cs_item_sk (type: bigint), cs_net_profit (type: decimal(7,2)), cs_sold_date_sk (type: bigint)
@@ -168,10 +168,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[206]_col0) AND DynamicValue(RS[206]_col1) and ss_item_sk BETWEEN DynamicValue(RS[206]_col2) AND DynamicValue(RS[206]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[206]_col4) AND DynamicValue(RS[206]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[206]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 12292602293640 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[206]_col0) AND DynamicValue(RS[206]_col1) and ss_item_sk BETWEEN DynamicValue(RS[206]_col2) AND DynamicValue(RS[206]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[206]_col4) AND DynamicValue(RS[206]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[206]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 11720403920960 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_net_profit (type: decimal(7,2)), ss_sold_date_sk (type: bigint)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query29.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query29.q.out
@@ -22,10 +22,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: catalog_sales
-                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[196]_col0) AND DynamicValue(RS[196]_col1) and cs_item_sk BETWEEN DynamicValue(RS[196]_col2) AND DynamicValue(RS[196]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[196]_col4))) (type: boolean)
+                  filterExpr: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
                   Statistics: Num rows: 43005109025 Data size: 1202866239204 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[196]_col0) AND DynamicValue(RS[196]_col1) and cs_item_sk BETWEEN DynamicValue(RS[196]_col2) AND DynamicValue(RS[196]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[196]_col4))) (type: boolean)
+                    predicate: (cs_bill_customer_sk is not null and cs_bill_customer_sk BETWEEN DynamicValue(RS[197]_col0) AND DynamicValue(RS[197]_col1) and cs_item_sk BETWEEN DynamicValue(RS[197]_col2) AND DynamicValue(RS[197]_col3) and in_bloom_filter(hash(cs_bill_customer_sk,cs_item_sk), DynamicValue(RS[197]_col4))) (type: boolean)
                     Statistics: Num rows: 42899393143 Data size: 1199909333196 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: cs_bill_customer_sk (type: bigint), cs_item_sk (type: bigint), cs_quantity (type: int), cs_sold_date_sk (type: bigint)
@@ -185,10 +185,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: store_sales
-                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[206]_col0) AND DynamicValue(RS[206]_col1) and ss_item_sk BETWEEN DynamicValue(RS[206]_col2) AND DynamicValue(RS[206]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[206]_col4) AND DynamicValue(RS[206]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[206]_col6))) (type: boolean)
+                  filterExpr: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                   Statistics: Num rows: 82510879939 Data size: 3591605541540 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[206]_col0) AND DynamicValue(RS[206]_col1) and ss_item_sk BETWEEN DynamicValue(RS[206]_col2) AND DynamicValue(RS[206]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[206]_col4) AND DynamicValue(RS[206]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[206]_col6))) (type: boolean)
+                    predicate: (ss_customer_sk is not null and ss_store_sk is not null and ss_customer_sk BETWEEN DynamicValue(RS[207]_col0) AND DynamicValue(RS[207]_col1) and ss_item_sk BETWEEN DynamicValue(RS[207]_col2) AND DynamicValue(RS[207]_col3) and ss_ticket_number BETWEEN DynamicValue(RS[207]_col4) AND DynamicValue(RS[207]_col5) and in_bloom_filter(hash(ss_customer_sk,ss_item_sk,ss_ticket_number), DynamicValue(RS[207]_col6))) (type: boolean)
                     Statistics: Num rows: 78670147920 Data size: 3424422808632 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ss_item_sk (type: bigint), ss_customer_sk (type: bigint), ss_store_sk (type: bigint), ss_ticket_number (type: bigint), ss_quantity (type: int), ss_sold_date_sk (type: bigint)

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
@@ -7,6 +7,7 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
+<<<<<<< HEAD
         Map 1 <- Map 10 (BROADCAST_EDGE), Map 11 (BROADCAST_EDGE), Map 9 (BROADCAST_EDGE)
         Map 12 <- Reducer 6 (BROADCAST_EDGE)
         Map 15 <- Reducer 6 (BROADCAST_EDGE)
@@ -19,12 +20,30 @@ STAGE PLANS:
         Reducer 6 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 7 <- Map 1 (SIMPLE_EDGE)
         Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
+=======
+        Map 1 <- Map 10 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Map 9 (BROADCAST_EDGE)
+        Map 11 <- Reducer 7 (BROADCAST_EDGE)
+        Map 13 <- Reducer 7 (BROADCAST_EDGE)
+        Map 14 <- Reducer 6 (BROADCAST_EDGE)
+        Map 17 <- Reducer 6 (BROADCAST_EDGE)
+        Reducer 12 <- Map 11 (CUSTOM_SIMPLE_EDGE), Map 13 (CUSTOM_SIMPLE_EDGE)
+        Reducer 15 <- Map 14 (CUSTOM_SIMPLE_EDGE), Map 17 (CUSTOM_SIMPLE_EDGE)
+        Reducer 16 <- Map 14 (CUSTOM_SIMPLE_EDGE), Reducer 15 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 12 (CUSTOM_SIMPLE_EDGE)
+        Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
+        Reducer 6 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
 #### A masked pattern was here ####
       Vertices:
         Map 1 
             Map Operator Tree:
                 TableScan
                   alias: ws1
+                  filterExpr: (ws_ship_addr_sk is not null and ws_web_site_sk is not null and ws_ship_date_sk is not null) (type: boolean)
+                  probeDecodeDetails: cacheKey:HASH_MAP_MAPJOIN_210_container, bigKeyColName:ws_web_site_sk, smallTablePos:1, keyRatio:2.7777730824410645E-10
                   Statistics: Num rows: 21600036511 Data size: 5528875272680 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: (ws_ship_addr_sk is not null and ws_web_site_sk is not null and ws_ship_date_sk is not null) (type: boolean)
@@ -41,7 +60,7 @@ STAGE PLANS:
                           1 _col0 (type: bigint)
                         outputColumnNames: _col0, _col2, _col3, _col4, _col5
                         input vertices:
-                          1 Map 9
+                          1 Map 8
                         Statistics: Num rows: 407242361 Data size: 100305764080 Basic stats: COMPLETE Column stats: COMPLETE
                         Map Join Operator
                           condition map:
@@ -51,7 +70,7 @@ STAGE PLANS:
                             1 _col0 (type: bigint)
                           outputColumnNames: _col0, _col3, _col4, _col5
                           input vertices:
-                            1 Map 10
+                            1 Map 9
                           Statistics: Num rows: 58177483 Data size: 13315405840 Basic stats: COMPLETE Column stats: COMPLETE
                           Map Join Operator
                             condition map:
@@ -61,7 +80,7 @@ STAGE PLANS:
                               1 _col0 (type: bigint)
                             outputColumnNames: _col3, _col4, _col5
                             input vertices:
-                              1 Map 11
+                              1 Map 10
                             Statistics: Num rows: 6463723 Data size: 895528872 Basic stats: COMPLETE Column stats: COMPLETE
                             Select Operator
                               expressions: _col3 (type: bigint), _col4 (type: decimal(7,2)), _col5 (type: decimal(7,2))
@@ -74,6 +93,7 @@ STAGE PLANS:
                                 Map-reduce partition columns: _col0 (type: bigint)
                                 Statistics: Num rows: 6463723 Data size: 895528872 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col1 (type: decimal(7,2)), _col2 (type: decimal(7,2))
+<<<<<<< HEAD
                   Select Operator
                     expressions: ws_warehouse_sk (type: bigint), ws_order_number (type: bigint)
                     outputColumnNames: _col0, _col1
@@ -99,30 +119,26 @@ STAGE PLANS:
                       Map-reduce partition columns: _col1 (type: bigint)
                       Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: bigint)
+=======
+                              Select Operator
+                                expressions: _col0 (type: bigint)
+                                outputColumnNames: _col0
+                                Statistics: Num rows: 6463723 Data size: 51709784 Basic stats: COMPLETE Column stats: COMPLETE
+                                Group By Operator
+                                  aggregations: min(_col0), max(_col0), bloom_filter(_col0, expectedEntries=1000000)
+                                  minReductionHashAggr: 0.99
+                                  mode: hash
+                                  outputColumnNames: _col0, _col1, _col2
+                                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                  Reduce Output Operator
+                                    null sort order: 
+                                    sort order: 
+                                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                    value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 10 
-            Map Operator Tree:
-                TableScan
-                  alias: web_site
-                  filterExpr: (web_company_name = 'pri                                               ') (type: boolean)
-                  Statistics: Num rows: 84 Data size: 8064 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (web_company_name = 'pri                                               ') (type: boolean)
-                    Statistics: Num rows: 12 Data size: 1152 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: web_site_sk (type: bigint)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: bigint)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 11 
             Map Operator Tree:
                 TableScan
                   alias: date_dim
@@ -143,9 +159,56 @@ STAGE PLANS:
                         Statistics: Num rows: 8116 Data size: 519424 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 12 
+        Map 11 
             Map Operator Tree:
                 TableScan
+                  alias: ws1
+                  filterExpr: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
+                  Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
+                    Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: ws_warehouse_sk (type: bigint), ws_order_number (type: bigint)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: bigint)
+                        Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 13 
+            Map Operator Tree:
+                TableScan
+<<<<<<< HEAD
+=======
+                  alias: ws2
+                  filterExpr: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
+                  Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
+                    Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: ws_warehouse_sk (type: bigint), ws_order_number (type: bigint)
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col1 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: bigint)
+                        Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 14 
+            Map Operator Tree:
+                TableScan
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
                   alias: ws1
                   filterExpr: (ws_order_number BETWEEN DynamicValue(RS_52_ws1_ws_order_number_min) AND DynamicValue(RS_52_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_52_ws1_ws_order_number_bloom_filter))) (type: boolean)
                   Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
@@ -163,9 +226,20 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: bigint)
                         Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
+                      Reduce Output Operator
+                        key expressions: _col1 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col1 (type: bigint)
+                        Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+<<<<<<< HEAD
         Map 15 
+=======
+        Map 17 
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Map Operator Tree:
                 TableScan
                   alias: web_returns
@@ -186,7 +260,7 @@ STAGE PLANS:
                         Statistics: Num rows: 2160007345 Data size: 17280058760 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-        Map 9 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: customer_address
@@ -207,7 +281,31 @@ STAGE PLANS:
                         Statistics: Num rows: 754717 Data size: 6037736 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
+<<<<<<< HEAD
         Reducer 13 
+=======
+        Map 9 
+            Map Operator Tree:
+                TableScan
+                  alias: web_site
+                  filterExpr: (web_company_name = 'pri                                               ') (type: boolean)
+                  Statistics: Num rows: 84 Data size: 8064 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (web_company_name = 'pri                                               ') (type: boolean)
+                    Statistics: Num rows: 12 Data size: 1152 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: web_site_sk (type: bigint)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: bigint)
+                        Statistics: Num rows: 12 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 12 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Map Join Operator
@@ -218,7 +316,45 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
+                  1 Map 13
+                Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
+                DynamicPartitionHashJoin: true
+                Filter Operator
+                  predicate: (_col0 <> _col2) (type: boolean)
+                  Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col1 (type: bigint)
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 258749294920 Data size: 2069994359360 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      keys: _col0 (type: bigint)
+                      minReductionHashAggr: 0.99
+                      mode: hash
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: bigint)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: bigint)
+                        Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 15 
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Map Join Operator
+                condition map:
+                     Inner Join 0 to 1
+                keys:
+                  0 KEY.reducesinkkey0 (type: bigint)
+                  1 KEY.reducesinkkey0 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2
+                input vertices:
+<<<<<<< HEAD
                   1 Map 15
+=======
+                  1 Map 17
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
                 Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Reduce Output Operator
@@ -228,7 +364,11 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: bigint)
                   Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col2 (type: bigint)
+<<<<<<< HEAD
         Reducer 14 
+=======
+        Reducer 16 
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Map Join Operator
@@ -239,7 +379,7 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col2, _col3
                 input vertices:
-                  1 Map 1
+                  1 Map 14
                 Statistics: Num rows: 309959254381 Data size: 7438935683304 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Filter Operator
@@ -272,7 +412,7 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
-                  1 Reducer 8
+                  1 Reducer 12
                 Statistics: Num rows: 6463723 Data size: 895528872 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Reduce Output Operator
@@ -381,6 +521,7 @@ STAGE PLANS:
                 expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1
                 Reduce Output Operator
+<<<<<<< HEAD
                   key expressions: _col1 (type: bigint)
                   null sort order: z
                   sort order: +
@@ -420,6 +561,17 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: _col0 (type: bigint)
                         Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+                Reduce Output Operator
+                  null sort order: 
+                  sort order: 
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+>>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
+++ b/ql/src/test/results/clientpositive/perf/tpcds30tb/tez/query95.q.out
@@ -7,35 +7,20 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-<<<<<<< HEAD
-        Map 1 <- Map 10 (BROADCAST_EDGE), Map 11 (BROADCAST_EDGE), Map 9 (BROADCAST_EDGE)
-        Map 12 <- Reducer 6 (BROADCAST_EDGE)
-        Map 15 <- Reducer 6 (BROADCAST_EDGE)
-        Reducer 13 <- Map 12 (CUSTOM_SIMPLE_EDGE), Map 15 (CUSTOM_SIMPLE_EDGE)
-        Reducer 14 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 13 (CUSTOM_SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 8 (CUSTOM_SIMPLE_EDGE)
-        Reducer 3 <- Reducer 14 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
-        Reducer 6 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
-        Reducer 7 <- Map 1 (SIMPLE_EDGE)
-        Reducer 8 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 7 (CUSTOM_SIMPLE_EDGE)
-=======
         Map 1 <- Map 10 (BROADCAST_EDGE), Map 8 (BROADCAST_EDGE), Map 9 (BROADCAST_EDGE)
         Map 11 <- Reducer 7 (BROADCAST_EDGE)
-        Map 13 <- Reducer 7 (BROADCAST_EDGE)
         Map 14 <- Reducer 6 (BROADCAST_EDGE)
         Map 17 <- Reducer 6 (BROADCAST_EDGE)
-        Reducer 12 <- Map 11 (CUSTOM_SIMPLE_EDGE), Map 13 (CUSTOM_SIMPLE_EDGE)
+        Reducer 12 <- Map 11 (SIMPLE_EDGE)
+        Reducer 13 <- Map 11 (CUSTOM_SIMPLE_EDGE), Reducer 12 (CUSTOM_SIMPLE_EDGE)
         Reducer 15 <- Map 14 (CUSTOM_SIMPLE_EDGE), Map 17 (CUSTOM_SIMPLE_EDGE)
         Reducer 16 <- Map 14 (CUSTOM_SIMPLE_EDGE), Reducer 15 (CUSTOM_SIMPLE_EDGE)
-        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 12 (CUSTOM_SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE), Reducer 13 (CUSTOM_SIMPLE_EDGE)
         Reducer 3 <- Reducer 16 (SIMPLE_EDGE), Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
         Reducer 7 <- Map 1 (CUSTOM_SIMPLE_EDGE)
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -93,33 +78,6 @@ STAGE PLANS:
                                 Map-reduce partition columns: _col0 (type: bigint)
                                 Statistics: Num rows: 6463723 Data size: 895528872 Basic stats: COMPLETE Column stats: COMPLETE
                                 value expressions: _col1 (type: decimal(7,2)), _col2 (type: decimal(7,2))
-<<<<<<< HEAD
-                  Select Operator
-                    expressions: ws_warehouse_sk (type: bigint), ws_order_number (type: bigint)
-                    outputColumnNames: _col0, _col1
-                    Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                    Reduce Output Operator
-                      key expressions: _col1 (type: bigint)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: bigint)
-                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-                    Reduce Output Operator
-                      key expressions: _col1 (type: bigint)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: bigint)
-                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-                    Reduce Output Operator
-                      key expressions: _col1 (type: bigint)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col1 (type: bigint)
-                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: _col0 (type: bigint)
-=======
                               Select Operator
                                 expressions: _col0 (type: bigint)
                                 outputColumnNames: _col0
@@ -135,7 +93,6 @@ STAGE PLANS:
                                     sort order: 
                                     Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                     value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Map 10 
@@ -179,23 +136,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col1 (type: bigint)
                         Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col0 (type: bigint)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Map 13 
-            Map Operator Tree:
-                TableScan
-<<<<<<< HEAD
-=======
-                  alias: ws2
-                  filterExpr: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
-                  Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: (ws_order_number BETWEEN DynamicValue(RS_47_ws1_ws_order_number_min) AND DynamicValue(RS_47_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_47_ws1_ws_order_number_bloom_filter))) (type: boolean)
-                    Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: ws_warehouse_sk (type: bigint), ws_order_number (type: bigint)
-                      outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: bigint)
                         null sort order: z
@@ -208,7 +148,6 @@ STAGE PLANS:
         Map 14 
             Map Operator Tree:
                 TableScan
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
                   alias: ws1
                   filterExpr: (ws_order_number BETWEEN DynamicValue(RS_52_ws1_ws_order_number_min) AND DynamicValue(RS_52_ws1_ws_order_number_max) and in_bloom_filter(ws_order_number, DynamicValue(RS_52_ws1_ws_order_number_bloom_filter))) (type: boolean)
                   Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
@@ -235,11 +174,7 @@ STAGE PLANS:
                         value expressions: _col0 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-<<<<<<< HEAD
-        Map 15 
-=======
         Map 17 
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Map Operator Tree:
                 TableScan
                   alias: web_returns
@@ -281,9 +216,6 @@ STAGE PLANS:
                         Statistics: Num rows: 754717 Data size: 6037736 Basic stats: COMPLETE Column stats: COMPLETE
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
-<<<<<<< HEAD
-        Reducer 13 
-=======
         Map 9 
             Map Operator Tree:
                 TableScan
@@ -308,6 +240,19 @@ STAGE PLANS:
         Reducer 12 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: bigint)
+                outputColumnNames: _col0, _col1
+                Reduce Output Operator
+                  key expressions: _col1 (type: bigint)
+                  null sort order: z
+                  sort order: +
+                  Map-reduce partition columns: _col1 (type: bigint)
+                  Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col0 (type: bigint)
+        Reducer 13 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
               Map Join Operator
                 condition map:
                      Inner Join 0 to 1
@@ -316,7 +261,7 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
-                  1 Map 13
+                  1 Map 11
                 Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Filter Operator
@@ -339,7 +284,6 @@ STAGE PLANS:
                         Map-reduce partition columns: _col0 (type: bigint)
                         Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
         Reducer 15 
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Map Join Operator
@@ -350,11 +294,7 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
-<<<<<<< HEAD
-                  1 Map 15
-=======
                   1 Map 17
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
                 Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Reduce Output Operator
@@ -364,11 +304,7 @@ STAGE PLANS:
                   Map-reduce partition columns: _col1 (type: bigint)
                   Statistics: Num rows: 25874973741 Data size: 620956158864 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col2 (type: bigint)
-<<<<<<< HEAD
-        Reducer 14 
-=======
         Reducer 16 
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Map Join Operator
@@ -412,7 +348,7 @@ STAGE PLANS:
                   1 KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1, _col2
                 input vertices:
-                  1 Reducer 12
+                  1 Reducer 13
                 Statistics: Num rows: 6463723 Data size: 895528872 Basic stats: COMPLETE Column stats: COMPLETE
                 DynamicPartitionHashJoin: true
                 Reduce Output Operator
@@ -517,61 +453,16 @@ STAGE PLANS:
         Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: bigint), KEY.reducesinkkey0 (type: bigint)
-                outputColumnNames: _col0, _col1
-                Reduce Output Operator
-<<<<<<< HEAD
-                  key expressions: _col1 (type: bigint)
-                  null sort order: z
-                  sort order: +
-                  Map-reduce partition columns: _col1 (type: bigint)
-                  Statistics: Num rows: 21600036511 Data size: 345557373256 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint)
-        Reducer 8 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Map Join Operator
-                condition map:
-                     Inner Join 0 to 1
-                keys:
-                  0 KEY.reducesinkkey0 (type: bigint)
-                  1 KEY.reducesinkkey0 (type: bigint)
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), bloom_filter(VALUE._col2, expectedEntries=1000000)
+                mode: final
                 outputColumnNames: _col0, _col1, _col2
-                input vertices:
-                  1 Map 1
-                Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
-                DynamicPartitionHashJoin: true
-                Filter Operator
-                  predicate: (_col0 <> _col2) (type: boolean)
-                  Statistics: Num rows: 258749294920 Data size: 6209896656240 Basic stats: COMPLETE Column stats: COMPLETE
-                  Select Operator
-                    expressions: _col1 (type: bigint)
-                    outputColumnNames: _col0
-                    Statistics: Num rows: 258749294920 Data size: 2069994359360 Basic stats: COMPLETE Column stats: COMPLETE
-                    Group By Operator
-                      keys: _col0 (type: bigint)
-                      minReductionHashAggr: 0.99
-                      mode: hash
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: bigint)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: bigint)
-                        Statistics: Num rows: 21600036511 Data size: 172800292088 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                  null sort order: 
-                  sort order: 
-                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                  value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
+                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 Reduce Output Operator
                   null sort order: 
                   sort order: 
                   Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col0 (type: bigint), _col1 (type: bigint), _col2 (type: binary)
->>>>>>> HIVE-24564: Extend PPD filter transitivity to be able to discover new opportunities
 
   Stage: Stage-0
     Fetch Operator

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
@@ -1545,10 +1545,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                  filterExpr: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    predicate: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 350 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
@@ -1585,8 +1585,13 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
+<<<<<<< HEAD
                           1 Reducer 5
                         Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                          1 Map 4
+                        Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1595,8 +1600,13 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
+<<<<<<< HEAD
                             1 Map 6
                           Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                            1 Map 5
+                          Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1604,8 +1614,13 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
+<<<<<<< HEAD
                               1 Map 4
                             Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                              1 Map 6
+                            Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1622,17 +1637,32 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
+<<<<<<< HEAD
                   filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
+=======
+                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+>>>>>>> update q test
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (key is not null and (value < 'zzzzzzzz')) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
+<<<<<<< HEAD
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: z2
+                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1782,10 +1812,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: x
-                  filterExpr: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                  filterExpr: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 25 Data size: 4375 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((value < 'zzzzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    predicate: ((key < 'zzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
                     Statistics: Num rows: 2 Data size: 350 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
@@ -1823,8 +1853,13 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
+<<<<<<< HEAD
                           1 Reducer 5
                         Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                          1 Map 4
+                        Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                         HybridGraceHashJoin: true
                         Map Join Operator
                           condition map:
@@ -1834,8 +1869,13 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
+<<<<<<< HEAD
                             1 Map 6
                           Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                            1 Map 5
+                          Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                           HybridGraceHashJoin: true
                           Map Join Operator
                             condition map:
@@ -1844,8 +1884,13 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
+<<<<<<< HEAD
                               1 Map 4
                             Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                              1 Map 6
+                            Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                             HybridGraceHashJoin: true
                             Group By Operator
                               aggregations: count()
@@ -1863,17 +1908,32 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
+<<<<<<< HEAD
                   filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
+=======
+                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+>>>>>>> update q test
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: (key is not null and (value < 'zzzzzzzz')) (type: boolean)
-                    Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
+                    Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: key (type: string)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
+<<<<<<< HEAD
                       Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+=======
+                      Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
+            Execution mode: vectorized
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: z2
+                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
+                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
+>>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
+++ b/ql/src/test/results/clientpositive/tez/hybridgrace_hashjoin_2.q.out
@@ -1585,13 +1585,8 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
-<<<<<<< HEAD
                           1 Reducer 5
-                        Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                          1 Map 4
                         Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                         Map Join Operator
                           condition map:
                                Inner Join 0 to 1
@@ -1600,13 +1595,8 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
-<<<<<<< HEAD
                             1 Map 6
-                          Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                            1 Map 5
                           Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                           Map Join Operator
                             condition map:
                                  Inner Join 0 to 1
@@ -1614,13 +1604,8 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
-<<<<<<< HEAD
                               1 Map 4
-                            Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                              1 Map 6
                             Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                             Group By Operator
                               aggregations: count()
                               minReductionHashAggr: 0.99
@@ -1637,11 +1622,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
-<<<<<<< HEAD
-                  filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
-=======
-                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
->>>>>>> update q test
+                  filterExpr: (((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
@@ -1651,18 +1632,7 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-<<<<<<< HEAD
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                       Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: z2
-                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1715,7 +1685,7 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: key (type: string)
-                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator
@@ -1853,13 +1823,8 @@ STAGE PLANS:
                           1 key (type: string)
                         outputColumnNames: _col1
                         input vertices:
-<<<<<<< HEAD
                           1 Reducer 5
-                        Statistics: Num rows: 12 Data size: 1068 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                          1 Map 4
                         Statistics: Num rows: 18 Data size: 1602 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                         HybridGraceHashJoin: true
                         Map Join Operator
                           condition map:
@@ -1869,13 +1834,8 @@ STAGE PLANS:
                             1 value (type: string)
                           outputColumnNames: _col1
                           input vertices:
-<<<<<<< HEAD
                             1 Map 6
-                          Statistics: Num rows: 76 Data size: 6764 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                            1 Map 5
                           Statistics: Num rows: 114 Data size: 10146 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                           HybridGraceHashJoin: true
                           Map Join Operator
                             condition map:
@@ -1884,13 +1844,8 @@ STAGE PLANS:
                               0 _col1 (type: string)
                               1 value (type: string)
                             input vertices:
-<<<<<<< HEAD
                               1 Map 4
-                            Statistics: Num rows: 123 Data size: 984 Basic stats: COMPLETE Column stats: COMPLETE
-=======
-                              1 Map 6
                             Statistics: Num rows: 185 Data size: 1480 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                             HybridGraceHashJoin: true
                             Group By Operator
                               aggregations: count()
@@ -1908,11 +1863,7 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: y1
-<<<<<<< HEAD
-                  filterExpr: ((key is not null and (value < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
-=======
-                  filterExpr: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
->>>>>>> update q test
+                  filterExpr: (((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) or (value < 'zzzzzzzzzz')) (type: boolean)
                   Statistics: Num rows: 500 Data size: 89000 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
                     predicate: ((value < 'zzzzzzzz') and (key < 'zzzzzzzz')) (type: boolean)
@@ -1922,18 +1873,7 @@ STAGE PLANS:
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: key (type: string)
-<<<<<<< HEAD
-                      Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
-=======
                       Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
-            Execution mode: vectorized
-        Map 5 
-            Map Operator Tree:
-                TableScan
-                  alias: z2
-                  filterExpr: ((key < 'zzzzzzzzzz') and (value < 'zzzzzzzzzz')) (type: boolean)
-                  Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
->>>>>>> update q test
                   Filter Operator
                     predicate: (value < 'zzzzzzzzzz') (type: boolean)
                     Statistics: Num rows: 166 Data size: 15106 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1986,7 +1926,7 @@ STAGE PLANS:
                   null sort order: z
                   sort order: +
                   Map-reduce partition columns: key (type: string)
-                  Statistics: Num rows: 166 Data size: 29548 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 55 Data size: 9790 Basic stats: COMPLETE Column stats: COMPLETE
 
   Stage: Stage-0
     Fetch Operator


### PR DESCRIPTION
### What changes were proposed in this pull request?
When transitively replicate predicate filters over equijoin conditions if the replication is failed due to referenced column in the predicate is not a key column in the ReduceSink operator 
1. traverse the branches of the join operator to find a an equijoin having a join expression where the column referenced in the predicate
2. replace the column in the predicate with the column coming from the other side of the equijoin expression found int step 1.
3. continue with the modified predicate.

### Why are the changes needed?
See jira for detailes

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Executing `explain logical` query95.q:
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestTezTPCDS30TBPerfCliDriver -Dqfile=query95.q -pl itests/qtest -Pitests
```
Check the difference of the output of above command when this ppd extension is turned on/off.
On:
```
$hdt$_2:$hdt$_4:ws2 
  TableScan (TS_35)
    alias: ws2
    filterExpr: ((ws_order_number) IN (RS[40]) and (ws_order_number) IN (RS[37]) and (ws_order_number) IN (RS[38]) and (ws_order_number) IN (RS[52]) and (ws_order_number) IN (RS[47]) and (ws_order_number) IN (RS[48]) and (ws_order_number) IN (RS[26]) and (ws_order_number) IN (RS[27])) (type: boolean)
```
Off
```
$hdt$_2:$hdt$_4:ws2 
  TableScan (TS_35)
    alias: ws2
    filterExpr: ((ws_order_number) IN (RS[40]) and (ws_order_number) IN (RS[37]) and (ws_order_number) IN (RS[38])) (type: boolean)
```
If the extension is turned on TS has additional `filterExpr`s like:
```
and (ws_order_number) IN (RS[52]) and (ws_order_number) IN (RS[47]) and (ws_order_number) IN (RS[48]) and (ws_order_number) IN (RS[26]) and (ws_order_number) IN (RS[27])
```