### PR TITLE
HIVE-24602: Retry compaction after configured time

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestCompactionTxnHandler.java
@@ -59,6 +59,8 @@ import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME;
+import static org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_THRESHOLD;
 
 /**
  * Tests for CompactionTxnHandler.
@@ -290,15 +292,15 @@ public class TestCompactionTxnHandler {
     assertFalse(txnHandler.checkFailedCompactions(ci));
 
     // Add more failed compactions so that the total is exactly COMPACTOR_INITIATOR_FAILED_THRESHOLD
-    for (int i = 1; i < MetastoreConf.getIntVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_THRESHOLD); i++) {
+    for (int i = 1; i < MetastoreConf.getIntVar(conf, COMPACTOR_INITIATOR_FAILED_THRESHOLD); i++) {
       addFailedCompaction(dbName, tableName, CompactionType.MINOR, partitionName, errorMessage);
     }
     // Now checkFailedCompactions() will return true
     assertTrue(txnHandler.checkFailedCompactions(ci));
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME, 1, TimeUnit.MILLISECONDS);
-    // Now checkFailedCompactions() should ignore the treshold
+    MetastoreConf.setTimeVar(conf, COMPACTOR_INITIATOR_FAILED_RETRY_TIME, 1, TimeUnit.MILLISECONDS);
+    // Now checkFailedCompactions() should ignore the threshold
     assertFalse(txnHandler.checkFailedCompactions(ci));
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME, 7, TimeUnit.DAYS);
+    MetastoreConf.setTimeVar(conf, COMPACTOR_INITIATOR_FAILED_RETRY_TIME, 7, TimeUnit.DAYS);
     // Check the output of show compactions
     checkShowCompaction(dbName, tableName, partitionName, status, errorMessage);
     // Now add enough failed compactions to ensure purgeCompactionHistory() will attempt delete;

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -415,6 +415,10 @@ public class MetastoreConf {
         new RangeValidator(1, 20), "Number of consecutive compaction failures (per table/partition) " +
         "after which automatic compactions will not be scheduled any more.  Note that this must be less " +
         "than hive.compactor.history.retention.failed."),
+    COMPACTOR_INITIATOR_FAILED_RETRY_TIME("metastore.compactor.initiator.failed.retry.time",
+        "hive.compactor.initiator.failed.retry.time", 7, TimeUnit.DAYS,
+        "Time after Initiator will ignore metastore.compactor.initiator.failed.compacts.threshold and retry with compaction again. \n"
+            + "This will try to auto heal tables / partitions with previous failed compaction without manual intervention."),
     COMPACTOR_RUN_AS_USER("metastore.compactor.run.as.user", "hive.compactor.run.as.user", "",
         "Specify the user to run compactor Initiator and Worker as. If empty string, defaults to table/partition " +
         "directory owner."),

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -417,8 +417,9 @@ public class MetastoreConf {
         "than hive.compactor.history.retention.failed."),
     COMPACTOR_INITIATOR_FAILED_RETRY_TIME("metastore.compactor.initiator.failed.retry.time",
         "hive.compactor.initiator.failed.retry.time", 7, TimeUnit.DAYS,
-        "Time after Initiator will ignore metastore.compactor.initiator.failed.compacts.threshold and retry with compaction again. \n"
-            + "This will try to auto heal tables / partitions with previous failed compaction without manual intervention."),
+        "Time after Initiator will ignore metastore.compactor.initiator.failed.compacts.threshold "
+            + "and retry with compaction again. This will try to auto heal tables with previous failed compaction "
+            + "without manual intervention. Setting it to 0 or negative value will disable this feature."),
     COMPACTOR_RUN_AS_USER("metastore.compactor.run.as.user", "hive.compactor.run.as.user", "",
         "Specify the user to run compactor Initiator and Worker as. If empty string, defaults to table/partition " +
         "directory owner."),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -1021,9 +1021,11 @@ class CompactionTxnHandler extends TxnHandler {
             numFailed--;
           }
         }
-        // If the last attempt was too long ago, ignore the failed treshold and try compaction again
-        long retryTime = MetastoreConf.getTimeVar(conf, ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME, TimeUnit.MILLISECONDS);
-        return (numFailed == failedThreshold) && (lastEnqueueTime + retryTime > System.currentTimeMillis());
+        // If the last attempt was too long ago, ignore the failed threshold and try compaction again
+        long retryTime = MetastoreConf.getTimeVar(conf,
+            ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME, TimeUnit.MILLISECONDS);
+        boolean needsRetry = (retryTime > 0) && (lastEnqueueTime + retryTime < System.currentTimeMillis());
+        return (numFailed == failedThreshold) && !needsRetry;
       }
       catch (SQLException e) {
         LOG.error("Unable to check for failed compactions " + e.getMessage());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.apache.hadoop.hive.metastore.txn.TxnUtils.getEpochFn;
 
@@ -993,7 +994,7 @@ class CompactionTxnHandler extends TxnHandler {
     try {
       try {
         dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
-        pStmt = dbConn.prepareStatement("SELECT \"CC_STATE\" FROM \"COMPLETED_COMPACTIONS\" WHERE " +
+        pStmt = dbConn.prepareStatement("SELECT \"CC_STATE\", \"CC_ENQUEUE_TIME\" FROM \"COMPLETED_COMPACTIONS\" WHERE " +
           "\"CC_DATABASE\" = ? AND " +
           "\"CC_TABLE\" = ? " +
           (ci.partName != null ? "AND \"CC_PARTITION\" = ?" : "") +
@@ -1006,8 +1007,13 @@ class CompactionTxnHandler extends TxnHandler {
         rs = pStmt.executeQuery();
         int numFailed = 0;
         int numTotal = 0;
+        long lastEnqueueTime = -1;
         int failedThreshold = MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_INITIATOR_FAILED_THRESHOLD);
         while(rs.next() && ++numTotal <= failedThreshold) {
+          long enqueueTime = rs.getLong(2);
+          if (enqueueTime > lastEnqueueTime) {
+            lastEnqueueTime = enqueueTime;
+          }
           if(rs.getString(1).charAt(0) == FAILED_STATE) {
             numFailed++;
           }
@@ -1015,7 +1021,9 @@ class CompactionTxnHandler extends TxnHandler {
             numFailed--;
           }
         }
-        return numFailed == failedThreshold;
+        // If the last attempt was too long ago, ignore the failed treshold and try compaction again
+        long retryTime = MetastoreConf.getTimeVar(conf, ConfVars.COMPACTOR_INITIATOR_FAILED_RETRY_TIME, TimeUnit.MILLISECONDS);
+        return (numFailed == failedThreshold) && (lastEnqueueTime + retryTime > System.currentTimeMillis());
       }
       catch (SQLException e) {
         LOG.error("Unable to check for failed compactions " + e.getMessage());


### PR DESCRIPTION

### What changes were proposed in this pull request?
Automatic compaction initiation stops if compaction fails for a given partition two consecutive time. The Initiator should retry after some time elapses.


### Why are the changes needed?
Compaction not running for a table / partition can have serious performance impact


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added unittest.
