### PR TITLE
HIVE-21961: Upgrade Hadoop to 3.1.4, Guava to 27.0-jre and Jetty to 9.4.20.v20190813

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,10 +134,10 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2</dropwizard-metrics-hadoop-metrics2-reporter.version>
     <druid.version>0.17.1</druid.version>
     <flatbuffers.version>1.6.0.1</flatbuffers.version>
-    <guava.version>19.0</guava.version>
+    <guava.version>27.0-jre</guava.version>
     <groovy.version>2.4.11</groovy.version>
     <h2database.version>1.3.166</h2database.version>
-    <hadoop.version>3.1.0</hadoop.version>
+    <hadoop.version>3.1.4</hadoop.version>
     <hadoop.bin.path>${basedir}/${hive.path.to.root}/testutils/hadoop</hadoop.bin.path>
     <hamcrest.version>1.3</hamcrest.version>
     <hbase.version>2.0.0-alpha4</hbase.version>
@@ -157,7 +157,7 @@
     <javax-servlet-jsp.version>2.3.1</javax-servlet-jsp.version>
     <javolution.version>5.5.1</javolution.version>
     <jettison.version>1.1</jettison.version>
-    <jetty.version>9.3.27.v20190418</jetty.version>
+    <jetty.version>9.4.20.v20190813</jetty.version>
     <jersey.version>1.19</jersey.version>
     <!-- Glassfish jersey is included for Spark client test only -->
     <glassfish.jersey.version>2.22.2</glassfish.jersey.version>

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -20,7 +20,6 @@ package org.apache.hive.service.cli.thrift;
 
 import java.security.KeyStore;
 import java.util.Arrays;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -89,11 +88,10 @@ public class ThriftHttpCLIService extends ThriftCLIService {
       // Start with minWorkerThreads, expand till maxWorkerThreads and reject
       // subsequent requests
       String threadPoolName = "HiveServer2-HttpHandler-Pool";
-      ExecutorService executorService = new ThreadPoolExecutorWithOomHook(minWorkerThreads,
+      ThreadPoolExecutor threadPoolExecutorWithOomHook = new ThreadPoolExecutorWithOomHook(minWorkerThreads,
           maxWorkerThreads,workerKeepAliveTime, TimeUnit.SECONDS,
           new SynchronousQueue<Runnable>(), new ThreadFactoryWithGarbageCleanup(threadPoolName), oomHook);
-
-      ExecutorThreadPool threadPool = new ExecutorThreadPool((ThreadPoolExecutor) executorService);
+      ExecutorThreadPool threadPool = new ExecutorThreadPool(threadPoolExecutorWithOomHook);
 
       // HTTP Server
       server = new Server(threadPool);

--- a/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
+++ b/standalone-metastore/metastore-tools/tools-common/src/main/java/org/apache/hadoop/hive/metastore/tools/Util.java
@@ -549,9 +549,9 @@ public final class Util {
     HostAndPort hp = HostAndPort.fromString(host)
             .withDefaultPort(port);
 
-    LOG.info("Connecting to {}:{}", hp.getHostText(), hp.getPort());
+    LOG.info("Connecting to {}:{}", hp.getHost(), hp.getPort());
 
-    return new URI(THRIFT_SCHEMA, null, hp.getHostText(), hp.getPort(),
+    return new URI(THRIFT_SCHEMA, null, hp.getHost(), hp.getPort(),
             null, null, null);
   }
 

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -79,8 +79,8 @@
     <dropwizard-metrics-hadoop-metrics2-reporter.version>0.1.2
     </dropwizard-metrics-hadoop-metrics2-reporter.version>
     <dropwizard.version>3.1.0</dropwizard.version>
-    <guava.version>19.0</guava.version>
-    <hadoop.version>3.1.0</hadoop.version>
+    <guava.version>27.0-jre</guava.version>
+    <hadoop.version>3.1.4</hadoop.version>
     <hikaricp.version>2.6.1</hikaricp.version>
     <jackson.version>2.10.5</jackson.version>
     <javolution.version>5.5.1</javolution.version>

--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -32,8 +32,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <commons-logging.version>1.1.3</commons-logging.version>
-    <guava.version>19.0</guava.version>
-    <hadoop.version>3.1.0</hadoop.version>
+    <guava.version>27.0-jre</guava.version>
+    <hadoop.version>3.1.4</hadoop.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.3</junit.jupiter.version>
     <junit.vintage.version>5.6.3</junit.vintage.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

Upgrade Hadoop to 3.1.4, Guava to 27.0-jre and Jetty to 9.4.20.v20190813.


### Why are the changes needed?

Fix compatibility issues: https://github.com/apache/hive/pull/1812#issuecomment-750782636


### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Existing test.
