### PR TITLE
HIVE-24698. Sync ACL's for the table directory during external table replication.

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/BaseReplicationAcrossInstances.java
@@ -57,6 +57,7 @@ public class BaseReplicationAcrossInstances {
     conf.set("dfs.client.use.datanode.hostname", "true");
     conf.set("hadoop.proxyuser." + Utils.getUGI().getShortUserName() + ".hosts", "*");
     conf.set("hive.repl.cmrootdir", "/tmp/");
+    conf.set("dfs.namenode.acls.enabled", "true");
     MiniDFSCluster miniDFSCluster =
         new MiniDFSCluster.Builder(conf).numDataNodes(1).format(true).build();
     Map<String, String> localOverrides = new HashMap<String, String>() {{

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/HdfsUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/HdfsUtils.java
@@ -193,15 +193,7 @@ public class HdfsUtils {
 
   private static List<String> constructDistCpParams(List<Path> srcPaths, Path dst,
                                                     Configuration conf) {
-    List<String> params = new ArrayList<>();
-    for (Map.Entry<String,String> entry : conf.getPropsWithPrefix(DISTCP_OPTIONS_PREFIX).entrySet()){
-      String distCpOption = entry.getKey();
-      String distCpVal = entry.getValue();
-      params.add("-" + distCpOption);
-      if ((distCpVal != null) && (!distCpVal.isEmpty())){
-        params.add(distCpVal);
-      }
-    }
+    List<String> params = constructDistCpOptions(conf);
     if (params.size() == 0){
       // if no entries were added via conf, we initiate our defaults
       params.add("-update");
@@ -213,6 +205,21 @@ public class HdfsUtils {
     params.add(dst.toString());
     return params;
   }
+
+  public static List<String> constructDistCpOptions(Configuration conf) {
+    List<String> options = new ArrayList<>();
+    for (Map.Entry<String, String> entry : conf
+        .getPropsWithPrefix(DISTCP_OPTIONS_PREFIX).entrySet()) {
+      String distCpOption = entry.getKey();
+      String distCpVal = entry.getValue();
+      options.add("-" + distCpOption);
+      if ((distCpVal != null) && (!distCpVal.isEmpty())) {
+        options.add(distCpVal);
+      }
+    }
+    return options;
+  }
+
 
   public static Path getFileIdPath(
       FileSystem fileSystem, Path path, long fileId) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24698