### PR TITLE
HIVE-24615: Remove unnecessary FileSystem listing from Initiator

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -829,6 +829,10 @@ public class AcidUtils {
     List<ParsedDelta> getDeleteDeltas();
   }
 
+  public interface ParsedDirectory {
+    public List<HdfsFileStatusWithId> getFiles(FileSystem fs, Ref<Boolean> useFileIds) throws IOException;
+  }
+
   /**
    * Since version 3 but prior to version 4, format of a base is "base_X" where X is a writeId.
    * If this base was produced by a compactor, X is the highest writeId that the compactor included.
@@ -888,7 +892,7 @@ public class AcidUtils {
    * requires looking at the footer of the data file which can be expensive so if this info is
    * not needed {@link ParsedBaseLight} should be used.
    */
-  public static final class ParsedBase extends ParsedBaseLight {
+  public static final class ParsedBase extends ParsedBaseLight implements ParsedDirectory {
 
     private boolean rawFormat;
     private List<HdfsFileStatusWithId> files;
@@ -943,7 +947,7 @@ public class AcidUtils {
    * not needed {@link ParsedDeltaLight} should be used.
    */
   @Immutable
-  public static final class ParsedDelta extends ParsedDeltaLight {
+  public static final class ParsedDelta extends ParsedDeltaLight implements ParsedDirectory{
     private final boolean isRawFormat;
     private List<HdfsFileStatusWithId> files;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -947,7 +947,7 @@ public class AcidUtils {
    * not needed {@link ParsedDeltaLight} should be used.
    */
   @Immutable
-  public static final class ParsedDelta extends ParsedDeltaLight implements ParsedDirectory{
+  public static final class ParsedDelta extends ParsedDeltaLight implements ParsedDirectory {
     private final boolean isRawFormat;
     private List<HdfsFileStatusWithId> files;
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -21,7 +21,6 @@ import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.ValidReadTxnList;
 import org.apache.hadoop.hive.common.ValidTxnList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
@@ -48,6 +47,7 @@ import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.ql.io.AcidDirectory;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.io.AcidUtils.ParsedDirectory;
 import org.apache.hadoop.hive.shims.HadoopShims.HdfsFileStatusWithId;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
@@ -320,33 +320,19 @@ public class Initiator extends MetaStoreCompactorThread {
     Path location = new Path(sd.getLocation());
     FileSystem fs = location.getFileSystem(conf);
     AcidDirectory dir = AcidUtils.getAcidState(fs, location, conf, writeIds, Ref.from(false), false);
-    Path base = dir.getBaseDirectory();
     long baseSize = 0;
-    FileStatus stat = null;
-    if (base != null) {
-      stat = fs.getFileStatus(base);
-      if (!stat.isDirectory()) {
-        LOG.error("Was assuming base " + base.toString() + " is directory, but it's a file!");
-        return null;
+    if (dir.getBase() != null) {
+      baseSize = sumDirSize(fs, dir.getBase());
+    } else {
+      for (HdfsFileStatusWithId origStat : dir.getOriginalFiles()) {
+        baseSize += origStat.getFileStatus().getLen();
       }
-      baseSize = sumDirSize(fs, base);
-    }
-
-    List<HdfsFileStatusWithId> originals = dir.getOriginalFiles();
-    for (HdfsFileStatusWithId origStat : originals) {
-      baseSize += origStat.getFileStatus().getLen();
     }
 
     long deltaSize = 0;
     List<AcidUtils.ParsedDelta> deltas = dir.getCurrentDirectories();
     for (AcidUtils.ParsedDelta delta : deltas) {
-      stat = fs.getFileStatus(delta.getPath());
-      if (!stat.isDirectory()) {
-        LOG.error("Was assuming delta " + delta.getPath().toString() + " is a directory, " +
-            "but it's a file!");
-        return null;
-      }
-      deltaSize += sumDirSize(fs, delta.getPath());
+      deltaSize += sumDirSize(fs, delta);
     }
 
     if (baseSize == 0 && deltaSize > 0) {
@@ -408,12 +394,11 @@ public class Initiator extends MetaStoreCompactorThread {
     return noBase ? CompactionType.MAJOR : CompactionType.MINOR;
   }
 
-  private long sumDirSize(FileSystem fs, Path dir) throws IOException {
-    long size = 0;
-    FileStatus[] buckets = fs.listStatus(dir, FileUtils.HIDDEN_FILES_PATH_FILTER);
-    for (int i = 0; i < buckets.length; i++) {
-      size += buckets[i].getLen();
-    }
+  private long sumDirSize(FileSystem fs, ParsedDirectory dir) throws IOException {
+    long size = dir.getFiles(fs, Ref.from(false)).stream()
+        .map(HdfsFileStatusWithId::getFileStatus)
+        .mapToLong(FileStatus::getLen)
+        .sum();
     return size;
   }
 


### PR DESCRIPTION


### What changes were proposed in this pull request?
AcidUtils already returns the file list in base and delta directories if it does recursive listing on S3, listing those directories can be removed from the Initiator


### Why are the changes needed?
Performance improvement


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing unit tests
