### PR TITLE
HIVE-24707: Apply Sane Default for Tez Containers as Last Resort

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MemoryInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MemoryInfo.java
@@ -21,8 +21,11 @@ package org.apache.hadoop.hive.ql.exec;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.llap.LlapUtil;
+import org.apache.hadoop.hive.ql.exec.tez.DagUtils;
 import org.apache.hadoop.hive.ql.optimizer.physical.LlapClusterStateForCompile;
 import org.apache.tez.mapreduce.hadoop.MRJobConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Contains information about executor memory, various memory thresholds used for join conversions etc. based on
@@ -34,9 +37,8 @@ public class MemoryInfo {
   private Configuration conf;
   private boolean isTez;
   private boolean isLlap;
-  private long maxExecutorMemory;
-  private long mapJoinMemoryThreshold;
-  private long dynPartJoinMemoryThreshold;
+  private long maxExecutorMemory; // value in Bytes
+  private final Logger LOG = LoggerFactory.getLogger(MemoryInfo.class);
 
   public MemoryInfo(Configuration conf) {
     this.isTez = "tez".equalsIgnoreCase(HiveConf.getVar(conf, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE));
@@ -46,30 +48,25 @@ public class MemoryInfo {
       llapInfo.initClusterInfo();
       if (llapInfo.hasClusterInfo()) {
         this.maxExecutorMemory = llapInfo.getMemoryPerExecutor();
+        LOG.info("Using LLAP registry executor MB {}", maxExecutorMemory / (1024L * 1024L));
       } else {
-        long memPerInstance =
-            HiveConf.getLongVar(conf, HiveConf.ConfVars.LLAP_DAEMON_MEMORY_PER_INSTANCE_MB) * 1024L * 1024L;
+        long memPerInstanceMb =
+            HiveConf.getLongVar(conf, HiveConf.ConfVars.LLAP_DAEMON_MEMORY_PER_INSTANCE_MB);
+        LOG.info("Using LLAP default executor MB {}", memPerInstanceMb);
         long numExecutors = HiveConf.getIntVar(conf, HiveConf.ConfVars.LLAP_DAEMON_NUM_EXECUTORS);
-        this.maxExecutorMemory = memPerInstance / numExecutors;
+        this.maxExecutorMemory = (memPerInstanceMb * 1024L * 1024L) / numExecutors;
       }
-    } else {
-      if (isTez) {
+    } else if (isTez) {
+        long containerSizeMb = DagUtils.getContainerResource(conf).getMemorySize();
         float heapFraction = HiveConf.getFloatVar(conf, HiveConf.ConfVars.TEZ_CONTAINER_MAX_JAVA_HEAP_FRACTION);
-        int containerSizeMb = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE) > 0 ?
-            HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE) :
-            conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB);
-        // this can happen when config is explicitly set to "-1", in which case defaultValue also does not work
-        if (containerSizeMb < 0) {
-          containerSizeMb =  MRJobConfig.DEFAULT_MAP_MEMORY_MB;
-        }
         this.maxExecutorMemory = (long) ((containerSizeMb * 1024L * 1024L) * heapFraction);
-      } else {
-        this.maxExecutorMemory =
-            conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB) * 1024L * 1024L;
-        // this can happen when config is explicitly set to "-1", in which case defaultValue also does not work
-        if (maxExecutorMemory < 0) {
-          maxExecutorMemory =  MRJobConfig.DEFAULT_MAP_MEMORY_MB * 1024L * 1024L;
-        }
+    } else {
+      this.maxExecutorMemory =
+          conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB) * 1024L * 1024L;
+      // this can happen when config is explicitly set to "-1", in which case defaultValue also does not work
+      if (maxExecutorMemory < 0) {
+        LOG.warn("Falling back to default container MB {}", MRJobConfig.DEFAULT_MAP_MEMORY_MB);
+        maxExecutorMemory = MRJobConfig.DEFAULT_MAP_MEMORY_MB * 1024L * 1024L;
       }
     }
   }
@@ -94,21 +91,11 @@ public class MemoryInfo {
     return maxExecutorMemory;
   }
 
