### PR TITLE
HIVE-24635: Support Values clause as operand of set operation

### DIFF
--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -2416,8 +2416,6 @@ queryStatementExpression
       }
     }
     ->  queryStatementExpressionBody
-    |
-    valuesSource
     ;
 
 queryStatementExpressionBody
@@ -2474,13 +2472,8 @@ regularBody
    :
    i=insertClause
    (
-   s=selectStatement
-     {$s.tree.getFirstChildWithType(TOK_INSERT).replaceChildren(0, 0, $i.tree);} -> {$s.tree}
-     |
-     valuesClause
-      -> ^(TOK_QUERY
-            ^(TOK_INSERT {$i.tree} ^(TOK_SELECT ^(TOK_SELEXPR ^(TOK_FUNCTION Identifier["inline"] valuesClause))))
-          )
+   s=selectStatement {$s.tree.getFirstChildWithType(TOK_INSERT).replaceChildren(0, 0, $i.tree);}
+   -> {$s.tree}
    )
    |
    selectStatement
@@ -2498,6 +2491,8 @@ atomSelectStatement
                      $s $w? $g? $h? $win?))
    |
    LPAREN! selectStatement RPAREN!
+   |
+   valuesSource
    ;
 
 selectStatement

--- a/parser/src/test/org/apache/hadoop/hive/ql/parse/TestValuesClause.java
+++ b/parser/src/test/org/apache/hadoop/hive/ql/parse/TestValuesClause.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestValuesClause {
   ParseDriver parseDriver = new ParseDriver();
+
   @Test
   public void testParseValues() throws Exception {
     ASTNode tree = parseDriver.parse(
@@ -85,4 +86,21 @@ public class TestValuesClause {
           "                     4\n" +
           "                     5\n" +
           "                     6\n";
+
+  @Test
+  public void testParseValuesInUnion() throws Exception {
+    parseDriver.parse("values(1,2,3),(4,5,6)\n" +
+            "union all\n" +
+            "values(1,2,3),(4,5,6)", null);
+  }
+
+  @Test
+  public void testParseInsertValues() throws Exception {
+    parseDriver.parse("INSERT INTO t1(a, b) VALUES (1,2),(3,4)", null);
+  }
+
+  @Test
+  public void testParseInsertFromValuesAsSubQuery() throws Exception {
+    parseDriver.parse("insert into table FOO select a,b from (values(1,2),(3,4)) as BAR", null);
+  }
 }

--- a/ql/src/test/queries/clientpositive/values.q
+++ b/ql/src/test/queries/clientpositive/values.q
@@ -19,3 +19,17 @@ WITH t1 AS (VALUES('a', 'b'), ('b', 'c'))
 SELECT * FROM t1 WHERE col1 = 'a'
 UNION ALL
 SELECT * from t1 WHERE col1 = 'b';
+
+
+EXPLAIN CBO
+VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0);
+
+VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0);

--- a/ql/src/test/results/clientpositive/llap/values.q.out
+++ b/ql/src/test/results/clientpositive/llap/values.q.out
@@ -95,3 +95,55 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 col1	col2
 a	b
 b	c
+PREHOOK: query: EXPLAIN CBO
+VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveProject(col1=[$0], col2=[$1], col3=[null:NULL], col4=[$2])
+  HiveUnion(all=[true])
+    HiveProject(col1=[$0], col2=[$1], col4=[$3])
+      HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(1, _UTF-16LE'a':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:NULL, 10:DECIMAL(2, 0))))], rowType=[RecordType(INTEGER col1, VARCHAR(2147483647) col2, NULL col3, DECIMAL(2, 0) col4)])
+        HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+    HiveProject(col1=[$0], col2=[$1], col4=[$3])
+      HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(2, _UTF-16LE'b':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:NULL, 20:DECIMAL(2, 0))))], rowType=[RecordType(INTEGER col1, VARCHAR(2147483647) col2, NULL col3, DECIMAL(2, 0) col4)])
+        HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+    HiveProject(col1=[$0], col2=[$1], col4=[$3])
+      HiveTableFunctionScan(invocation=[inline(ARRAY(ROW(3, _UTF-16LE'c':VARCHAR(2147483647) CHARACTER SET "UTF-16LE", null:NULL, 30:DECIMAL(2, 0))))], rowType=[RecordType(INTEGER col1, VARCHAR(2147483647) col2, NULL col3, DECIMAL(2, 0) col4)])
+        HiveTableScan(table=[[_dummy_database, _dummy_table]], table:alias=[_dummy_table])
+
+PREHOOK: query: VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: VALUES(1, 'a', NULL, 10.0)
+UNION ALL
+VALUES(2, 'b', NULL, 20.0)
+UNION ALL
+VALUES(3, 'c', NULL, 30.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+col1	col2	col3	col4
+1	a	NULL	10
+2	b	NULL	20
+3	c	NULL	30


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Move the `valuesSource` rule alternative from `queryStatementExpression` parser rule to `atomSelectStatement`
2. Remove `valuesClause` rule alternative from `regularBody` since it is covered through 
`selectStatement`->`atomSelectStatement`->`valuesSource`->`valuesClause`


### Why are the changes needed?
Enable queries which has values clause as operand of set operation. See jira or `values.q` for example

### Does this PR introduce _any_ user-facing change?
Yes. Users can write queries which has values clause as operand of set operation. This feature was not enabled in the past and Hive thrown exception such cases. Existing queries are not affected.

### How was this patch tested?
```
mvn test -Dtest=TestValuesClause -pl parser
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=values.q -pl itests/qtest -Pitests
```