### PR TITLE
HIVE-24633: Support CTE with column labels

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -470,6 +470,7 @@ public enum ErrorMsg {
           "The number of hypothetical direct arguments ({0}) must match the number of ordering columns ({1})", true),
   AMBIGUOUS_STRUCT_ATTRIBUTE(10423, "Attribute \"{0}\" specified more than once in structured type.", true),
   OFFSET_NOT_SUPPORTED_IN_SUBQUERY(10424, "OFFSET is not supported in subquery of exists", true),
+  WITH_COL_LIST_NUM_OVERFLOW(10425, "WITH-clause query {0} returns {1} columns, but {2} labels were specified. The number of column labels must be smaller or equal to the number of expressions returned by the query.", true),
 
   //========================== 20000 range starts here ========================//
 

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -2431,8 +2431,8 @@ withClause
 
 cteStatement
    :
-   identifier KW_AS LPAREN queryStatementExpression RPAREN
-   -> ^(TOK_SUBQUERY queryStatementExpression identifier)
+   identifier (LPAREN colAliases=columnNameList RPAREN)? KW_AS LPAREN queryStatementExpression RPAREN
+   -> ^(TOK_SUBQUERY queryStatementExpression identifier $colAliases?)
 ;
 
 fromStatement

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -5352,6 +5352,10 @@ public class CalcitePlanner extends SemanticAnalyzer {
         RowResolver newRR = new RowResolver();
         String alias = qb.getParseInfo().getAlias();
         List<String> targetColNames = processTableColumnNames(qb.getParseInfo().getColAliases(), alias);
+        if (targetColNames.size() > rr.getColumnInfos().size()) {
+          throw new SemanticException(ErrorMsg.WITH_COL_LIST_NUM_OVERFLOW, alias,
+                  Integer.toString(rr.getColumnInfos().size()), Integer.toString(targetColNames.size()));
+        }
 
         for (int i = 0; i < rr.getColumnInfos().size(); ++i) {
           ColumnInfo colInfo = rr.getColumnInfos().get(i);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QB.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QB.java
@@ -476,7 +476,7 @@ public class QB {
     QBExpr qbexpr = new QBExpr(alias);
 
     ASTNode subqref = (ASTNode) expressionTree.getChild(1);
-    semanticAnalyzer.doPhase1QBExpr(subqref, qbexpr, getId(), alias, isInsideView());
+    semanticAnalyzer.doPhase1QBExpr(subqref, qbexpr, getId(), alias, isInsideView(), null);
 
     // Insert this map into the stats
     aliasToSubqExpr.put(alias, qbexpr);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBParseInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBParseInfo.java
@@ -53,6 +53,7 @@ public class QBParseInfo {
   private String alias;
   private ASTNode joinExpr;
   private ASTNode hints;
+  private ASTNode colAliases;
   private List<ASTNode> hintList;
   private final Map<String, ASTNode> aliasToSrc;
   /**
@@ -725,6 +726,14 @@ public class QBParseInfo {
     }
 
     return true;
+  }
+
+  public ASTNode getColAliases() {
+    return colAliases;
+  }
+
+  public void setColAliases(ASTNode colAliases) {
+    this.colAliases = colAliases;
   }
 }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1986,8 +1986,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       //we have "insert into foo(a,b)..."; parser will enforce that 1+ columns are listed if TOK_TABCOLNAME is present
       String fullTableName = getUnescapedName((ASTNode) ast.getChild(0).getChild(0),
           SessionState.get().getCurrentDatabase());
-      List<String> targetColumns = processTableColumnNames(tabColName, fullTableName);
-      qbp.setDestSchemaForClause(ctx_1.dest, targetColumns);
+      List<String> targetColumnNames = processTableColumnNames(tabColName, fullTableName);
+      qbp.setDestSchemaForClause(ctx_1.dest, targetColumnNames);
       Table targetTable;
       try {
         targetTable = getTableObjectByName(fullTableName);
@@ -1999,6 +1999,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         throw new SemanticException(generateErrorMessage(ast,
             "Unable to access metadata for table " + fullTableName));
       }
+      Set<String> targetColumns = new HashSet<>(targetColumnNames);
       for(FieldSchema f : targetTable.getCols()) {
         //parser only allows foo(a,b), not foo(foo.a, foo.b)
         targetColumns.remove(f.getName());

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -615,13 +615,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     return returnVal;
   }
 
-  private void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias)
+  private void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias, ASTNode tabColNames)
       throws SemanticException {
-    doPhase1QBExpr(ast, qbexpr, id, alias, false);
+    doPhase1QBExpr(ast, qbexpr, id, alias, false, tabColNames);
   }
 
   @SuppressWarnings("nls")
-  void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias, boolean insideView)
+  void doPhase1QBExpr(ASTNode ast, QBExpr qbexpr, String id, String alias, boolean insideView, ASTNode tabColNames)
       throws SemanticException {
 
     assert (ast.getToken() != null);
@@ -629,6 +629,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       QB qb = new QB(id, alias, true);
       qb.setInsideView(insideView);
       Phase1Ctx ctx_1 = initPhase1Ctx();
+      qb.getParseInfo().setColAliases(tabColNames);
       doPhase1(ast, qb, ctx_1, null);
 
       qbexpr.setOpcode(QBExpr.Opcode.NULLOP);
@@ -660,14 +661,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       assert (ast.getChild(0) != null);
       QBExpr qbexpr1 = new QBExpr(alias + SUBQUERY_TAG_1);
       doPhase1QBExpr((ASTNode) ast.getChild(0), qbexpr1, id,
-          alias + SUBQUERY_TAG_1, insideView);
+          alias + SUBQUERY_TAG_1, insideView, tabColNames);
       qbexpr.setQBExpr1(qbexpr1);
 
       // query 2
       assert (ast.getChild(1) != null);
       QBExpr qbexpr2 = new QBExpr(alias + SUBQUERY_TAG_2);
       doPhase1QBExpr((ASTNode) ast.getChild(1), qbexpr2, id,
-          alias + SUBQUERY_TAG_2, insideView);
+          alias + SUBQUERY_TAG_2, insideView, tabColNames);
       qbexpr.setQBExpr2(qbexpr2);
     }
   }
@@ -1246,7 +1247,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     // Recursively do the first phase of semantic analysis for the subquery
     QBExpr qbexpr = new QBExpr(alias);
 
-    doPhase1QBExpr(subqref, qbexpr, qb.getId(), alias, qb.isInsideView());
+    doPhase1QBExpr(subqref, qbexpr, qb.getId(), alias, qb.isInsideView(), null);
 
     // If the alias is already there then we have a conflict
     if (qb.exists(alias)) {
@@ -1275,6 +1276,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       ASTNode cte = (ASTNode) ctes.getChild(i);
       ASTNode cteQry = (ASTNode) cte.getChild(0);
       String alias = unescapeIdentifier(cte.getChild(1).getText());
+      ASTNode withColList = cte.getChildCount() == 3 ? (ASTNode) cte.getChild(2) : null;
 
       String qName = qb.getId() == null ? "" : qb.getId() + ":";
       qName += alias.toLowerCase();
@@ -1284,7 +1286,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
             ErrorMsg.AMBIGUOUS_TABLE_ALIAS.getMsg(),
             cte.getChild(1)));
       }
-      aliasToCTEs.put(qName, new CTEClause(qName, cteQry));
+      aliasToCTEs.put(qName, new CTEClause(qName, cteQry, withColList));
     }
   }
 
@@ -1335,11 +1337,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     CTEClause cte = findCTEFromName(qb, cteName);
     ASTNode cteQryNode = cte.cteNode;
     QBExpr cteQBExpr = new QBExpr(cteAlias);
-    doPhase1QBExpr(cteQryNode, cteQBExpr, qb.getId(), cteAlias);
+    doPhase1QBExpr(cteQryNode, cteQBExpr, qb.getId(), cteAlias, cte.withColList);
     qb.rewriteCTEToSubq(cteAlias, cteName, cteQBExpr);
   }
 
-  private final CTEClause rootClause = new CTEClause(null, null);
+  private final CTEClause rootClause = new CTEClause(null, null, null);
 
   @Override
   public List<Task<?>> getAllRootTasks() {
@@ -1373,12 +1375,14 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   }
 
   class CTEClause {
-    CTEClause(String alias, ASTNode cteNode) {
+    CTEClause(String alias, ASTNode cteNode, ASTNode withColList) {
       this.alias = alias;
       this.cteNode = cteNode;
+      this.withColList = withColList;
     }
     String alias;
     ASTNode cteNode;
+    ASTNode withColList;
     boolean materialize;
     int reference;
     QBExpr qbExpr;
@@ -1980,20 +1984,10 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     ASTNode tabColName = (ASTNode)ast.getChild(1);
     if(ast.getType() == HiveParser.TOK_INSERT_INTO && tabColName != null && tabColName.getType() == HiveParser.TOK_TABCOLNAME) {
       //we have "insert into foo(a,b)..."; parser will enforce that 1+ columns are listed if TOK_TABCOLNAME is present
-      List<String> targetColNames = new ArrayList<String>();
-      for(Node col : tabColName.getChildren()) {
-        assert ((ASTNode)col).getType() == HiveParser.Identifier :
-            "expected token " + HiveParser.Identifier + " found " + ((ASTNode)col).getType();
-        targetColNames.add(((ASTNode)col).getText().toLowerCase());
-      }
       String fullTableName = getUnescapedName((ASTNode) ast.getChild(0).getChild(0),
           SessionState.get().getCurrentDatabase());
-      qbp.setDestSchemaForClause(ctx_1.dest, targetColNames);
-      Set<String> targetColumns = new HashSet<>(targetColNames);
-      if(targetColNames.size() != targetColumns.size()) {
-        throw new SemanticException(generateErrorMessage(tabColName,
-            "Duplicate column name detected in " + fullTableName + " table schema specification"));
-      }
+      List<String> targetColumns = processTableColumnNames(tabColName, fullTableName);
+      qbp.setDestSchemaForClause(ctx_1.dest, targetColumns);
       Table targetTable;
       try {
         targetTable = getTableObjectByName(fullTableName);
@@ -2065,6 +2059,24 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
+  protected List<String> processTableColumnNames(ASTNode tabColName, String tableName) throws SemanticException {
+    if (tabColName == null) {
+      return Collections.emptyList();
+    }
+    List<String> targetColNames = new ArrayList<>(tabColName.getChildren().size());
+    for(Node col : tabColName.getChildren()) {
+      assert ((ASTNode)col).getType() == HiveParser.Identifier :
+          "expected token " + HiveParser.Identifier + " found " + ((ASTNode)col).getType();
+      targetColNames.add(((ASTNode)col).getText().toLowerCase());
+    }
+    Set<String> targetColumns = new HashSet<>(targetColNames);
+    if(targetColNames.size() != targetColumns.size()) {
+      throw new SemanticException(generateErrorMessage(tabColName,
+              "Duplicate column name detected in " + tableName + " table schema specification"));
+    }
+    return targetColNames;
+  }
+
   private void getMaterializationMetadata(QB qb) throws SemanticException {
     if (qb.isCTAS()) {
       return;
@@ -2117,7 +2129,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
           continue;
         }
         cte.qbExpr = new QBExpr(cteName);
-        doPhase1QBExpr(cte.cteNode, cte.qbExpr, qb.getId(), cteName);
+        doPhase1QBExpr(cte.cteNode, cte.qbExpr, qb.getId(), cteName, cte.withColList);
 
         ctesExpanded.add(cteName);
         gatherCTEReferences(cte.qbExpr, cte);
@@ -2694,7 +2706,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       throw new SemanticException(sb.toString(), e);
     }
     QBExpr qbexpr = new QBExpr(alias);
-    doPhase1QBExpr(viewTree, qbexpr, qb.getId(), alias, true);
+    doPhase1QBExpr(viewTree, qbexpr, qb.getId(), alias, true, null);
     // if skip authorization, skip checking;
     // if it is inside a view, skip checking;
     // if authorization flag is not enabled, skip checking.

--- a/ql/src/test/queries/clientnegative/cte_col_alias.q
+++ b/ql/src/test/queries/clientnegative/cte_col_alias.q
@@ -1,0 +1,5 @@
+create table t1(int_col int, bigint_col bigint);
+
+explain cbo
+with cte1(a, b, c) as (select int_col x, bigint_col y from t1)
+select a, b from cte1;

--- a/ql/src/test/queries/clientnegative/cte_col_alias_clash.q
+++ b/ql/src/test/queries/clientnegative/cte_col_alias_clash.q
@@ -1,0 +1,5 @@
+create table t1(int_col int, bigint_col bigint);
+
+explain cbo
+with cte1(a) as (select int_col, bigint_col a from t1)
+select a from cte1;

--- a/ql/src/test/queries/clientpositive/cte_8.q
+++ b/ql/src/test/queries/clientpositive/cte_8.q
@@ -32,3 +32,9 @@ with cte1(c1, c2) as (
     select int_col x, bigint_col y from t1 where int_col = 2
 )
 select * from cte1;
+
+with cte1(a) as (select int_col x, bigint_col a from t1)
+select * from cte1;
+
+with cte1(a) as (select int_col x, bigint_col a from t1)
+select cte1.* from cte1;

--- a/ql/src/test/queries/clientpositive/cte_8.q
+++ b/ql/src/test/queries/clientpositive/cte_8.q
@@ -1,0 +1,34 @@
+set hive.cli.print.header=true;
+
+create table t1(int_col int, bigint_col bigint);
+
+insert into t1 values(1, 2), (3, 4);
+
+explain cbo
+with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1;
+
+with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1;
+
+with cte1(a) as (select int_col x, bigint_col y from t1)
+select a, y from cte1;
+
+with cte1 as (select int_col x, bigint_col y from t1)
+select x, y from cte1;
+
+with cte1 as (select int_col, bigint_col from t1)
+select * from cte1;
+
+with cte(c1, c2) as (select int_col, bigint_col y from t1)
+select * from cte limit 1;
+
+with cte1(c1, c2) as (select int_col x, sum(bigint_col) y from t1 group by int_col)
+select * from cte1;
+
+with cte1(c1, c2) as (
+    select int_col x, bigint_col y from t1 where int_col = 1
+    union all
+    select int_col x, bigint_col y from t1 where int_col = 2
+)
+select * from cte1;

--- a/ql/src/test/queries/clientpositive/cte_mat_1.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_1.q
@@ -4,7 +4,7 @@ set hive.optimize.cte.materialize.threshold=-1;
 set hive.explain.user=true;
 
 explain
-with q1 as (select * from src where key= '5')
-select a.key
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey
 from q1 a join q1 b
-on a.key=b.key;
+on a.srcKey=b.srcKey;

--- a/ql/src/test/results/clientnegative/cte_col_alias.q.out
+++ b/ql/src/test/results/clientnegative/cte_col_alias.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table t1(int_col int, bigint_col bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(int_col int, bigint_col bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+FAILED: SemanticException [Error 10425]: WITH-clause query cte1 returns 2 columns, but 3 labels were specified. The number of column labels must be smaller or equal to the number of expressions returned by the query.

--- a/ql/src/test/results/clientnegative/cte_col_alias_clash.q.out
+++ b/ql/src/test/results/clientnegative/cte_col_alias_clash.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: create table t1(int_col int, bigint_col bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(int_col int, bigint_col bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+FAILED: SemanticException Ambiguous column reference: .a

--- a/ql/src/test/results/clientpositive/llap/cte_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_8.q.out
@@ -131,3 +131,29 @@ POSTHOOK: Input: default@t1
 #### A masked pattern was here ####
 cte1.c1	cte1.c2
 1	2
+PREHOOK: query: with cte1(a) as (select int_col x, bigint_col a from t1)
+select * from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(a) as (select int_col x, bigint_col a from t1)
+select * from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte1.a	cte1._col1
+1	2
+3	4
+PREHOOK: query: with cte1(a) as (select int_col x, bigint_col a from t1)
+select cte1.* from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(a) as (select int_col x, bigint_col a from t1)
+select cte1.* from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte1.a	cte1._col1
+1	2
+3	4

--- a/ql/src/test/results/clientpositive/llap/cte_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_8.q.out
@@ -1,0 +1,133 @@
+PREHOOK: query: create table t1(int_col int, bigint_col bigint)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(int_col int, bigint_col bigint)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: insert into t1 values(1, 2), (3, 4)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1 values(1, 2), (3, 4)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.bigint_col SCRIPT []
+POSTHOOK: Lineage: t1.int_col SCRIPT []
+_col0	_col1
+PREHOOK: query: explain cbo
+with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveProject(int_col=[$0], bigint_col=[$1])
+  HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(a, b) as (select int_col x, bigint_col y from t1)
+select a, b from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+a	b
+1	2
+3	4
+PREHOOK: query: with cte1(a) as (select int_col x, bigint_col y from t1)
+select a, y from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(a) as (select int_col x, bigint_col y from t1)
+select a, y from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+a	y
+1	2
+3	4
+PREHOOK: query: with cte1 as (select int_col x, bigint_col y from t1)
+select x, y from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1 as (select int_col x, bigint_col y from t1)
+select x, y from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+x	y
+1	2
+3	4
+PREHOOK: query: with cte1 as (select int_col, bigint_col from t1)
+select * from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1 as (select int_col, bigint_col from t1)
+select * from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte1.int_col	cte1.bigint_col
+1	2
+3	4
+PREHOOK: query: with cte(c1, c2) as (select int_col, bigint_col y from t1)
+select * from cte limit 1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte(c1, c2) as (select int_col, bigint_col y from t1)
+select * from cte limit 1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte.c1	cte.c2
+1	2
+PREHOOK: query: with cte1(c1, c2) as (select int_col x, sum(bigint_col) y from t1 group by int_col)
+select * from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(c1, c2) as (select int_col x, sum(bigint_col) y from t1 group by int_col)
+select * from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte1.c1	cte1.c2
+3	4
+1	2
+PREHOOK: query: with cte1(c1, c2) as (
+    select int_col x, bigint_col y from t1 where int_col = 1
+    union all
+    select int_col x, bigint_col y from t1 where int_col = 2
+)
+select * from cte1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: with cte1(c1, c2) as (
+    select int_col x, bigint_col y from t1 where int_col = 1
+    union all
+    select int_col x, bigint_col y from t1 where int_col = 2
+)
+select * from cte1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+cte1.c1	cte1.c2
+1	2

--- a/ql/src/test/results/clientpositive/llap/cte_mat_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_1.q.out
@@ -1,17 +1,17 @@
 Warning: Shuffle Join MERGEJOIN[13][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain
-with q1 as (select * from src where key= '5')
-select a.key
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey
 from q1 a join q1 b
-on a.key=b.key
+on a.srcKey=b.srcKey
 PREHOOK: type: QUERY
 PREHOOK: Input: default@src
 #### A masked pattern was here ####
 POSTHOOK: query: explain
-with q1 as (select * from src where key= '5')
-select a.key
+with q1(srcKey, srcValue) as (select * from src where key= '5')
+select a.srcKey
 from q1 a join q1 b
-on a.key=b.key
+on a.srcKey=b.srcKey
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@src
 #### A masked pattern was here ####


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Improve the parser to accept CTE clause has `with column list` specified:
```
WITH cte(a, b) AS ...
```
2. When transforming subquery AST tree to Calcite RelNode tree a new RowResolver is created for the subquery's top node to point its alias. Extend this logic with assign the `with column list` elements to each entry if explicitly specified in the `WITH` clause.

### Why are the changes needed?
SQL standard enables this feature.

### Does this PR introduce _any_ user-facing change?
Yes. When users specify `with column list` the list elements must be used to reference expressions in the CTE' select clause from the main query.

### How was this patch tested?
```
mvn test -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=cte_8.q,cte_mat_1.q -pl itests/qtest -Pitests
mvn test -DskipSparkTests -Dtest=TestNegativeCliDriver -Dqfile=cte_col_alias_clash.q,cte_col_alias.q  -pl itests/qtest -Pitests
```