### PR TITLE
HIVE-14165: Remove unnecessary file listing from FetchOperator

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hive.ql.exec;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -31,12 +32,10 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringEscapeUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.common.ValidReaderWriteIdList;
 import org.apache.hadoop.hive.common.ValidWriteIdList;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -68,11 +67,11 @@ import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.InvalidInputException;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobConfigurable;
 import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.Reporter;
-import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hive.common.util.AnnotationUtils;
 import org.apache.hive.common.util.ReflectionUtil;
@@ -268,36 +267,6 @@ public class FetchOperator implements Serializable {
     return partValues;
   }
 
-  private boolean getNextPath() throws Exception {
-    while (iterPath.hasNext()) {
-      currPath = iterPath.next();
-      currDesc = iterPartDesc.next();
-      if (isNonNativeTable) {
-        return true;
-      }
-      // if fetch is not being done from table and file sink has provided a list
-      // of files to fetch from then there is no need to query FS to check the existence
-      // of currpath
-      if(!this.getWork().isSourceTable() && this.getWork().getFilesToFetch() != null
-          && !this.getWork().getFilesToFetch().isEmpty()) {
-        return true;
-      }
-      FileSystem fs = currPath.getFileSystem(job);
-      if (fs.exists(currPath)) {
-        if (extractValidWriteIdList() != null &&
-            AcidUtils.isInsertOnlyTable(currDesc.getTableDesc().getProperties())) {
-          return true;
-        }
-        for (FileStatus fStat : listStatusUnderPath(fs, currPath)) {
-          if (fStat.getLen() > 0) {
-            return true;
-          }
-        }
-      }
-    }
-    return false;
-  }
-
   /**
    * Set context for this fetch operator in to the jobconf.
    * This helps InputFormats make decisions based on the scope of the complete
@@ -388,7 +357,9 @@ public class FetchOperator implements Serializable {
   }
 
   private List<FetchInputFormatSplit> getNextSplits() throws Exception {
-    while (getNextPath()) {
+    while (iterPath.hasNext()) {
+      currPath = iterPath.next();
+      currDesc = iterPartDesc.next();
       // not using FileInputFormat.setInputPaths() here because it forces a connection to the
       // default file system - which may or may not be online during pure metadata operations
       job.set("mapred.input.dir", StringUtils.escapeString(currPath.toString()));
@@ -456,9 +427,19 @@ public class FetchOperator implements Serializable {
     return null;
   }
 
-  private void generateWrappedSplits(InputFormat inputFormat,
-      List<FetchInputFormatSplit> inputSplits, JobConf job) throws IOException {
-    InputSplit[] splits = inputFormat.getSplits(job, 1);
+  private void generateWrappedSplits(InputFormat inputFormat, List<FetchInputFormatSplit> inputSplits, JobConf job)
+      throws IOException {
+    InputSplit[] splits;
+    try {
+      splits = inputFormat.getSplits(job, 1);
+    } catch (Exception ex) {
+      Throwable t = ExceptionUtils.getRootCause(ex);
+      if (t instanceof FileNotFoundException || t instanceof InvalidInputException) {
+        LOG.warn("Input path " + currPath + " is empty", t.getMessage());
+        return;
+      }
+      throw ex;
+    }
     for (int i = 0; i < splits.length; i++) {
       inputSplits.add(new FetchInputFormatSplit(splits[i], inputFormat));
     }
@@ -762,31 +743,6 @@ public class FetchOperator implements Serializable {
       }
     }
     return false;
-  }
-
-  /**
-   * Lists status for all files under a given path. Whether or not this is recursive depends on the
-   * setting of job configuration parameter mapred.input.dir.recursive.
-   *
-   * @param fs
-   *          file system
-   *
-   * @param p
-   *          path in file system
-   *
-   * @return list of file status entries
-   */
-  private FileStatus[] listStatusUnderPath(FileSystem fs, Path p) throws IOException {
-    boolean recursive = job.getBoolean(FileInputFormat.INPUT_DIR_RECURSIVE, false);
-    // If this is in acid format always read it recursively regardless of what the jobconf says.
-    if (!recursive && !AcidUtils.isAcid(fs, p, job)) {
-      return fs.listStatus(p, FileUtils.HIDDEN_FILES_PATH_FILTER);
-    }
-    List<FileStatus> results = new ArrayList<FileStatus>();
-    for (FileStatus stat : fs.listStatus(p, FileUtils.HIDDEN_FILES_PATH_FILTER)) {
-      FileUtils.listStatusRecursively(fs, stat, results);
-    }
-    return results.toArray(new FileStatus[results.size()]);
   }
 
   // for split sampling. shrinkedLength is checked against IOContext.getCurrentBlockStart,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FetchOperator.java
