### PR TITLE
HIVE-24594: Disable flaky test TestMiniLlapLocalCliDriver[results_cache_invalidation2.q]

### DIFF
--- a/ql/src/test/queries/clientpositive/results_cache_invalidation2.q
+++ b/ql/src/test/queries/clientpositive/results_cache_invalidation2.q
@@ -1,3 +1,4 @@
+--! qt:disabled:HIVE-24594
 --! qt:dataset:src
 set hive.metastore.event.listeners=org.apache.hive.hcatalog.listener.DbNotificationListener;
 


### PR DESCRIPTION
The PR disables results_cache_invalidation2.q which fails intermittently on unrelated PRs.

### What changes were proposed in this pull request?
Disable TestMiniLlapLocalCliDriver[results_cache_invalidation2.q] due to flakiness.


### Why are the changes needed?
Reduce unrelated intermittent errors on the PRs to improve dev productivity.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ran the split locally and made sure that the test is not run.
