### PR TITLE
HIVE-24626: LLAP: reader threads could be starvated if all IO elevator threads are busy to enqueue to another readers with full queue

### DIFF
--- a/itests/util/src/main/java/org/apache/hadoop/hive/llap/LlapItUtils.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/llap/LlapItUtils.java
@@ -56,6 +56,7 @@ public class LlapItUtils {
     // 75% for 4 executors
     final long totalExecutorMemory = (long) (0.75f * maxMemory);
     final int numExecutors = HiveConf.getIntVar(conf, HiveConf.ConfVars.LLAP_DAEMON_NUM_EXECUTORS);
+    HiveConf.setIntVar(conf, HiveConf.ConfVars.LLAP_IO_THREADPOOL_SIZE, numExecutors);
     final boolean asyncIOEnabled = true;
     // enabling this will cause test failures in Mac OS X
     final boolean directMemoryEnabled = false;

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/LlapDaemon.java
@@ -208,6 +208,13 @@ public class LlapDaemon extends CompositeService implements ContainerRunner, Lla
     Preconditions.checkArgument(simpleAverageWindowDataSize >= 0,
         "hive.llap.daemon.metrics.simple.average.data.points should be greater or equal to 0");
 
+    if (ioEnabled) {
+      int numThreads = HiveConf.getIntVar(daemonConf, HiveConf.ConfVars.LLAP_IO_THREADPOOL_SIZE);
+      Preconditions.checkArgument(numThreads >= numExecutors,
+          "hive.llap.io.threadpool.size (%s) should be greater or equal to hive.llap.daemon.num.executors (%s)",
+          numThreads, numExecutors);
+    }
+
     final String logMsg = "Attempting to start LlapDaemon with the following configuration: " +
       "maxJvmMemory=" + maxJvmMemory + " ("
       + LlapUtil.humanReadableByteCount(maxJvmMemory) + ")" +

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemon.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestLlapDaemon.java
@@ -86,6 +86,18 @@ public class TestLlapDaemon {
     daemon.shutdown();
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void testEnforceProperNumberOfIOThreads() throws IOException {
+    Configuration thisHiveConf = new HiveConf();
+    HiveConf.setVar(thisHiveConf, HiveConf.ConfVars.LLAP_DAEMON_SERVICE_HOSTS, "@llap");
+    HiveConf.setIntVar(thisHiveConf, HiveConf.ConfVars.LLAP_DAEMON_NUM_EXECUTORS, 4);
+    HiveConf.setIntVar(thisHiveConf, HiveConf.ConfVars.LLAP_IO_THREADPOOL_SIZE, 3);
+
+    LlapDaemon thisDaemon = new LlapDaemon(thisHiveConf, 1, LlapDaemon.getTotalHeapSize(), false, false,
+            -1, new String[1], 0, false, 0,0, 0, -1, "TestLlapDaemon");
+    thisDaemon.close();
+  }
+
   @Test
   public void testUpdateRegistration() throws IOException {
     // Given


### PR DESCRIPTION
### What changes were proposed in this pull request?
Llap daemon should enforce the proper number of io threads (>= executors)

### Why are the changes needed?
It can cause query hang otherwise.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
On Cloudera Data Warehouse.
