### PR TITLE
HIVE-24683

### DIFF
--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -69,6 +69,7 @@ import org.apache.hadoop.hdfs.protocol.EncryptionZone;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicy;
 import org.apache.hadoop.hdfs.protocol.ErasureCodingPolicyInfo;
 import org.apache.hadoop.hdfs.protocol.HdfsConstants;
+import org.apache.hadoop.hdfs.protocol.HdfsFileStatus;
 import org.apache.hadoop.hdfs.protocol.HdfsLocatedFileStatus;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.ipc.CallerContext;
@@ -1444,7 +1445,11 @@ public class Hadoop23Shims extends HadoopShimsSecure {
 
   @Override
   public long getFileId(FileSystem fs, String path) throws IOException {
-    return ensureDfs(fs).getClient().getFileInfo(path).getFileId();
+    HdfsFileStatus fileInfo = ensureDfs(fs).getClient().getFileInfo(path);
+    if (fileInfo == null) {
+      throw new FileNotFoundException(path + " does not exist.");
+    }
+    return fileInfo.getFileId();
   }
 
 

--- a/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
+++ b/shims/0.23/src/main/test/org/apache/hadoop/hive/shims/TestHadoop23Shims.java
@@ -20,13 +20,19 @@ package org.apache.hadoop.hive.shims;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.DFSClient;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
 import org.junit.Test;
 
+import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 
 
 public class TestHadoop23Shims {
@@ -86,6 +92,19 @@ public class TestHadoop23Shims {
     assertEquals(copySrc.toString(), paramsWithCustomParamInjection.get(6));
     assertEquals(copyDst.toString(), paramsWithCustomParamInjection.get(7));
 
+  }
+
+  @Test(expected = FileNotFoundException.class)
+  public void testGetFileIdForNonexistingPath() throws Exception {
+    Hadoop23Shims shims = new Hadoop23Shims();
+
+    DistributedFileSystem fs = mock(DistributedFileSystem.class);
+    DFSClient dfsClient = mock(DFSClient.class);
+    doAnswer(invocationOnMock -> {
+      return dfsClient;
+    }).when(fs).getClient();
+
+    shims.getFileId(fs, "badpath");
   }
 
 }


### PR DESCRIPTION
HIVE-23840 introduced the feature of reading delete deltas from LLAP cache if it's available. This refactor opens an opportunity for NPE to happen:

Caused by: java.lang.NullPointerException
at org.apache.hadoop.hive.shims.Hadoop23Shims.getFileId(Hadoop23Shims.java:1410)
at org.apache.hadoop.hive.ql.io.HdfsUtils.getFileId(HdfsUtils.java:55)
at org.apache.hadoop.hive.llap.io.encoded.OrcEncodedDataReader.determineFileId(OrcEncodedDataReader.java:509)
at org.apache.hadoop.hive.llap.io.encoded.OrcEncodedDataReader.getOrcTailForPath(OrcEncodedDataReader.java:579)
at org.apache.hadoop.hive.llap.io.api.impl.LlapIoImpl.getOrcTailFromCache(LlapIoImpl.java:322)
at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader.getOrcTail(VectorizedOrcAcidRowBatchReader.java:683)
at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader.access$500(VectorizedOrcAcidRowBatchReader.java:82)
at org.apache.hadoop.hive.ql.io.orc.VectorizedOrcAcidRowBatchReader$ColumnizedDeleteEventRegistry.<init>(VectorizedOrcAcidRowBatchReader.java:1581)
ColumnizedDeleteEventRegistry infers the file name of a delete delta bucket by looking at the bucket number (from the corresponding split) but this file may not exist if no deletion happen from that particular bucket.

Earlier this was handled by always trying to open an ORC reader on the path and catching FileNotFoundException. However in the refactor we first try to look into the cache, and for that try to retrieve a file ID first. This entails a getFileStatus call on HDFS which returns null for non-existing paths, causing the NPE eventually.

This was later fixed by HIVE-23956, nevertheless Hadoop23Shims.getFileId should be refactored in a way that it's not error prone anymore.