### PR TITLE
HIVE-24607: Add JUnit annotation for running tests only if ports are available

### DIFF
--- a/testutils/pom.xml
+++ b/testutils/pom.xml
@@ -44,6 +44,11 @@
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.jupiter.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
       <scope>test</scope>
     </dependency>

--- a/testutils/src/java/org/apache/hive/testutils/junit/extensions/EnabledIfPortsAvailable.java
+++ b/testutils/src/java/org/apache/hive/testutils/junit/extensions/EnabledIfPortsAvailable.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to use for running tests only when the specified ports are available.
+ *
+ * If the ports are not available then the test is skipped with an appropriate message.
+ */
+@Target({ ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(EnabledIfPortsAvailableCondition.class)
+public @interface EnabledIfPortsAvailable {
+  /**
+   * Returns the ports that should be available, in order to run the test.
+   */
+  int[] value();
+}

--- a/testutils/src/java/org/apache/hive/testutils/junit/extensions/EnabledIfPortsAvailableCondition.java
+++ b/testutils/src/java/org/apache/hive/testutils/junit/extensions/EnabledIfPortsAvailableCondition.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.junit.jupiter.api.extension.ConditionEvaluationResult;
+import org.junit.jupiter.api.extension.ExecutionCondition;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.ServerSocket;
+
+import static org.junit.platform.commons.util.AnnotationUtils.findAnnotation;
+
+/**
+ * JUnit Jupiter extension to selectively enable tests when certain ports are available.
+ *
+ * @see EnabledIfPortsAvailable
+ */
+class EnabledIfPortsAvailableCondition implements ExecutionCondition {
+  @Override
+  public ConditionEvaluationResult evaluateExecutionCondition(ExtensionContext context) {
+    return findAnnotation(context.getElement(), EnabledIfPortsAvailable.class) //
+        .map(annotation -> {
+          for (int port : annotation.value()) {
+            if (!isPortAvailable(port)) {
+              return ConditionEvaluationResult.disabled("Port " + port + " is not available.");
+            }
+          }
+          return ConditionEvaluationResult.enabled("All required ports are free");
+        }).orElse(ConditionEvaluationResult.enabled(""));
+  }
+
+  private static boolean isPortAvailable(int port) {
+    try (@SuppressWarnings("unused") ServerSocket ss = new ServerSocket(port);
+        @SuppressWarnings("unused") DatagramSocket ds = new DatagramSocket(port)) {
+      return true;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+}

--- a/testutils/src/test/java/org/apache/hive/testutils/junit/extensions/TestEnabledIfPortsAvailableCondition.java
+++ b/testutils/src/test/java/org/apache/hive/testutils/junit/extensions/TestEnabledIfPortsAvailableCondition.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.testutils.junit.extensions;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+/**
+ * Tests for {@link EnabledIfPortsAvailable}.
+ */
+public class TestEnabledIfPortsAvailableCondition {
+
+  private static ServerSocket server;
+
+  @BeforeAll
+  static void setupSocket2000() {
+    try {
+      // Best effort to force some tests to be skipped.
+      server = new ServerSocket(2000);
+    } catch (IOException exception) {
+      // It is fine if we don't manage to bind the socket
+      // tests should not fail cause of it.
+    }
+  }
+
+  @AfterAll
+  static void tearDownSocket2000() throws IOException {
+    if (server != null) {
+      server.close();
+      server = null;
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(2000)
+  @SuppressWarnings("EmptyTryBlock")
+  void testPortMostLikelyInUse() throws IOException {
+    // Most of the time the test should be skipped since we are explicitly binding the port with server.
+    // If we fail to bind the server to the given port:
+    // - due to the port that is already taken; in that case the test should be skipped via the annotation
+    // - due to another reason (port is free); in that case the test should pass
+    try (@SuppressWarnings("unused") ServerSocket s = new ServerSocket(2000)) {
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(2001)
+  @SuppressWarnings("EmptyTryBlock")
+  void testPortMostLikelyAvailableV1() throws IOException {
+    // Most of the time the test should pass. In some cases it may happen that the port 2001
+    // is bound by somebody else so the test should be skipped.
+    try (@SuppressWarnings("unused") ServerSocket s = new ServerSocket(2001)) {
+    }
+  }
+
+  @Test
+  @EnabledIfPortsAvailable(5050)
+  @SuppressWarnings("EmptyTryBlock")
+  void testPortMostLikelyAvailableV2() throws IOException {
+    // Most of the time the test should pass. In some cases it may happen that the port 5050
+    // is bound by somebody else so the test should be skipped.
+    try (@SuppressWarnings("unused") ServerSocket s = new ServerSocket(5050)) {
+    }
+  }
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?
New JUnit annotation for running/skipping tests when ports are available/taken

### Why are the changes needed?
Avoid unexpected failures in tests when ports required in tests are taken.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn test -pl testutils -Dtest=TestEnabledIfPortsAvailableCondition`
[WARNING] Tests run: 3, Failures: 0, Errors: 0, Skipped: 1
```
nc -l 2001 &
mvn test -pl testutils -Dtest=TestEnabledIfPortsAvailableCondition
```
[WARNING] Tests run: 3, Failures: 0, Errors: 0, Skipped: 2
```
nc -l 5050 &
mvn test -pl testutils -Dtest=TestEnabledIfPortsAvailableCondition
```
[WARNING] Tests run: 3, Failures: 0, Errors: 0, Skipped: 3
```
nc -l 2000 &
mvn test -pl testutils -Dtest=TestEnabledIfPortsAvailableCondition
```
[WARNING] Tests run: 3, Failures: 0, Errors: 0, Skipped: 3