@@ -30,6 +30,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
@@ -465,12 +466,14 @@ public class FetchOperator implements Serializable {
   }
 
   private String makeInputString(List<Path> dirs) {
-    if (dirs == null || dirs.isEmpty()) return "";
-    StringBuffer str = new StringBuffer(StringUtils.escapeString(dirs.get(0).toString()));
-    for(int i = 1; i < dirs.size(); i++) {
-      str.append(",").append(StringUtils.escapeString(dirs.get(i).toString()));
+    if (dirs == null || dirs.isEmpty()) {
+      return "";
     }
-    return str.toString();
+    // remove duplicates
+    return dirs.stream()
+        .map(dir -> StringUtils.escapeString(dir.toString()))
+        .distinct()
+        .collect(Collectors.joining(","));
 
   }
   private ValidWriteIdList extractValidWriteIdList() {

--- a/ql/src/test/queries/clientpositive/exim_04_evolved_parts.q
+++ b/ql/src/test/queries/clientpositive/exim_04_evolved_parts.q
@@ -15,7 +15,7 @@ alter table exim_employee_n12 clustered by (emp_sex, emp_dept) sorted by (emp_id
 alter table exim_employee_n12 add partition (emp_country='in', emp_state='tn');
 
 alter table exim_employee_n12 set fileformat 
-	inputformat  "org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat" 
+	inputformat  "org.apache.hadoop.hive.ql.io.RCFileInputFormat"
 	outputformat "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"
         serde        "org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe";
     

--- a/ql/src/test/results/clientpositive/llap/exim_04_evolved_parts.q.out
+++ b/ql/src/test/results/clientpositive/llap/exim_04_evolved_parts.q.out
@@ -40,14 +40,14 @@ POSTHOOK: type: ALTERTABLE_ADDPARTS
 POSTHOOK: Output: default@exim_employee_n12
 POSTHOOK: Output: default@exim_employee_n12@emp_country=in/emp_state=tn
 PREHOOK: query: alter table exim_employee_n12 set fileformat 
-	inputformat  "org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat" 
+	inputformat  "org.apache.hadoop.hive.ql.io.RCFileInputFormat"
 	outputformat "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"
         serde        "org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe"
 PREHOOK: type: ALTERTABLE_FILEFORMAT
 PREHOOK: Input: default@exim_employee_n12
 PREHOOK: Output: default@exim_employee_n12
 POSTHOOK: query: alter table exim_employee_n12 set fileformat 
-	inputformat  "org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat" 
+	inputformat  "org.apache.hadoop.hive.ql.io.RCFileInputFormat"
 	outputformat "org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat"
         serde        "org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe"
 POSTHOOK: type: ALTERTABLE_FILEFORMAT
@@ -176,7 +176,7 @@ POSTHOOK: query: show table extended like exim_employee_n12
 POSTHOOK: type: SHOW_TABLESTATUS
 tableName:exim_employee_n12
 #### A masked pattern was here ####
-inputformat:org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat
+inputformat:org.apache.hadoop.hive.ql.io.RCFileInputFormat
 outputformat:org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
 columns:struct columns { i32 emp_id, string emp_name, string emp_dob, string emp_sex, i32 emp_dept}
 partitioned:true


### PR DESCRIPTION

### What changes were proposed in this pull request?
Remove unnecessary file listing from Fetchoperator, rather handle FileNotFoundException, to make it more performant on s3.
Rebased the original patch from Sahil Takiar.

### Why are the changes needed?
Performance improvement


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Current unit tests. Manually test: deleted some directories during execution to cause FileNotFoundEx.
