### PR TITLE
HIVE-24682: Collect dynamic partition info in FileSink for direct insert 

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -562,11 +562,12 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
           tbd.getMoveTaskId(), work.getLoadTableWork().getWriteType(), tbd.getSourcePath());
       LOG.debug("The statementId used when loading the dynamic partitions is " + statementId);
     }
-    Set<String> dynamiPartitionSpecs = queryPlan.getDynamicPartitionSpecs(work.getLoadTableWork().getWriteId(),
-        tbd.getMoveTaskId(), work.getLoadTableWork().getWriteType(), tbd.getSourcePath());
-    Map<Path, Utilities.PartitionDetails> dps =
-        Utilities.getFullDPSpecs(conf, dpCtx, work.getLoadTableWork().getWriteId(),statementId, tbd.isMmTable(),
-            tbd.isDirectInsert(), tbd.isInsertOverwrite(), work.getLoadTableWork().getWriteType(), dynamiPartitionSpecs);
+    Set<String> dynamicPartitionSpecs = null;
+    if (tbd.isMmTable() || tbd.isDirectInsert()) {
+      dynamicPartitionSpecs = queryPlan.getDynamicPartitionSpecs(work.getLoadTableWork().getWriteId(), tbd.getMoveTaskId(),
+          work.getLoadTableWork().getWriteType(), tbd.getSourcePath());
+    }
+    Map<Path, Utilities.PartitionDetails> dps = Utilities.getFullDPSpecs(conf, dpCtx, dynamicPartitionSpecs);
 
     console.printInfo(System.getProperty("line.separator"));
     long startTime = System.currentTimeMillis();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4504,6 +4504,10 @@ public final class Utilities {
     } catch (FileNotFoundException ex) {
       Utilities.FILE_OP_LOGGER.info("No manifests found in directory {} - query produced no output", manifestDir);
       manifestDir = null;
+      if (!fs.exists(specPath)) {
+        // Empty insert to new partition
+        fs.mkdirs(specPath);
+      }
     }
 
     Set<String> dynamicPartitionSpecs = new HashSet<>();
@@ -4530,7 +4534,7 @@ public final class Utilities {
             throw new HiveException(nextFile + " was specified in multiple manifests");
           }
           Path parentDirPath = path.getParent();
