### PR TITLE
HIVE-24568: Fix guice compatibility issues

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -479,7 +479,7 @@
       <dependency>
         <groupId>com.google.inject</groupId>
         <artifactId>guice</artifactId>
-        <version>4.1</version>
+        <version>4.1.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -363,6 +363,12 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-common</artifactId>
         <version>${hadoop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.inject</groupId>
+            <artifactId>guice</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hadoop</groupId>
@@ -469,6 +475,11 @@
         <groupId>org.apache.hadoop</groupId>
         <artifactId>hadoop-yarn-registry</artifactId>
         <version>${hadoop.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.inject</groupId>
+        <artifactId>guice</artifactId>
+        <version>4.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/itests/qtest-druid/pom.xml
+++ b/itests/qtest-druid/pom.xml
@@ -43,9 +43,7 @@
     <druid.jetty.version>9.4.10.v20180503</druid.jetty.version>
     <druid.derby.version>10.11.1.1</druid.derby.version>
     <druid.guava.version>16.0.1</druid.guava.version>
-    <druid.guice.version>4.1.0</druid.guice.version>
     <kafka.test.version>2.5.0</kafka.test.version>
-    <druid.guice.version>4.1.0</druid.guice.version>
     <slf4j.version>1.7.30</slf4j.version>
   </properties>
       <dependencies>
@@ -240,7 +238,6 @@
         <dependency>
           <groupId>com.google.inject</groupId>
           <artifactId>guice</artifactId>
-          <version>${druid.guice.version}</version>
         </dependency>
         <dependency>
           <groupId>org.apache.kafka</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr fix guice compatibility issues.
```
Exception in thread "main" java.lang.NoSuchMethodError: com.google.inject.util.Types.collectionOf(Ljava/lang/reflect/Type;)Ljava/lang/reflect/ParameterizedType;
» at com.google.inject.multibindings.Multibinder.collectionOfProvidersOf(Multibinder.java:202)
» at com.google.inject.multibindings.Multibinder$RealMultibinder.<init>(Multibinder.java:283)
» at com.google.inject.multibindings.Multibinder$RealMultibinder.<init>(Multibinder.java:258)
```

druid dependency guice 4.1.0:
https://github.com/apache/hive/blob/f7ec294764cdc03474a954edc0f4fcd2a8f0f587/itests/qtest-druid/pom.xml#L46
hadoop dependency guice 4.0.0:
https://github.com/apache/hadoop/blob/release-3.1.0-RC1/hadoop-project/pom.xml#L92

https://github.com/google/guice/blob/4.1/core/src/com/google/inject/util/Types.java#L110-L112
https://github.com/google/guice/blob/4.0/core/src/com/google/inject/util/Types.java

### Why are the changes needed?

Fix compatibility issues.


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

N/A.
