### PR TITLE
HIVE-24613: Support Values clause without Insert

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -316,7 +316,7 @@ valuesTableConstructor
 @init { gParent.pushMsg("values table constructor", state); }
 @after { gParent.popMsg(state); }
     :
-    valueRowConstructor (options{greedy=true;}: COMMA! valueRowConstructor)*
+    valueRowConstructor (COMMA! valueRowConstructor)*
     ;
 
 valueRowConstructor

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -100,6 +100,7 @@ atomjoinSource
     |  virtualTableSource (lateralView^)*
     |  (LPAREN (KW_WITH|KW_SELECT|KW_MAP|KW_REDUCE|KW_FROM)) => subQuerySource (lateralView^)*
     |  (LPAREN LPAREN atomSelectStatement RPAREN setOperator ) => subQuerySource (lateralView^)*
+    |  (LPAREN valuesSource) => subQuerySource (lateralView^)*
     |  partitionedTableFunction (lateralView^)*
     |  LPAREN! joinSource RPAREN!
     ;
@@ -287,6 +288,15 @@ searchCondition
 //-----------------------------------------------------------------------------------
 
 //-------- Row Constructor ----------------------------------------------------------
+valuesSource
+    :
+    valuesClause
+       -> ^(TOK_QUERY ^(TOK_INSERT
+               ^(TOK_DESTINATION ^(TOK_DIR TOK_TMP_FILE))
+               ^(TOK_SELECT ^(TOK_SELEXPR ^(TOK_FUNCTION Identifier["inline"] valuesClause)))
+               ))
+    ;
+
 //in support of SELECT * FROM (VALUES(1,2,3),(4,5,6),...) as FOO(a,b,c) and
 // INSERT INTO <table> (col1,col2,...) VALUES(...),(...),...
 // INSERT INTO <table> (col1,col2,...) SELECT * FROM (VALUES(1,2,3),(4,5,6),...) as Foo(a,b,c)
@@ -306,7 +316,7 @@ valuesTableConstructor
 @init { gParent.pushMsg("values table constructor", state); }
 @after { gParent.popMsg(state); }
     :
-    valueRowConstructor (COMMA! valueRowConstructor)*
+    valueRowConstructor (options{greedy=true;}: COMMA! valueRowConstructor)*
     ;
 
 valueRowConstructor

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -2416,6 +2416,8 @@ queryStatementExpression
       }
     }
     ->  queryStatementExpressionBody
+    |
+    valuesSource
     ;
 
 queryStatementExpressionBody

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestValuesClause.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestValuesClause.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.parse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test cases for parse WITHIN GROUP clause syntax.
+ * function(expression) WITHIN GROUP (ORDER BY sort_expression)
+ */
+public class TestValuesClause {
+  ParseDriver parseDriver = new ParseDriver();
+  @Test
+  public void testParseValues() throws Exception {
+    ASTNode tree = parseDriver.parse(
+            "VALUES(1,2,3),(4,5,6)", null).getTree();
+
+    ASTNode queryNode = (ASTNode) tree.getChild(0);
+    Assert.assertEquals(EXPECTED_VALUES_CLAUSE_TREE, queryNode.dump());
+  }
+
+  @Test
+  public void testParseValuesAsSubQuery() throws Exception {
+    ASTNode tree = parseDriver.parse("SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo", null).getTree();
+
+    ASTNode queryNode = (ASTNode) tree.getChild(0);
+    ASTNode fromNode = (ASTNode) queryNode.getChild(0);
+    ASTNode subQueryNode = (ASTNode) fromNode.getChild(0);
+    ASTNode subQueryQueryNode = (ASTNode) subQueryNode.getChild(0);
+
+    assertEquals(EXPECTED_VALUES_CLAUSE_TREE, subQueryQueryNode.dump());
+  }
+
+  @Test
+  public void testParseValuesAsSubQueryWhenJoined() throws Exception {
+    ASTNode tree = parseDriver.parse("SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo\n" +
+            "JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1", null).getTree();
+
+    ASTNode queryNode = (ASTNode) tree.getChild(0);
+    ASTNode fromNode = (ASTNode) queryNode.getChild(0);
+    ASTNode joinNode = (ASTNode) fromNode.getChild(0);
+    ASTNode subQueryNode0 = (ASTNode) joinNode.getChild(0);
+    ASTNode subQueryQueryNode = (ASTNode) subQueryNode0.getChild(0);
+
+    assertEquals(EXPECTED_VALUES_CLAUSE_TREE, subQueryQueryNode.dump());
+  }
+
+  public static final String EXPECTED_VALUES_CLAUSE_TREE = "\n" +
+          "TOK_QUERY\n" +
+          "   TOK_INSERT\n" +
+          "      TOK_DESTINATION\n" +
+          "         TOK_DIR\n" +
+          "            TOK_TMP_FILE\n" +
+          "      TOK_SELECT\n" +
+          "         TOK_SELEXPR\n" +
+          "            TOK_FUNCTION\n" +
+          "               inline\n" +
+          "               TOK_FUNCTION\n" +
+          "                  array\n" +
+          "                  TOK_FUNCTION\n" +
+          "                     struct\n" +
+          "                     1\n" +
+          "                     2\n" +
+          "                     3\n" +
+          "                  TOK_FUNCTION\n" +
+          "                     struct\n" +
+          "                     4\n" +
+          "                     5\n" +
+          "                     6\n";
+}

--- a/ql/src/test/queries/clientpositive/values.q
+++ b/ql/src/test/queries/clientpositive/values.q
@@ -1,10 +1,21 @@
 set hive.cli.print.header=true;
 
+EXPLAIN CBO
+VALUES(1,2,3),(4,5,6);
 VALUES(1,2,3),(4,5,6);
 