-          while (AcidUtils.isChildOfDelta(parentDirPath, path)) {
+          while (AcidUtils.isChildOfDelta(parentDirPath, specPath)) {
             // Some cases there are other directory layers between the delta and the datafiles
             // (export-import mm table, insert with union all to mm table, skewed tables).
             // But it does not matter for the AcidState, we just need the deltas and the data files

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -2861,35 +2861,17 @@ public final class Utilities {
    * Construct a list of full partition spec from Dynamic Partition Context and the directory names
    * corresponding to these dynamic partitions.
    */
-  public static Map<Path, PartitionDetails> getFullDPSpecs(Configuration conf, DynamicPartitionCtx dpCtx, long writeId,
-      int stmtId, boolean isMmTable, boolean isDirectInsert, boolean isInsertOverwrite,
-      AcidUtils.Operation acidOperation, Set<String> dynamiPartitionSpecs) throws HiveException {
+  public static Map<Path, PartitionDetails> getFullDPSpecs(Configuration conf, DynamicPartitionCtx dpCtx,
+      Set<String> dynamicPartitionSpecs) throws HiveException {
 
     try {
       Path loadPath = dpCtx.getRootPath();
       FileSystem fs = loadPath.getFileSystem(conf);
       int numDPCols = dpCtx.getNumDPCols();
       List<Path> allPartition = new ArrayList<>();
-      if (isMmTable || isDirectInsert) {
-        int stmtIdToUse = -1;
-        if (isDirectInsert) {
-          stmtIdToUse = stmtId;
-        }
-        Path[] leafStatus = Utilities.getDirectInsertDirectoryCandidates(fs, loadPath, numDPCols, null, writeId, stmtIdToUse,
-            conf, isInsertOverwrite, acidOperation);
-        for (Path p : leafStatus) {
-          Path dpPath = p.getParent();
-          String partitionSpec = dpPath.toString().substring(loadPath.toString().length() + 1);
-          if (!allPartition.contains(dpPath)) {
-            if (isInsertOverwrite) {
-              if (dynamiPartitionSpecs == null || dynamiPartitionSpecs.contains(partitionSpec)) {
-                allPartition.add(dpPath);
-              }
-            }
-            else {
-              allPartition.add(dpPath);
-            }
-          }
+      if (dynamicPartitionSpecs != null) {
+        for (String partSpec : dynamicPartitionSpecs) {
+          allPartition.add(new Path(loadPath, partSpec));
         }
       } else {
         List<FileStatus> status = HiveStatsUtils.getFileStatusRecurse(loadPath, numDPCols, fs);
@@ -4431,7 +4413,7 @@ public final class Utilities {
     // a manifest file will still be written, otherwise the missing manifest file
     // would result a clean-up on table level which could delete the data written by
     // the other FileSinkOperators. (For further details please see HIVE-23114.)
-    boolean writeDynamicPartitionsToManifest = isInsertOverwrite && hasDynamicPartitions;
+    boolean writeDynamicPartitionsToManifest = hasDynamicPartitions;
     if (commitPaths.isEmpty() && !writeDynamicPartitionsToManifest) {
       return;
     }
@@ -4516,20 +4498,21 @@ public final class Utilities {
 
     Utilities.FILE_OP_LOGGER.debug("Looking for manifests in: {} ({})", manifestDir, writeId);
     List<Path> manifests = new ArrayList<>();
-    if (fs.exists(manifestDir)) {
+    try {
       FileStatus[] manifestFiles = fs.listStatus(manifestDir);
       manifests = selectManifestFiles(manifestFiles);
-    } else {
+    } catch (FileNotFoundException ex) {
       Utilities.FILE_OP_LOGGER.info("No manifests found in directory {} - query produced no output", manifestDir);
       manifestDir = null;
     }
 
     Set<String> dynamicPartitionSpecs = new HashSet<>();
     Set<Path> committed = Collections.newSetFromMap(new ConcurrentHashMap<>());
+    ArrayList<Path> directInsertDirectories = new ArrayList<>();
     for (Path mfp : manifests) {
       Utilities.FILE_OP_LOGGER.info("Looking at manifest file: {}", mfp);
       try (FSDataInputStream mdis = fs.open(mfp)) {
-        if (isInsertOverwrite && dpLevels > 0) {
+        if (dpLevels > 0) {
           int partitionCount = mdis.readInt();
           for (int i = 0; i < partitionCount; ++i) {
             String nextPart = mdis.readUTF();
@@ -4546,29 +4529,16 @@ public final class Utilities {
           if (!committed.add(path)) {
             throw new HiveException(nextFile + " was specified in multiple manifests");
           }
+          Path parentDirPath = path.getParent();
+          while (AcidUtils.isChildOfDelta(parentDirPath, path)) {
+            // Some cases there are other directory layers between the delta and the datafiles
+            // (export-import mm table, insert with union all to mm table, skewed tables).
+            // But it does not matter for the AcidState, we just need the deltas and the data files
+            // So build the snapshot with the files inside the delta directory
+            parentDirPath = parentDirPath.getParent();
+          }
+          directInsertDirectories.add(parentDirPath);
         }
-      }
-    }
-
-    Utilities.FILE_OP_LOGGER.debug("Looking for files in: {}", specPath);
-    AcidUtils.IdPathFilter filter =
-        new AcidUtils.IdPathFilter(writeId, stmtId, dynamicPartitionSpecs, dpLevels);
-    if (!fs.exists(specPath)) {
-      Utilities.FILE_OP_LOGGER.info("Creating directory with no output at {}", specPath);
-      FileUtils.mkdir(fs, specPath, hconf);
-    }
-
-    Path[] files = null;
-    if (!isInsertOverwrite || dpLevels == 0 || !dynamicPartitionSpecs.isEmpty()) {
-      files = getDirectInsertDirectoryCandidates(
-          fs, specPath, dpLevels, filter, writeId, stmtId, hconf, isInsertOverwrite, acidOperation);
-    }
-
-    ArrayList<Path> directInsertDirectories = new ArrayList<>();
-    if (files != null) {
-      for (Path path : files) {
-        Utilities.FILE_OP_LOGGER.info("Looking at path: {}", path);
-        directInsertDirectories.add(path);
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4537,8 +4537,6 @@ public final class Utilities {
           while (AcidUtils.isChildOfDelta(parentDirPath, specPath)) {
             // Some cases there are other directory layers between the delta and the datafiles
             // (export-import mm table, insert with union all to mm table, skewed tables).
-            // But it does not matter for the AcidState, we just need the deltas and the data files
-            // So build the snapshot with the files inside the delta directory
             parentDirPath = parentDirPath.getParent();
           }
           directInsertDirectories.add(parentDirPath);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1477,9 +1477,8 @@ public class AcidUtils {
     // We do not want to look outside the original directory
     String fullName = childDir.toUri().toString().substring(rootPath.toUri().toString().length() + 1);
     String dirName = childDir.getName();
-    return (fullName.contains(BASE_PREFIX) && !dirName.startsWith(BASE_PREFIX)) ||
-        (fullName.contains(DELTA_PREFIX) && !dirName.startsWith(DELTA_PREFIX)) ||
-        (fullName.contains(DELETE_DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX));
+    return (!dirName.startsWith(BASE_PREFIX)) && !dirName.startsWith(DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX)
+          && (fullName.contains(BASE_PREFIX) || fullName.contains(DELTA_PREFIX) || fullName.contains(DELETE_DELTA_PREFIX));
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1470,7 +1470,7 @@ public class AcidUtils {
     return dirToSnapshots;
   }
 
-  private static boolean isChildOfDelta(Path childDir, Path rootPath) {
+  public static boolean isChildOfDelta(Path childDir, Path rootPath) {
     if (childDir.toUri().toString().length() <= rootPath.toUri().toString().length()) {
       return false;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1477,9 +1477,9 @@ public class AcidUtils {
     // We do not want to look outside the original directory
     String fullName = childDir.toUri().toString().substring(rootPath.toUri().toString().length() + 1);
     String dirName = childDir.getName();
-    return (fullName.startsWith(BASE_PREFIX) && !dirName.startsWith(BASE_PREFIX)) ||
-        (fullName.startsWith(DELTA_PREFIX) && !dirName.startsWith(DELTA_PREFIX)) ||
-        (fullName.startsWith(DELETE_DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX));
+    return (fullName.contains(BASE_PREFIX) && !dirName.startsWith(BASE_PREFIX)) ||
+        (fullName.contains(DELTA_PREFIX) && !dirName.startsWith(DELTA_PREFIX)) ||
+        (fullName.contains(DELETE_DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX));
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidUtils.java
@@ -1477,7 +1477,7 @@ public class AcidUtils {
     // We do not want to look outside the original directory
     String fullName = childDir.toUri().toString().substring(rootPath.toUri().toString().length() + 1);
     String dirName = childDir.getName();
-    return (!dirName.startsWith(BASE_PREFIX)) && !dirName.startsWith(DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX)
+    return !dirName.startsWith(BASE_PREFIX) && !dirName.startsWith(DELTA_PREFIX) && !dirName.startsWith(DELETE_DELTA_PREFIX)
           && (fullName.contains(BASE_PREFIX) || fullName.contains(DELTA_PREFIX) || fullName.contains(DELETE_DELTA_PREFIX));
   }
 

--- a/ql/src/test/results/clientpositive/llap/acid_multiinsert_dyn_part.q.out
+++ b/ql/src/test/results/clientpositive/llap/acid_multiinsert_dyn_part.q.out
@@ -649,14 +649,8 @@ POSTHOOK: Output: default@multiinsert_test_mm@c=2222
 POSTHOOK: Output: default@multiinsert_test_mm@c=__HIVE_DEFAULT_PARTITION__
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=1111).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=1111).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=1111).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=1111).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=2222).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=2222).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=2222).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=2222).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=__HIVE_DEFAULT_PARTITION__).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
-POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=__HIVE_DEFAULT_PARTITION__).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=__HIVE_DEFAULT_PARTITION__).a SIMPLE [(multiinsert_test_text)a.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: multiinsert_test_mm PARTITION(c=__HIVE_DEFAULT_PARTITION__).b SIMPLE [(multiinsert_test_text)a.FieldSchema(name:b, type:int, comment:null), ]
 PREHOOK: query: select * from multiinsert_test_mm

--- a/ql/src/test/results/clientpositive/llap/mm_all.q.out
+++ b/ql/src/test/results/clientpositive/llap/mm_all.q.out
@@ -1649,8 +1649,6 @@ POSTHOOK: Lineage: ###Masked###
 POSTHOOK: Lineage: ###Masked###
 POSTHOOK: Lineage: ###Masked###
 POSTHOOK: Lineage: ###Masked###
-POSTHOOK: Lineage: ###Masked###
-POSTHOOK: Lineage: ###Masked###
 PREHOOK: query: select key, key2, p from multi1_mm order by key, key2, p
 PREHOOK: type: QUERY
 PREHOOK: Input: default@multi1_mm


### PR DESCRIPTION


### What changes were proposed in this pull request?
The dynamic partition infos can be collected from the manifest files, no need to do a costly file listing later in the MoveTask


### Why are the changes needed?
Performance improvement

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
All unit tests are working, local performance tests
