### PR TITLE
HIVE-24585

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -694,15 +694,18 @@ public class VectorizedOrcAcidRowBatchReader
     ReaderData readerData = new ReaderData();
     if (!skipLlapCache && LlapHiveUtils.isLlapMode(conf) && LlapProxy.isDaemon()) {
       try {
+        if (LlapProxy.getIo() == null) {
+          throw new IllegalCacheConfigurationException("LLAP IO is not enabled.");
+        }
         readerData.orcTail = LlapProxy.getIo().getOrcTailFromCache(path, conf, cacheTag, fileKey);
+        return readerData;
       } catch (IllegalCacheConfigurationException icce) {
         LOG.warn("Cache is not usable. Please fix the configuration", icce);
         skipLlapCache = true;
       }
-    } else {
-      readerData.reader = OrcFile.createReader(path, OrcFile.readerOptions(conf));
-      readerData.orcTail = new OrcTail(readerData.reader.getFileTail(), readerData.reader.getSerializedFileFooter());
     }
+    readerData.reader = OrcFile.createReader(path, OrcFile.readerOptions(conf));
+    readerData.orcTail = new OrcTail(readerData.reader.getFileTail(), readerData.reader.getSerializedFileFooter());
     return readerData;
   }
 


### PR DESCRIPTION
NPE is thrown if LLAP mode is turned on and LLAP daemon executes a query on an ACID table if LLAP IO is disabled. Although this doesn't seem to be a very useful LLAP environment setup, we'll need to cover this edge case too.