### PR TITLE
HIVE-24695: Clean up session resources, if TezSession is unable to start

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -485,8 +485,10 @@ public class TezSessionState {
       if (isOnThread && !isSuccessful) {
         closeAndIgnoreExceptions(session);
       }
-      cleanupScratchDir();
-      cleanupDagResources();
+      if (!isSuccessful) {
+        cleanupScratchDir();
+        cleanupDagResources();
+      }
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezSessionState.java
@@ -443,9 +443,9 @@ public class TezSessionState {
   private TezClient startSessionAndContainers(TezClient session, HiveConf conf,
       Map<String, LocalResource> commonLocalResources, TezConfiguration tezConfig,
       boolean isOnThread) throws TezException, IOException {
-    session.start();
     boolean isSuccessful = false;
     try {
+      session.start();
       if (HiveConf.getBoolVar(conf, ConfVars.HIVE_PREWARM_ENABLED)) {
         int n = HiveConf.getIntVar(conf, ConfVars.HIVE_PREWARM_NUM_CONTAINERS);
         LOG.info("Prewarming " + n + " containers  (id: " + sessionId
@@ -485,6 +485,8 @@ public class TezSessionState {
       if (isOnThread && !isSuccessful) {
         closeAndIgnoreExceptions(session);
       }
+      cleanupScratchDir();
+      cleanupDagResources();
     }
   }
 
@@ -721,6 +723,7 @@ public class TezSessionState {
   }
 
   protected final void cleanupScratchDir() throws IOException {
+    LOG.info("Attempting to clean up scratchDir for {} : {}", sessionId, tezScratchDir);
     if (tezScratchDir != null) {
       FileSystem fs = tezScratchDir.getFileSystem(conf);
       fs.delete(tezScratchDir, true);
@@ -729,7 +732,7 @@ public class TezSessionState {
   }
 
   protected final void cleanupDagResources() throws IOException {
-    LOG.info("Attemting to clean up resources for " + sessionId + ": " + resources);
+    LOG.info("Attempting to clean up resources for {} : {}", sessionId, resources);
     if (resources != null) {
       FileSystem fs = resources.dagResourcesDir.getFileSystem(conf);
       fs.delete(resources.dagResourcesDir, true);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24695

### What changes were proposed in this pull request?
There are cases when TezSessionState would not be able to start. (e.g resource constraints on YARN queues).

However by this time, session directories & certain resources are localized. (e.g, hive-exec jars are stored in hdfs:///tmp/hive/hive/_tez_session_dir//hive-exec.jar). When tezClient is not started, it does not clear up the resources. This leaks ~100MB data in HDFS per failure.

e.g 
hdfs:///tmp/hive/_tez_session_dir/006cac9b-93d5-47f3-bdb2-0a0cb626a8cd-resources/hive-exec.jar
hdfs:///tmp/hive/hive/_tez_session_dir/53531429-d119-4e47-bcb2-5cb686d537ff/


### Why are the changes needed?
Need to clear up resources in session directory, when errors are encountered in tez session init phase.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Small scale cluster