+EXPLAIN CBO
+SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo;
 SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo;
 
-with t1 as (values('a', 'b'), ('b', 'c'))
-select * from t1 where col1 = 'a'
-union all
-select * from t1 where col1 = 'b';
+
+EXPLAIN CBO
+WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b';
+
+WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b';

--- a/ql/src/test/queries/clientpositive/values.q
+++ b/ql/src/test/queries/clientpositive/values.q
@@ -1,0 +1,10 @@
+set hive.cli.print.header=true;
+
+VALUES(1,2,3),(4,5,6);
+
+SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo;
+
+with t1 as (values('a', 'b'), ('b', 'c'))
+select * from t1 where col1 = 'a'
+union all
+select * from t1 where col1 = 'b';

--- a/ql/src/test/results/clientpositive/llap/values.q.out
+++ b/ql/src/test/results/clientpositive/llap/values.q.out
@@ -10,18 +10,16 @@ col1	col2	col3
 1	2	3
 4	5	6
 PREHOOK: query: SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
-JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
-JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-foo.col1	foo.col2	foo.col3	bar.col1	bar.col2
-1	2	3	1	a
-4	5	6	4	b
+foo.col1	foo.col2	foo.col3
+1	2	3
+4	5	6
 PREHOOK: query: with t1 as (values('a', 'b'), ('b', 'c'))
 select * from t1 where col1 = 'a'
 union all

--- a/ql/src/test/results/clientpositive/llap/values.q.out
+++ b/ql/src/test/results/clientpositive/llap/values.q.out
@@ -1,3 +1,18 @@
+PREHOOK: query: EXPLAIN CBO
+VALUES(1,2,3),(4,5,6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+VALUES(1,2,3),(4,5,6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(1, 2, 3), ROW(4, 5, 6)))], rowType=[RecordType(INTEGER col1, INTEGER col2, INTEGER col3)])
+  HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+
 PREHOOK: query: VALUES(1,2,3),(4,5,6)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -9,6 +24,21 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 col1	col2	col3
 1	2	3
 4	5	6
+PREHOOK: query: EXPLAIN CBO
+SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(1, 2, 3), ROW(4, 5, 6)))], rowType=[RecordType(INTEGER col1, INTEGER col2, INTEGER col3)])
+  HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+
 PREHOOK: query: SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -20,17 +50,45 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 foo.col1	foo.col2	foo.col3
 1	2	3
 4	5	6
-PREHOOK: query: with t1 as (values('a', 'b'), ('b', 'c'))
-select * from t1 where col1 = 'a'
-union all
-select * from t1 where col1 = 'b'
+PREHOOK: query: EXPLAIN CBO
+WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b'
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-POSTHOOK: query: with t1 as (values('a', 'b'), ('b', 'c'))
-select * from t1 where col1 = 'a'
-union all
-select * from t1 where col1 = 'b'
+POSTHOOK: query: EXPLAIN CBO
+WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveUnion(all=[true])
+  HiveProject(col1=[CAST(_UTF-16LE'a':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], col2=[$1])
+    HiveFilter(condition=[=($0, _UTF-16LE'a')])
+      HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(_UTF-16LE'a':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), ROW(_UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'c':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")))], rowType=[RecordType(VARCHAR(2147483647) col1, VARCHAR(2147483647) col2)])
+        HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+  HiveProject(col1=[CAST(_UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"], col2=[$1])
+    HiveFilter(condition=[=($0, _UTF-16LE'b')])
+      HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(_UTF-16LE'a':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE"), ROW(_UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", _UTF-16LE'c':VARCHAR(2147483647) CHARACTER SET "UTF-16LE")))], rowType=[RecordType(VARCHAR(2147483647) col1, VARCHAR(2147483647) col2)])
+        HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+
+PREHOOK: query: WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
+SELECT * FROM t1 WHERE col1 = 'a'
+UNION ALL
+SELECT * from t1 WHERE col1 = 'b'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/values.q.out
+++ b/ql/src/test/results/clientpositive/llap/values.q.out
@@ -1,0 +1,41 @@
+PREHOOK: query: VALUES(1,2,3),(4,5,6)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: VALUES(1,2,3),(4,5,6)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+col1	col2	col3
+1	2	3
+4	5	6
+PREHOOK: query: SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
+JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM (VALUES(1,2,3),(4,5,6)) as foo
+JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+foo.col1	foo.col2	foo.col3	bar.col1	bar.col2
+1	2	3	1	a
+4	5	6	4	b
+PREHOOK: query: with t1 as (values('a', 'b'), ('b', 'c'))
+select * from t1 where col1 = 'a'
+union all
+select * from t1 where col1 = 'b'
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: with t1 as (values('a', 'b'), ('b', 'c'))
+select * from t1 where col1 = 'a'
+union all
+select * from t1 where col1 = 'b'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+col1	col2
+a	b
+b	c


### PR DESCRIPTION
### What changes were proposed in this pull request?
Prior this patch for defining a row of constant values Select clause could be used:
```
SELECT * FROM t1 foo
JOIN (select 1,'a') as bar ON foo.col1 = bar.col1
```
This enables the usage of Values clasuse:
```
SELECT * FROM t1 foo
JOIN (VALUES(1,'a'),(4,'b')) as bar ON foo.col1 = bar.col1
```


### Why are the changes needed?
With Select clause only one row could be defined. There is no such limitation with Values clause.

### Does this PR introduce _any_ user-facing change?
Yes. From now the Values clause can be used in subqueries and can be a query itself.

### How was this patch tested?
```
mvn test -Dtest=TestValuesClause -pl parser
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=values.q -pl itests/qtest -Pitests
```