### PR TITLE
HIVE-24586: Rename compaction 'attempted' status

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3147,12 +3147,11 @@ public class HiveConf extends Configuration {
       new RangeValidator(0, 100), "Determines how many failed compaction records will be " +
       "retained in compaction history for a given table/partition."),
     /**
-     * @deprecated Use MetastoreConf.COMPACTOR_HISTORY_RETENTION_ATTEMPTED
+     * @deprecated Use MetastoreConf.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE
      */
-    @Deprecated
-    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("hive.compactor.history.retention.attempted", 2,
-      new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
-      "retained in compaction history for a given table/partition."),
+    @Deprecated COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("hive.compactor.history.retention.attempted", 2,
+      new RangeValidator(0, 100), "Determines how many compaction records in state " +
+        "'did not initiate' will be retained in compaction history for a given table/partition."),
     /**
      * @deprecated Use MetastoreConf.ACID_HOUSEKEEPER_SERVICE_INTERVAL
      */

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3149,9 +3149,10 @@ public class HiveConf extends Configuration {
     /**
      * @deprecated Use MetastoreConf.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE
      */
-    @Deprecated COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("hive.compactor.history.retention.attempted", 2,
-      new RangeValidator(0, 100), "Determines how many compaction records in state " +
-        "'did not initiate' will be retained in compaction history for a given table/partition."),
+    @Deprecated
+    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("hive.compactor.history.retention.attempted", 2,
+      new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
+      "retained in compaction history for a given table/partition."),
     /**
      * @deprecated Use MetastoreConf.ACID_HOUSEKEEPER_SERVICE_INTERVAL
      */

--- a/metastore/scripts/upgrade/hive/hive-schema-4.0.0.hive.sql
+++ b/metastore/scripts/upgrade/hive/hive-schema-4.0.0.hive.sql
@@ -1180,7 +1180,8 @@ SELECT
   CC_TABLE,
   CC_PARTITION,
   CASE WHEN CC_TYPE = 'i' THEN 'minor' WHEN CC_TYPE = 'a' THEN 'major' ELSE 'UNKNOWN' END,
-  CASE WHEN CC_STATE = 'f' THEN 'failed' WHEN CC_STATE = 's' THEN 'succeeded' WHEN CC_STATE = 'a' THEN 'attempted' ELSE 'UNKNOWN' END,
+  CASE WHEN CC_STATE = 'f' THEN 'failed' WHEN CC_STATE = 's' THEN 'succeeded'
+    WHEN CC_STATE = 'a' THEN 'did not initiate' ELSE 'UNKNOWN' END,
   CASE WHEN CC_WORKER_ID IS NULL THEN cast (null as string) ELSE split(CC_WORKER_ID,"-")[0] END,
   CASE WHEN CC_WORKER_ID IS NULL THEN cast (null as string) ELSE split(CC_WORKER_ID,"-")[1] END,
   CC_ENQUEUE_TIME,

--- a/metastore/scripts/upgrade/hive/upgrade-3.1.0-to-4.0.0.hive.sql
+++ b/metastore/scripts/upgrade/hive/upgrade-3.1.0-to-4.0.0.hive.sql
@@ -298,7 +298,8 @@ SELECT
   CC_TABLE,
   CC_PARTITION,
   CASE WHEN CC_TYPE = 'i' THEN 'minor' WHEN CC_TYPE = 'a' THEN 'major' ELSE 'UNKNOWN' END,
-  CASE WHEN CC_STATE = 'f' THEN 'failed' WHEN CC_STATE = 's' THEN 'succeeded' WHEN CC_STATE = 'a' THEN 'attempted' ELSE 'UNKNOWN' END,
+  CASE WHEN CC_STATE = 'f' THEN 'failed' WHEN CC_STATE = 's' THEN 'succeeded'
+    WHEN CC_STATE = 'a' THEN 'did not initiate' ELSE 'UNKNOWN' END,
   CASE WHEN CC_WORKER_ID IS NULL THEN cast (null as string) ELSE split(CC_WORKER_ID,"-")[0] END,
   CASE WHEN CC_WORKER_ID IS NULL THEN cast (null as string) ELSE split(CC_WORKER_ID,"-")[1] END,
   CC_ENQUEUE_TIME,

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -209,7 +209,8 @@ public class Initiator extends MetaStoreCompactorThread {
     }
   }
 
