### PR TITLE
HIVE-24648 Clean up FetchTask and related classes

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
@@ -381,9 +381,9 @@ public class Compiler {
       TableDesc td = ft.getTblDesc();
       // partitioned tables don't have tableDesc set on the FetchTask. Instead they have a list of PartitionDesc
       // objects, each with a table desc. Let's try to fetch the desc for the first partition and use it's deserializer.
-      if (td == null && ft.getWork() != null && ft.getWork().getPartDesc() != null) {
-        if (ft.getWork().getPartDesc().size() > 0) {
-          td = ft.getWork().getPartDesc().get(0).getTableDesc();
+      if (td == null && ft.getWork() != null && ft.getWork().getPartitionDescs() != null) {
+        if (ft.getWork().getPartitionDescs().size() > 0) {
+          td = ft.getWork().getPartitionDescs().get(0).getTableDesc();
         }
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/cache/results/QueryResultsCache.java
@@ -276,7 +276,7 @@ public final class QueryResultsCache {
 
     public FetchWork getFetchWork() {
       // FetchWork's sink is used to hold results, so each query needs a separate copy of FetchWork
-      FetchWork fetch = new FetchWork(fetchWork.getTblDir(), fetchWork.getTblDesc(), fetchWork.getLimit());
+      FetchWork fetch = new FetchWork(fetchWork.getTableDir(), fetchWork.getTableDesc(), fetchWork.getLimit());
       fetch.setCachedResult(true);
       fetch.setFilesToFetch(this.cachedResultPaths);
       return fetch;
@@ -530,7 +530,7 @@ public final class QueryResultsCache {
       assert(fetchWork.getFilesToFetch() != null );
 
       boolean requiresCaching = true;
-      queryResultsPath = fetchWork.getTblDir();
+      queryResultsPath = fetchWork.getTableDir();
       FileSystem resultsFs = queryResultsPath.getFileSystem(conf);
 
       long resultSize = 0;
@@ -567,7 +567,7 @@ public final class QueryResultsCache {
 
         // Create a new FetchWork to reference the new cache location.
         FetchWork fetchWorkForCache =
-            new FetchWork(fetchWork.getTblDir(), fetchWork.getTblDesc(), fetchWork.getLimit());
+            new FetchWork(fetchWork.getTableDir(), fetchWork.getTableDesc(), fetchWork.getLimit());
         fetchWorkForCache.setCachedResult(true);
         fetchWorkForCache.setFilesToFetch(fetchWork.getFilesToFetch());
         cacheEntry.fetchWork = fetchWorkForCache;
@@ -749,7 +749,7 @@ public final class QueryResultsCache {
   }
 
   private void calculateEntrySize(CacheEntry entry, FetchWork fetchWork) throws IOException {
-    Path queryResultsPath = fetchWork.getTblDir();
+    Path queryResultsPath = fetchWork.getTableDir();
     FileSystem resultsFs = queryResultsPath.getFileSystem(conf);
     ContentSummary cs = resultsFs.getContentSummary(queryResultsPath);
     entry.size = cs.getLength();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/desc/DescDatabaseAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/desc/DescDatabaseAnalyzer.java
@@ -56,6 +56,6 @@ public class DescDatabaseAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(desc.getSchema()));
+    addFetchTask(desc.getSchema());
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/show/ShowDatabasesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/show/ShowDatabasesAnalyzer.java
@@ -52,6 +52,6 @@ public class ShowDatabasesAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowDatabasesDesc.SHOW_DATABASES_SCHEMA));
+    addFetchTask(ShowDatabasesDesc.SHOW_DATABASES_SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/database/showcreate/ShowCreateDatabaseAnalyzer.java
@@ -53,6 +53,6 @@ public class ShowCreateDatabaseAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowCreateDatabaseDesc.SCHEMA));
+    addFetchTask(ShowCreateDatabaseDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/desc/DescFunctionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/desc/DescFunctionAnalyzer.java
@@ -53,6 +53,6 @@ public class DescFunctionAnalyzer extends AbstractFunctionAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(DescFunctionDesc.SCHEMA));
+    addFetchTask(DescFunctionDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/show/ShowFunctionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/function/show/ShowFunctionsAnalyzer.java
@@ -54,6 +54,6 @@ public class ShowFunctionsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowFunctionsDesc.SCHEMA));
+    addFetchTask(ShowFunctionsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/conf/ShowConfAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/misc/conf/ShowConfAnalyzer.java
@@ -47,6 +47,6 @@ public class ShowConfAnalyzer extends AbstractFunctionAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowConfDesc.SCHEMA));
+    addFetchTask(ShowConfDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/role/show/ShowCurrentRoleAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/role/show/ShowCurrentRoleAnalyzer.java
@@ -53,6 +53,6 @@ public class ShowCurrentRoleAnalyzer extends AbstractPrivilegeAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowRolesDesc.SCHEMA));
+    addFetchTask(ShowRolesDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/role/show/ShowRolesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/role/show/ShowRolesAnalyzer.java
@@ -52,7 +52,7 @@ public class ShowRolesAnalyzer extends AbstractPrivilegeAnalyzer {
       rootTasks.add(task);
 
       task.setFetchSource(true);
-      setFetchTask(createFetchTask(ShowRolesDesc.SCHEMA));
+      addFetchTask(ShowRolesDesc.SCHEMA);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/grant/ShowGrantAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/grant/ShowGrantAnalyzer.java
@@ -51,7 +51,7 @@ public class ShowGrantAnalyzer extends AbstractPrivilegeAnalyzer {
       rootTasks.add(task);
 
       task.setFetchSource(true);
-      setFetchTask(createFetchTask(ShowGrantDesc.SCHEMA));
+      addFetchTask(ShowGrantDesc.SCHEMA);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/principals/ShowPrincipalsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/principals/ShowPrincipalsAnalyzer.java
@@ -52,7 +52,7 @@ public class ShowPrincipalsAnalyzer extends AbstractPrivilegeAnalyzer {
       rootTasks.add(task);
 
       task.setFetchSource(true);
-      setFetchTask(createFetchTask(ShowPrincipalsDesc.SCHEMA));
+      addFetchTask(ShowPrincipalsDesc.SCHEMA);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/rolegrant/ShowRoleGrantAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/privilege/show/rolegrant/ShowRoleGrantAnalyzer.java
@@ -52,7 +52,7 @@ public class ShowRoleGrantAnalyzer extends AbstractPrivilegeAnalyzer {
       rootTasks.add(task);
 
       task.setFetchSource(true);
-      setFetchTask(createFetchTask(ShowRoleGrantDesc.SCHEMA));
+      addFetchTask(ShowRoleGrantDesc.SCHEMA);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsAnalyzer.java
@@ -45,6 +45,6 @@ public class ShowCompactionsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowCompactionsDesc.SCHEMA));
+    addFetchTask(ShowCompactionsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/transactions/ShowTransactionsAnalyzer.java
@@ -45,6 +45,6 @@ public class ShowTransactionsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowTransactionsDesc.SCHEMA));
+    addFetchTask(ShowTransactionsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/column/show/ShowColumnsAnalyzer.java
@@ -88,6 +88,6 @@ public class ShowColumnsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowColumnsDesc.SCHEMA));
+    addFetchTask(ShowColumnsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/show/ShowCreateTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/create/show/ShowCreateTableAnalyzer.java
@@ -58,6 +58,6 @@ public class ShowCreateTableAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowCreateTableDesc.SCHEMA));
+    addFetchTask(ShowCreateTableDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableAnalyzer.java
@@ -108,7 +108,7 @@ public class DescTableAnalyzer extends BaseSemanticAnalyzer {
 
     task.setFetchSource(true);
     String schema = showColStats ? DescTableDesc.COLUMN_STATISTICS_SCHEMA : DescTableDesc.SCHEMA;
-    setFetchTask(createFetchTask(schema));
+    addFetchTask(schema);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/properties/ShowTablePropertiesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/properties/ShowTablePropertiesAnalyzer.java
@@ -52,6 +52,6 @@ public class ShowTablePropertiesAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowTablePropertiesDesc.SCHEMA));
+    addFetchTask(ShowTablePropertiesDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/status/ShowTableStatusAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/status/ShowTableStatusAnalyzer.java
@@ -78,6 +78,6 @@ public class ShowTableStatusAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowTableStatusDesc.SCHEMA));
+    addFetchTask(ShowTableStatusDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/show/tables/ShowTablesAnalyzer.java
@@ -78,6 +78,6 @@ public class ShowTablesAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(desc.getSchema()));
+    addFetchTask(desc.getSchema());
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowDbLocksAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowDbLocksAnalyzer.java
@@ -50,7 +50,7 @@ public class ShowDbLocksAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(desc.getSchema()));
+    addFetchTask(desc.getSchema());
 
     // Need to initialize the lock manager
     ctx.setNeedLockMgr(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowLocksAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/lock/show/ShowLocksAnalyzer.java
@@ -71,7 +71,7 @@ public class ShowLocksAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(desc.getSchema()));
+    addFetchTask(desc.getSchema());
 
     // Need to initialize the lock manager
     ctx.setNeedLockMgr(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/show/ShowPartitionAnalyzer.java
@@ -87,7 +87,7 @@ public  class ShowPartitionAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowPartitionsDesc.SCHEMA));
+    addFetchTask(ShowPartitionsDesc.SCHEMA);
   }
 
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/show/ShowMaterializedViewsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/show/ShowMaterializedViewsAnalyzer.java
@@ -73,6 +73,6 @@ public class ShowMaterializedViewsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowMaterializedViewsDesc.SCHEMA));
+    addFetchTask(ShowMaterializedViewsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/show/ShowViewsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/show/ShowViewsAnalyzer.java
@@ -73,6 +73,6 @@ public class ShowViewsAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(ShowViewsDesc.SCHEMA));
+    addFetchTask(ShowViewsDesc.SCHEMA);
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/workloadmanagement/resourceplan/alter/validate/AlterResourcePlanValidateAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/workloadmanagement/resourceplan/alter/validate/AlterResourcePlanValidateAnalyzer.java
@@ -53,7 +53,7 @@ public class AlterResourcePlanValidateAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(AlterResourcePlanValidateDesc.SCHEMA));
+    addFetchTask(AlterResourcePlanValidateDesc.SCHEMA);
 
     DDLUtils.addServiceOutput(conf, getOutputs());
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/workloadmanagement/resourceplan/show/ShowResourcePlanAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/workloadmanagement/resourceplan/show/ShowResourcePlanAnalyzer.java
@@ -53,7 +53,7 @@ public class ShowResourcePlanAnalyzer extends BaseSemanticAnalyzer {
     rootTasks.add(task);
 
     task.setFetchSource(true);
-    setFetchTask(createFetchTask(desc.getSchema()));
+    addFetchTask(desc.getSchema());
 
     DDLUtils.addServiceOutput(conf, getOutputs());
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/SMBMapJoinOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/SMBMapJoinOperator.java
@@ -716,7 +716,7 @@ public class SMBMapJoinOperator extends AbstractMapJoinOperator<SMBJoinDesc> imp
     // But if hive supports assigning bucket number for each partition, this can be vary
     public void setupContext(List<Path> paths) throws HiveException {
       int segmentLen = paths.size();
-      FetchOperator.setFetchOperatorContext(jobConf, fetchWork.getPartDir());
+      FetchOperator.setFetchOperatorContext(jobConf, fetchWork.getPartitionDirs());
       FetchOperator[] segments = segmentsForSize(segmentLen);
       for (int i = 0 ; i < segmentLen; i++) {
         Path path = paths.get(i);

--- a/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/hooks/PostExecOrcFileDump.java
@@ -81,11 +81,11 @@ public class PostExecOrcFileDump implements ExecuteWithHookContext {
       List<Path> directories;
       if (partitionedTable) {
         LOG.info("Printing orc file dump for files from partitioned directory..");
-        directories = fetchWork.getPartDir();
+        directories = fetchWork.getPartitionDirs();
       } else {
         LOG.info("Printing orc file dump for files from table directory..");
         directories = Lists.newArrayList();
-        directories.add(fetchWork.getTblDir());
+        directories.add(fetchWork.getTableDir());
       }
 
       for (Path dir : directories) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/SimpleFetchOptimizer.java
@@ -421,7 +421,7 @@ public class SimpleFetchOptimizer extends Transform {
       if (!table.isPartitioned()) {
         inputs.add(new ReadEntity(table, parent, !table.isView() && parent == null));
         FetchWork work = new FetchWork(table.getPath(), tableDesc);
-        PlanUtils.configureInputJobPropertiesForStorageHandler(work.getTblDesc());
+        PlanUtils.configureInputJobPropertiesForStorageHandler(work.getTableDesc());
         work.setSplitSample(splitSample);
         return work;
       }
@@ -437,8 +437,8 @@ public class SimpleFetchOptimizer extends Transform {
       inputs.add(new ReadEntity(sourceTable, parent, parent == null));
       TableDesc table = Utilities.getTableDesc(sourceTable);
       FetchWork work = new FetchWork(listP, partP, table);
-      if (!work.getPartDesc().isEmpty()) {
-        PartitionDesc part0 = work.getPartDesc().get(0);
+      if (!work.getPartitionDescs().isEmpty()) {
+        PartitionDesc part0 = work.getPartitionDescs().get(0);
         PlanUtils.configureInputJobPropertiesForStorageHandler(part0.getTableDesc());
         work.setSplitSample(splitSample);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SortMergeJoinTaskDispatcher.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/SortMergeJoinTaskDispatcher.java
@@ -116,10 +116,10 @@ public class SortMergeJoinTaskDispatcher extends AbstractJoinTaskDispatcher impl
       currWork.getAliasToWork().put(alias, op);
 
       PartitionDesc partitionInfo = currWork.getAliasToPartnInfo().get(alias);
-      if (fetchWork.getTblDir() != null) {
-        currWork.mergeAliasedInput(alias, fetchWork.getTblDir(), partitionInfo);
+      if (fetchWork.getTableDir() != null) {
+        currWork.mergeAliasedInput(alias, fetchWork.getTableDir(), partitionInfo);
       } else {
-        for (Path pathDir : fetchWork.getPartDir()) {
+        for (Path pathDir : fetchWork.getPartitionDirs()) {
           currWork.mergeAliasedInput(alias, pathDir, partitionInfo);
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/physical/Vectorizer.java
@@ -237,6 +237,8 @@ import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
@@ -1288,7 +1290,9 @@ public class Vectorizer implements PhysicalPlanResolver {
       Class<? extends InputFormat> inputFileFormatClass) {
 
       try {
-        InputFormat inputFormat = FetchOperator.getInputFormatFromCache(inputFileFormatClass, hiveConf);
+        @SuppressWarnings("unchecked")
+        InputFormat inputFormat = FetchOperator.getInputFormatFromCache(
+            (Class<? extends InputFormat<WritableComparable<?>, Writable>>) inputFileFormatClass, hiveConf);
         if (inputFormat instanceof VectorizedInputFormatInterface) {
           return ((VectorizedInputFormatInterface) inputFormat).getSupportedFeatures();
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ReplicationSemanticAnalyzer.java
@@ -218,7 +218,7 @@ public class ReplicationSemanticAnalyzer extends BaseSemanticAnalyzer {
           inputs.add(new ReadEntity(db.getDatabase(dbName)));
         }
       }
-      setFetchTask(createFetchTask(dumpSchema));
+      addFetchTask(dumpSchema);
     } catch (Exception e) {
       // TODO : simple wrap & rethrow for now, clean up with error codes
       LOG.warn("Error during analyzeReplDump", e);
@@ -432,7 +432,7 @@ public class ReplicationSemanticAnalyzer extends BaseSemanticAnalyzer {
     String dbNameOrPattern = replScope.getDbName();
     String replLastId = getReplStatus(dbNameOrPattern);
     prepareReturnValues(Collections.singletonList(replLastId), "last_repl_id#string");
-    setFetchTask(createFetchTask("last_repl_id#string"));
+    addFetchTask("last_repl_id#string");
     LOG.debug("ReplicationSemanticAnalyzer.analyzeReplStatus: writing repl.last.id={} out to {} using configuration {}",
         replLastId, ctx.getResFile(), conf);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MapredLocalWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MapredLocalWork.java
@@ -138,7 +138,7 @@ public class MapredLocalWork implements Serializable {
     }
     for (FetchWork fetchWork : aliasToFetchWork.values()) {
       PlanUtils.configureInputJobPropertiesForStorageHandler(
-        fetchWork.getTblDesc());
+        fetchWork.getTableDesc());
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreSchemaInfo.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreSchemaInfo.java
@@ -243,7 +243,7 @@ public class MetaStoreSchemaInfo implements IMetaStoreSchemaInfo {
       }
       return currentSchemaVersion;
     } catch (SQLException e) {
-      throw new HiveMetaException("Failed to get schema version, Cause:" + e.getMessage());
+      throw new HiveMetaException("Failed to get schema version", e);
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
To clean up the messy FetchTask, FetchOperation and FetchWork classes, and remove the unused codes from them.

### Why are the changes needed?
These classes are messy, hard to read, and contain unused codes that are misleading by their presence.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
All the tests are still running.