-  public long getMapJoinMemoryThreshold() {
-    return mapJoinMemoryThreshold;
-  }
-
-  public long getDynPartJoinMemoryThreshold() {
-    return dynPartJoinMemoryThreshold;
-  }
-
   @Override
   public String toString() {
     return "MEMORY INFO - { isTez: " + isTez() +
         ", isLlap: " + isLlap() +
         ", maxExecutorMemory: " + LlapUtil.humanReadableByteCount(getMaxExecutorMemory()) +
-        ", mapJoinMemoryThreshold: "+ LlapUtil.humanReadableByteCount(getMapJoinMemoryThreshold()) +
-        ", dynPartJoinMemoryThreshold: " + LlapUtil.humanReadableByteCount(getDynPartJoinMemoryThreshold()) +
         " }";
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MemoryInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MemoryInfo.java
@@ -34,10 +34,9 @@ import org.slf4j.LoggerFactory;
 
 public class MemoryInfo {
 
-  private Configuration conf;
-  private boolean isTez;
-  private boolean isLlap;
-  private long maxExecutorMemory; // value in Bytes
+  private final boolean isTez;
+  private final boolean isLlap;
+  private final long maxExecutorMemory;
   private final Logger LOG = LoggerFactory.getLogger(MemoryInfo.class);
 
   public MemoryInfo(Configuration conf) {
@@ -61,32 +60,38 @@ public class MemoryInfo {
         float heapFraction = HiveConf.getFloatVar(conf, HiveConf.ConfVars.TEZ_CONTAINER_MAX_JAVA_HEAP_FRACTION);
         this.maxExecutorMemory = (long) ((containerSizeMb * 1024L * 1024L) * heapFraction);
     } else {
-      this.maxExecutorMemory =
+      long executorMemoryFromConf =
           conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB) * 1024L * 1024L;
       // this can happen when config is explicitly set to "-1", in which case defaultValue also does not work
-      if (maxExecutorMemory < 0) {
+      if (executorMemoryFromConf < 0L) {
         LOG.warn("Falling back to default container MB {}", MRJobConfig.DEFAULT_MAP_MEMORY_MB);
-        maxExecutorMemory = MRJobConfig.DEFAULT_MAP_MEMORY_MB * 1024L * 1024L;
+        this.maxExecutorMemory = MRJobConfig.DEFAULT_MAP_MEMORY_MB * 1024L * 1024L;
+      } else {
+        this.maxExecutorMemory = executorMemoryFromConf;
       }
     }
   }
 
-  public Configuration getConf() {
-    return conf;
-  }
-
-  public void setConf(final Configuration conf) {
-    this.conf = conf;
-  }
-
+  /**
+   * Returns True when in TEZ execution mode.
+   * @return boolean
+   */
   public boolean isTez() {
     return isTez;
   }
 
+  /**
+   * Returns True when in LLAP execution mode.
+   * @return boolean
+   */
   public boolean isLlap() {
     return isLlap;
   }
 
+  /**
+   * Get the Container max Memory value in bytes.
+   * @return bytes value as long
+   */
   public long getMaxExecutorMemory() {
     return maxExecutorMemory;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -700,13 +700,26 @@ public class DagUtils {
    * container size isn't set.
    */
   public static Resource getContainerResource(Configuration conf) {
-    int memory = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE) > 0 ?
-      HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE) :
-      conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB);
-    int cpus = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCPUVCORES) > 0 ?
-      HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCPUVCORES) :
-      conf.getInt(MRJobConfig.MAP_CPU_VCORES, MRJobConfig.DEFAULT_MAP_CPU_VCORES);
-    return Resource.newInstance(memory, cpus);
+    int memorySizeMb = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE);
+    if (memorySizeMb <= 0) {
+      LOG.warn("Falling back to MapReduce container MB {}", MRJobConfig.MAP_MEMORY_MB);
+      memorySizeMb = conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB);
+      // When config is explicitly set to "-1" defaultValue does not work!
+      if (memorySizeMb <= 0) {
+        LOG.warn("Falling back to default container MB {}", MRJobConfig.DEFAULT_MAP_MEMORY_MB);
+        memorySizeMb = MRJobConfig.DEFAULT_MAP_MEMORY_MB;
+      }
+    }
+    int cpuCores = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCPUVCORES);
+    if (cpuCores <= 0) {
+      LOG.warn("Falling back to MapReduce container VCores {}", MRJobConfig.MAP_CPU_VCORES);
+      cpuCores = conf.getInt(MRJobConfig.MAP_CPU_VCORES, MRJobConfig.DEFAULT_MAP_CPU_VCORES);
+      if (cpuCores <= 0) {
+        LOG.warn("Falling back to default container VCores {}", MRJobConfig.DEFAULT_MAP_CPU_VCORES);
+        cpuCores = MRJobConfig.DEFAULT_MAP_CPU_VCORES;
+      }
+    }
+    return Resource.newInstance(memorySizeMb, cpuCores);
   }
 
   /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DagUtils.java