-  private ValidWriteIdList resolveValidWriteIds(Table t) throws NoSuchTxnException, MetaException {
+  @VisibleForTesting
+  ValidWriteIdList resolveValidWriteIds(Table t) throws NoSuchTxnException, MetaException {
     ValidTxnList validTxnList = new ValidReadTxnList(conf.get(ValidTxnList.VALID_TXNS_KEY));
     // The response will have one entry per table and hence we get only one ValidWriteIdList
     String fullTableName = TxnUtils.getFullTableName(t.getDbName(), t.getTableName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -203,14 +203,15 @@ public class Initiator extends MetaStoreCompactorThread {
         requestCompaction(ci, runAs, type);
       }
     } catch (Throwable ex) {
-      LOG.error("Caught exception while trying to determine if we should compact {}. " +
-          "Marking failed to avoid repeated failures, {}", ci, ex);
+      String errorMessage = "Caught exception while trying to determine if we should compact " + ci + ". Marking "
+          + "failed to avoid repeated failures, " + ex;
+      LOG.error(errorMessage);
+      ci.errorMessage = errorMessage;
       txnHandler.markFailed(ci);
     }
   }
 
-  @VisibleForTesting
-  ValidWriteIdList resolveValidWriteIds(Table t) throws NoSuchTxnException, MetaException {
+  private ValidWriteIdList resolveValidWriteIds(Table t) throws NoSuchTxnException, MetaException {
     ValidTxnList validTxnList = new ValidReadTxnList(conf.get(ValidTxnList.VALID_TXNS_KEY));
     // The response will have one entry per table and hence we get only one ValidWriteIdList
     String fullTableName = TxnUtils.getFullTableName(t.getDbName(), t.getTableName());

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -297,7 +297,7 @@ public class TestCompactionTxnHandler {
     // Check the output of show compactions
     checkShowCompaction(dbName, tableName, partitionName, status, errorMessage);
     // Now add enough failed compactions to ensure purgeCompactionHistory() will attempt delete;
-    // HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED is enough for this.
+    // HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE is enough for this.
     // But we also want enough to tickle the code in TxnUtils.buildQueryWithINClauseStrings()
     // so that it produces multiple queries. For that we need at least 290.
     for (int i = 0 ; i < 300; i++) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands2.java
@@ -1000,7 +1000,7 @@ public class TestTxnCommands2 {
     //insert overwrite not supported for ACID tables
   }
   private static void checkCompactionState(CompactionsByState expected, CompactionsByState actual) {
-    Assert.assertEquals(TxnStore.ATTEMPTED_RESPONSE, expected.attempted, actual.attempted);
+    Assert.assertEquals(TxnStore.DID_NOT_INITIATE_RESPONSE, expected.didNotInitiate, actual.didNotInitiate);
     Assert.assertEquals(TxnStore.FAILED_RESPONSE, expected.failed, actual.failed);
     Assert.assertEquals(TxnStore.INITIATED_RESPONSE, expected.initiated, actual.initiated);
     Assert.assertEquals(TxnStore.CLEANING_RESPONSE, expected.readyToClean, actual.readyToClean);
@@ -1039,61 +1039,61 @@ public class TestTxnCommands2 {
       txnHandler.compact(new CompactionRequest("default", tblName, CompactionType.MINOR));
       runWorker(hiveConf);
     }
-    //this should not schedule a new compaction due to prior failures, but will create Attempted entry
+    //this should not schedule a new compaction due to prior failures, but will create 'did not initiate' entry
     Initiator init = new Initiator();
     init.setThreadId((int)init.getId());
     init.setConf(hiveConf);
     init.init(stop);
     init.run();
-    int numAttemptedCompactions = 1;
-    checkCompactionState(new CompactionsByState(numAttemptedCompactions,numFailedCompactions,0,0,0,0,numFailedCompactions + numAttemptedCompactions), countCompacts(txnHandler));
+    int numDidNotInitiateCompactions = 1;
+    checkCompactionState(new CompactionsByState(numDidNotInitiateCompactions,numFailedCompactions,0,0,0,0,numFailedCompactions + numDidNotInitiateCompactions), countCompacts(txnHandler));
 
     hiveConf.setTimeVar(HiveConf.ConfVars.COMPACTOR_HISTORY_REAPER_INTERVAL, 10, TimeUnit.MILLISECONDS);
     MetastoreTaskThread houseKeeper = new AcidHouseKeeperService();
     houseKeeper.setConf(hiveConf);
     houseKeeper.run();
-    checkCompactionState(new CompactionsByState(numAttemptedCompactions,numFailedCompactions,0,0,0,0,numFailedCompactions + numAttemptedCompactions), countCompacts(txnHandler));
+    checkCompactionState(new CompactionsByState(numDidNotInitiateCompactions,numFailedCompactions,0,0,0,0,numFailedCompactions + numDidNotInitiateCompactions), countCompacts(txnHandler));
 
     txnHandler.compact(new CompactionRequest("default", tblName, CompactionType.MAJOR));
     runWorker(hiveConf);//will fail
     txnHandler.compact(new CompactionRequest("default", tblName, CompactionType.MINOR));
     runWorker(hiveConf);//will fail
     init.run();
-    numAttemptedCompactions++;
+    numDidNotInitiateCompactions++;
     init.run();
-    numAttemptedCompactions++;
-    checkCompactionState(new CompactionsByState(numAttemptedCompactions,numFailedCompactions + 2,0,0,0,0,numFailedCompactions + 2 + numAttemptedCompactions), countCompacts(txnHandler));
+    numDidNotInitiateCompactions++;
+    checkCompactionState(new CompactionsByState(numDidNotInitiateCompactions,numFailedCompactions + 2,0,0,0,0,numFailedCompactions + 2 + numDidNotInitiateCompactions), countCompacts(txnHandler));
 
     houseKeeper.run();
     //COMPACTOR_HISTORY_RETENTION_FAILED failed compacts left (and no other since we only have failed ones here)
     checkCompactionState(new CompactionsByState(
-      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED),
+      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE),
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED),0,0,0,0,
-      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED) + hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED)), countCompacts(txnHandler));
+      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED) + hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE)), countCompacts(txnHandler));
 
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, false);
     txnHandler.compact(new CompactionRequest("default", tblName, CompactionType.MINOR));
     //at this point "show compactions" should have (COMPACTOR_HISTORY_RETENTION_FAILED) failed + 1 initiated (explicitly by user)
     checkCompactionState(new CompactionsByState(
-      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED),
+      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE),
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED),1,0,0,0,
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED) +
-        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED)+ 1), countCompacts(txnHandler));
+        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE)+ 1), countCompacts(txnHandler));
 
     runWorker(hiveConf);//will succeed and transition to Initiated->Working->Ready for Cleaning
     checkCompactionState(new CompactionsByState(
-      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED),
+      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE),
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED),0,1,0,0,
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED) +
-        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED)+ 1), countCompacts(txnHandler));
+        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE)+ 1), countCompacts(txnHandler));
 
     runCleaner(hiveConf); // transition to Success state
     houseKeeper.run();
     checkCompactionState(new CompactionsByState(
-      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED),
+      hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE),
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED),0,0,1,0,
       hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED) +
