### PR TITLE
HIVE-24606: Multi-stage materialized CTEs can lose intermediate data

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -38,6 +38,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -1347,7 +1348,9 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   @Override
   public List<Task<?>> getAllRootTasks() {
     if (!rootTasksResolved) {
-      rootTasks = toRealRootTasks(rootClause.asExecutionOrder());
+      LinkedHashMap<CTEClause, LinkedHashSet<CTEClause>> realDependencies = listRealDependencies();
+      linkRealDependencies(realDependencies);
+      rootTasks = toRealRootTasks(realDependencies);
       rootTasksResolved = true;
     }
     return rootTasks;
@@ -1417,47 +1420,78 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
   }
 
-  private List<Task<?>> toRealRootTasks(List<CTEClause> execution) {
-    List<Task<?>> cteRoots = new ArrayList<>();
-    List<Task<?>> cteLeafs = new ArrayList<>();
-    List<Task<?>> curTopRoots = null;
-    List<Task<?>> curBottomLeafs = null;
-    for (CTEClause current : execution) {
-      if (current.parents.isEmpty() && curTopRoots != null) {
-        cteRoots.addAll(curTopRoots);
-        cteLeafs.addAll(curBottomLeafs);
-        curTopRoots = curBottomLeafs = null;
+  private List<Task<?>> getRealTasks(CTEClause cte) {
+    if (cte == rootClause) {
+      return rootTasks;
+    } else {
+      return cte.getTasks();
+    }
+  }
+
+  /**
+   * Links tasks based on dependencies among CTEs which have actual tasks.
+   * For example, when materialized CTE X depends on materialized CTE Y,
+   * the leaf tasks of Y must have the root tasks of X as its child tasks.
+   */
+  private void linkRealDependencies(LinkedHashMap<CTEClause, LinkedHashSet<CTEClause>> realDependencies) {
+    LinkedHashMap<CTEClause, List<Task<?>>> dependentTasks = new LinkedHashMap<>();
+    for (CTEClause child : realDependencies.keySet()) {
+      for (CTEClause parent : realDependencies.get(child)) {
+        if (!dependentTasks.containsKey(parent)) {
+          dependentTasks.put(parent, new ArrayList<>());
+        }
+        dependentTasks.get(parent).addAll(getRealTasks(child));
       }
-      List<Task<?>> curTasks = current.getTasks();
-      if (curTasks == null) {
+    }
+    // This operation must be performed only once per CTE since it creates new leaves
+    for (CTEClause parent : dependentTasks.keySet()) {
+      List<Task<?>> sources = Task.findLeafs(getRealTasks(parent));
+      linkTasks(sources, dependentTasks.get(parent));
+    }
+  }
+
+  private static void linkTasks(List<Task<?>> sources, Iterable<Task<?>> sinks) {
+    for (Task<?> source : sources) {
+      for (Task<?> sink : sinks) {
+        source.addDependentTask(sink);
+      }
+    }
+  }
+
+  // Returns tasks which have no dependencies and can start without waiting for any tasks
+  private List<Task<?>> toRealRootTasks(LinkedHashMap<CTEClause, LinkedHashSet<CTEClause>> realDependencies) {
+    List<Task<?>> realRootTasks = new ArrayList<>();
+    for (CTEClause cte : realDependencies.keySet()) {
+      if (realDependencies.get(cte).isEmpty()) {
+        realRootTasks.addAll(getRealTasks(cte));
+      }
+    }
+    return realRootTasks;
+  }
+
+  // child with tasks -> list of parents with tasks
+  private LinkedHashMap<CTEClause, LinkedHashSet<CTEClause>> listRealDependencies() {
+    LinkedHashMap<CTEClause, LinkedHashSet<CTEClause>> realDependencies = new LinkedHashMap<>();
+    for (CTEClause child : rootClause.asExecutionOrder()) {
+      if (getRealTasks(child) == null) {
+        // This CTE will be executed as a part of other CTEs or a root statement
         continue;
       }
-      if (curTopRoots == null) {
-        curTopRoots = curTasks;
-      }
-      if (curBottomLeafs != null) {
-        for (Task<?> topLeafTask : curBottomLeafs) {
-          for (Task<?> currentRootTask : curTasks) {
-            topLeafTask.addDependentTask(currentRootTask);
-          }
-        }
-      }
-      curBottomLeafs = Task.findLeafs(curTasks);
+      LinkedHashSet<CTEClause> parents = new LinkedHashSet<>();
+      collectRealDependencies(child, parents);
+      realDependencies.put(child, parents);
     }
-    if (curTopRoots != null) {
-      cteRoots.addAll(curTopRoots);
-      cteLeafs.addAll(curBottomLeafs);
-    }
+    return realDependencies;
+  }
 
-    if (cteRoots.isEmpty()) {
-      return rootTasks;
-    }
-    for (Task<?> cteLeafTask : cteLeafs) {
-      for (Task<?> mainRootTask : rootTasks) {
-        cteLeafTask.addDependentTask(mainRootTask);
+  private void collectRealDependencies(CTEClause cte, LinkedHashSet<CTEClause> realDependencies) {
+    for (CTEClause parent : cte.parents) {
+      if (getRealTasks(parent) == null) {
+        collectRealDependencies(parent, realDependencies);
+      } else {
+        realDependencies.add(parent);
       }
     }
-    return cteRoots;
   }
 
   Table materializeCTE(String cteName, CTEClause cte) throws HiveException {

--- a/ql/src/test/queries/clientpositive/cte_mat_10.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_10.q
@@ -1,0 +1,23 @@
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+set hive.explain.user=true;
+
+with x as ( select 'x' as id ),
+a1 as ( select 'a1' as id),
+a2 as ( select 'a2 <- ' || id as id from a1 ),
+a3 as ( select 'a3 <- ' || id as id from a2 ),
+b1 as ( select 'b1' as id ),
+b2 as (
+  select 'b2 <- ' || id as id from b1
+  union all
+  select 'b2 <- ' || id as id from b1
+)
+select * from a2
+union all
+select * from x
+union all
+select * from a3
+union all
+select * from a3
+union all
+select * from b2;

--- a/ql/src/test/queries/clientpositive/cte_mat_8.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_8.q
@@ -1,0 +1,14 @@
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+set hive.explain.user=true;
+
+with x as ( select 'x' as id ), -- not materialized
+a1 as ( select 'a1' as id ), -- materialized by a2 and the root
+a2 as ( select 'a2 <- ' || id as id from a1) -- materialized by the root
+select * from a1
+union all
+select * from x
+union all
+select * from a2
+union all
+select * from a2;

--- a/ql/src/test/queries/clientpositive/cte_mat_9.q
+++ b/ql/src/test/queries/clientpositive/cte_mat_9.q
@@ -1,0 +1,39 @@
+set hive.optimize.cte.materialize.threshold=2;
+set hive.optimize.cte.materialize.full.aggregate.only=false;
+set hive.explain.user=true;
+
+drop table if exists cte_mat_9_a;
+create table cte_mat_9_a (id int);
+insert into cte_mat_9_a (id) values (1);
+
+drop table if exists cte_mat_9_b;
+create table cte_mat_9_b (id int);
+insert into cte_mat_9_b (id) values (1);
+
+with a0 AS (
+  select id, 'a0' as tag from cte_mat_9_a
+),
+a1 as (
+  select id, 'a1 <- ' || tag as tag from a0
+),
+b0 as (
+  select id, 'b0' as tag from cte_mat_9_b
+),
+b1 as (
+  select id, 'b1 <- ' || tag as tag from b0
+),
+b2 as (
+  select id, 'b2 <- ' || tag as tag  from b1
+),
+b3 as (
+  select id, 'b3 <- ' || tag as tag from b2
+),
+c as (
+  select b2.id, 'c <- (' || b2.tag || ' & ' || b3.tag || ')' as tag
+  from b2
+  full outer join b3 on b2.id = b3.id
+)
+select b1.id, b1.tag, a1.tag, c.tag
+from b1
+full outer join a1 on b1.id = a1.id
+full outer join c on c.id = c.id;

--- a/ql/src/test/results/clientpositive/llap/cte_mat_10.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_10.q.out
@@ -1,0 +1,64 @@
+PREHOOK: query: with x as ( select 'x' as id ),
+a1 as ( select 'a1' as id),
+a2 as ( select 'a2 <- ' || id as id from a1 ),
+a3 as ( select 'a3 <- ' || id as id from a2 ),
+b1 as ( select 'b1' as id ),
+b2 as (
+  select 'b2 <- ' || id as id from b1
+  union all
+  select 'b2 <- ' || id as id from b1
+)
+select * from a2
+union all
+select * from x
+union all
+select * from a3
+union all
+select * from a3
+union all
+select * from b2
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Input: default@a2
+PREHOOK: Input: default@a3
+PREHOOK: Input: default@b1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@a2
+PREHOOK: Output: default@a3
+PREHOOK: Output: default@b1
+#### A masked pattern was here ####
+POSTHOOK: query: with x as ( select 'x' as id ),
+a1 as ( select 'a1' as id),
+a2 as ( select 'a2 <- ' || id as id from a1 ),
+a3 as ( select 'a3 <- ' || id as id from a2 ),
+b1 as ( select 'b1' as id ),
+b2 as (
+  select 'b2 <- ' || id as id from b1
+  union all
+  select 'b2 <- ' || id as id from b1
+)
+select * from a2
+union all
+select * from x
+union all
+select * from a3
+union all
+select * from a3
+union all
+select * from b2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Input: default@a2
+POSTHOOK: Input: default@a3
+POSTHOOK: Input: default@b1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@a2
+POSTHOOK: Output: default@a3
+POSTHOOK: Output: default@b1
+#### A masked pattern was here ####
+a2 <- a1
+x
+a3 <- a2 <- a1
+a3 <- a2 <- a1
+b2 <- b1
+b2 <- b1

--- a/ql/src/test/results/clientpositive/llap/cte_mat_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_8.q.out
@@ -1,0 +1,40 @@
+PREHOOK: query: with x as ( select 'x' as id ), -- not materialized
+a1 as ( select 'a1' as id ), -- materialized by a2 and the root
+a2 as ( select 'a2 <- ' || id as id from a1) -- materialized by the root
+select * from a1
+union all
+select * from x
+union all
+select * from a2
+union all
+select * from a2
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Input: default@a1
+PREHOOK: Input: default@a2
+PREHOOK: Output: database:default
+PREHOOK: Output: default@a1
+PREHOOK: Output: default@a2
+#### A masked pattern was here ####
+POSTHOOK: query: with x as ( select 'x' as id ), -- not materialized
+a1 as ( select 'a1' as id ), -- materialized by a2 and the root
+a2 as ( select 'a2 <- ' || id as id from a1) -- materialized by the root
+select * from a1
+union all
+select * from x
+union all
+select * from a2
+union all
+select * from a2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Input: default@a1
+POSTHOOK: Input: default@a2
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@a1
+POSTHOOK: Output: default@a2
+#### A masked pattern was here ####
+a1
+x
+a2 <- a1
+a2 <- a1

--- a/ql/src/test/results/clientpositive/llap/cte_mat_9.q.out
+++ b/ql/src/test/results/clientpositive/llap/cte_mat_9.q.out
@@ -1,0 +1,116 @@
+PREHOOK: query: drop table if exists cte_mat_9_a
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists cte_mat_9_a
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table cte_mat_9_a (id int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cte_mat_9_a
+POSTHOOK: query: create table cte_mat_9_a (id int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cte_mat_9_a
+PREHOOK: query: insert into cte_mat_9_a (id) values (1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cte_mat_9_a
+POSTHOOK: query: insert into cte_mat_9_a (id) values (1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cte_mat_9_a
+POSTHOOK: Lineage: cte_mat_9_a.id SCRIPT []
+PREHOOK: query: drop table if exists cte_mat_9_b
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists cte_mat_9_b
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table cte_mat_9_b (id int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@cte_mat_9_b
+POSTHOOK: query: create table cte_mat_9_b (id int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@cte_mat_9_b
+PREHOOK: query: insert into cte_mat_9_b (id) values (1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@cte_mat_9_b
+POSTHOOK: query: insert into cte_mat_9_b (id) values (1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@cte_mat_9_b
+POSTHOOK: Lineage: cte_mat_9_b.id SCRIPT []
+Warning: Shuffle Join MERGEJOIN[32][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Reducer 5' is a cross product
+PREHOOK: query: with a0 AS (
+  select id, 'a0' as tag from cte_mat_9_a
+),
+a1 as (
+  select id, 'a1 <- ' || tag as tag from a0
+),
+b0 as (
+  select id, 'b0' as tag from cte_mat_9_b
+),
+b1 as (
+  select id, 'b1 <- ' || tag as tag from b0
+),
+b2 as (
+  select id, 'b2 <- ' || tag as tag  from b1
+),
+b3 as (
+  select id, 'b3 <- ' || tag as tag from b2
+),
+c as (
+  select b2.id, 'c <- (' || b2.tag || ' & ' || b3.tag || ')' as tag
+  from b2
+  full outer join b3 on b2.id = b3.id
+)
+select b1.id, b1.tag, a1.tag, c.tag
+from b1
+full outer join a1 on b1.id = a1.id
+full outer join c on c.id = c.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@b1
+PREHOOK: Input: default@b2
+PREHOOK: Input: default@cte_mat_9_a
+PREHOOK: Input: default@cte_mat_9_b
+PREHOOK: Output: database:default
+PREHOOK: Output: default@b1
+PREHOOK: Output: default@b2
+#### A masked pattern was here ####
+POSTHOOK: query: with a0 AS (
+  select id, 'a0' as tag from cte_mat_9_a
+),
+a1 as (
+  select id, 'a1 <- ' || tag as tag from a0
+),
+b0 as (
+  select id, 'b0' as tag from cte_mat_9_b
+),
+b1 as (
+  select id, 'b1 <- ' || tag as tag from b0
+),
+b2 as (
+  select id, 'b2 <- ' || tag as tag  from b1
+),
+b3 as (
+  select id, 'b3 <- ' || tag as tag from b2
+),
+c as (
+  select b2.id, 'c <- (' || b2.tag || ' & ' || b3.tag || ')' as tag
+  from b2
+  full outer join b3 on b2.id = b3.id
+)
+select b1.id, b1.tag, a1.tag, c.tag
+from b1
+full outer join a1 on b1.id = a1.id
+full outer join c on c.id = c.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@b1
+POSTHOOK: Input: default@b2
+POSTHOOK: Input: default@cte_mat_9_a
+POSTHOOK: Input: default@cte_mat_9_b
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@b1
+POSTHOOK: Output: default@b2
+#### A masked pattern was here ####
+1	b1 <- b0	a1 <- a0	c <- (b2 <- b1 <- b0 & b3 <- b2 <- b1 <- b0)


### PR DESCRIPTION
### What changes were proposed in this pull request?
Build correct dependencies among CTEs in order to prevent wrong results.

### Why are the changes needed?
A Hive query with `hive.optimize.cte.materialize.threshold` can return wrong results when it has complex CTEs.
The issue can happen when multistage CTEs have dependencies and SemanticAnalyzer fails to link their tasks.
https://issues.apache.org/jira/browse/HIVE-24606

### Does this PR introduce _any_ user-facing change?
No. Just a bug fix.

### How was this patch tested?
This PR adds three test cases. All fail when using the latest revision(`58552a0c6b42988efb5160b045a3bf985477f117`).