### PR TITLE
HIVE-24625 CTAS non transactional table loads data from incorrect path (amagyar, rajkrrsingh)

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetastoreTransformer.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.conf.Configuration;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_NONE;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_READONLY;
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.ACCESSTYPE_READWRITE;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -552,6 +553,30 @@ public class TestHiveMetastoreTransformer {
       resetHMSClient();
 
       LOG.info("Test execution complete:testTransformerManagedTable");
+    } catch (Exception e) {
+      e.printStackTrace();
+      fail("testTransformerManagedTable failed with " + e.getMessage());
+    } finally {
+      resetHMSClient();
+    }
+  }
+
+
+  @Test
+  public void testLeavesCtasTableAlone() throws Exception {
+    try {
+      resetHMSClient();
+      final String dbName = "db1";
+      String basetblName = "oldstylemgdtable";
+      Map<String, Object> tProps = new HashMap<>();
+      String tblName = basetblName;
+      tProps.put("DBNAME", dbName);
+      tProps.put("TBLNAME", tblName);
+      tProps.put("TBLTYPE", TableType.MANAGED_TABLE);
+      tProps.put("PROPERTIES", TABLE_IS_CTAS + "=true;transactional=false");
+      createTableWithCapabilities(tProps);
+      Table tbl2 = client.getTable(dbName, tblName);
+      assertEquals(TableType.MANAGED_TABLE.name(), tbl2.getTableType());
     } catch (Exception e) {
       e.printStackTrace();
       fail("testTransformerManagedTable failed with " + e.getMessage());

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/CreateTableDesc.java
@@ -18,8 +18,11 @@
 
 package org.apache.hadoop.hive.ql.ddl.table.create;
 
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
+
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -488,9 +491,15 @@ public class CreateTableDesc implements DDLDesc, Serializable {
   /**
    * @return the table properties
    */
-  @Explain(displayName = "table properties")
   public Map<String, String> getTblProps() {
     return tblProps;
+  }
+
+  @Explain(displayName = "table properties")
+  public Map<String, String> getTblPropsExplain() { // only for displaying plan
+    HashMap<String, String> copy = new HashMap<>(tblProps);
+    copy.remove(TABLE_IS_CTAS);
+    return copy;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/like/CreateTableLikeDesc.java
@@ -18,7 +18,10 @@
 
 package org.apache.hadoop.hive.ql.ddl.table.create.like;
 
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
+
 import java.io.Serializable;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.hive.ql.ddl.DDLDesc;
@@ -107,9 +110,15 @@ public class CreateTableLikeDesc implements DDLDesc, Serializable {
     return likeTableName;
   }
 
-  @Explain(displayName = "table properties")
   public Map<String, String> getTblProps() {
     return tblProps;
+  }
+
+  @Explain(displayName = "table properties")
+  public Map<String, String> getTblPropsExplain() {
+    HashMap<String, String> copy = new HashMap<>(tblProps);
+    copy.remove(TABLE_IS_CTAS);
+    return copy;
   }
 
   @Explain(displayName = "isTemporary", displayOnlyOnTrue = true)

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/show/ShowCreateTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/show/ShowCreateTableOperation.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.ddl.table.create.show;
 
 import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -347,7 +348,7 @@ public class ShowCreateTableOperation extends DDLOperation<ShowCreateTableDesc> 
   }
 
   private static final Set<String> PROPERTIES_TO_IGNORE_AT_TBLPROPERTIES = Sets.union(
-      ImmutableSet.<String>of("TEMPORARY", "EXTERNAL", "comment", "SORTBUCKETCOLSPREFIX", META_TABLE_STORAGE),
+      ImmutableSet.<String>of("TEMPORARY", "EXTERNAL", "comment", "SORTBUCKETCOLSPREFIX", META_TABLE_STORAGE, TABLE_IS_CTAS),
       new HashSet<String>(StatsSetupConst.TABLE_PARAMS_STATS_KEYS));
 
   private String getProperties(Table table) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/formatter/TextDescTableFormatter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/formatter/TextDescTableFormatter.java
@@ -64,6 +64,7 @@ import java.util.TreeMap;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hadoop.hive.ql.ddl.ShowUtils.ALIGNMENT;
 import static org.apache.hadoop.hive.ql.ddl.ShowUtils.DEFAULT_STRINGBUILDER_SIZE;
 import static org.apache.hadoop.hive.ql.ddl.ShowUtils.FIELD_DELIM;
@@ -341,6 +342,9 @@ class TextDescTableFormatter extends DescTableFormatter {
     Collections.sort(keys);
     for (String key : keys) {
       String value = params.get(key);
+      if (TABLE_IS_CTAS.equals(key)) {
+        continue;
+      }
       if (key.equals(StatsSetupConst.NUM_ERASURE_CODED_FILES)) {
         if ("0".equals(value)) {
           continue;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13219,7 +13219,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         retValue = convertToAcidByDefault(storageFormat, qualifiedTableName, sortCols, retValue);
       }
     }
-    retValue.put(TABLE_IS_CTAS, Boolean.toString(isCTAS));
+    if (isCTAS) {
+      retValue.put(TABLE_IS_CTAS, Boolean.toString(isCTAS));
+    }
     return retValue;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PlanUtils.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.plan;
 
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hive.common.util.HiveStringUtils.quoteComments;
 
 import java.io.IOException;
@@ -1236,6 +1237,12 @@ public final class PlanUtils {
           clone = new HashMap<>(properties);
         }
         clone.remove(StatsSetupConst.NUM_ERASURE_CODED_FILES);
+      }
+      if (properties.containsKey(TABLE_IS_CTAS)) {
+        if (clone == null) {
+          clone = new HashMap<>(properties);
+        }
+        clone.remove(TABLE_IS_CTAS);
       }
       if (clone != null) {
         return clone;

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/hive_metastoreConstants.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/hive_metastoreConstants.java
@@ -61,6 +61,8 @@ package org.apache.hadoop.hive.metastore.api;
 
   public static final java.lang.String TABLE_IS_TRANSACTIONAL = "transactional";
 
+  public static final java.lang.String TABLE_IS_CTAS = "created_with_ctas";
+
   public static final java.lang.String TABLE_NO_AUTO_COMPACT = "no_auto_compaction";
 
   public static final java.lang.String TABLE_TRANSACTIONAL_PROPERTIES = "transactional_properties";

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -172,6 +172,7 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_COMMENT;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_DATABASE_NAME;
 import static org.apache.hadoop.hive.metastore.Warehouse.getCatalogQualifiedTableName;
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.TABLE_IS_CTAS;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.CAT_NAME;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.DB_NAME;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getDefaultCatalog;
@@ -2139,6 +2140,9 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     if (transformer != null && !isInTest) {
       tbl = transformer.transformCreateTable(tbl, processorCapabilities, processorId);
+    }
+    if (tbl.getParameters() != null) {
+      tbl.getParameters().remove(TABLE_IS_CTAS);
     }
 
     // If the given table has column statistics, save it here. We will update it later.


### PR DESCRIPTION
When table is created using CTAS, with transactional=false, data is loaded in managed location where as table metadata has location pointing to external location, resulting in 0 rows when querying the table.

cc: @rajkrrsingh, @nrg4878 