-        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED)+ 1), countCompacts(txnHandler));
+        hiveConf.getIntVar(HiveConf.ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE)+ 1), countCompacts(txnHandler));
   }
 
   /**
@@ -1140,7 +1140,7 @@ public class TestTxnCommands2 {
   }
 
   private static class CompactionsByState {
-    private int attempted;
+    private int didNotInitiate;
     private int failed;
     private int initiated;
     private int readyToClean;
@@ -1150,8 +1150,8 @@ public class TestTxnCommands2 {
     CompactionsByState() {
       this(0,0,0,0,0,0,0);
     }
-    CompactionsByState(int attempted, int failed, int initiated, int readyToClean, int succeeded, int working, int total) {
-      this.attempted = attempted;
+    CompactionsByState(int didNotInitiate, int failed, int initiated, int readyToClean, int succeeded, int working, int total) {
+      this.didNotInitiate = didNotInitiate;
       this.failed = failed;
       this.initiated = initiated;
       this.readyToClean = readyToClean;
@@ -1180,8 +1180,8 @@ public class TestTxnCommands2 {
       else if(TxnStore.WORKING_RESPONSE.equals(compact.getState())) {
         compactionsByState.working++;
       }
-      else if(TxnStore.ATTEMPTED_RESPONSE.equals(compact.getState())) {
-        compactionsByState.attempted++;
+      else if(TxnStore.DID_NOT_INITIATE_RESPONSE.equals(compact.getState())) {
+        compactionsByState.didNotInitiate++;
       }
       else {
         throw new IllegalStateException("Unexpected state: " + compact.getState());

--- a/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.txn.compactor.Cleaner;
+import org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtilities.CompactorThreadType;
 import org.apache.hadoop.hive.ql.txn.compactor.CompactorThread;
 import org.apache.hadoop.hive.ql.txn.compactor.Initiator;
 import org.apache.hadoop.hive.ql.txn.compactor.Worker;
@@ -215,7 +216,6 @@ public abstract class TxnCommandsBaseForTests {
   public static void runInitiator(HiveConf hiveConf) throws Exception {
     runCompactorThread(hiveConf, CompactorThreadType.INITIATOR);
   }
-  private enum CompactorThreadType {INITIATOR, WORKER, CLEANER}
   private static void runCompactorThread(HiveConf hiveConf, CompactorThreadType type)
       throws Exception {
     AtomicBoolean stop = new AtomicBoolean(true);

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -93,7 +93,7 @@ import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtilities.CompactorThreadType;
+import org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtilities.CompactorThreadType;
 
 /**
  * Super class for all of the compactor test modules.

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -93,6 +93,8 @@ import java.util.Stack;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.apache.hadoop.hive.ql.txn.compactor.CompactorTestUtilities.CompactorThreadType;
+
 /**
  * Super class for all of the compactor test modules.
  */
