### PR TITLE
HIVE-24637 make Tez progress log interval configurable

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/RenderStrategy.java
@@ -31,6 +31,7 @@ import java.io.StringWriter;
 import java.util.Map;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
 
 class RenderStrategy {
 
@@ -39,7 +40,7 @@ class RenderStrategy {
   }
 
   private abstract static class BaseUpdateFunction implements UpdateFunction {
-    private static final int PRINT_INTERVAL = 3000;
+    private final long print_interval;
 
     final TezJobMonitor monitor;
     private final PerfLogger perfLogger;
@@ -49,6 +50,11 @@ class RenderStrategy {
 
     BaseUpdateFunction(TezJobMonitor monitor) {
       this.monitor = monitor;
+      print_interval = HiveConf.getTimeVar(
+          monitor.getHiveConf(),
+          HiveConf.ConfVars.HIVE_LOG_INCREMENTAL_PLAN_PROGRESS_INTERVAL,
+          TimeUnit.MILLISECONDS
+      );
       perfLogger = SessionState.getPerfLogger();
     }
 
@@ -65,7 +71,7 @@ class RenderStrategy {
 
     private boolean showReport(String report) {
       return !report.equals(lastReport)
-          || System.currentTimeMillis() >= lastPrintTime + PRINT_INTERVAL;
+          || System.currentTimeMillis() >= lastPrintTime + print_interval;
     }
 
     /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/TezJobMonitor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/monitoring/TezJobMonitor.java
@@ -493,6 +493,10 @@ public class TezJobMonitor {
     return (tezCounter == null) ? 0 : tezCounter.getValue();
   }
 
+  public HiveConf getHiveConf() {
+    return hiveConf;
+  }
+
   public String getDiagnostics() {
     return diagnostics.toString();
   }


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
This makes the Hive on tez progress log interval configurable using the same parameter used in map reduce
(https://issues.apache.org/jira/browse/HIVE-24637)

### Why are the changes needed?
For long running Hive jobs the current hardcoded value of 3seconds can result in very large logs


### Does this PR introduce _any_ user-facing change?
Default interval of logging progress log when running on Tez changes from 3 to 6 sec


### How was this patch tested?
Internal Hive deployment
