### PR TITLE
HIVE-24645: Call configure for UDFs after fetch task conversion

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -171,6 +171,7 @@ minillap.query.files=\
   transform_ppr1.q,\
   transform_ppr2.q,\
   udaf_sum_list.q,\
+  udf_configure.q,\
   udf_printf.q,\
   union23.q,\
   unionDistinct_1.q,\

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/udf/generic/TestConfigureUDF.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/udf/generic/TestConfigureUDF.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.udf.generic;
+
+import org.apache.hadoop.hive.ql.exec.Description;
+import org.apache.hadoop.hive.ql.exec.MapredContext;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.io.Text;
+
+@Description(name = "testconfigure", value = "_FUNC_(col) - UDF to test configure")
+public class TestConfigureUDF extends GenericUDF {
+
+  private MapredContext context;
+  private Text result = new Text();
+
+  public ObjectInspector initialize(ObjectInspector[] arguments) throws UDFArgumentException {
+    return PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+  }
+
+  public Object evaluate(DeferredObject[] arguments) throws HiveException {
+    result.set(context.getJobConf().get("testconf.udf.test"));
+    return result;
+  }
+
+  public String getDisplayString(String[] children) {
+    return "testconfigure()";
+  }
+
+  @Override
+  public void configure(MapredContext context) {
+    this.context = context;
+    context.getJobConf().set("testconf.udf.test", "configure was called");
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MapredContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MapredContext.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.exec.tez.TezContext;
@@ -56,6 +57,15 @@ public class MapredContext {
       logger.debug("MapredContext initialized.");
     }
     return context;
+  }
+
+  // Creates a dummy MapredContext that uses conf as the basis for JobConf
+  // - the intent is for this to be used in situations where there is a
+  // need to provide a MapredContext but one is not available. (For example
+  // when hive.fetch.task.conversion optimization kicks in UDFs still expect
+  // configure to be called but a MapredContext isn't available)
+  public static MapredContext createDummy(Configuration conf) {
+    return new MapredContext(false, new JobConf(conf));
   }
 
   public static void close() {

--- a/ql/src/test/queries/clientpositive/udf_configure.q
+++ b/ql/src/test/queries/clientpositive/udf_configure.q
@@ -1,0 +1,8 @@
+--! qt:dataset:src
+SET hive.vectorized.execution.enabled=false;
+set hive.test.vectorized.execution.enabled.override=disable;
+--- This test attempts to verify HIVE-24645 which relies on fetch task conversion kicking in
+set hive.fetch.task.conversion=more;
+create temporary function testconfigure as 'org.apache.hadoop.hive.ql.udf.generic.TestConfigureUDF';
+set hive.input.format = org.apache.hadoop.hive.ql.io.BucketizedHiveInputFormat;
+select *, testconfigure(key) from src limit 20;

--- a/ql/src/test/results/clientpositive/llap/udf_configure.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_configure.q.out
@@ -1,0 +1,34 @@
+PREHOOK: query: create temporary function testconfigure as 'org.apache.hadoop.hive.ql.udf.generic.TestConfigureUDF'
+PREHOOK: type: CREATEFUNCTION
+PREHOOK: Output: testconfigure
+POSTHOOK: query: create temporary function testconfigure as 'org.apache.hadoop.hive.ql.udf.generic.TestConfigureUDF'
+POSTHOOK: type: CREATEFUNCTION
+POSTHOOK: Output: testconfigure
+PREHOOK: query: select *, testconfigure(key) from src limit 20
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select *, testconfigure(key) from src limit 20
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+238	val_238	configure was called
+86	val_86	configure was called
+311	val_311	configure was called
+27	val_27	configure was called
+165	val_165	configure was called
+409	val_409	configure was called
+255	val_255	configure was called
+278	val_278	configure was called
+98	val_98	configure was called
+484	val_484	configure was called
+265	val_265	configure was called
+193	val_193	configure was called
+401	val_401	configure was called
+150	val_150	configure was called
+273	val_273	configure was called
+224	val_224	configure was called
+369	val_369	configure was called
+66	val_66	configure was called
+128	val_128	configure was called
+213	val_213	configure was called


### PR DESCRIPTION
Change-Id: Ic6ddbf9ffb14c293caadf1f8ec1e7ec0f9291a31

### What changes were proposed in this pull request?
UDF configure does not get called if fetch task conversion happens.
This attempts to resolve this by calling configure with a dummy MapredContext.
It is a bit ugly in that MapredContext seems to be legacy baggage with various members that do not make sense for a variety of engines and code.


### Why are the changes needed?
Some custom UDFs are designed with the expectation that configure is called in all instances. Users sometimes use it to inspect configuration values or to set new values to propagate to the evaluate method or to do one time setup.

### Does this PR introduce _any_ user-facing change?
Yes - it will now call configure in cases where configure was not called before.


### How was this patch tested?
Added udf_configure.q and manual testing