@@ -123,15 +125,15 @@ public abstract class CompactorTest {
   }
 
   protected void startInitiator() throws Exception {
-    startThread('i', true);
+    startThread(CompactorThreadType.INITIATOR, true);
   }
 
   protected void startWorker() throws Exception {
-    startThread('w', true);
+    startThread(CompactorThreadType.WORKER, true);
   }
 
   protected void startCleaner() throws Exception {
-    startThread('c', true);
+    startThread(CompactorThreadType.CLEANER, true);
   }
 
   protected Table newTable(String dbName, String tableName, boolean partitioned) throws TException {
@@ -307,13 +309,13 @@ public abstract class CompactorTest {
   }
 
   // I can't do this with @Before because I want to be able to control when the thread starts
-  private void startThread(char type, boolean stopAfterOne) throws Exception {
+  private void startThread(CompactorThreadType type, boolean stopAfterOne) throws Exception {
     TestTxnDbUtil.setConfValues(conf);
     CompactorThread t;
     switch (type) {
-      case 'i': t = new Initiator(); break;
-      case 'w': t = new Worker(); break;
-      case 'c': t = new Cleaner(); break;
+      case INITIATOR: t = new Initiator(); break;
+      case WORKER: t = new Worker(); break;
+      case CLEANER: t = new Cleaner(); break;
       default: throw new RuntimeException("Huh? Unknown thread type.");
     }
     t.setThreadId((int) t.getId());

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTestUtilities.java
@@ -42,6 +42,7 @@ public class CompactorTestUtilities {
 
   private static final Charset UTF8 = Charset.forName("UTF-8");
   private static final int ORC_ACID_VERSION_DEFAULT = 0;
+  public enum CompactorThreadType {INITIATOR, WORKER, CLEANER}
 
   /**
    * This is smart enough to handle streaming ingest where there could be a

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator.java
@@ -1188,7 +1188,8 @@ public class TestInitiator extends CompactorTest {
     initiator.setThreadId((int) t.getId());
     initiator.setConf(conf);
     initiator.init(new AtomicBoolean(true));
-    doThrow(new RuntimeException()).when(initiator).resolveValidWriteIds(any());
+    doThrow(new RuntimeException("This was thrown on purpose by testInitiatorFailure"))
+        .when(initiator).resolveTable(any());
     initiator.run();
 
     // verify status of table compaction

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestInitiator.java
@@ -1167,7 +1167,10 @@ public class TestInitiator extends CompactorTest {
     String tableName = "my_table";
     Table t = newTable("default", tableName, false);
 
-    for (int i = 0; i < 11; i++) {
+    HiveConf.setIntVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_ABORTEDTXN_THRESHOLD, 1);
+
+    // 2 aborts
+    for (int i = 0; i < 2; i++) {
       long txnid = openTxn();
       LockComponent comp = new LockComponent(LockType.SHARED_WRITE, LockLevel.TABLE, "default");
       comp.setTablename(tableName);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -402,7 +402,8 @@ public class MetastoreConf {
         "hive.compactor.history.retention.did.not.initiate", 2,
         new RangeValidator(0, 100), "Determines how many compaction records in state " +
         "'did not initiate' will be retained in compaction history for a given table/partition.",
-        "metastore.compactor.history.retention.attempted"),
+        // deprecated keys:
+        "metastore.compactor.history.retention.attempted", "hive.compactor.history.retention.attempted"),
     COMPACTOR_HISTORY_RETENTION_FAILED("metastore.compactor.history.retention.failed",
         "hive.compactor.history.retention.failed", 3,
         new RangeValidator(0, 100), "Determines how many failed compaction records will be " +
@@ -1417,8 +1418,8 @@ public class MetastoreConf {
     LONG_TEST_ENTRY("test.long", "hive.test.long", 42, "comment"),
     DOUBLE_TEST_ENTRY("test.double", "hive.test.double", Math.PI, "comment"),
     TIME_TEST_ENTRY("test.time", "hive.test.time", 1, TimeUnit.SECONDS, "comment"),
-    DEPRECATED_TEST_ENTRY("test.deprecated", "hive.test.deprecated", 1, new RangeValidator(0, 3),
-        "comment", "this.is.the.deprecated.name"),
+    DEPRECATED_TEST_ENTRY("test.deprecated", "hive.test.deprecated", 0, new RangeValidator(0, 3), "comment",
+        "this.is.the.metastore.deprecated.name", "this.is.the.hive.deprecated.name"),
     TIME_VALIDATOR_ENTRY_INCLUSIVE("test.time.validator.inclusive", "hive.test.time.validator.inclusive", 1,
         TimeUnit.SECONDS,
         new TimeValidator(TimeUnit.MILLISECONDS, 500L, true, 1500L, true), "comment"),
@@ -1435,6 +1436,7 @@ public class MetastoreConf {
     private final boolean caseSensitive;
     private final String description;
     private String deprecatedName = null;
+    private String hiveDeprecatedName = null;
 
     ConfVars(String varname, String hiveName, String defaultVal, String description) {
       this.varname = varname;
@@ -1485,7 +1487,7 @@ public class MetastoreConf {
     }
 
     ConfVars(String varname, String hiveName, long defaultVal, Validator validator,
-        String description, String deprecatedName) {
+        String description, String deprecatedName, String hiveDeprecatedName) {
       this.varname = varname;
       this.hiveName = hiveName;
       this.defaultVal = defaultVal;
@@ -1493,6 +1495,7 @@ public class MetastoreConf {
       caseSensitive = false;
       this.description = description;
       this.deprecatedName = deprecatedName;
+      this.hiveDeprecatedName = hiveDeprecatedName;
     }
 
     ConfVars(String varname, String hiveName, boolean defaultVal, String description) {
@@ -1701,14 +1704,18 @@ public class MetastoreConf {
 
     /*
     Add deprecated config names to configuration.
-    The parameters for Configuration.addDeprecation are (oldKey, newKey) and it is assumed that the config is set via 
+    The parameters for Configuration.addDeprecation are (oldKey, newKey) and it is assumed that the config is set via
     newKey and the value is retrieved via oldKey.
-    However in this case we assume the value is set with the deprecated key (oldKey) in some config file and we 
+    However in this case we assume the value is set with the deprecated key (oldKey) in some config file and we
     retrieve it in the code via the new key. So the parameter order we use here is: (newKey, deprecatedKey).
+    We do this with the HiveConf configs as well.
      */
     for (ConfVars var : ConfVars.values()) {
       if (var.deprecatedName != null) {
         Configuration.addDeprecation(var.getVarname(), var.deprecatedName);
+      }
+      if (var.hiveDeprecatedName != null) {
+        Configuration.addDeprecation(var.getHiveName(), var.hiveDeprecatedName);
       }
     }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -398,18 +398,11 @@ public class MetastoreConf {
             "has an infinite lifetime."),
     CLIENT_SOCKET_TIMEOUT("metastore.client.socket.timeout", "hive.metastore.client.socket.timeout", 600,
             TimeUnit.SECONDS, "MetaStore Client socket timeout in seconds"),
-    /**
-     * @deprecated use metastore.compactor.history.retention.did.not.initiate
-     */
-    @Deprecated
-    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("metastore.compactor.history.retention.attempted",
-        "hive.compactor.history.retention.attempted", 2,
-        new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
-        "retained in compaction history for a given table/partition."),
     COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("metastore.compactor.history.retention.did.not.initiate",
         "hive.compactor.history.retention.did.not.initiate", 2,
         new RangeValidator(0, 100), "Determines how many compaction records in state " +
-        "'did not initiate' will be retained in compaction history for a given table/partition."),
+        "'did not initiate' will be retained in compaction history for a given table/partition.",
+        "metastore.compactor.history.retention.attempted"),
     COMPACTOR_HISTORY_RETENTION_FAILED("metastore.compactor.history.retention.failed",
         "hive.compactor.history.retention.failed", 3,
         new RangeValidator(0, 100), "Determines how many failed compaction records will be " +
@@ -1424,6 +1417,8 @@ public class MetastoreConf {
     LONG_TEST_ENTRY("test.long", "hive.test.long", 42, "comment"),
     DOUBLE_TEST_ENTRY("test.double", "hive.test.double", Math.PI, "comment"),
     TIME_TEST_ENTRY("test.time", "hive.test.time", 1, TimeUnit.SECONDS, "comment"),
+    DEPRECATED_TEST_ENTRY("test.deprecated", "hive.test.deprecated", 1, new RangeValidator(0, 3),
+        "comment", "this.is.the.deprecated.name"),
     TIME_VALIDATOR_ENTRY_INCLUSIVE("test.time.validator.inclusive", "hive.test.time.validator.inclusive", 1,
         TimeUnit.SECONDS,
         new TimeValidator(TimeUnit.MILLISECONDS, 500L, true, 1500L, true), "comment"),
@@ -1439,6 +1434,7 @@ public class MetastoreConf {
     private final Validator validator;
     private final boolean caseSensitive;
     private final String description;
+    private String deprecatedName = null;
 
     ConfVars(String varname, String hiveName, String defaultVal, String description) {
       this.varname = varname;
@@ -1486,6 +1482,17 @@ public class MetastoreConf {
       this.validator = validator;
       caseSensitive = false;
       this.description = description;
+    }
+
+    ConfVars(String varname, String hiveName, long defaultVal, Validator validator,
+        String description, String deprecatedName) {
+      this.varname = varname;
+      this.hiveName = hiveName;
+      this.defaultVal = defaultVal;
+      this.validator = validator;
+      caseSensitive = false;
+      this.description = description;
+      this.deprecatedName = deprecatedName;
     }
 
     ConfVars(String varname, String hiveName, boolean defaultVal, String description) {
@@ -1691,6 +1698,20 @@ public class MetastoreConf {
         LOG.isDebugEnabled()) {
       LOG.debug(dumpConfig(conf));
     }
+
+    /*
+    Add deprecated config names to configuration.
+    The parameters for Configuration.addDeprecation are (oldKey, newKey) and it is assumed that the config is set via 
+    newKey and the value is retrieved via oldKey.
+    However in this case we assume the value is set with the deprecated key (oldKey) in some config file and we 
+    retrieve it in the code via the new key. So the parameter order we use here is: (newKey, deprecatedKey).
+     */
+    for (ConfVars var : ConfVars.values()) {
+      if (var.deprecatedName != null) {
+        Configuration.addDeprecation(var.getVarname(), var.deprecatedName);
+      }
+    }
+
     return conf;
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -398,10 +398,10 @@ public class MetastoreConf {
             "has an infinite lifetime."),
     CLIENT_SOCKET_TIMEOUT("metastore.client.socket.timeout", "hive.metastore.client.socket.timeout", 600,
             TimeUnit.SECONDS, "MetaStore Client socket timeout in seconds"),
-    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("metastore.compactor.history.retention.attempted",
+    COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("metastore.compactor.history.retention.attempted",
         "hive.compactor.history.retention.attempted", 2,
-        new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
-        "retained in compaction history for a given table/partition."),
+        new RangeValidator(0, 100), "Determines how many compaction records in state 'did not initiate'" + 
+        " will be retained in compaction history for a given table/partition."),
     COMPACTOR_HISTORY_RETENTION_FAILED("metastore.compactor.history.retention.failed",
         "hive.compactor.history.retention.failed", 3,
         new RangeValidator(0, 100), "Determines how many failed compaction records will be " +

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -398,10 +398,18 @@ public class MetastoreConf {
             "has an infinite lifetime."),
     CLIENT_SOCKET_TIMEOUT("metastore.client.socket.timeout", "hive.metastore.client.socket.timeout", 600,
             TimeUnit.SECONDS, "MetaStore Client socket timeout in seconds"),
-    COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("metastore.compactor.history.retention.attempted",
+    /**
+     * @deprecated use metastore.compactor.history.retention.did.not.initiate
+     */
+    @Deprecated
+    COMPACTOR_HISTORY_RETENTION_ATTEMPTED("metastore.compactor.history.retention.attempted",
         "hive.compactor.history.retention.attempted", 2,
-        new RangeValidator(0, 100), "Determines how many compaction records in state 'did not initiate'" + 
-        " will be retained in compaction history for a given table/partition."),
+        new RangeValidator(0, 100), "Determines how many attempted compaction records will be " +
+        "retained in compaction history for a given table/partition."),
+    COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE("metastore.compactor.history.retention.did.not.initiate",
+        "hive.compactor.history.retention.did.not.initiate", 2,
+        new RangeValidator(0, 100), "Determines how many compaction records in state " +
+        "'did not initiate' will be retained in compaction history for a given table/partition."),
     COMPACTOR_HISTORY_RETENTION_FAILED("metastore.compactor.history.retention.failed",
         "hive.compactor.history.retention.failed", 3,
         new RangeValidator(0, 100), "Determines how many failed compaction records will be " +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -31,7 +31,6 @@ import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.prependCatal
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.prependNotNullCatToDbName;
 
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
@@ -81,7 +80,6 @@ import com.google.common.collect.Lists;
 import org.apache.commons.cli.OptionBuilder;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -205,7 +203,6 @@ import org.apache.thrift.server.TThreadPoolServer;
 import org.apache.thrift.transport.TServerSocket;
 import org.apache.thrift.transport.TTransport;
 import org.apache.thrift.transport.TTransportFactory;
-import org.codehaus.jackson.map.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -10682,7 +10679,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
     HMSHandler.LOG
         .info("hive.metastore.runworker.in = {}", MetastoreConf.getVar(conf, ConfVars.HIVE_METASTORE_RUNWORKER_IN));
     HMSHandler.LOG.info("metastore.compactor.history.retention.attempted = {}",
-        MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_ATTEMPTED));
+        MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_DID_NOT_INITIATE));
     HMSHandler.LOG.info("metastore.compactor.history.retention.failed = {}",
         MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_FAILED));
     HMSHandler.LOG.info("metastore.compactor.history.retention.succeeded = {}",

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -228,7 +228,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   static final protected char READY_FOR_CLEANING = 'r';
   static final char FAILED_STATE = 'f';
   static final char SUCCEEDED_STATE = 's';
-  static final char ATTEMPTED_STATE = 'a';
+  static final char DID_NOT_INITIATE = 'a';
 
   // Compactor types
   static final protected char MAJOR_TYPE = 'a';
@@ -3510,7 +3510,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
       case READY_FOR_CLEANING: return CLEANING_RESPONSE;
       case FAILED_STATE: return FAILED_RESPONSE;
       case SUCCEEDED_STATE: return SUCCEEDED_RESPONSE;
-      case ATTEMPTED_STATE: return ATTEMPTED_RESPONSE;
+      case DID_NOT_INITIATE: return DID_NOT_INITIATE_RESPONSE;
       default:
         return Character.toString(s);
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnStore.java
@@ -56,10 +56,10 @@ public interface TxnStore extends Configurable {
   String CLEANING_RESPONSE = "ready for cleaning";
   String FAILED_RESPONSE = "failed";
   String SUCCEEDED_RESPONSE = "succeeded";
-  String ATTEMPTED_RESPONSE = "attempted";
+  String DID_NOT_INITIATE_RESPONSE = "did not initiate";
 
   String[] COMPACTION_STATES = new String[] {INITIATED_RESPONSE, WORKING_RESPONSE, CLEANING_RESPONSE, FAILED_RESPONSE,
-      SUCCEEDED_RESPONSE, ATTEMPTED_RESPONSE};
+      SUCCEEDED_RESPONSE, DID_NOT_INITIATE_RESPONSE };
 
   int TIMED_OUT_TXN_ABORT_BATCH_SIZE = 50000;
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -310,6 +310,28 @@ public class TestMetastoreConf {
     Assert.assertEquals("false", MetastoreConf.getAsString(conf, ConfVars.BOOLEAN_TEST_ENTRY));
   }
 
+  /**
+   * Verify that a config can be set with a deprecated key/name.
+   */
+  @Test
+  public void testDeprecatedConfigs() throws IOException {
+    // set deprecated config
+    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
+        "hive.test.str", "hivedefault",
+        "this.is.the.deprecated.name", "2" // default is 1
+    ));
+    conf = MetastoreConf.newMetastoreConf();
+    Assert.assertEquals(2, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
+
+    // set new config
+    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
+        "hive.test.str", "hivedefault",
+        "test.deprecated", "0" // default is 1
+    ));
+    conf = MetastoreConf.newMetastoreConf();
+    Assert.assertEquals(0, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
+  }
+
   @Test
   public void timeUnits() throws IOException {
     conf = MetastoreConf.newMetastoreConf();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/conf/TestMetastoreConf.java
@@ -315,21 +315,29 @@ public class TestMetastoreConf {
    */
   @Test
   public void testDeprecatedConfigs() throws IOException {
-    // set deprecated config
+    // set with deprecated key
     createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
         "hive.test.str", "hivedefault",
-        "this.is.the.deprecated.name", "2" // default is 1
+        "this.is.the.metastore.deprecated.name", "1" // default is 0
+    ));
+    conf = MetastoreConf.newMetastoreConf();
+    Assert.assertEquals(1, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
+
+    // set with hive (HiveConf) deprecated key
+    createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
+        "hive.test.str", "hivedefault",
+        "this.is.the.hive.deprecated.name", "2" // default is 0
     ));
     conf = MetastoreConf.newMetastoreConf();
     Assert.assertEquals(2, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
 
-    // set new config
+    // set with normal key
     createConfFile("metastore-site.xml", false, "METASTORE_CONF_DIR", instaMap(
         "hive.test.str", "hivedefault",
-        "test.deprecated", "0" // default is 1
+        "test.deprecated", "3" // default is 0
     ));
     conf = MetastoreConf.newMetastoreConf();
-    Assert.assertEquals(0, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
+    Assert.assertEquals(3, MetastoreConf.getIntVar(conf, ConfVars.DEPRECATED_TEST_ENTRY));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Rename compaction 'attempted' status to 'did not initiate'


### Why are the changes needed?
See HIVE-24587.

### Does this PR introduce _any_ user-facing change?
Show compactions and sys.COMPACTIONS tables will list "attempted" status as "did not initiate" now.

### How was this patch tested?
Unit test for case of initiator failure.
