### PR TITLE
HIVE-24587: DataFileReader is not closed in AvroGenericRecordReader#extractWriterProlepticFromMetadata

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
@@ -174,13 +174,12 @@ public class AvroGenericRecordReader implements
   }
 
   private Boolean extractWriterProlepticFromMetadata(JobConf job, FileSplit split,
-      GenericDatumReader<GenericRecord> gdr) throws IOException {
+      GenericDatumReader<GenericRecord> gdr) {
     if (job == null || gdr == null || split == null || split.getPath() == null) {
       return null;
     }
-    try {
-      DataFileReader<GenericRecord> dataFileReader =
-          new DataFileReader<GenericRecord>(new FsInput(split.getPath(), job), gdr);
+    try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<GenericRecord>(
+        new FsInput(split.getPath(), job), gdr)) {
       if (dataFileReader.getMeta(AvroSerDe.WRITER_PROLEPTIC) != null) {
         try {
           return Boolean.valueOf(new String(dataFileReader.getMeta(AvroSerDe.WRITER_PROLEPTIC),
@@ -191,6 +190,7 @@ public class AvroGenericRecordReader implements
       }
     } catch (IOException e) {
       // Can't access metadata, carry on.
+      LOG.debug(e.getMessage(), e);
     }
     return null;
   }


### PR DESCRIPTION
See HIVE-24587.