### PR TITLE
HIVE-24636: Memory leak due to referencing UDFClassLoader from LogFactory

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
@@ -24,6 +24,7 @@ import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.logging.LogFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,6 +97,7 @@ public final class JavaUtils {
       LOG.warn("Ignoring attempt to close class loader ({}) -- not instance of UDFClassLoader.",
           loader == null ? "mull" : loader.getClass().getSimpleName());
     }
+    LogFactory.release(loader);
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a class loader is being closed, it should also be released from the `org.apache.commons.logging.LogFactory#factories`, where it is being used as a key.

### Why are the changes needed?

Current implementation has a slow but steady memory leak.

### Does this PR introduce _any_ user-facing change?

No

### How was this patch tested?
