### PR TITLE
HIVE-24588: Run tests using specific log4j2 configuration conveniently

### DIFF
--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -43,6 +43,16 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j2.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>

--- a/testutils/src/java/org/apache/hive/testutils/junit/extensions/Log4jConfig.java
+++ b/testutils/src/java/org/apache/hive/testutils/junit/extensions/Log4jConfig.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Indicates the Log4j2 configuration to be used for the duration of a test.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(Log4jConfigExtension.class)
+public @interface Log4jConfig {
+  /**
+   * Returns the name of the log4j2 configuration file to use.
+   *
+   * The file should be present in the resources.
+   */
+  String value();
+}

--- a/testutils/src/java/org/apache/hive/testutils/junit/extensions/Log4jConfigExtension.java
+++ b/testutils/src/java/org/apache/hive/testutils/junit/extensions/Log4jConfigExtension.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.lang.reflect.AnnotatedElement;
+import java.net.URL;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A JUnit Jupiter extension that loads a log4j2 configuration from a file present in the resources of the project
+ * when the test uses the {@link Log4jConfig} annotation.
+ *
+ * The configuration that was in use before starting the annotated test is restored when the test completes
+ * (success, or failure).
+ *
+ * The class is thread-safe but tests with {@link Log4jConfig} cannot run in parallel due to the nature of the log4j
+ * configuration.
+ *
+ * @see Log4jConfig
+ */
+public class Log4jConfigExtension implements BeforeEachCallback, AfterEachCallback {
+  private static final ReentrantLock LOCK = new ReentrantLock();
+  private static Configuration oldConfig = null;
+
+  @Override
+  public void beforeEach(ExtensionContext context) throws Exception {
+    if (!LOCK.tryLock(1, TimeUnit.MINUTES)) {
+      throw new IllegalStateException(
+          "Lock acquisition failed cause another test is using a custom Log4j configuration.");
+    }
+    assert oldConfig == null;
+    LoggerContext ctx = LoggerContext.getContext(false);
+    oldConfig = ctx.getConfiguration();
+    Optional<AnnotatedElement> element = context.getElement();
+    if (!element.isPresent()) {
+      throw new IllegalStateException("The extension needs an annotated method");
+    }
+    Log4jConfig annotation = element.get().getAnnotation(Log4jConfig.class);
+    if (annotation == null) {
+      throw new IllegalStateException(Log4jConfig.class.getSimpleName() + " annotation is missing.");
+    }
+    String configFileName = annotation.value();
+    URL config = Log4jConfig.class.getClassLoader().getResource(configFileName);
+    if (config == null) {
+      throw new IllegalStateException("File " + configFileName + " was not found in resources.");
+    }
+    ctx.setConfigLocation(config.toURI());
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    try {
+      LoggerContext ctx = LoggerContext.getContext(false);
+      ctx.setConfiguration(oldConfig);
+      oldConfig = null;
+    } finally {
+      LOCK.unlock();
+    }
+  }
+}

--- a/testutils/src/test/java/org/apache/hive/testutils/junit/extensions/TestLog4jConfigExtension.java
+++ b/testutils/src/test/java/org/apache/hive/testutils/junit/extensions/TestLog4jConfigExtension.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+/**
+ * Tests for {@link Log4jConfigExtension}.
+ */
+public class TestLog4jConfigExtension {
+
+  @Test
+  @Log4jConfig("test0-log4j2.properties")
+  void testUseExplicitConfig0() {
+    LoggerContext ctx = LoggerContext.getContext(false);
+    Configuration c = ctx.getConfiguration();
+    assertEquals("TestConfig0Log4j2", c.getName());
+    assertNotNull(c.getAppender("appender_zero"));
+    assertEquals(1, c.getAppenders().size());
+    assertEquals(2, c.getLoggers().size());
+    assertNotNull(c.getLoggerConfig("logger_zero"));
+    assertNotNull(c.getLoggerConfig("root"));
+  }
+
+  @Test
+  void testNoExplicitConfig() {
+    LoggerContext ctx = LoggerContext.getContext(false);
+    Configuration c = ctx.getConfiguration();
+    assertEquals("HiveLog4j2Test", c.getName());
+  }
+
+  @Test
+  @Log4jConfig("test1-log4j2.properties")
+  void testUseExplicitConfig1() {
+    LoggerContext ctx = LoggerContext.getContext(false);
+    Configuration c = ctx.getConfiguration();
+    assertEquals("TestConfig1Log4j2", c.getName());
+    assertNotNull(c.getAppender("appender_one"));
+    assertEquals(1, c.getAppenders().size());
+    assertEquals(2, c.getLoggers().size());
+    assertNotNull(c.getLoggerConfig("logger_one"));
+    assertNotNull(c.getLoggerConfig("root"));
+  }
+
+}

--- a/testutils/src/test/resources/test0-log4j2.properties
+++ b/testutils/src/test/resources/test0-log4j2.properties
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Log4j2 configuration only for testing purposes
+
+status = INFO
+name = TestConfig0Log4j2
+
+appenders = ap0
+
+appender.ap0.type = Console
+appender.ap0.name = appender_zero
+
+loggers = log0
+logger.log0.name = logger_zero
+
+rootLogger.level = INFO
+rootLogger.appenderRefs = root
+rootLogger.appenderRef.root.ref = ap0

--- a/testutils/src/test/resources/test1-log4j2.properties
+++ b/testutils/src/test/resources/test1-log4j2.properties
@@ -1,0 +1,32 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Log4j2 configuration only for testing purposes
+
+status = INFO
+name = TestConfig1Log4j2
+
+appenders = ap1
+
+appender.ap1.type = Console
+appender.ap1.name = appender_one
+
+loggers = log1
+logger.log1.name = logger_one
+
+rootLogger.level = INFO
+rootLogger.appenderRefs = root
+rootLogger.appenderRef.root.ref = ap1


### PR DESCRIPTION
### What changes were proposed in this pull request?
Add new Junit Jupiter annotation/extension.

### Why are the changes needed?
Run easily unit tests using a specific log4j configuration with minimal side-effects.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn test -pl testutils -Dtest=TestLog4jConfigExtension`