@@ -702,7 +702,8 @@ public class DagUtils {
   public static Resource getContainerResource(Configuration conf) {
     int memorySizeMb = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE);
     if (memorySizeMb <= 0) {
-      LOG.warn("Falling back to MapReduce container MB {}", MRJobConfig.MAP_MEMORY_MB);
+      LOG.warn("No Tez container size specified by {}. Falling back to MapReduce container MB {}",
+          HiveConf.ConfVars.HIVETEZCONTAINERSIZE,  MRJobConfig.MAP_MEMORY_MB);
       memorySizeMb = conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB);
       // When config is explicitly set to "-1" defaultValue does not work!
       if (memorySizeMb <= 0) {
@@ -712,7 +713,8 @@ public class DagUtils {
     }
     int cpuCores = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCPUVCORES);
     if (cpuCores <= 0) {
-      LOG.warn("Falling back to MapReduce container VCores {}", MRJobConfig.MAP_CPU_VCORES);
+      LOG.warn("No Tez VCore size specified by {}. Falling back to MapReduce container VCores {}",
+          HiveConf.ConfVars.HIVETEZCPUVCORES,  MRJobConfig.MAP_CPU_VCORES);
       cpuCores = conf.getInt(MRJobConfig.MAP_CPU_VCORES, MRJobConfig.DEFAULT_MAP_CPU_VCORES);
       if (cpuCores <= 0) {
         LOG.warn("Falling back to default container VCores {}", MRJobConfig.DEFAULT_MAP_CPU_VCORES);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hive.ql.exec.SelectOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
 import org.apache.hadoop.hive.ql.exec.UDTFOperator;
 import org.apache.hadoop.hive.ql.exec.Utilities;
+import org.apache.hadoop.hive.ql.exec.tez.DagUtils;
 import org.apache.hadoop.hive.ql.lib.Node;
 import org.apache.hadoop.hive.ql.lib.SemanticNodeProcessor;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
@@ -1741,8 +1742,8 @@ public class StatsRulesProcFactory {
         float hashAggMem = conf.getFloatVar(HiveConf.ConfVars.HIVEMAPAGGRHASHMEMORY);
         float hashAggMaxThreshold = conf.getFloatVar(HiveConf.ConfVars.HIVEMAPAGGRMEMORYTHRESHOLD);
 
-        // get available map memory
-        long totalMemory = StatsUtils.getAvailableMemory(conf) * 1000L * 1000L;
+        // get available map memory in bytes
+        long totalMemory = DagUtils.getContainerResource(conf).getMemorySize() * 1024L * 1024L;
         long maxMemHashAgg = Math.round(totalMemory * hashAggMem * hashAggMaxThreshold);
 
         // estimated number of rows will be product of NDVs

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/StatsUtils.java
@@ -1915,17 +1915,6 @@ public class StatsUtils {
     return result;
   }
 
-  public static long getAvailableMemory(Configuration conf) {
-    int memory = HiveConf.getIntVar(conf, HiveConf.ConfVars.HIVETEZCONTAINERSIZE);
-    if (memory <= 0) {
-      memory = conf.getInt(MRJobConfig.MAP_MEMORY_MB, MRJobConfig.DEFAULT_MAP_MEMORY_MB);
-      if (memory <= 0) {
-        memory = 1024;
-      }
-    }
-    return memory;
-  }
-
   /**
    * negative number of rows or data sizes are invalid. It could be because of
    * long overflow in which case return Long.MAX_VALUE


### PR DESCRIPTION
### What changes were proposed in this pull request?
Apply Sane Default for Tez Containers as Last Resort


### Why are the changes needed?
If Tez Container Size is an invalid value ( <= 0 ) then it falls back onto the MapReduce configurations, but if the MapReduce configurations have invalid values ( <= 0 ), they are excepted regardless and this will cause failures down the road.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
