### PR TITLE
HIVE-24636: Memory leak due LogFactory retaining ClassLoaders

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/JavaUtils.java
@@ -28,7 +28,7 @@ import java.net.URLClassLoader;
 import java.util.Arrays;
 import java.util.List;
 
-
+import org.apache.commons.logging.LogFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,6 +138,7 @@ public final class JavaUtils {
         newOutputStream.close();
       }
     }
+    LogFactory.release(loader);
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?

When a class loader is being closed, it should also be released from the `org.apache.commons.logging.LogFactory#factories`, where it is being used as a key.

### Why are the changes needed?

Current implementation has a slow but steady memory leak.

### Does this PR introduce any user-facing change?

No

### How was this patch tested?