### PR TITLE
HIVE-24670

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcAcidRowBatchReader.java
@@ -1426,7 +1426,9 @@ public class VectorizedOrcAcidRowBatchReader
           }
           // To prevent the record reader from allocating empty vectors for the actual table schema in its batch, we
           // specify the original schema to be an empty struct, thus only ACID columns will be read.
-          readerOptions.schema(DELETE_DELTA_EMPTY_STRUCT).include(new boolean[] { true });
+          // Note: clone() here makes sure not to alter the original options object, which is also used by
+          // SortMergeDeleteEventRegistry should a DeleteEventsOverflowMemoryException be thrown...
+          readerOptions = readerOptions.clone().schema(DELETE_DELTA_EMPTY_STRUCT).include(new boolean[] { true });
           this.recordReader = deleteDeltaReader.rowsOptions(readerOptions, conf);
         }
 


### PR DESCRIPTION
If delete delta caching is turned off, the plain record reader inside DeleteReaderValue allocates a batch with a schema that is equivalent to that of an insert delta.

This is unnecessary as the struct part in a delete delta file is always empty. In cases where we have many delete delta files (e.g. due to compaction failures) and a wide table definition (e.g. 200+ cols) this puts a significant amount of memory pressure on the executor, while these empty structures will never be filled or otherwise utilized.

I propose we specify an ACID schema with an empty struct part to this record reader to counter this.
