### PR TITLE
HIVE-24581: Remove AcidUtils call from OrcInputformat for non transactional tables

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hive.ql.hooks;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -31,7 +32,6 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryPlan;
 import org.apache.hadoop.hive.ql.exec.FetchTask;
-import org.apache.hadoop.hive.ql.io.HdfsUtils;
 import org.apache.orc.tools.FileDump;
 import org.apache.orc.FileFormatException;
 import org.apache.hadoop.hive.ql.io.orc.OrcFile;
@@ -99,9 +99,7 @@ public class PostExecOrcFileDump implements ExecuteWithHookContext {
   }
 
   private void printFileStatus(SessionState.LogHelper console, FileSystem fs, Path dir) throws Exception {
-    List<FileStatus> fileList = HdfsUtils.listLocatedStatus(fs, dir,
-        hiddenFileFilter);
-
+    List<FileStatus> fileList = Arrays.asList(fs.listStatus(dir, hiddenFileFilter));
     Collections.sort(fileList);
 
     for (FileStatus fileStatus : fileList) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -2554,7 +2554,6 @@ public class AcidUtils {
 
   public static List<FileStatus> getAcidFilesForStats(
       Table table, Path dir, Configuration jc, FileSystem fs) throws IOException {
-    List<FileStatus> fileList = new ArrayList<>();
     ValidWriteIdList idList = AcidUtils.getTableValidWriteIdList(jc,
         AcidUtils.getFullTableName(table.getDbName(), table.getTableName()));
     if (idList == null) {
@@ -2573,16 +2572,11 @@ public class AcidUtils {
       Utilities.FILE_OP_LOGGER.warn(
           "Computing stats for an ACID table; stats may be inaccurate");
     }
-    for (HdfsFileStatusWithId hfs : acidInfo.getOriginalFiles()) {
-      fileList.add(hfs.getFileStatus());
-    }
-    for (ParsedDelta delta : acidInfo.getCurrentDirectories()) {
-      fileList.addAll(hdfsDirSnapshots.get(delta.getPath()).getFiles());
-    }
-    if (acidInfo.getBaseDirectory() != null) {
-      fileList.addAll(hdfsDirSnapshots.get(acidInfo.getBaseDirectory()).getFiles());
-    }
-    return fileList;
+    return acidInfo.getFiles()
+        .stream()
+        .map(FileInfo::getHdfsFileStatusWithId)
+        .map(HdfsFileStatusWithId::getFileStatus)
+        .collect(Collectors.toList());
   }
 
   public static List<Path> getValidDataPaths(Path dataPath, Configuration conf, String validWriteIdStr)

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HdfsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HdfsUtils.java
@@ -103,13 +103,17 @@ public class HdfsUtils {
     while (itr.hasNext()) {
       FileStatus stat = itr.next();
       // Recursive listing might list files inside hidden directories, we need to filter those out
-      Path relativePath = new Path(stat.getPath().toString().replace(path.toString(), ""));
-      if (org.apache.hadoop.hive.metastore.utils.FileUtils.RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
-        // Apply the user provided filter
-        if (filter == null || filter.accept(stat.getPath())) {
-          result.add(stat);
+      if (!stat.getPath().toString().equals(path.toString())) {
+        Path relativePath = new Path(stat.getPath().toString().replace(path.toString(), ""));
+        if (!org.apache.hadoop.hive.metastore.utils.FileUtils.RemoteIteratorWithFilter.HIDDEN_FILES_FULL_PATH_FILTER.accept(relativePath)) {
+          continue;
         }
       }
+      // Apply the user provided filter
+      if (filter == null || filter.accept(stat.getPath())) {
+        result.add(stat);
+      }
+
     }
     return result;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HdfsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HdfsUtils.java
@@ -26,9 +26,10 @@ import java.net.URI;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.hive.common.util.Ref;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -43,13 +44,20 @@ import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.shims.HadoopShims;
 import org.apache.hadoop.hive.shims.ShimLoader;
 
+/**
+ * Common FileSystem utilities around FileId.
+ */
 public class HdfsUtils {
   private static final HadoopShims SHIMS = ShimLoader.getHadoopShims();
   private static final Logger LOG = LoggerFactory.getLogger(HdfsUtils.class);
+  public static final PathFilter hiddenFileFilter = p -> {
+    String name = p.getName();
+    return !name.startsWith("_") && !name.startsWith(".");
+  };
 
   public static Object getFileId(FileSystem fileSystem, Path path,
       boolean allowSynthetic, boolean checkDefaultFs, boolean forceSyntheticIds) throws IOException {
-    if (forceSyntheticIds == false && fileSystem instanceof DistributedFileSystem) {
+    if (!forceSyntheticIds && fileSystem instanceof DistributedFileSystem) {
       DistributedFileSystem dfs = (DistributedFileSystem) fileSystem;
       if ((!checkDefaultFs) || isDefaultFs(dfs)) {
         Object result = SHIMS.getFileId(dfs, path.toUri().getPath());
@@ -82,13 +90,16 @@ public class HdfsUtils {
     return id;
   }
 
-  public static List<FileStatus> listLocatedStatus(final FileSystem fs,
-      final Path path,
-      final PathFilter filter
-      ) throws IOException {
-    RemoteIterator<LocatedFileStatus> itr = fs.listLocatedStatus(path);
-    List<FileStatus> result = new ArrayList<FileStatus>();
-    while(itr.hasNext()) {
+  public static List<FileStatus> listLocatedStatus(final FileSystem fs, final Path path, final PathFilter filter)
+      throws IOException {
+    return listLocatedStatus(fs, path, filter, false);
+  }
+
+  public static List<FileStatus> listLocatedStatus(final FileSystem fs, final Path path, final PathFilter filter,
+      final boolean recursive) throws IOException {
+    RemoteIterator<LocatedFileStatus> itr = fs.listFiles(path, recursive);
+    List<FileStatus> result = new ArrayList<>();
+    while (itr.hasNext()) {
       FileStatus stat = itr.next();
       if (filter == null || filter.accept(stat.getPath())) {
         result.add(stat);
@@ -133,5 +144,89 @@ public class HdfsUtils {
     } catch (IOException e) {
       throw new HiveException(e);
     }
+  }
+
+
+  public static class HdfsFileStatusWithoutId implements HadoopShims.HdfsFileStatusWithId {
+    private final FileStatus fs;
+
+    public HdfsFileStatusWithoutId(FileStatus fs) {
+      this.fs = fs;
+    }
+
+    @Override
+    public FileStatus getFileStatus() {
+      return fs;
+    }
+
+    @Override
+    public Long getFileId() {
+      return null;
+    }
+  }
+
+  /**
+   * List files recursively in the given directory.
+   * If the filesystem supports it will use file listing with FileIds.
+   * @param fs the filesystem
+   * @param dir the directory to list
+   * @param useFileIds use fileId if possible
+   * @param recursive do recursive listing
+   * @param filter filter to apply
+   * @return List of files
+   * @throws IOException ex
+   */
+  public static List<HadoopShims.HdfsFileStatusWithId> listFileStatusWithId(FileSystem fs, Path dir, Ref<Boolean> useFileIds,
+      boolean recursive, PathFilter filter) throws IOException {
+    if (filter == null) {
+      filter = hiddenFileFilter;
+    }
+    List<HadoopShims.HdfsFileStatusWithId> originals = new ArrayList<>();
+    List<HadoopShims.HdfsFileStatusWithId> childrenWithId = tryListLocatedHdfsStatus(useFileIds, fs, dir, filter);
+    if (childrenWithId != null) {
+      for (HadoopShims.HdfsFileStatusWithId child : childrenWithId) {
+        if (child.getFileStatus().isDirectory()) {
+          if (recursive) {
+            originals.addAll(listFileStatusWithId(fs, child.getFileStatus().getPath(), useFileIds,
+                true, filter));
+          }
+        } else {
+          if (child.getFileStatus().getLen() > 0) {
+            originals.add(child);
+          }
+        }
+      }
+    } else {
+      List<FileStatus> children = listLocatedStatus(fs, dir, filter, recursive);
+      originals = children.stream().map(HdfsFileStatusWithoutId::new).collect(Collectors.toList());
+    }
+    return originals;
+  }
+
+  public static List<HadoopShims.HdfsFileStatusWithId> tryListLocatedHdfsStatus(Ref<Boolean> useFileIds, FileSystem fs,
+      Path directory, PathFilter filter) {
+    if (useFileIds == null) {
+      return null;
+    }
+
+    List<HadoopShims.HdfsFileStatusWithId> childrenWithId = null;
+    final Boolean val = useFileIds.value;
+    if (val == null || val) {
+      try {
+        childrenWithId = SHIMS.listLocatedHdfsStatus(fs, directory, filter);
+        if (val == null) {
+          useFileIds.value = true;
+        }
+      } catch (UnsupportedOperationException uoe) {
+        LOG.info("Failed to get files with ID; using regular API: " + uoe.getMessage());
+        if (val == null) {
+          useFileIds.value = false;
+        }
+      } catch (IOException ioe) {
+        LOG.info("Failed to get files with ID; using regular API: " + ioe.getMessage());
+        LOG.debug("Failed to get files with ID", ioe);
+      }
+    }
+    return childrenWithId;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/OriginalDirectory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/OriginalDirectory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Basic implementation of AcidUtils.Directory.
+ * All files in the given path are original files and should be read by the queries.
+ */
+public final class OriginalDirectory implements  AcidUtils.Directory {
+
+  List<AcidUtils.FileInfo> files;
+  FileSystem fs;
+  Path path;
+
+  public OriginalDirectory(List<AcidUtils.FileInfo> files, FileSystem fs, Path path) {
+    this.files = files;
+    this.fs = fs;
+    this.path = path;
+  }
+
+  @Override
+  public List<AcidUtils.FileInfo> getFiles() throws IOException {
+    return files;
+  }
+
+  @Override
+  public FileSystem getFs() {
+    return fs;
+  }
+
+  @Override
+  public Path getPath() {
+    return path;
+  }
+
+  @Override
+  public List<AcidUtils.ParsedDelta> getDeleteDeltas() {
+    return Collections.EMPTY_LIST;
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -18,12 +18,10 @@
 
 package org.apache.hadoop.hive.ql.io.orc;
 
-import com.google.common.collect.Sets;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.hdfs.protocol.HdfsLocatedFileStatus;
 import org.apache.hadoop.hive.common.BlobStorageUtils;
 import org.apache.hadoop.hive.common.NoDynamicValuesException;
-import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
 
 import java.io.IOException;
@@ -70,9 +68,10 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedSupport;
 import org.apache.hadoop.hive.ql.io.AcidInputFormat;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
-import org.apache.hadoop.hive.ql.io.AcidUtils.AcidBaseFileInfo;
 import org.apache.hadoop.hive.ql.io.AcidUtils.AcidOperationalProperties;
 import org.apache.hadoop.hive.ql.io.AcidDirectory;
+import org.apache.hadoop.hive.ql.io.AcidUtils.Directory;
+import org.apache.hadoop.hive.ql.io.AcidUtils.FileInfo;
 import org.apache.hadoop.hive.ql.io.AcidUtils.ParsedDelta;
 import org.apache.hadoop.hive.ql.io.BatchToRowInputFormat;
 import org.apache.hadoop.hive.ql.io.BatchToRowReader;
@@ -82,6 +81,7 @@ import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.InputFormatChecker;
 import org.apache.hadoop.hive.ql.io.LlapWrappableInputFormatInterface;
+import org.apache.hadoop.hive.ql.io.OriginalDirectory;
 import org.apache.hadoop.hive.ql.io.RecordIdentifier;
 import org.apache.hadoop.hive.ql.io.SelfDescribingInputFormatInterface;
 import org.apache.hadoop.hive.ql.io.StatsProvidingRecordReader;
@@ -849,7 +849,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     public SplitInfo(Context context, FileSystem fs, FileStatus fileStatus, OrcTail orcTail,
         List<OrcProto.Type> readerTypes,  boolean isOriginal, ArrayList<DeltaMetaData> deltas,
         boolean hasBase, Path dir, boolean[] covered) throws IOException {
-      this(context, fs, new AcidUtils.HdfsFileStatusWithoutId(fileStatus),
+      this(context, fs, new HdfsUtils.HdfsFileStatusWithoutId(fileStatus),
           orcTail, readerTypes, isOriginal, deltas, hasBase, dir, covered, null);
     }
   }
@@ -1230,7 +1230,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
    * Given a directory, get the list of files and blocks in those files.
    * To parallelize file generator use "mapreduce.input.fileinputformat.list-status.num-threads"
    */
-  static final class FileGenerator implements Callable<AcidDirectory> {
+  static final class FileGenerator implements Callable<Directory> {
     private final Context context;
     private final Supplier<FileSystem> fs;
     /**
@@ -1260,12 +1260,12 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     }
 
     @Override
-    public AcidDirectory call() throws IOException {
+    public Directory call() throws IOException {
       if (ugi == null) {
         return callInternal();
       }
       try {
-        return ugi.doAs((PrivilegedExceptionAction<AcidDirectory>) () -> callInternal());
+        return ugi.doAs((PrivilegedExceptionAction<Directory>) () -> callInternal());
       } catch (InterruptedException e) {
         throw new IOException(e);
       }
@@ -1282,23 +1282,28 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     }
 
 
-    private AcidDirectory callInternal() throws IOException {
-      if (context.acidOperationalProperties != null
-          && context.acidOperationalProperties.isInsertOnly()) {
-        // See the class comment - HIF handles MM for all input formats, so if we try to handle it
-        // again, in particular for the non-recursive originals-only getSplits call, we will just
-        // get confused. This bypass was not necessary when MM tables didn't support originals. Now
-        // that they do, we use this path for anything MM table related, although everything except
-        // the originals could still be handled by AcidUtils like a regular non-txn table.
-        boolean isRecursive = context.conf.getBoolean(FileInputFormat.INPUT_DIR_RECURSIVE,
-            context.conf.getBoolean("mapred.input.dir.recursive", false));
-        AcidDirectory directory = new AcidDirectory(dir, fs.get(), useFileIds);
-        List<HdfsFileStatusWithId> originals = AcidUtils.findOriginals(fs.get(), dir, useFileIds, true, isRecursive);
-        directory.getOriginalFiles().addAll(originals);
-        return directory;
+    private Directory callInternal() throws IOException {
+      if (context.acidOperationalProperties == null
+          || context.acidOperationalProperties.isInsertOnly()) {
+        // For plain non-acid tables we just need to list all the files in the table / partition directory.
+        // For MM tables HiveInputFormat#processPathsForMmRead already did filter out which
+        // base / delta directories this query should read. The path in dir is either a base / delta / original
+        // directory not the table / partition. So we just need to list the files, no need to do any acid related filtering.
+        // In this context every file is considered original (since none of them is full ACID schema) this is not the same
+        // as original files in the context of MM tables (see HiveConf.HIVE_MM_ALLOW_ORIGINALS)
+        return listOriginalFiles();
       }
       //todo: shouldn't ignoreEmptyFiles be set based on ExecutionEngine?
       return getAcidState();
+    }
+    private OriginalDirectory listOriginalFiles() throws IOException {
+      boolean isRecursive = context.conf.getBoolean(FileInputFormat.INPUT_DIR_RECURSIVE,
+          context.conf.getBoolean("mapred.input.dir.recursive", false));
+
+      List<FileInfo> originals = HdfsUtils
+          .listFileStatusWithId(fs.get(), dir, Ref.from(fs instanceof DistributedFileSystem), isRecursive, null)
+          .stream().map(f -> new FileInfo(f, ORIGINAL_BASE)).collect(Collectors.toList());
+      return new OriginalDirectory(originals, fs.get(), dir);
     }
   }
 
@@ -1741,14 +1746,14 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     boolean allowSyntheticFileIds = useFileIdsConfig && HiveConf.getBoolVar(
         conf, ConfVars.HIVE_ORC_ALLOW_SYNTHETIC_FILE_ID_IN_SPLITS);
     List<OrcSplit> splits = Lists.newArrayList();
-    List<Future<AcidDirectory>> pathFutures = Lists.newArrayList();
+    List<Future<Directory>> pathFutures = Lists.newArrayList();
     List<Future<Void>> strategyFutures = Lists.newArrayList();
     final List<Future<List<OrcSplit>>> splitFutures = Lists.newArrayList();
     UserGroupInformation ugi = UserGroupInformation.getCurrentUser();
 
     // multi-threaded file statuses and split strategy
     Path[] paths = getInputPaths(conf);
-    CompletionService<AcidDirectory> ecs = new ExecutorCompletionService<>(Context.threadPool);
+    CompletionService<Directory> ecs = new ExecutorCompletionService<>(Context.threadPool);
     for (Path dir : paths) {
       Supplier<FileSystem> fsSupplier = () -> {
         try {
@@ -1757,7 +1762,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
           throw new RuntimeException(e);
         }
       };
-      FileGenerator fileGenerator = new FileGenerator(context, fsSupplier, dir, useFileIds, ugi);
+      Callable<Directory> fileGenerator = new FileGenerator(context, fsSupplier, dir, useFileIds, ugi);
       pathFutures.add(ecs.submit(fileGenerator));
     }
 
@@ -1781,18 +1786,18 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
       long maxWaitUs = context.splitStrategyBatchMs * 1000000;
       int resultsLeft = paths.length;
       while (resultsLeft > 0) {
-        AcidDirectory adi = null;
+        Directory directory = null;
         if (combinedCtx != null && combinedCtx.combined != null) {
           long waitTimeUs = combinedCtx.combineStartUs + maxWaitUs - System.nanoTime();
           if (waitTimeUs >= 0) {
-            Future<AcidDirectory> f = ecs.poll(waitTimeUs, TimeUnit.NANOSECONDS);
-            adi = (f == null) ? null : f.get();
+            Future<Directory> f = ecs.poll(waitTimeUs, TimeUnit.NANOSECONDS);
+            directory = (f == null) ? null : f.get();
           }
         } else {
-          adi = ecs.take().get();
+          directory = ecs.take().get();
         }
 
-        if (adi == null) {
+        if (directory == null) {
           // We were combining SS-es and the time has expired.
           assert combinedCtx.combined != null;
           scheduleSplits(combinedCtx.combined, context, splitFutures, strategyFutures, splits);
@@ -1802,7 +1807,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
 
         // We have received a new directory information, make split strategies.
         --resultsLeft;
-        if(adi.getBaseAndDeltaFiles().isEmpty()) {
+        if (directory.getFiles().isEmpty()) {
           //no files found, for example empty table/partition
           continue;
         }
@@ -1810,8 +1815,8 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
         // case when we have a mix of original base files & insert deltas, we will produce two
         // independent split strategies for them. There is a global flag 'isOriginal' that is set
         // on a per split strategy basis and it has to be same for all the files in that strategy.
-        List<SplitStrategy<?>> splitStrategies = determineSplitStrategies(combinedCtx, context, adi.getFs(),
-            adi.getPath(), adi.getBaseAndDeltaFiles(), adi.getDeleteDeltas(), readerTypes, ugi,
+        List<SplitStrategy<?>> splitStrategies = determineSplitStrategies(combinedCtx, context, directory.getFs(),
+            directory.getPath(), directory.getFiles(), directory.getDeleteDeltas(), readerTypes, ugi,
             allowSyntheticFileIds);
 
         for (SplitStrategy<?> splitStrategy : splitStrategies) {
@@ -2257,7 +2262,7 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
   @VisibleForTesting
   static List<SplitStrategy<?>> determineSplitStrategies(CombinedCtx combinedCtx, Context context,
       FileSystem fs, Path dir,
-      List<AcidBaseFileInfo> baseFiles,
+      List<FileInfo> baseFiles,
       List<ParsedDelta> parsedDeltas,
       List<OrcProto.Type> readerTypes,
       UserGroupInformation ugi, boolean allowSyntheticFileIds) throws IOException {
@@ -2285,11 +2290,10 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
     List<HdfsFileStatusWithId> acidSchemaFiles = new ArrayList<>();
     List<HdfsFileStatusWithId> originalSchemaFiles = new ArrayList<HdfsFileStatusWithId>();
     // Separate the base files into acid schema and non-acid(original) schema files.
-    for (AcidBaseFileInfo acidBaseFileInfo : baseFiles) {
+    for (FileInfo acidBaseFileInfo : baseFiles) {
       if (acidBaseFileInfo.isOriginal()) {
         originalSchemaFiles.add(acidBaseFileInfo.getHdfsFileStatusWithId());
       } else {
-        assert acidBaseFileInfo.isAcidSchema();
         acidSchemaFiles.add(acidBaseFileInfo.getHdfsFileStatusWithId());
       }
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestAcidInputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestAcidInputFormat.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.io;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -39,7 +38,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.io.AcidInputFormat.DeltaMetaData;
-import org.apache.hive.common.util.MockFileSystem;
+import org.apache.hadoop.hive.ql.io.HdfsUtils.HdfsFileStatusWithoutId;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -99,7 +98,7 @@ public class TestAcidInputFormat {
   public void testDeltaMetaWithFile() throws Exception {
     FileStatus fs = new FileStatus(200, false, 100, 100, 100, new Path("mypath"));
     DeltaMetaData deltaMetaData = new AcidInputFormat.DeltaMetaData(2000L, 2001L, new ArrayList<>(), 0,
-        Collections.singletonList(new AcidInputFormat.DeltaFileMetaData(new AcidUtils.HdfsFileStatusWithoutId(fs), null, 1)));
+        Collections.singletonList(new AcidInputFormat.DeltaFileMetaData(new HdfsFileStatusWithoutId(fs), null, 1)));
 
     assertEquals(2000L, deltaMetaData.getMinWriteId());
     assertEquals(2001L, deltaMetaData.getMaxWriteId());
@@ -192,7 +191,7 @@ public class TestAcidInputFormat {
   public void testDeltaMetaWithFileMultiStatement() throws Exception {
     FileStatus fs = new FileStatus(200, false, 100, 100, 100, new Path("mypath"));
     DeltaMetaData deltaMetaData = new AcidInputFormat.DeltaMetaData(2000L, 2001L, Arrays.asList(97, 98, 99), 0,
-        Collections.singletonList(new AcidInputFormat.DeltaFileMetaData(new AcidUtils.HdfsFileStatusWithoutId(fs), 97, 1)));
+        Collections.singletonList(new AcidInputFormat.DeltaFileMetaData(new HdfsFileStatusWithoutId(fs), 97, 1)));
 
     assertEquals(2000L, deltaMetaData.getMinWriteId());
     assertEquals(2001L, deltaMetaData.getMaxWriteId());

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestInputOutputFormat.java
@@ -73,10 +73,10 @@ import org.apache.hadoop.hive.ql.exec.vector.StructColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
-import org.apache.hadoop.hive.ql.io.AcidDirectory;
 import org.apache.hadoop.hive.ql.io.AcidInputFormat;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.io.AcidUtils.Directory;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.io.CombineHiveInputFormat;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
@@ -1013,13 +1013,13 @@ public class TestInputOutputFormat {
 
   public List<SplitStrategy<?>> createOrCombineStrategies(OrcInputFormat.Context context,
       MockFileSystem fs, String path, OrcInputFormat.CombinedCtx combineCtx) throws IOException {
-    AcidDirectory adi = createAdi(context, fs, path);
+    Directory adi = createAdi(context, fs, path);
     return OrcInputFormat.determineSplitStrategies(combineCtx, context,
-        adi.getFs(), adi.getPath(), adi.getBaseAndDeltaFiles(), adi.getDeleteDeltas(),
+        adi.getFs(), adi.getPath(), adi.getFiles(), adi.getDeleteDeltas(),
         null, null, true);
   }
 
-  public AcidDirectory createAdi(
+  public Directory createAdi(
       OrcInputFormat.Context context, final MockFileSystem fs, String path) throws IOException {
     return new OrcInputFormat.FileGenerator(
         context, () -> fs, new MockPath(fs, path), false, null).call();
@@ -1027,9 +1027,9 @@ public class TestInputOutputFormat {
 
   private List<OrcInputFormat.SplitStrategy<?>> createSplitStrategies(
       OrcInputFormat.Context context, OrcInputFormat.FileGenerator gen) throws IOException {
-    AcidDirectory adi = gen.call();
+    Directory adi = gen.call();
     return OrcInputFormat.determineSplitStrategies(
-        null, context, adi.getFs(), adi.getPath(), adi.getBaseAndDeltaFiles(), adi.getDeleteDeltas(),
+        null, context, adi.getFs(), adi.getPath(), adi.getFiles(), adi.getDeleteDeltas(),
         null, null, true);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestVectorizedOrcAcidRowBatchReader.java
@@ -37,10 +37,10 @@ import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
-import org.apache.hadoop.hive.ql.io.AcidDirectory;
 import org.apache.hadoop.hive.ql.io.AcidInputFormat;
 import org.apache.hadoop.hive.ql.io.AcidOutputFormat;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.io.AcidUtils.Directory;
 import org.apache.hadoop.hive.ql.io.BucketCodec;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.RecordIdentifier;
@@ -63,8 +63,6 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
-
-import com.google.common.collect.Lists;
 
 /**
  * This class tests the VectorizedOrcAcidRowBatchReader by creating an actual split and a set
@@ -1090,9 +1088,9 @@ public class TestVectorizedOrcAcidRowBatchReader {
     OrcInputFormat.Context context = new OrcInputFormat.Context(conf);
     OrcInputFormat.FileGenerator gen = new OrcInputFormat.FileGenerator(
         context, () -> fs, root, false, null);
-    AcidDirectory adi = gen.call();
+    Directory adi = gen.call();
     return OrcInputFormat.determineSplitStrategies(
-        null, context, adi.getFs(), adi.getPath(), adi.getBaseAndDeltaFiles(), adi.getDeleteDeltas(),
+        null, context, adi.getFs(), adi.getPath(), adi.getFiles(), adi.getDeleteDeltas(),
         null, null, true);
 
   }


### PR DESCRIPTION


### What changes were proposed in this pull request?

- Remove unneccessary AcidUtils.getAcidState call from OrcInputformat when the table is not transactional
- Remove redundant filesystem utility functions from AcidUtils to HdfsUtils

### Why are the changes needed?
Make the code more readable


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Current unit tests.
