### PR TITLE
HIVE-24590: Operation logging still leaks log4j appenders

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/LogUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/LogUtils.java
@@ -19,10 +19,7 @@
 package org.apache.hadoop.hive.common;
 
 import java.io.File;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URL;
-import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -31,11 +28,8 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RollingRandomAccessFileAppender;
-import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
 import org.apache.logging.log4j.core.config.Configurator;
-import org.apache.logging.log4j.core.config.LoggerConfig;
 import org.apache.logging.log4j.core.impl.Log4jContextFactory;
 import org.apache.logging.log4j.spi.DefaultThreadContextMap;
 import org.slf4j.Logger;
@@ -260,32 +254,6 @@ public class LogUtils {
       }
     }
     return logFilePath;
-  }
-
-  /**
-   * Stop the subordinate appender for the operation log so it will not leak a file descriptor.
-   * @param routingAppenderName the name of the RoutingAppender
-   * @param queryId the id of the query that is closing
-   */
-  public static void stopQueryAppender(String routingAppenderName, String queryId) {
-    LoggerContext context = (LoggerContext) LogManager.getContext(false);
-    org.apache.logging.log4j.core.config.Configuration configuration = context.getConfiguration();
-    LoggerConfig loggerConfig = configuration.getRootLogger();
-    Map<String, Appender> appenders = loggerConfig.getAppenders();
-    RoutingAppender routingAppender = (RoutingAppender) appenders.get(routingAppenderName);
-    // routingAppender can be null if it has not been registered
-    if (routingAppender != null) {
-      // The appender is configured to use ${ctx:queryId} by registerRoutingAppender()
-      try {
-        Class<? extends RoutingAppender> clazz = routingAppender.getClass();
-        Method method = clazz.getDeclaredMethod("deleteAppender", String.class);
-        method.setAccessible(true);
-        method.invoke(routingAppender, queryId);
-      } catch (NoSuchMethodException | SecurityException | IllegalAccessException |
-          IllegalArgumentException | InvocationTargetException e) {
-        l4j.warn("Unable to close the operation log appender for query id " + queryId, e);
-      }
-    }
   }
 
 }

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingLayout.java
@@ -152,6 +152,9 @@ public class TestOperationLoggingLayout {
     checkAppenderState("before operation close ", LogDivertAppender.QUERY_ROUTING_APPENDER, queryId, expectedStopped);
     checkAppenderState("before operation close ", LogDivertAppenderForTest.TEST_QUERY_ROUTING_APPENDER, queryId, expectedStopped);
     client.closeOperation(operationHandle);
+    checkAppenderState("after operation close ", LogDivertAppender.QUERY_ROUTING_APPENDER, queryId, expectedStopped);
+    checkAppenderState("after operation close ", LogDivertAppenderForTest.TEST_QUERY_ROUTING_APPENDER, queryId, expectedStopped);
+    Thread.sleep(8000);
     checkAppenderState("after operation close ", LogDivertAppender.QUERY_ROUTING_APPENDER, queryId, true);
     checkAppenderState("after operation close ", LogDivertAppenderForTest.TEST_QUERY_ROUTING_APPENDER, queryId, true);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppender.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppender.java
@@ -29,6 +29,8 @@ import org.apache.hadoop.hive.ql.stats.BasicStatsTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.routing.IdlePurgePolicy;
+import org.apache.logging.log4j.core.appender.routing.PurgePolicy;
 import org.apache.logging.log4j.core.appender.routing.Route;
 import org.apache.logging.log4j.core.appender.routing.Routes;
 import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
@@ -242,12 +244,17 @@ public class LogDivertAppender {
     LoggerContext context = (LoggerContext) LogManager.getContext(false);
     Configuration configuration = context.getConfiguration();
 
+    PurgePolicy purgePolicy = IdlePurgePolicy.createPurgePolicy("60", null, "SECONDS", configuration);
+    // Hack: due to the (non-standard) way that log4j configuration is extended to introduce the routing appender
+    // the life-cycle methods are not called as expected leading to initialization problems (such as the scheduler)
+    configuration.getScheduler().incrementScheduledItems();
+
     RoutingAppender routingAppender = RoutingAppender.createAppender(QUERY_ROUTING_APPENDER,
         "true",
         routes,
         configuration,
         null,
-        null,
+        purgePolicy,
         null);
 
     LoggerConfig loggerConfig = configuration.getRootLogger();

--- a/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppenderForTest.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppenderForTest.java
@@ -22,6 +22,8 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.routing.IdlePurgePolicy;
+import org.apache.logging.log4j.core.appender.routing.PurgePolicy;
 import org.apache.logging.log4j.core.appender.routing.Route;
 import org.apache.logging.log4j.core.appender.routing.Routes;
 import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
@@ -172,6 +174,10 @@ public final class LogDivertAppenderForTest {
 
     LoggerContext context = (LoggerContext)LogManager.getContext(false);
     Configuration configuration = context.getConfiguration();
+    PurgePolicy purgePolicy = IdlePurgePolicy.createPurgePolicy("5", null, "SECONDS", configuration);
+    // Hack: due to the (non-standard) way that log4j configuration is extended to introduce the routing appender
+    // the life-cycle methods are not called as expected leading to initialization problems (such as the scheduler)
+    configuration.getScheduler().incrementScheduledItems();
 
     // Create the appender
     RoutingAppender routingAppender = RoutingAppender.createAppender(TEST_QUERY_ROUTING_APPENDER,
@@ -179,7 +185,7 @@ public final class LogDivertAppenderForTest {
         routes,
         configuration,
         null,
-        null,
+        purgePolicy,
         null);
 
     LoggerConfig loggerConfig = configuration.getRootLogger();

--- a/service/src/java/org/apache/hive/service/cli/operation/Operation.java
+++ b/service/src/java/org/apache/hive/service/cli/operation/Operation.java
@@ -35,8 +35,6 @@ import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
 import org.apache.hadoop.hive.common.metrics.common.MetricsScope;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.QueryState;
-import org.apache.hadoop.hive.ql.log.LogDivertAppender;
-import org.apache.hadoop.hive.ql.log.LogDivertAppenderForTest;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.session.OperationLog;
 import org.apache.hadoop.hive.shims.ShimLoader;
@@ -307,10 +305,6 @@ public abstract class Operation {
   }
 
   protected synchronized void cleanupOperationLog(final long operationLogCleanupDelayMs) {
-    // stop the appenders for the operation log
-    String queryId = queryState.getQueryId();
-    LogUtils.stopQueryAppender(LogDivertAppender.QUERY_ROUTING_APPENDER, queryId);
-    LogUtils.stopQueryAppender(LogDivertAppenderForTest.TEST_QUERY_ROUTING_APPENDER, queryId);
     if (isOperationLogEnabled) {
       if (opHandle == null) {
         log.warn("Operation seems to be in invalid state, opHandle is null");


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Handle dynamic routing appenders via Log4j's `IdlePurgePolicy`
2. Remove in-house management of appenders.

### Why are the changes needed?
1. Solve descriptor leak as shown in HIVE-24590
2. Delegate burden of managing appenders to Log4j.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
`mvn test -Dtest=TestOperationLoggingLayout`
