### PR TITLE
HIVE-24610 Remove superfluous throws IOException from Context

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -387,8 +387,6 @@ public enum ErrorMsg {
 
   UPDATEDELETE_PARSE_ERROR(10290, "Encountered parse error while parsing rewritten merge/update or " +
       "delete query"),
-  UPDATEDELETE_IO_ERROR(10291, "Encountered I/O error while parsing rewritten update or " +
-      "delete query"),
   UPDATE_CANNOT_UPDATE_PART_VALUE(10292, "Updating values of partition columns is not supported"),
   INSERT_CANNOT_CREATE_TEMP_FILE(10293, "Unable to create temp file for insert values "),
   ACID_OP_ON_NONACID_TXNMGR(10294, "Attempt to do update or delete using transaction manager that" +
@@ -461,7 +459,6 @@ public enum ErrorMsg {
       true),
   ACID_OP_ON_INSERTONLYTRAN_TABLE(10414, "Attempt to do update or delete on table {0} that is " +
     "insert-only transactional", true),
-  LOAD_DATA_LAUNCH_JOB_IO_ERROR(10415, "Encountered I/O error while parsing rewritten load data into insert query"),
   LOAD_DATA_LAUNCH_JOB_PARSE_ERROR(10416, "Encountered parse error while parsing rewritten load data into insert query"),
   RESOURCE_PLAN_ALREADY_EXISTS(10417, "Resource plan {0} already exists", true),
   RESOURCE_PLAN_NOT_EXISTS(10418, "Resource plan {0} does not exist", true),
@@ -542,7 +539,6 @@ public enum ErrorMsg {
   COLUMNSTATSCOLLECTOR_INVALID_PARTITION(30007, "Invalid partitioning key/value specified in " +
     "ANALYZE statement"),
   COLUMNSTATSCOLLECTOR_PARSE_ERROR(30009, "Encountered parse error while parsing rewritten query"),
-  COLUMNSTATSCOLLECTOR_IO_ERROR(30010, "Encountered I/O exception while parsing rewritten query"),
   DROP_COMMAND_NOT_ALLOWED_FOR_PARTITION(30011, "Partition protected from being dropped"),
   COLUMNSTATSCOLLECTOR_INVALID_COLUMN(30012, "Column statistics are not supported "
       + "for partition columns"),

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -323,7 +323,7 @@ public class Context {
     return insertBranchToNamePrefix.put(pos, prefix);
   }
 
-  public Context(Configuration conf) throws IOException {
+  public Context(Configuration conf) {
     this(conf, generateExecutionId());
   }
 
@@ -331,7 +331,7 @@ public class Context {
    * Create a Context with a given executionId.  ExecutionId, together with
    * user name and conf, will determine the temporary directory locations.
    */
-  private Context(Configuration conf, String executionId)  {
+  private Context(Configuration conf, String executionId) {
     this.conf = conf;
     this.executionId = executionId;
     this.subContexts = new HashSet<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -512,13 +512,9 @@ public class Driver implements IDriver {
       closeInProcess(false);
     }
 
-    try {
-      if (context == null) {
-        context = new Context(driverContext.getConf());
+    if (context == null) {
+      context = new Context(driverContext.getConf());
       }
-    } catch (IOException e) {
-      throw new CommandProcessorException(e);
-    }
 
     context.setHiveTxnManager(driverContext.getTxnManager());
     context.setStatsSource(driverContext.getStatsSource());

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/rcfile/truncate/ColumnTruncateTask.java
@@ -87,15 +87,9 @@ public class ColumnTruncateTask extends Task<ColumnTruncateWork> implements Seri
 
     Context ctx = context;
     boolean ctxCreated = false;
-    try {
-      if (ctx == null) {
-        ctx = new Context(job);
-        ctxCreated = true;
-      }
-    }catch (IOException e) {
-      LOG.error(org.apache.hadoop.util.StringUtils.stringifyException(e));
-      setException(e);
-      return 5;
+    if (ctx == null) {
+      ctx = new Context(job);
+      ctxCreated = true;
     }
 
     job.setMapOutputKeyClass(NullWritable.class);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/AcidExportSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/AcidExportSemanticAnalyzer.java
@@ -163,7 +163,7 @@ public class AcidExportSemanticAnalyzer extends RewriteSemanticAnalyzer {
       createTableTask.initialize(null, null, new TaskQueue(context), context);
       createTableTask.execute();
       newTable = db.getTable(newTableName);
-    } catch(IOException|HiveException ex) {
+    } catch(HiveException ex) {
       throw new SemanticException(ex);
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsAutoGatherContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsAutoGatherContext.java
@@ -140,7 +140,7 @@ public class ColumnStatsAutoGatherContext {
     Operator<?> selOp = null;
     try {
       selOp = genSelOp(command, rewritten, origCtx);
-    } catch (IOException | ParseException e) {
+    } catch (ParseException e) {
       throw new SemanticException(e);
     }
 
@@ -158,7 +158,7 @@ public class ColumnStatsAutoGatherContext {
   }
 
   private Operator genSelOp(String command, boolean rewritten, Context origCtx)
-      throws IOException, ParseException, SemanticException {
+      throws ParseException, SemanticException {
     // 1. initialization
     Context ctx = new Context(conf);
     origCtx.addSubContext(ctx);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ColumnStatsSemanticAnalyzer.java
@@ -493,11 +493,7 @@ public class ColumnStatsSemanticAnalyzer extends SemanticAnalyzer {
 
   private ASTNode genRewrittenTree(String rewrittenQuery) throws SemanticException {
     // Parse the rewritten query string
-    try {
-      ctx = new Context(conf);
-    } catch (IOException e) {
-      throw new SemanticException(ErrorMsg.COLUMNSTATSCOLLECTOR_IO_ERROR.getMsg());
-    }
+    ctx = new Context(conf);
     ctx.setCmd(rewrittenQuery);
     ctx.setHDFSCleanup(true);
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/LoadSemanticAnalyzer.java
@@ -530,14 +530,10 @@ public class LoadSemanticAnalyzer extends SemanticAnalyzer {
     HiveConf.setVar(conf, HiveConf.ConfVars.DYNAMICPARTITIONINGMODE, "nonstrict");
     // Parse the rewritten query string
     Context rewrittenCtx;
-    try {
-      rewrittenCtx = new Context(conf);
-      // We keep track of all the contexts that are created by this query
-      // so we can clear them when we finish execution
-      ctx.addSubContext(rewrittenCtx);
-    } catch (IOException e) {
-      throw new SemanticException(ErrorMsg.LOAD_DATA_LAUNCH_JOB_IO_ERROR.getMsg());
-    }
+    rewrittenCtx = new Context(conf);
+    // We keep track of all the contexts that are created by this query
+    // so we can clear them when we finish execution
+    ctx.addSubContext(rewrittenCtx);
     rewrittenCtx.setExplainConfig(ctx.getExplainConfig());
     rewrittenCtx.setExplainPlan(ctx.isExplainPlan());
     rewrittenCtx.setCmd(rewrittenQueryStr.toString());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -554,7 +554,7 @@ public final class ParseUtils {
     }
 
   public static CBOPlan parseQuery(HiveConf conf, String viewQuery)
-      throws SemanticException, IOException, ParseException {
+      throws SemanticException, ParseException {
     final Context ctx = new Context(conf);
     ctx.setIsLoadingMaterializedView(true);
     final ASTNode ast = parse(viewQuery, ctx);
@@ -564,7 +564,7 @@ public final class ParseUtils {
   }
 
   public static List<FieldSchema> parseQueryAndGetSchema(HiveConf conf, String viewQuery)
-      throws SemanticException, IOException, ParseException {
+      throws SemanticException, ParseException {
     final Context ctx = new Context(conf);
     ctx.setIsLoadingMaterializedView(true);
     final ASTNode ast = parse(viewQuery, ctx);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
@@ -257,15 +257,11 @@ public abstract class RewriteSemanticAnalyzer extends CalcitePlanner {
     HiveConf.setBoolVar(conf, ConfVars.LLAP_IO_ROW_WRAPPER_ENABLED, false);
     // Parse the rewritten query string
     Context rewrittenCtx;
-    try {
-      rewrittenCtx = new Context(conf);
-      rewrittenCtx.setHDFSCleanup(true);
-      // We keep track of all the contexts that are created by this query
-      // so we can clear them when we finish execution
-      ctx.addSubContext(rewrittenCtx);
-    } catch (IOException e) {
-      throw new SemanticException(ErrorMsg.UPDATEDELETE_IO_ERROR.getMsg());
-    }
+    rewrittenCtx = new Context(conf);
+    rewrittenCtx.setHDFSCleanup(true);
+    // We keep track of all the contexts that are created by this query
+    // so we can clear them when we finish execution
+    ctx.addSubContext(rewrittenCtx);
     rewrittenCtx.setExplainConfig(ctx.getExplainConfig());
     rewrittenCtx.setExplainPlan(ctx.isExplainPlan());
     rewrittenCtx.setStatsSource(ctx.getStatsSource());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -12360,7 +12360,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         ctx.addSubContext(rewriteCtx);
         rewrittenTree = ParseUtils.parse(rewrittenQuery, rewriteCtx);
         return new ParseResult(rewrittenTree, rewriteCtx.getTokenRewriteStream());
-      } catch (ParseException | IOException e) {
+      } catch (ParseException e) {
         throw new SemanticException(e);
       }
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSQLSchema.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSQLSchema.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hive.ql.udf.generic;
 
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
@@ -69,7 +68,7 @@ public class GenericUDTFGetSQLSchema extends GenericUDTF {
     List<FieldSchema> fieldSchemas = null;
     try {
       fieldSchemas = ParseUtils.parseQueryAndGetSchema(conf, query);
-    } catch (IOException | ParseException e) {
+    } catch (ParseException e) {
       throw new HiveException(e);
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDTFGetSplits.java
@@ -304,7 +304,7 @@ public class GenericUDTFGetSplits extends GenericUDTF {
         List<FieldSchema> fieldSchemas = ParseUtils.parseQueryAndGetSchema(conf, query);
         Schema schema = new Schema(convertSchema(fieldSchemas));
         return new PlanFragment(null, schema, null);
-      } catch (IOException | ParseException e) {
+      } catch (ParseException e) {
         throw new HiveException(e);
       }
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/TestContext.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/TestContext.java
@@ -36,7 +36,7 @@ public class TestContext {
     private Context context;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
         /* Only called to create session directories used by the Context class */
         SessionState.start(conf);
         SessionState.detachSession();

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezTask.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestTezTask.java
@@ -93,7 +93,6 @@ public class TestTezTask {
   Path path;
   FileSystem fs;
 
-  @SuppressWarnings("unchecked")
   @Before
   public void setUp() throws Exception {
     utils = mock(DagUtils.class);
@@ -196,7 +195,7 @@ public class TestTezTask {
   }
 
   @Test
-  public void testBuildDag() throws IllegalArgumentException, IOException, Exception {
+  public void testBuildDag() throws Exception {
     DAG dag = task.build(conf, work, path, new Context(conf),
         DagUtils.createTezLrMap(appLr, null));
     for (BaseWork w: work.getAllWork()) {
@@ -217,7 +216,7 @@ public class TestTezTask {
   }
 
   @Test
-  public void testEmptyWork() throws IllegalArgumentException, IOException, Exception {
+  public void testEmptyWork() throws Exception {
     DAG dag = task.build(conf, new TezWork("", null), path, new Context(conf),
         DagUtils.createTezLrMap(appLr, null));
     assertEquals(dag.getVertices().size(), 0);

--- a/ql/src/test/org/apache/hadoop/hive/ql/optimizer/physical/TestNullScanTaskDispatcher.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/optimizer/physical/TestNullScanTaskDispatcher.java
@@ -82,7 +82,7 @@ public class TestNullScanTaskDispatcher {
   private Map aliasToWork = new HashMap();
 
   @Before
-  public void setup() throws IOException {
+  public void setup() {
     hiveConf = new HiveConf();
     hiveConf.set("fs.mock.impl", MockFileSystem.class.getName());
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVEMETADATAONLYQUERIES, true);

--- a/ql/src/test/org/apache/hadoop/hive/ql/tool/TestLineageInfo.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/tool/TestLineageInfo.java
@@ -39,7 +39,7 @@ public class TestLineageInfo {
   private Context ctx;
 
   @Before
-  public void before() throws Exception {
+  public void before() {
     HiveConf conf = new HiveConf();
     SessionState.start(conf);
     ctx = new Context(conf);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove superfluous throws IOException from Context constructor, which may never be thrown.

### Why are the changes needed?
To keep the code clean by not having unused parts in it.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
All the tests are still running fine.