### PR TITLE
HIVE-23785: Databases, Catalogs and Partitions should have unique id

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -3881,6 +3881,9 @@ private void constructOneLBLocationMap(FileStatus fSta,
           part.setParameters(partitionWithoutSD.getParameters());
           part.setPrivileges(partitionWithoutSD.getPrivileges());
           part.setSd(partitionSpec.getSharedSDPartitionSpec().getSd().deepCopy());
+          if (partitionWithoutSD.isSetId()) {
+            part.setId(partitionWithoutSD.getId());
+          }
           String partitionLocation = null;
           if(partitionWithoutSD.getRelativePath() == null
               || partitionWithoutSD.getRelativePath().isEmpty()) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -798,21 +798,8 @@ public class TestHive {
     List<Partition> allParts3 = new ArrayList<Partition>();
     hm.getPartitionsByExpr(tbl, trueExpr, hm.getConf(), allParts3);
 
-    comparePartitionsIgnoreId("inconsistent results: getPartitionsByExpr", allParts2,
-        allParts3);
-  }
+    assertEquals("inconsistent results: getPartitionsByExpr", allParts2, allParts3);
 
-  private static void comparePartitionsIgnoreId(String msg, List<Partition> expected,
-      List<Partition> actual) {
-    assertEquals(msg, expected.size(), actual.size());
-    for (int i=0; i< expected.size(); i++) {
-      // set the id from the actual partition object to ignore the id difference
-      long beforeId = expected.get(i).getTPartition().getId();
-      expected.get(i).getTPartition().setId(actual.get(i).getTPartition().getId());
-      assertEquals(expected.get(i), actual.get(i));
-      // set the expected TPartition to beforeId back
-      expected.get(i).getTPartition().setId(beforeId);
-    }
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestHive.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
 import org.apache.hadoop.hive.metastore.PartitionDropOptions;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.api.Database;
@@ -797,8 +798,21 @@ public class TestHive {
     List<Partition> allParts3 = new ArrayList<Partition>();
     hm.getPartitionsByExpr(tbl, trueExpr, hm.getConf(), allParts3);
 
-    assertEquals("inconsistent results: getPartitionsByExpr", allParts2, allParts3);
+    comparePartitionsIgnoreId("inconsistent results: getPartitionsByExpr", allParts2,
+        allParts3);
+  }
 
+  private static void comparePartitionsIgnoreId(String msg, List<Partition> expected,
+      List<Partition> actual) {
+    assertEquals(msg, expected.size(), actual.size());
+    for (int i=0; i< expected.size(); i++) {
+      // set the id from the actual partition object to ignore the id difference
+      long beforeId = expected.get(i).getTPartition().getId();
+      expected.get(i).getTPartition().setId(actual.get(i).getTPartition().getId());
+      assertEquals(expected.get(i), actual.get(i));
+      // set the expected TPartition to beforeId back
+      expected.get(i).getTPartition().setId(beforeId);
+    }
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientGetPartitionsTempTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientGetPartitionsTempTable.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.metastore.client.builder.TableBuilder;
 import org.apache.hadoop.hive.metastore.minihms.AbstractMetaStoreService;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.thrift.TException;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -47,6 +48,7 @@ import java.util.Map;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 /**
  * Test class for get partitions related methods on temporary tables.
@@ -168,6 +170,11 @@ public class TestSessionHiveMetastoreClientGetPartitionsTempTable extends TestGe
   public void testGetPartitionWithAuthInfoNullTblName()
       throws Exception {
     super.testGetPartitionWithAuthInfoNullTblName();
+  }
+
+  @Override
+  protected void assertPartitionId(Partition p) {
+    //no-op; for temp tables we don't set the partition ids
   }
 
   private void assertAuthInfoReturned(String userName, List<String> groups, Partition partition) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientListPartitionsTempTable.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestSessionHiveMetastoreClientListPartitionsTempTable.java
@@ -112,6 +112,10 @@ public class TestSessionHiveMetastoreClientListPartitionsTempTable
     return table;
   }
 
+  protected void assertPartitionId(Partition p) {
+    // no-op we don't have partition ids for temp tables.
+  }
+
   @Override
   protected void addPartition(IMetaStoreClient client, Table table, List<String> values) throws TException {
     PartitionBuilder builder = new PartitionBuilder().inTable(table);

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -5783,6 +5783,11 @@ void Catalog::__set_createTime(const int32_t val) {
   this->createTime = val;
 __isset.createTime = true;
 }
+
+void Catalog::__set_id(const int64_t val) {
+  this->id = val;
+__isset.id = true;
+}
 std::ostream& operator<<(std::ostream& out, const Catalog& obj)
 {
   obj.printTo(out);
@@ -5843,6 +5848,14 @@ uint32_t Catalog::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 5:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->id);
+          this->__isset.id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -5878,6 +5891,11 @@ uint32_t Catalog::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeI32(this->createTime);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.id) {
+    xfer += oprot->writeFieldBegin("id", ::apache::thrift::protocol::T_I64, 5);
+    xfer += oprot->writeI64(this->id);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -5889,6 +5907,7 @@ void swap(Catalog &a, Catalog &b) {
   swap(a.description, b.description);
   swap(a.locationUri, b.locationUri);
   swap(a.createTime, b.createTime);
+  swap(a.id, b.id);
   swap(a.__isset, b.__isset);
 }
 
@@ -5897,6 +5916,7 @@ Catalog::Catalog(const Catalog& other178) {
   description = other178.description;
   locationUri = other178.locationUri;
   createTime = other178.createTime;
+  id = other178.id;
   __isset = other178.__isset;
 }
 Catalog& Catalog::operator=(const Catalog& other179) {
@@ -5904,6 +5924,7 @@ Catalog& Catalog::operator=(const Catalog& other179) {
   description = other179.description;
   locationUri = other179.locationUri;
   createTime = other179.createTime;
+  id = other179.id;
   __isset = other179.__isset;
   return *this;
 }
@@ -5914,6 +5935,7 @@ void Catalog::printTo(std::ostream& out) const {
   out << ", " << "description="; (__isset.description ? (out << to_string(description)) : (out << "<null>"));
   out << ", " << "locationUri=" << to_string(locationUri);
   out << ", " << "createTime="; (__isset.createTime ? (out << to_string(createTime)) : (out << "<null>"));
+  out << ", " << "id="; (__isset.id ? (out << to_string(id)) : (out << "<null>"));
   out << ")";
 }
 
@@ -6559,6 +6581,11 @@ void Database::__set_managedLocationUri(const std::string& val) {
   this->managedLocationUri = val;
 __isset.managedLocationUri = true;
 }
+
+void Database::__set_id(const int64_t val) {
+  this->id = val;
+__isset.id = true;
+}
 std::ostream& operator<<(std::ostream& out, const Database& obj)
 {
   obj.printTo(out);
@@ -6684,6 +6711,14 @@ uint32_t Database::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 11:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->id);
+          this->__isset.id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -6756,6 +6791,11 @@ uint32_t Database::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += oprot->writeString(this->managedLocationUri);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.id) {
+    xfer += oprot->writeFieldBegin("id", ::apache::thrift::protocol::T_I64, 11);
+    xfer += oprot->writeI64(this->id);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -6773,6 +6813,7 @@ void swap(Database &a, Database &b) {
   swap(a.catalogName, b.catalogName);
   swap(a.createTime, b.createTime);
   swap(a.managedLocationUri, b.managedLocationUri);
+  swap(a.id, b.id);
   swap(a.__isset, b.__isset);
 }
 
@@ -6787,6 +6828,7 @@ Database::Database(const Database& other207) {
   catalogName = other207.catalogName;
   createTime = other207.createTime;
   managedLocationUri = other207.managedLocationUri;
+  id = other207.id;
   __isset = other207.__isset;
 }
 Database& Database::operator=(const Database& other208) {
@@ -6800,6 +6842,7 @@ Database& Database::operator=(const Database& other208) {
   catalogName = other208.catalogName;
   createTime = other208.createTime;
   managedLocationUri = other208.managedLocationUri;
+  id = other208.id;
   __isset = other208.__isset;
   return *this;
 }
@@ -6816,6 +6859,7 @@ void Database::printTo(std::ostream& out) const {
   out << ", " << "catalogName="; (__isset.catalogName ? (out << to_string(catalogName)) : (out << "<null>"));
   out << ", " << "createTime="; (__isset.createTime ? (out << to_string(createTime)) : (out << "<null>"));
   out << ", " << "managedLocationUri="; (__isset.managedLocationUri ? (out << to_string(managedLocationUri)) : (out << "<null>"));
+  out << ", " << "id="; (__isset.id ? (out << to_string(id)) : (out << "<null>"));
   out << ")";
 }
 
@@ -11289,6 +11333,11 @@ void Partition::__set_colStats(const ColumnStatistics& val) {
   this->colStats = val;
 __isset.colStats = true;
 }
+
+void Partition::__set_id(const int64_t val) {
+  this->id = val;
+__isset.id = true;
+}
 std::ostream& operator<<(std::ostream& out, const Partition& obj)
 {
   obj.printTo(out);
@@ -11440,6 +11489,14 @@ uint32_t Partition::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 13:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->id);
+          this->__isset.id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -11527,6 +11584,11 @@ uint32_t Partition::write(::apache::thrift::protocol::TProtocol* oprot) const {
     xfer += this->colStats.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.id) {
+    xfer += oprot->writeFieldBegin("id", ::apache::thrift::protocol::T_I64, 13);
+    xfer += oprot->writeI64(this->id);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -11546,6 +11608,7 @@ void swap(Partition &a, Partition &b) {
   swap(a.writeId, b.writeId);
   swap(a.isStatsCompliant, b.isStatsCompliant);
   swap(a.colStats, b.colStats);
+  swap(a.id, b.id);
   swap(a.__isset, b.__isset);
 }
 
@@ -11562,6 +11625,7 @@ Partition::Partition(const Partition& other372) {
   writeId = other372.writeId;
   isStatsCompliant = other372.isStatsCompliant;
   colStats = other372.colStats;
+  id = other372.id;
   __isset = other372.__isset;
 }
 Partition& Partition::operator=(const Partition& other373) {
@@ -11577,6 +11641,7 @@ Partition& Partition::operator=(const Partition& other373) {
   writeId = other373.writeId;
   isStatsCompliant = other373.isStatsCompliant;
   colStats = other373.colStats;
+  id = other373.id;
   __isset = other373.__isset;
   return *this;
 }
@@ -11595,6 +11660,7 @@ void Partition::printTo(std::ostream& out) const {
   out << ", " << "writeId="; (__isset.writeId ? (out << to_string(writeId)) : (out << "<null>"));
   out << ", " << "isStatsCompliant="; (__isset.isStatsCompliant ? (out << to_string(isStatsCompliant)) : (out << "<null>"));
   out << ", " << "colStats="; (__isset.colStats ? (out << to_string(colStats)) : (out << "<null>"));
+  out << ", " << "id="; (__isset.id ? (out << to_string(id)) : (out << "<null>"));
   out << ")";
 }
 
@@ -11626,6 +11692,11 @@ void PartitionWithoutSD::__set_parameters(const std::map<std::string, std::strin
 void PartitionWithoutSD::__set_privileges(const PrincipalPrivilegeSet& val) {
   this->privileges = val;
 __isset.privileges = true;
+}
+
+void PartitionWithoutSD::__set_id(const int64_t val) {
+  this->id = val;
+__isset.id = true;
 }
 std::ostream& operator<<(std::ostream& out, const PartitionWithoutSD& obj)
 {
@@ -11730,6 +11801,14 @@ uint32_t PartitionWithoutSD::read(::apache::thrift::protocol::TProtocol* iprot) 
           xfer += iprot->skip(ftype);
         }
         break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_I64) {
+          xfer += iprot->readI64(this->id);
+          this->__isset.id = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -11789,6 +11868,11 @@ uint32_t PartitionWithoutSD::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += this->privileges.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.id) {
+    xfer += oprot->writeFieldBegin("id", ::apache::thrift::protocol::T_I64, 7);
+    xfer += oprot->writeI64(this->id);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -11802,6 +11886,7 @@ void swap(PartitionWithoutSD &a, PartitionWithoutSD &b) {
   swap(a.relativePath, b.relativePath);
   swap(a.parameters, b.parameters);
   swap(a.privileges, b.privileges);
+  swap(a.id, b.id);
   swap(a.__isset, b.__isset);
 }
 
@@ -11812,6 +11897,7 @@ PartitionWithoutSD::PartitionWithoutSD(const PartitionWithoutSD& other388) {
   relativePath = other388.relativePath;
   parameters = other388.parameters;
   privileges = other388.privileges;
+  id = other388.id;
   __isset = other388.__isset;
 }
 PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& other389) {
@@ -11821,6 +11907,7 @@ PartitionWithoutSD& PartitionWithoutSD::operator=(const PartitionWithoutSD& othe
   relativePath = other389.relativePath;
   parameters = other389.parameters;
   privileges = other389.privileges;
+  id = other389.id;
   __isset = other389.__isset;
   return *this;
 }
@@ -11833,6 +11920,7 @@ void PartitionWithoutSD::printTo(std::ostream& out) const {
   out << ", " << "relativePath=" << to_string(relativePath);
   out << ", " << "parameters=" << to_string(parameters);
   out << ", " << "privileges="; (__isset.privileges ? (out << to_string(privileges)) : (out << "<null>"));
+  out << ", " << "id="; (__isset.id ? (out << to_string(id)) : (out << "<null>"));
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -2723,11 +2723,12 @@ void swap(GrantRevokeRoleResponse &a, GrantRevokeRoleResponse &b);
 std::ostream& operator<<(std::ostream& out, const GrantRevokeRoleResponse& obj);
 
 typedef struct _Catalog__isset {
-  _Catalog__isset() : name(false), description(false), locationUri(false), createTime(false) {}
+  _Catalog__isset() : name(false), description(false), locationUri(false), createTime(false), id(false) {}
   bool name :1;
   bool description :1;
   bool locationUri :1;
   bool createTime :1;
+  bool id :1;
 } _Catalog__isset;
 
 class Catalog : public virtual ::apache::thrift::TBase {
@@ -2735,7 +2736,7 @@ class Catalog : public virtual ::apache::thrift::TBase {
 
   Catalog(const Catalog&);
   Catalog& operator=(const Catalog&);
-  Catalog() : name(), description(), locationUri(), createTime(0) {
+  Catalog() : name(), description(), locationUri(), createTime(0), id(0) {
   }
 
   virtual ~Catalog() noexcept;
@@ -2743,6 +2744,7 @@ class Catalog : public virtual ::apache::thrift::TBase {
   std::string description;
   std::string locationUri;
   int32_t createTime;
+  int64_t id;
 
   _Catalog__isset __isset;
 
@@ -2753,6 +2755,8 @@ class Catalog : public virtual ::apache::thrift::TBase {
   void __set_locationUri(const std::string& val);
 
   void __set_createTime(const int32_t val);
+
+  void __set_id(const int64_t val);
 
   bool operator == (const Catalog & rhs) const
   {
@@ -2767,6 +2771,10 @@ class Catalog : public virtual ::apache::thrift::TBase {
     if (__isset.createTime != rhs.__isset.createTime)
       return false;
     else if (__isset.createTime && !(createTime == rhs.createTime))
+      return false;
+    if (__isset.id != rhs.__isset.id)
+      return false;
+    else if (__isset.id && !(id == rhs.id))
       return false;
     return true;
   }
@@ -3045,7 +3053,7 @@ void swap(DropCatalogRequest &a, DropCatalogRequest &b);
 std::ostream& operator<<(std::ostream& out, const DropCatalogRequest& obj);
 
 typedef struct _Database__isset {
-  _Database__isset() : name(false), description(false), locationUri(false), parameters(false), privileges(false), ownerName(false), ownerType(false), catalogName(false), createTime(false), managedLocationUri(false) {}
+  _Database__isset() : name(false), description(false), locationUri(false), parameters(false), privileges(false), ownerName(false), ownerType(false), catalogName(false), createTime(false), managedLocationUri(false), id(false) {}
   bool name :1;
   bool description :1;
   bool locationUri :1;
@@ -3056,6 +3064,7 @@ typedef struct _Database__isset {
   bool catalogName :1;
   bool createTime :1;
   bool managedLocationUri :1;
+  bool id :1;
 } _Database__isset;
 
 class Database : public virtual ::apache::thrift::TBase {
@@ -3063,7 +3072,7 @@ class Database : public virtual ::apache::thrift::TBase {
 
   Database(const Database&);
   Database& operator=(const Database&);
-  Database() : name(), description(), locationUri(), ownerName(), ownerType((PrincipalType::type)0), catalogName(), createTime(0), managedLocationUri() {
+  Database() : name(), description(), locationUri(), ownerName(), ownerType((PrincipalType::type)0), catalogName(), createTime(0), managedLocationUri(), id(0) {
   }
 
   virtual ~Database() noexcept;
@@ -3077,6 +3086,7 @@ class Database : public virtual ::apache::thrift::TBase {
   std::string catalogName;
   int32_t createTime;
   std::string managedLocationUri;
+  int64_t id;
 
   _Database__isset __isset;
 
@@ -3099,6 +3109,8 @@ class Database : public virtual ::apache::thrift::TBase {
   void __set_createTime(const int32_t val);
 
   void __set_managedLocationUri(const std::string& val);
+
+  void __set_id(const int64_t val);
 
   bool operator == (const Database & rhs) const
   {
@@ -3133,6 +3145,10 @@ class Database : public virtual ::apache::thrift::TBase {
     if (__isset.managedLocationUri != rhs.__isset.managedLocationUri)
       return false;
     else if (__isset.managedLocationUri && !(managedLocationUri == rhs.managedLocationUri))
+      return false;
+    if (__isset.id != rhs.__isset.id)
+      return false;
+    else if (__isset.id && !(id == rhs.id))
       return false;
     return true;
   }
@@ -4667,7 +4683,7 @@ void swap(Table &a, Table &b);
 std::ostream& operator<<(std::ostream& out, const Table& obj);
 
 typedef struct _Partition__isset {
-  _Partition__isset() : values(false), dbName(false), tableName(false), createTime(false), lastAccessTime(false), sd(false), parameters(false), privileges(false), catName(false), writeId(true), isStatsCompliant(false), colStats(false) {}
+  _Partition__isset() : values(false), dbName(false), tableName(false), createTime(false), lastAccessTime(false), sd(false), parameters(false), privileges(false), catName(false), writeId(true), isStatsCompliant(false), colStats(false), id(false) {}
   bool values :1;
   bool dbName :1;
   bool tableName :1;
@@ -4680,6 +4696,7 @@ typedef struct _Partition__isset {
   bool writeId :1;
   bool isStatsCompliant :1;
   bool colStats :1;
+  bool id :1;
 } _Partition__isset;
 
 class Partition : public virtual ::apache::thrift::TBase {
@@ -4687,7 +4704,7 @@ class Partition : public virtual ::apache::thrift::TBase {
 
   Partition(const Partition&);
   Partition& operator=(const Partition&);
-  Partition() : dbName(), tableName(), createTime(0), lastAccessTime(0), catName(), writeId(-1LL), isStatsCompliant(0) {
+  Partition() : dbName(), tableName(), createTime(0), lastAccessTime(0), catName(), writeId(-1LL), isStatsCompliant(0), id(0) {
   }
 
   virtual ~Partition() noexcept;
@@ -4703,6 +4720,7 @@ class Partition : public virtual ::apache::thrift::TBase {
   int64_t writeId;
   bool isStatsCompliant;
   ColumnStatistics colStats;
+  int64_t id;
 
   _Partition__isset __isset;
 
@@ -4729,6 +4747,8 @@ class Partition : public virtual ::apache::thrift::TBase {
   void __set_isStatsCompliant(const bool val);
 
   void __set_colStats(const ColumnStatistics& val);
+
+  void __set_id(const int64_t val);
 
   bool operator == (const Partition & rhs) const
   {
@@ -4766,6 +4786,10 @@ class Partition : public virtual ::apache::thrift::TBase {
       return false;
     else if (__isset.colStats && !(colStats == rhs.colStats))
       return false;
+    if (__isset.id != rhs.__isset.id)
+      return false;
+    else if (__isset.id && !(id == rhs.id))
+      return false;
     return true;
   }
   bool operator != (const Partition &rhs) const {
@@ -4785,13 +4809,14 @@ void swap(Partition &a, Partition &b);
 std::ostream& operator<<(std::ostream& out, const Partition& obj);
 
 typedef struct _PartitionWithoutSD__isset {
-  _PartitionWithoutSD__isset() : values(false), createTime(false), lastAccessTime(false), relativePath(false), parameters(false), privileges(false) {}
+  _PartitionWithoutSD__isset() : values(false), createTime(false), lastAccessTime(false), relativePath(false), parameters(false), privileges(false), id(false) {}
   bool values :1;
   bool createTime :1;
   bool lastAccessTime :1;
   bool relativePath :1;
   bool parameters :1;
   bool privileges :1;
+  bool id :1;
 } _PartitionWithoutSD__isset;
 
 class PartitionWithoutSD : public virtual ::apache::thrift::TBase {
@@ -4799,7 +4824,7 @@ class PartitionWithoutSD : public virtual ::apache::thrift::TBase {
 
   PartitionWithoutSD(const PartitionWithoutSD&);
   PartitionWithoutSD& operator=(const PartitionWithoutSD&);
-  PartitionWithoutSD() : createTime(0), lastAccessTime(0), relativePath() {
+  PartitionWithoutSD() : createTime(0), lastAccessTime(0), relativePath(), id(0) {
   }
 
   virtual ~PartitionWithoutSD() noexcept;
@@ -4809,6 +4834,7 @@ class PartitionWithoutSD : public virtual ::apache::thrift::TBase {
   std::string relativePath;
   std::map<std::string, std::string>  parameters;
   PrincipalPrivilegeSet privileges;
+  int64_t id;
 
   _PartitionWithoutSD__isset __isset;
 
@@ -4823,6 +4849,8 @@ class PartitionWithoutSD : public virtual ::apache::thrift::TBase {
   void __set_parameters(const std::map<std::string, std::string> & val);
 
   void __set_privileges(const PrincipalPrivilegeSet& val);
+
+  void __set_id(const int64_t val);
 
   bool operator == (const PartitionWithoutSD & rhs) const
   {
@@ -4839,6 +4867,10 @@ class PartitionWithoutSD : public virtual ::apache::thrift::TBase {
     if (__isset.privileges != rhs.__isset.privileges)
       return false;
     else if (__isset.privileges && !(privileges == rhs.privileges))
+      return false;
+    if (__isset.id != rhs.__isset.id)
+      return false;
+    else if (__isset.id && !(id == rhs.id))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Catalog.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Catalog.java
@@ -15,6 +15,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField DESCRIPTION_FIELD_DESC = new org.apache.thrift.protocol.TField("description", org.apache.thrift.protocol.TType.STRING, (short)2);
   private static final org.apache.thrift.protocol.TField LOCATION_URI_FIELD_DESC = new org.apache.thrift.protocol.TField("locationUri", org.apache.thrift.protocol.TType.STRING, (short)3);
   private static final org.apache.thrift.protocol.TField CREATE_TIME_FIELD_DESC = new org.apache.thrift.protocol.TField("createTime", org.apache.thrift.protocol.TType.I32, (short)4);
+  private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("id", org.apache.thrift.protocol.TType.I64, (short)5);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new CatalogStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new CatalogTupleSchemeFactory();
@@ -23,13 +24,15 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String description; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String locationUri; // required
   private int createTime; // optional
+  private long id; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
     NAME((short)1, "name"),
     DESCRIPTION((short)2, "description"),
     LOCATION_URI((short)3, "locationUri"),
-    CREATE_TIME((short)4, "createTime");
+    CREATE_TIME((short)4, "createTime"),
+    ID((short)5, "id");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -53,6 +56,8 @@ package org.apache.hadoop.hive.metastore.api;
           return LOCATION_URI;
         case 4: // CREATE_TIME
           return CREATE_TIME;
+        case 5: // ID
+          return ID;
         default:
           return null;
       }
@@ -95,8 +100,9 @@ package org.apache.hadoop.hive.metastore.api;
 
   // isset id assignments
   private static final int __CREATETIME_ISSET_ID = 0;
+  private static final int __ID_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.DESCRIPTION,_Fields.CREATE_TIME};
+  private static final _Fields optionals[] = {_Fields.DESCRIPTION,_Fields.CREATE_TIME,_Fields.ID};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -108,6 +114,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
     tmpMap.put(_Fields.CREATE_TIME, new org.apache.thrift.meta_data.FieldMetaData("createTime", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
+    tmpMap.put(_Fields.ID, new org.apache.thrift.meta_data.FieldMetaData("id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Catalog.class, metaDataMap);
   }
@@ -139,6 +147,7 @@ package org.apache.hadoop.hive.metastore.api;
       this.locationUri = other.locationUri;
     }
     this.createTime = other.createTime;
+    this.id = other.id;
   }
 
   public Catalog deepCopy() {
@@ -152,6 +161,8 @@ package org.apache.hadoop.hive.metastore.api;
     this.locationUri = null;
     setCreateTimeIsSet(false);
     this.createTime = 0;
+    setIdIsSet(false);
+    this.id = 0;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -248,6 +259,28 @@ package org.apache.hadoop.hive.metastore.api;
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __CREATETIME_ISSET_ID, value);
   }
 
+  public long getId() {
+    return this.id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+    setIdIsSet(true);
+  }
+
+  public void unsetId() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  /** Returns true if field id is set (has been assigned a value) and false otherwise */
+  public boolean isSetId() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  public void setIdIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __ID_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case NAME:
@@ -282,6 +315,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case ID:
+      if (value == null) {
+        unsetId();
+      } else {
+        setId((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -299,6 +340,9 @@ package org.apache.hadoop.hive.metastore.api;
 
     case CREATE_TIME:
       return getCreateTime();
+
+    case ID:
+      return getId();
 
     }
     throw new java.lang.IllegalStateException();
@@ -319,6 +363,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetLocationUri();
     case CREATE_TIME:
       return isSetCreateTime();
+    case ID:
+      return isSetId();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -374,6 +420,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_id = true && this.isSetId();
+    boolean that_present_id = true && that.isSetId();
+    if (this_present_id || that_present_id) {
+      if (!(this_present_id && that_present_id))
+        return false;
+      if (this.id != that.id)
+        return false;
+    }
+
     return true;
   }
 
@@ -396,6 +451,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetCreateTime()) ? 131071 : 524287);
     if (isSetCreateTime())
       hashCode = hashCode * 8191 + createTime;
+
+    hashCode = hashCode * 8191 + ((isSetId()) ? 131071 : 524287);
+    if (isSetId())
+      hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(id);
 
     return hashCode;
   }
@@ -444,6 +503,16 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetCreateTime()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.createTime, other.createTime);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetId()).compareTo(other.isSetId());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetId()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.id, other.id);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -498,6 +567,12 @@ package org.apache.hadoop.hive.metastore.api;
       if (!first) sb.append(", ");
       sb.append("createTime:");
       sb.append(this.createTime);
+      first = false;
+    }
+    if (isSetId()) {
+      if (!first) sb.append(", ");
+      sb.append("id:");
+      sb.append(this.id);
       first = false;
     }
     sb.append(")");
@@ -577,6 +652,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 5: // ID
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.id = iprot.readI64();
+              struct.setIdIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -612,6 +695,11 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeI32(struct.createTime);
         oprot.writeFieldEnd();
       }
+      if (struct.isSetId()) {
+        oprot.writeFieldBegin(ID_FIELD_DESC);
+        oprot.writeI64(struct.id);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -642,7 +730,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetCreateTime()) {
         optionals.set(3);
       }
-      oprot.writeBitSet(optionals, 4);
+      if (struct.isSetId()) {
+        optionals.set(4);
+      }
+      oprot.writeBitSet(optionals, 5);
       if (struct.isSetName()) {
         oprot.writeString(struct.name);
       }
@@ -655,12 +746,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetCreateTime()) {
         oprot.writeI32(struct.createTime);
       }
+      if (struct.isSetId()) {
+        oprot.writeI64(struct.id);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Catalog struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(4);
+      java.util.BitSet incoming = iprot.readBitSet(5);
       if (incoming.get(0)) {
         struct.name = iprot.readString();
         struct.setNameIsSet(true);
@@ -676,6 +770,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(3)) {
         struct.createTime = iprot.readI32();
         struct.setCreateTimeIsSet(true);
+      }
+      if (incoming.get(4)) {
+        struct.id = iprot.readI64();
+        struct.setIdIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Database.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField CATALOG_NAME_FIELD_DESC = new org.apache.thrift.protocol.TField("catalogName", org.apache.thrift.protocol.TType.STRING, (short)8);
   private static final org.apache.thrift.protocol.TField CREATE_TIME_FIELD_DESC = new org.apache.thrift.protocol.TField("createTime", org.apache.thrift.protocol.TType.I32, (short)9);
   private static final org.apache.thrift.protocol.TField MANAGED_LOCATION_URI_FIELD_DESC = new org.apache.thrift.protocol.TField("managedLocationUri", org.apache.thrift.protocol.TType.STRING, (short)10);
+  private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("id", org.apache.thrift.protocol.TType.I64, (short)11);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new DatabaseStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new DatabaseTupleSchemeFactory();
@@ -35,6 +36,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String catalogName; // optional
   private int createTime; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String managedLocationUri; // optional
+  private long id; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -51,7 +53,8 @@ package org.apache.hadoop.hive.metastore.api;
     OWNER_TYPE((short)7, "ownerType"),
     CATALOG_NAME((short)8, "catalogName"),
     CREATE_TIME((short)9, "createTime"),
-    MANAGED_LOCATION_URI((short)10, "managedLocationUri");
+    MANAGED_LOCATION_URI((short)10, "managedLocationUri"),
+    ID((short)11, "id");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -87,6 +90,8 @@ package org.apache.hadoop.hive.metastore.api;
           return CREATE_TIME;
         case 10: // MANAGED_LOCATION_URI
           return MANAGED_LOCATION_URI;
+        case 11: // ID
+          return ID;
         default:
           return null;
       }
@@ -129,8 +134,9 @@ package org.apache.hadoop.hive.metastore.api;
 
   // isset id assignments
   private static final int __CREATETIME_ISSET_ID = 0;
+  private static final int __ID_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.OWNER_NAME,_Fields.OWNER_TYPE,_Fields.CATALOG_NAME,_Fields.CREATE_TIME,_Fields.MANAGED_LOCATION_URI};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.OWNER_NAME,_Fields.OWNER_TYPE,_Fields.CATALOG_NAME,_Fields.CREATE_TIME,_Fields.MANAGED_LOCATION_URI,_Fields.ID};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -156,6 +162,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I32)));
     tmpMap.put(_Fields.MANAGED_LOCATION_URI, new org.apache.thrift.meta_data.FieldMetaData("managedLocationUri", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.ID, new org.apache.thrift.meta_data.FieldMetaData("id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Database.class, metaDataMap);
   }
@@ -210,6 +218,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetManagedLocationUri()) {
       this.managedLocationUri = other.managedLocationUri;
     }
+    this.id = other.id;
   }
 
   public Database deepCopy() {
@@ -229,6 +238,8 @@ package org.apache.hadoop.hive.metastore.api;
     setCreateTimeIsSet(false);
     this.createTime = 0;
     this.managedLocationUri = null;
+    setIdIsSet(false);
+    this.id = 0;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -488,6 +499,28 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  public long getId() {
+    return this.id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+    setIdIsSet(true);
+  }
+
+  public void unsetId() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  /** Returns true if field id is set (has been assigned a value) and false otherwise */
+  public boolean isSetId() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  public void setIdIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __ID_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case NAME:
@@ -570,6 +603,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case ID:
+      if (value == null) {
+        unsetId();
+      } else {
+        setId((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -606,6 +647,9 @@ package org.apache.hadoop.hive.metastore.api;
     case MANAGED_LOCATION_URI:
       return getManagedLocationUri();
 
+    case ID:
+      return getId();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -637,6 +681,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetCreateTime();
     case MANAGED_LOCATION_URI:
       return isSetManagedLocationUri();
+    case ID:
+      return isSetId();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -746,6 +792,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_id = true && this.isSetId();
+    boolean that_present_id = true && that.isSetId();
+    if (this_present_id || that_present_id) {
+      if (!(this_present_id && that_present_id))
+        return false;
+      if (this.id != that.id)
+        return false;
+    }
+
     return true;
   }
 
@@ -792,6 +847,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetManagedLocationUri()) ? 131071 : 524287);
     if (isSetManagedLocationUri())
       hashCode = hashCode * 8191 + managedLocationUri.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetId()) ? 131071 : 524287);
+    if (isSetId())
+      hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(id);
 
     return hashCode;
   }
@@ -904,6 +963,16 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.valueOf(isSetId()).compareTo(other.isSetId());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetId()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.id, other.id);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1010,6 +1079,12 @@ package org.apache.hadoop.hive.metastore.api;
       } else {
         sb.append(this.managedLocationUri);
       }
+      first = false;
+    }
+    if (isSetId()) {
+      if (!first) sb.append(", ");
+      sb.append("id:");
+      sb.append(this.id);
       first = false;
     }
     sb.append(")");
@@ -1153,6 +1228,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 11: // ID
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.id = iprot.readI64();
+              struct.setIdIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1234,6 +1317,11 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.isSetId()) {
+        oprot.writeFieldBegin(ID_FIELD_DESC);
+        oprot.writeI64(struct.id);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1282,7 +1370,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetManagedLocationUri()) {
         optionals.set(9);
       }
-      oprot.writeBitSet(optionals, 10);
+      if (struct.isSetId()) {
+        optionals.set(10);
+      }
+      oprot.writeBitSet(optionals, 11);
       if (struct.isSetName()) {
         oprot.writeString(struct.name);
       }
@@ -1320,12 +1411,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetManagedLocationUri()) {
         oprot.writeString(struct.managedLocationUri);
       }
+      if (struct.isSetId()) {
+        oprot.writeI64(struct.id);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Database struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(10);
+      java.util.BitSet incoming = iprot.readBitSet(11);
       if (incoming.get(0)) {
         struct.name = iprot.readString();
         struct.setNameIsSet(true);
@@ -1377,6 +1471,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(9)) {
         struct.managedLocationUri = iprot.readString();
         struct.setManagedLocationUriIsSet(true);
+      }
+      if (incoming.get(10)) {
+        struct.id = iprot.readI64();
+        struct.setIdIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Partition.java
@@ -23,6 +23,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField WRITE_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("writeId", org.apache.thrift.protocol.TType.I64, (short)10);
   private static final org.apache.thrift.protocol.TField IS_STATS_COMPLIANT_FIELD_DESC = new org.apache.thrift.protocol.TField("isStatsCompliant", org.apache.thrift.protocol.TType.BOOL, (short)11);
   private static final org.apache.thrift.protocol.TField COL_STATS_FIELD_DESC = new org.apache.thrift.protocol.TField("colStats", org.apache.thrift.protocol.TType.STRUCT, (short)12);
+  private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("id", org.apache.thrift.protocol.TType.I64, (short)13);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionTupleSchemeFactory();
@@ -39,6 +40,7 @@ package org.apache.hadoop.hive.metastore.api;
   private long writeId; // optional
   private boolean isStatsCompliant; // optional
   private @org.apache.thrift.annotation.Nullable ColumnStatistics colStats; // optional
+  private long id; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -53,7 +55,8 @@ package org.apache.hadoop.hive.metastore.api;
     CAT_NAME((short)9, "catName"),
     WRITE_ID((short)10, "writeId"),
     IS_STATS_COMPLIANT((short)11, "isStatsCompliant"),
-    COL_STATS((short)12, "colStats");
+    COL_STATS((short)12, "colStats"),
+    ID((short)13, "id");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -93,6 +96,8 @@ package org.apache.hadoop.hive.metastore.api;
           return IS_STATS_COMPLIANT;
         case 12: // COL_STATS
           return COL_STATS;
+        case 13: // ID
+          return ID;
         default:
           return null;
       }
@@ -138,8 +143,9 @@ package org.apache.hadoop.hive.metastore.api;
   private static final int __LASTACCESSTIME_ISSET_ID = 1;
   private static final int __WRITEID_ISSET_ID = 2;
   private static final int __ISSTATSCOMPLIANT_ISSET_ID = 3;
+  private static final int __ID_ISSET_ID = 4;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.CAT_NAME,_Fields.WRITE_ID,_Fields.IS_STATS_COMPLIANT,_Fields.COL_STATS};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.CAT_NAME,_Fields.WRITE_ID,_Fields.IS_STATS_COMPLIANT,_Fields.COL_STATS,_Fields.ID};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -170,6 +176,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     tmpMap.put(_Fields.COL_STATS, new org.apache.thrift.meta_data.FieldMetaData("colStats", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, ColumnStatistics.class)));
+    tmpMap.put(_Fields.ID, new org.apache.thrift.meta_data.FieldMetaData("id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Partition.class, metaDataMap);
   }
@@ -235,6 +243,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetColStats()) {
       this.colStats = new ColumnStatistics(other.colStats);
     }
+    this.id = other.id;
   }
 
   public Partition deepCopy() {
@@ -259,6 +268,8 @@ package org.apache.hadoop.hive.metastore.api;
     setIsStatsCompliantIsSet(false);
     this.isStatsCompliant = false;
     this.colStats = null;
+    setIdIsSet(false);
+    this.id = 0;
   }
 
   public int getValuesSize() {
@@ -568,6 +579,28 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  public long getId() {
+    return this.id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+    setIdIsSet(true);
+  }
+
+  public void unsetId() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  /** Returns true if field id is set (has been assigned a value) and false otherwise */
+  public boolean isSetId() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  public void setIdIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __ID_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case VALUES:
@@ -666,6 +699,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case ID:
+      if (value == null) {
+        unsetId();
+      } else {
+        setId((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -708,6 +749,9 @@ package org.apache.hadoop.hive.metastore.api;
     case COL_STATS:
       return getColStats();
 
+    case ID:
+      return getId();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -743,6 +787,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetIsStatsCompliant();
     case COL_STATS:
       return isSetColStats();
+    case ID:
+      return isSetId();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -870,6 +916,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_id = true && this.isSetId();
+    boolean that_present_id = true && that.isSetId();
+    if (this_present_id || that_present_id) {
+      if (!(this_present_id && that_present_id))
+        return false;
+      if (this.id != that.id)
+        return false;
+    }
+
     return true;
   }
 
@@ -920,6 +975,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetColStats()) ? 131071 : 524287);
     if (isSetColStats())
       hashCode = hashCode * 8191 + colStats.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetId()) ? 131071 : 524287);
+    if (isSetId())
+      hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(id);
 
     return hashCode;
   }
@@ -1052,6 +1111,16 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.valueOf(isSetId()).compareTo(other.isSetId());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetId()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.id, other.id);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -1160,6 +1229,12 @@ package org.apache.hadoop.hive.metastore.api;
       } else {
         sb.append(this.colStats);
       }
+      first = false;
+    }
+    if (isSetId()) {
+      if (!first) sb.append(", ");
+      sb.append("id:");
+      sb.append(this.id);
       first = false;
     }
     sb.append(")");
@@ -1337,6 +1412,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 13: // ID
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.id = iprot.readI64();
+              struct.setIdIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -1427,6 +1510,11 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.isSetId()) {
+        oprot.writeFieldBegin(ID_FIELD_DESC);
+        oprot.writeI64(struct.id);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -1481,7 +1569,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetColStats()) {
         optionals.set(11);
       }
-      oprot.writeBitSet(optionals, 12);
+      if (struct.isSetId()) {
+        optionals.set(12);
+      }
+      oprot.writeBitSet(optionals, 13);
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
@@ -1531,12 +1622,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetColStats()) {
         struct.colStats.write(oprot);
       }
+      if (struct.isSetId()) {
+        oprot.writeI64(struct.id);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, Partition struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(12);
+      java.util.BitSet incoming = iprot.readBitSet(13);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list315 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
@@ -1607,6 +1701,10 @@ package org.apache.hadoop.hive.metastore.api;
         struct.colStats = new ColumnStatistics();
         struct.colStats.read(iprot);
         struct.setColStatsIsSet(true);
+      }
+      if (incoming.get(12)) {
+        struct.id = iprot.readI64();
+        struct.setIdIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/PartitionWithoutSD.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField RELATIVE_PATH_FIELD_DESC = new org.apache.thrift.protocol.TField("relativePath", org.apache.thrift.protocol.TType.STRING, (short)4);
   private static final org.apache.thrift.protocol.TField PARAMETERS_FIELD_DESC = new org.apache.thrift.protocol.TField("parameters", org.apache.thrift.protocol.TType.MAP, (short)5);
   private static final org.apache.thrift.protocol.TField PRIVILEGES_FIELD_DESC = new org.apache.thrift.protocol.TField("privileges", org.apache.thrift.protocol.TType.STRUCT, (short)6);
+  private static final org.apache.thrift.protocol.TField ID_FIELD_DESC = new org.apache.thrift.protocol.TField("id", org.apache.thrift.protocol.TType.I64, (short)7);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new PartitionWithoutSDStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new PartitionWithoutSDTupleSchemeFactory();
@@ -27,6 +28,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.lang.String relativePath; // required
   private @org.apache.thrift.annotation.Nullable java.util.Map<java.lang.String,java.lang.String> parameters; // required
   private @org.apache.thrift.annotation.Nullable PrincipalPrivilegeSet privileges; // optional
+  private long id; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35,7 +37,8 @@ package org.apache.hadoop.hive.metastore.api;
     LAST_ACCESS_TIME((short)3, "lastAccessTime"),
     RELATIVE_PATH((short)4, "relativePath"),
     PARAMETERS((short)5, "parameters"),
-    PRIVILEGES((short)6, "privileges");
+    PRIVILEGES((short)6, "privileges"),
+    ID((short)7, "id");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -63,6 +66,8 @@ package org.apache.hadoop.hive.metastore.api;
           return PARAMETERS;
         case 6: // PRIVILEGES
           return PRIVILEGES;
+        case 7: // ID
+          return ID;
         default:
           return null;
       }
@@ -106,8 +111,9 @@ package org.apache.hadoop.hive.metastore.api;
   // isset id assignments
   private static final int __CREATETIME_ISSET_ID = 0;
   private static final int __LASTACCESSTIME_ISSET_ID = 1;
+  private static final int __ID_ISSET_ID = 2;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PRIVILEGES};
+  private static final _Fields optionals[] = {_Fields.PRIVILEGES,_Fields.ID};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -126,6 +132,8 @@ package org.apache.hadoop.hive.metastore.api;
             new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING))));
     tmpMap.put(_Fields.PRIVILEGES, new org.apache.thrift.meta_data.FieldMetaData("privileges", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, PrincipalPrivilegeSet.class)));
+    tmpMap.put(_Fields.ID, new org.apache.thrift.meta_data.FieldMetaData("id", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(PartitionWithoutSD.class, metaDataMap);
   }
@@ -171,6 +179,7 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetPrivileges()) {
       this.privileges = new PrincipalPrivilegeSet(other.privileges);
     }
+    this.id = other.id;
   }
 
   public PartitionWithoutSD deepCopy() {
@@ -187,6 +196,8 @@ package org.apache.hadoop.hive.metastore.api;
     this.relativePath = null;
     this.parameters = null;
     this.privileges = null;
+    setIdIsSet(false);
+    this.id = 0;
   }
 
   public int getValuesSize() {
@@ -356,6 +367,28 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  public long getId() {
+    return this.id;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+    setIdIsSet(true);
+  }
+
+  public void unsetId() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  /** Returns true if field id is set (has been assigned a value) and false otherwise */
+  public boolean isSetId() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __ID_ISSET_ID);
+  }
+
+  public void setIdIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __ID_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case VALUES:
@@ -406,6 +439,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case ID:
+      if (value == null) {
+        unsetId();
+      } else {
+        setId((java.lang.Long)value);
+      }
+      break;
+
     }
   }
 
@@ -430,6 +471,9 @@ package org.apache.hadoop.hive.metastore.api;
     case PRIVILEGES:
       return getPrivileges();
 
+    case ID:
+      return getId();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -453,6 +497,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetParameters();
     case PRIVILEGES:
       return isSetPrivileges();
+    case ID:
+      return isSetId();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -526,6 +572,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_id = true && this.isSetId();
+    boolean that_present_id = true && that.isSetId();
+    if (this_present_id || that_present_id) {
+      if (!(this_present_id && that_present_id))
+        return false;
+      if (this.id != that.id)
+        return false;
+    }
+
     return true;
   }
 
@@ -552,6 +607,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetPrivileges()) ? 131071 : 524287);
     if (isSetPrivileges())
       hashCode = hashCode * 8191 + privileges.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetId()) ? 131071 : 524287);
+    if (isSetId())
+      hashCode = hashCode * 8191 + org.apache.thrift.TBaseHelper.hashCode(id);
 
     return hashCode;
   }
@@ -624,6 +683,16 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.valueOf(isSetId()).compareTo(other.isSetId());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetId()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.id, other.id);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -684,6 +753,12 @@ package org.apache.hadoop.hive.metastore.api;
       } else {
         sb.append(this.privileges);
       }
+      first = false;
+    }
+    if (isSetId()) {
+      if (!first) sb.append(", ");
+      sb.append("id:");
+      sb.append(this.id);
       first = false;
     }
     sb.append(")");
@@ -805,6 +880,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 7: // ID
+            if (schemeField.type == org.apache.thrift.protocol.TType.I64) {
+              struct.id = iprot.readI64();
+              struct.setIdIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -861,6 +944,11 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.isSetId()) {
+        oprot.writeFieldBegin(ID_FIELD_DESC);
+        oprot.writeI64(struct.id);
+        oprot.writeFieldEnd();
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -897,7 +985,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPrivileges()) {
         optionals.set(5);
       }
-      oprot.writeBitSet(optionals, 6);
+      if (struct.isSetId()) {
+        optionals.set(6);
+      }
+      oprot.writeBitSet(optionals, 7);
       if (struct.isSetValues()) {
         {
           oprot.writeI32(struct.values.size());
@@ -929,12 +1020,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetPrivileges()) {
         struct.privileges.write(oprot);
       }
+      if (struct.isSetId()) {
+        oprot.writeI64(struct.id);
+      }
     }
 
     @Override
     public void read(org.apache.thrift.protocol.TProtocol prot, PartitionWithoutSD struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
-      java.util.BitSet incoming = iprot.readBitSet(6);
+      java.util.BitSet incoming = iprot.readBitSet(7);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list333 = new org.apache.thrift.protocol.TList(org.apache.thrift.protocol.TType.STRING, iprot.readI32());
@@ -979,6 +1073,10 @@ package org.apache.hadoop.hive.metastore.api;
         struct.privileges = new PrincipalPrivilegeSet();
         struct.privileges.read(iprot);
         struct.setPrivilegesIsSet(true);
+      }
+      if (incoming.get(6)) {
+        struct.id = iprot.readI64();
+        struct.setIdIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Catalog.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Catalog.php
@@ -41,6 +41,11 @@ class Catalog
             'isRequired' => false,
             'type' => TType::I32,
         ),
+        5 => array(
+            'var' => 'id',
+            'isRequired' => false,
+            'type' => TType::I64,
+        ),
     );
 
     /**
@@ -59,6 +64,10 @@ class Catalog
      * @var int
      */
     public $createTime = null;
+    /**
+     * @var int
+     */
+    public $id = null;
 
     public function __construct($vals = null)
     {
@@ -74,6 +83,9 @@ class Catalog
             }
             if (isset($vals['createTime'])) {
                 $this->createTime = $vals['createTime'];
+            }
+            if (isset($vals['id'])) {
+                $this->id = $vals['id'];
             }
         }
     }
@@ -125,6 +137,13 @@ class Catalog
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 5:
+                    if ($ftype == TType::I64) {
+                        $xfer += $input->readI64($this->id);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -157,6 +176,11 @@ class Catalog
         if ($this->createTime !== null) {
             $xfer += $output->writeFieldBegin('createTime', TType::I32, 4);
             $xfer += $output->writeI32($this->createTime);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->id !== null) {
+            $xfer += $output->writeFieldBegin('id', TType::I64, 5);
+            $xfer += $output->writeI64($this->id);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Database.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Database.php
@@ -80,6 +80,11 @@ class Database
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        11 => array(
+            'var' => 'id',
+            'isRequired' => false,
+            'type' => TType::I64,
+        ),
     );
 
     /**
@@ -122,6 +127,10 @@ class Database
      * @var string
      */
     public $managedLocationUri = null;
+    /**
+     * @var int
+     */
+    public $id = null;
 
     public function __construct($vals = null)
     {
@@ -155,6 +164,9 @@ class Database
             }
             if (isset($vals['managedLocationUri'])) {
                 $this->managedLocationUri = $vals['managedLocationUri'];
+            }
+            if (isset($vals['id'])) {
+                $this->id = $vals['id'];
             }
         }
     }
@@ -261,6 +273,13 @@ class Database
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 11:
+                    if ($ftype == TType::I64) {
+                        $xfer += $input->readI64($this->id);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -334,6 +353,11 @@ class Database
         if ($this->managedLocationUri !== null) {
             $xfer += $output->writeFieldBegin('managedLocationUri', TType::STRING, 10);
             $xfer += $output->writeString($this->managedLocationUri);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->id !== null) {
+            $xfer += $output->writeFieldBegin('id', TType::I64, 11);
+            $xfer += $output->writeI64($this->id);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Partition.php
@@ -96,6 +96,11 @@ class Partition
             'type' => TType::STRUCT,
             'class' => '\metastore\ColumnStatistics',
         ),
+        13 => array(
+            'var' => 'id',
+            'isRequired' => false,
+            'type' => TType::I64,
+        ),
     );
 
     /**
@@ -146,6 +151,10 @@ class Partition
      * @var \metastore\ColumnStatistics
      */
     public $colStats = null;
+    /**
+     * @var int
+     */
+    public $id = null;
 
     public function __construct($vals = null)
     {
@@ -185,6 +194,9 @@ class Partition
             }
             if (isset($vals['colStats'])) {
                 $this->colStats = $vals['colStats'];
+            }
+            if (isset($vals['id'])) {
+                $this->id = $vals['id'];
             }
         }
     }
@@ -316,6 +328,13 @@ class Partition
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 13:
+                    if ($ftype == TType::I64) {
+                        $xfer += $input->readI64($this->id);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -412,6 +431,11 @@ class Partition
             }
             $xfer += $output->writeFieldBegin('colStats', TType::STRUCT, 12);
             $xfer += $this->colStats->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->id !== null) {
+            $xfer += $output->writeFieldBegin('id', TType::I64, 13);
+            $xfer += $output->writeI64($this->id);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/PartitionWithoutSD.php
@@ -64,6 +64,11 @@ class PartitionWithoutSD
             'type' => TType::STRUCT,
             'class' => '\metastore\PrincipalPrivilegeSet',
         ),
+        7 => array(
+            'var' => 'id',
+            'isRequired' => false,
+            'type' => TType::I64,
+        ),
     );
 
     /**
@@ -90,6 +95,10 @@ class PartitionWithoutSD
      * @var \metastore\PrincipalPrivilegeSet
      */
     public $privileges = null;
+    /**
+     * @var int
+     */
+    public $id = null;
 
     public function __construct($vals = null)
     {
@@ -111,6 +120,9 @@ class PartitionWithoutSD
             }
             if (isset($vals['privileges'])) {
                 $this->privileges = $vals['privileges'];
+            }
+            if (isset($vals['id'])) {
+                $this->id = $vals['id'];
             }
         }
     }
@@ -198,6 +210,13 @@ class PartitionWithoutSD
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 7:
+                    if ($ftype == TType::I64) {
+                        $xfer += $input->readI64($this->id);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -258,6 +277,11 @@ class PartitionWithoutSD
             }
             $xfer += $output->writeFieldBegin('privileges', TType::STRUCT, 6);
             $xfer += $this->privileges->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->id !== null) {
+            $xfer += $output->writeFieldBegin('id', TType::I64, 7);
+            $xfer += $output->writeI64($this->id);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -3324,15 +3324,17 @@ class Catalog(object):
      - description
      - locationUri
      - createTime
+     - id
 
     """
 
 
-    def __init__(self, name=None, description=None, locationUri=None, createTime=None,):
+    def __init__(self, name=None, description=None, locationUri=None, createTime=None, id=None,):
         self.name = name
         self.description = description
         self.locationUri = locationUri
         self.createTime = createTime
+        self.id = id
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3363,6 +3365,11 @@ class Catalog(object):
                     self.createTime = iprot.readI32()
                 else:
                     iprot.skip(ftype)
+            elif fid == 5:
+                if ftype == TType.I64:
+                    self.id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3388,6 +3395,10 @@ class Catalog(object):
         if self.createTime is not None:
             oprot.writeFieldBegin('createTime', TType.I32, 4)
             oprot.writeI32(self.createTime)
+            oprot.writeFieldEnd()
+        if self.id is not None:
+            oprot.writeFieldBegin('id', TType.I64, 5)
+            oprot.writeI64(self.id)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -3784,11 +3795,12 @@ class Database(object):
      - catalogName
      - createTime
      - managedLocationUri
+     - id
 
     """
 
 
-    def __init__(self, name=None, description=None, locationUri=None, parameters=None, privileges=None, ownerName=None, ownerType=None, catalogName=None, createTime=None, managedLocationUri=None,):
+    def __init__(self, name=None, description=None, locationUri=None, parameters=None, privileges=None, ownerName=None, ownerType=None, catalogName=None, createTime=None, managedLocationUri=None, id=None,):
         self.name = name
         self.description = description
         self.locationUri = locationUri
@@ -3799,6 +3811,7 @@ class Database(object):
         self.catalogName = catalogName
         self.createTime = createTime
         self.managedLocationUri = managedLocationUri
+        self.id = id
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -3866,6 +3879,11 @@ class Database(object):
                     self.managedLocationUri = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 11:
+                if ftype == TType.I64:
+                    self.id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -3919,6 +3937,10 @@ class Database(object):
         if self.managedLocationUri is not None:
             oprot.writeFieldBegin('managedLocationUri', TType.STRING, 10)
             oprot.writeString(self.managedLocationUri.encode('utf-8') if sys.version_info[0] == 2 else self.managedLocationUri)
+            oprot.writeFieldEnd()
+        if self.id is not None:
+            oprot.writeFieldBegin('id', TType.I64, 11)
+            oprot.writeI64(self.id)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -6451,11 +6473,12 @@ class Partition(object):
      - writeId
      - isStatsCompliant
      - colStats
+     - id
 
     """
 
 
-    def __init__(self, values=None, dbName=None, tableName=None, createTime=None, lastAccessTime=None, sd=None, parameters=None, privileges=None, catName=None, writeId=-1, isStatsCompliant=None, colStats=None,):
+    def __init__(self, values=None, dbName=None, tableName=None, createTime=None, lastAccessTime=None, sd=None, parameters=None, privileges=None, catName=None, writeId=-1, isStatsCompliant=None, colStats=None, id=None,):
         self.values = values
         self.dbName = dbName
         self.tableName = tableName
@@ -6468,6 +6491,7 @@ class Partition(object):
         self.writeId = writeId
         self.isStatsCompliant = isStatsCompliant
         self.colStats = colStats
+        self.id = id
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6552,6 +6576,11 @@ class Partition(object):
                     self.colStats.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 13:
+                if ftype == TType.I64:
+                    self.id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6617,6 +6646,10 @@ class Partition(object):
             oprot.writeFieldBegin('colStats', TType.STRUCT, 12)
             self.colStats.write(oprot)
             oprot.writeFieldEnd()
+        if self.id is not None:
+            oprot.writeFieldBegin('id', TType.I64, 13)
+            oprot.writeI64(self.id)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
@@ -6644,17 +6677,19 @@ class PartitionWithoutSD(object):
      - relativePath
      - parameters
      - privileges
+     - id
 
     """
 
 
-    def __init__(self, values=None, createTime=None, lastAccessTime=None, relativePath=None, parameters=None, privileges=None,):
+    def __init__(self, values=None, createTime=None, lastAccessTime=None, relativePath=None, parameters=None, privileges=None, id=None,):
         self.values = values
         self.createTime = createTime
         self.lastAccessTime = lastAccessTime
         self.relativePath = relativePath
         self.parameters = parameters
         self.privileges = privileges
+        self.id = id
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -6707,6 +6742,11 @@ class PartitionWithoutSD(object):
                     self.privileges.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.I64:
+                    self.id = iprot.readI64()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -6747,6 +6787,10 @@ class PartitionWithoutSD(object):
         if self.privileges is not None:
             oprot.writeFieldBegin('privileges', TType.STRUCT, 6)
             self.privileges.write(oprot)
+            oprot.writeFieldEnd()
+        if self.id is not None:
+            oprot.writeFieldBegin('id', TType.I64, 7)
+            oprot.writeI64(self.id)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -27106,6 +27150,7 @@ Catalog.thrift_spec = (
     (2, TType.STRING, 'description', 'UTF8', None, ),  # 2
     (3, TType.STRING, 'locationUri', 'UTF8', None, ),  # 3
     (4, TType.I32, 'createTime', None, None, ),  # 4
+    (5, TType.I64, 'id', None, None, ),  # 5
 )
 all_structs.append(CreateCatalogRequest)
 CreateCatalogRequest.thrift_spec = (
@@ -27151,6 +27196,7 @@ Database.thrift_spec = (
     (8, TType.STRING, 'catalogName', 'UTF8', None, ),  # 8
     (9, TType.I32, 'createTime', None, None, ),  # 9
     (10, TType.STRING, 'managedLocationUri', 'UTF8', None, ),  # 10
+    (11, TType.I64, 'id', None, None, ),  # 11
 )
 all_structs.append(SerDeInfo)
 SerDeInfo.thrift_spec = (
@@ -27370,6 +27416,7 @@ Partition.thrift_spec = (
     (10, TType.I64, 'writeId', None, -1, ),  # 10
     (11, TType.BOOL, 'isStatsCompliant', None, None, ),  # 11
     (12, TType.STRUCT, 'colStats', [ColumnStatistics, None], None, ),  # 12
+    (13, TType.I64, 'id', None, None, ),  # 13
 )
 all_structs.append(PartitionWithoutSD)
 PartitionWithoutSD.thrift_spec = (
@@ -27380,6 +27427,7 @@ PartitionWithoutSD.thrift_spec = (
     (4, TType.STRING, 'relativePath', 'UTF8', None, ),  # 4
     (5, TType.MAP, 'parameters', (TType.STRING, 'UTF8', TType.STRING, 'UTF8', False), None, ),  # 5
     (6, TType.STRUCT, 'privileges', [PrincipalPrivilegeSet, None], None, ),  # 6
+    (7, TType.I64, 'id', None, None, ),  # 7
 )
 all_structs.append(PartitionSpecWithSharedSD)
 PartitionSpecWithSharedSD.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -1482,12 +1482,14 @@ class Catalog
   DESCRIPTION = 2
   LOCATIONURI = 3
   CREATETIME = 4
+  ID = 5
 
   FIELDS = {
     NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
     DESCRIPTION => {:type => ::Thrift::Types::STRING, :name => 'description', :optional => true},
     LOCATIONURI => {:type => ::Thrift::Types::STRING, :name => 'locationUri'},
-    CREATETIME => {:type => ::Thrift::Types::I32, :name => 'createTime', :optional => true}
+    CREATETIME => {:type => ::Thrift::Types::I32, :name => 'createTime', :optional => true},
+    ID => {:type => ::Thrift::Types::I64, :name => 'id', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -1608,6 +1610,7 @@ class Database
   CATALOGNAME = 8
   CREATETIME = 9
   MANAGEDLOCATIONURI = 10
+  ID = 11
 
   FIELDS = {
     NAME => {:type => ::Thrift::Types::STRING, :name => 'name'},
@@ -1619,7 +1622,8 @@ class Database
     OWNERTYPE => {:type => ::Thrift::Types::I32, :name => 'ownerType', :optional => true, :enum_class => ::PrincipalType},
     CATALOGNAME => {:type => ::Thrift::Types::STRING, :name => 'catalogName', :optional => true},
     CREATETIME => {:type => ::Thrift::Types::I32, :name => 'createTime', :optional => true},
-    MANAGEDLOCATIONURI => {:type => ::Thrift::Types::STRING, :name => 'managedLocationUri', :optional => true}
+    MANAGEDLOCATIONURI => {:type => ::Thrift::Types::STRING, :name => 'managedLocationUri', :optional => true},
+    ID => {:type => ::Thrift::Types::I64, :name => 'id', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -2254,6 +2258,7 @@ class Partition
   WRITEID = 10
   ISSTATSCOMPLIANT = 11
   COLSTATS = 12
+  ID = 13
 
   FIELDS = {
     VALUES => {:type => ::Thrift::Types::LIST, :name => 'values', :element => {:type => ::Thrift::Types::STRING}},
@@ -2267,7 +2272,8 @@ class Partition
     CATNAME => {:type => ::Thrift::Types::STRING, :name => 'catName', :optional => true},
     WRITEID => {:type => ::Thrift::Types::I64, :name => 'writeId', :default => -1, :optional => true},
     ISSTATSCOMPLIANT => {:type => ::Thrift::Types::BOOL, :name => 'isStatsCompliant', :optional => true},
-    COLSTATS => {:type => ::Thrift::Types::STRUCT, :name => 'colStats', :class => ::ColumnStatistics, :optional => true}
+    COLSTATS => {:type => ::Thrift::Types::STRUCT, :name => 'colStats', :class => ::ColumnStatistics, :optional => true},
+    ID => {:type => ::Thrift::Types::I64, :name => 'id', :optional => true}
   }
 
   def struct_fields; FIELDS; end
@@ -2286,6 +2292,7 @@ class PartitionWithoutSD
   RELATIVEPATH = 4
   PARAMETERS = 5
   PRIVILEGES = 6
+  ID = 7
 
   FIELDS = {
     VALUES => {:type => ::Thrift::Types::LIST, :name => 'values', :element => {:type => ::Thrift::Types::STRING}},
@@ -2293,7 +2300,8 @@ class PartitionWithoutSD
     LASTACCESSTIME => {:type => ::Thrift::Types::I32, :name => 'lastAccessTime'},
     RELATIVEPATH => {:type => ::Thrift::Types::STRING, :name => 'relativePath'},
     PARAMETERS => {:type => ::Thrift::Types::MAP, :name => 'parameters', :key => {:type => ::Thrift::Types::STRING}, :value => {:type => ::Thrift::Types::STRING}},
-    PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true}
+    PRIVILEGES => {:type => ::Thrift::Types::STRUCT, :name => 'privileges', :class => ::PrincipalPrivilegeSet, :optional => true},
+    ID => {:type => ::Thrift::Types::I64, :name => 'id', :optional => true}
   }
 
   def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/partition/spec/PartitionSpecWithSharedSDProxy.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/partition/spec/PartitionSpecWithSharedSDProxy.java
@@ -143,6 +143,7 @@ public class PartitionSpecWithSharedSDProxy extends PartitionSpecProxy {
           partSD,
           partWithoutSD.getParameters()
       );
+      p.setId(partWithoutSD.getId());
       p.setCatName(partitionSpecWithSharedSDProxy.partitionSpec.getCatName());
       return p;
     }

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -357,7 +357,8 @@ struct Catalog {
   3: string locationUri,              // default storage location.  When databases are created in
                                       // this catalog, if they do not specify a location, they will
                                       // be placed in this location.
-  4: optional i32 createTime          // creation time of catalog in seconds since epoch
+  4: optional i32 createTime,          // creation time of catalog in seconds since epoch
+  5: optional i64 id // unique identifier of this catalog
 }
 
 struct CreateCatalogRequest {
@@ -395,8 +396,9 @@ struct Database {
   6: optional string ownerName,
   7: optional PrincipalType ownerType,
   8: optional string catalogName,
-  9: optional i32 createTime               // creation time of database in seconds since epoch
-  10: optional string managedLocationUri // directory for managed tables
+  9: optional i32 createTime,               // creation time of database in seconds since epoch
+  10: optional string managedLocationUri, // directory for managed tables
+  11: optional i64 id // unique identifier of this database
 }
 
 // This object holds the information needed by SerDes
@@ -601,7 +603,8 @@ struct Partition {
   9: optional string catName,
   10: optional i64 writeId=-1,
   11: optional bool isStatsCompliant,
-  12: optional ColumnStatistics colStats // column statistics for partition
+  12: optional ColumnStatistics colStats, // column statistics for partition
+  13: optional i64 id // unique identifier of this partition object
 }
 
 struct PartitionWithoutSD {
@@ -611,6 +614,7 @@ struct PartitionWithoutSD {
   4: string       relativePath,
   5: map<string, string> parameters,
   6: optional PrincipalPrivilegeSet privileges
+  7: optional i64 id
 }
 
 struct PartitionSpecWithSharedSD {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -417,6 +417,7 @@ class MetaStoreDirectSql {
         }
       }
       Database db = new Database();
+      db.setId(dbid);
       db.setName(MetastoreDirectSqlUtils.extractSqlString(dbline[1]));
       db.setLocationUri(MetastoreDirectSqlUtils.extractSqlString(dbline[2]));
       db.setDescription(MetastoreDirectSqlUtils.extractSqlString(dbline[3]));
@@ -979,6 +980,7 @@ class MetaStoreDirectSql {
       part.setCatName(catName);
       part.setDbName(dbName);
       part.setTableName(tblName);
+      part.setId(partitionId);
       if (fields[4] != null) {
         part.setCreateTime(MetastoreDirectSqlUtils.extractSqlInt(fields[4]));
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -721,14 +721,14 @@ class MetaStoreDirectSql {
       case BY_EXPR:
         partitionIds =
             getPartitionIdsViaSqlFilter(catName, dbName, tblName, filter.filter, filter.params,
-                filter.joins, null);
+                filter.joins, -1);
         break;
       case BY_NAMES:
         String partNamesFilter =
             "" + PARTITIONS + ".\"PART_NAME\" in (" + makeParams(filterSpec.getFilters().size())
                 + ")";
         partitionIds = getPartitionIdsViaSqlFilter(catName, dbName, tblName, partNamesFilter,
-            filterSpec.getFilters(), Collections.EMPTY_LIST, null);
+            filterSpec.getFilters(), Collections.EMPTY_LIST, -1);
         break;
       case BY_VALUES:
         // we are going to use the SQL regex pattern in the LIKE clause below. So the default string
@@ -738,7 +738,7 @@ class MetaStoreDirectSql {
             "" + PARTITIONS + ".\"PART_NAME\" LIKE (?)";
         partitionIds =
             getPartitionIdsViaSqlFilter(catName, dbName, tblName, partNamesLikeFilter, Arrays.asList(partNameMatcher),
-                Collections.EMPTY_LIST, null);
+                Collections.EMPTY_LIST, -1);
         break;
         default:
           throw new MetaException("Unsupported filter mode " + filterSpec.getFilterMode());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -759,6 +759,7 @@ public class ObjectStore implements RawStore, Configurable {
       cat.setDescription(mCat.getDescription());
     }
     cat.setCreateTime(mCat.getCreateTime());
+    cat.setId(mCat.getId());
     return cat;
   }
 
@@ -863,6 +864,7 @@ public class ObjectStore implements RawStore, Configurable {
       }
     }
     Database db = new Database();
+    db.setId(mdb.getId());
     db.setName(mdb.getName());
     db.setDescription(mdb.getDescription());
     db.setLocationUri(mdb.getLocationUri());
@@ -2651,7 +2653,7 @@ public class ObjectStore implements RawStore, Configurable {
     return new MPartition(Warehouse.makePartName(convertToFieldSchemas(mt
         .getPartitionKeys()), part.getValues()), mt, part.getValues(), part
         .getCreateTime(), part.getLastAccessTime(),
-        msd, part.getParameters());
+        msd, part.getParameters(), part.getId());
   }
 
   private Partition convertToPart(MPartition mpart, boolean isAcidTable) throws MetaException {
@@ -2670,6 +2672,7 @@ public class ObjectStore implements RawStore, Configurable {
         mpart.getLastAccessTime(), convertToStorageDescriptor(mpart.getSd(), false, isAcidTable),
         params);
     p.setCatName(catName);
+    p.setId(mpart.getId());
     if(mpart.getWriteId()>0) {
       p.setWriteId(mpart.getWriteId());
     }else {
@@ -2688,6 +2691,7 @@ public class ObjectStore implements RawStore, Configurable {
     Partition p = new Partition(convertList(mpart.getValues()), dbName, tblName,
         mpart.getCreateTime(), mpart.getLastAccessTime(),
         convertToStorageDescriptor(mpart.getSd(), false, isAcidTable), params);
+    p.setId(mpart.getId());
     p.setCatName(catName);
     if(mpart.getWriteId()>0) {
       p.setWriteId(mpart.getWriteId());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2467,6 +2467,9 @@ public class ObjectStore implements RawStore, Configurable {
       }
 
       commited = commitTransaction();
+      // certain APIs like append_partition return back this partition object to the
+      // client. Since we added a partition here, its partition id should be set.
+      part.setId(mpart.getId());
       success = true;
     } finally {
       if (!commited) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/cache/CachedStore.java
@@ -1180,6 +1180,9 @@ public class CachedStore implements RawStore, Configurable {
     rawStore.createCatalog(cat);
     // in case of event based cache update, cache will not be updated for catalog.
     if (!canUseEvents) {
+      // TODO HIVE-24732 in case of CachedStore we cache directly the object send by the
+      //  client. This is problematic since certain fields of the object are populated
+      // after it is persisted. The cache will not be able to serve those fields correctly.
       sharedCache.addCatalogToCache(cat);
     }
   }
@@ -1226,6 +1229,9 @@ public class CachedStore implements RawStore, Configurable {
     rawStore.createDatabase(db);
     // in case of event based cache update, cache will be updated during commit.
     if (!canUseEvents) {
+      // TODO HIVE-24732 in case of CachedStore we cache directly the object send by the
+      // client. This is problematic since certain fields of the object are populated
+      // after it is persisted. The cache will not be able to serve those fields correctly.
       sharedCache.addDatabaseToCache(db);
     }
   }
@@ -1324,6 +1330,9 @@ public class CachedStore implements RawStore, Configurable {
       return;
     }
     validateTableType(tbl);
+    // TODO HIVE-24732 in case of CachedStore we cache directly the object send by the
+    //  client. This is problematic since certain fields of the object are populated
+    // after it is persisted. The cache will not be able to serve those fields correctly.
     sharedCache.addTableToCache(catName, dbName, tblName, tbl);
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MCatalog.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MCatalog.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hive.metastore.model;
 
 public class MCatalog {
+  private long id;
   private String name;
   private String description;
   private String locationUri;
@@ -27,7 +28,8 @@ public class MCatalog {
 
   }
 
-  public MCatalog(String name, String description, String locationUri) {
+  public MCatalog(String name, String description, String locationUri, long id) {
+    this.id = id;
     this.name = name;
     this.description = description;
     this.locationUri = locationUri;
@@ -63,5 +65,13 @@ public class MCatalog {
 
   public void setCreateTime(int createTime) {
     this.createTime = createTime;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getId() {
+    return id;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MDatabase.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MDatabase.java
@@ -33,6 +33,7 @@ import java.util.Set;
  *
  */
 public class MDatabase {
+  private long id;
   private String name;
   private String locationUri;
   private String managedLocationUri;
@@ -57,12 +58,13 @@ public class MDatabase {
    * @param parameters Parameters for the database
    */
   public MDatabase(String catalogName, String name, String locationUri, String description,
-      Map<String, String> parameters) {
-    this(catalogName, name, locationUri, description, parameters, null);
+      Map<String, String> parameters, long id) {
+    this(catalogName, name, locationUri, description, parameters, null, id);
   }
 
   /**
    * To create a database object
+   * @param id The id of the database object
    * @param catalogName Name of the catalog, the database belongs to.
    * @param name of the database
    * @param locationUri Default external Location of the database
@@ -70,8 +72,9 @@ public class MDatabase {
    * @param parameters Parameters for the database
    * @param managedLocationUri Default location for managed tables in database in the warehouse
    */
-  public MDatabase(String catalogName, String name, String locationUri, String description,
-      Map<String, String> parameters, String managedLocationUri) {
+  public MDatabase(String catalogName, String name, String locationUri,
+      String description, Map<String, String> parameters, String managedLocationUri, long id) {
+    this.id = id;
     this.name = name;
     this.locationUri = locationUri;
     this.managedLocationUri = managedLocationUri;
@@ -194,5 +197,13 @@ public class MDatabase {
 
   public void setCreateTime(int createTime) {
     this.createTime = createTime;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getId() {
+    return id;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartition.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartition.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 public class MPartition {
 
+  private long id;
   private String partitionName; // partitionname ==>  (key=value/)*(key=value)
   private MTable table; 
   private List<String> values;
@@ -44,7 +45,8 @@ public class MPartition {
    * @param parameters
    */
   public MPartition(String partitionName, MTable table, List<String> values, int createTime,
-      int lastAccessTime, MStorageDescriptor sd, Map<String, String> parameters) {
+      int lastAccessTime, MStorageDescriptor sd, Map<String, String> parameters, long id) {
+    this.id = id;
     this.partitionName = partitionName;
     this.table = table;
     this.values = values;
@@ -158,5 +160,13 @@ public class MPartition {
 
   public void setWriteId(long writeId) {
     this.writeId = writeId;
+  }
+
+  public void setId(long id) {
+    this.id = id;
+  }
+
+  public long getId() {
+    return id;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreServerUtils.java
@@ -1090,6 +1090,7 @@ public class MetaStoreServerUtils {
               (isUnsetKey || !partition.getSd().isSetLocation()) ? null : partition.getSd()
                   .getLocation().substring(tablePath.length()));
           partitionWithoutSD.setParameters(partition.getParameters());
+          partitionWithoutSD.setId(partition.getId());
 
           if (!sdToPartList.containsKey(key)) {
             sdToPartList.put(key, new ArrayList<>());

--- a/standalone-metastore/metastore-server/src/main/resources/package.jdo
+++ b/standalone-metastore/metastore-server/src/main/resources/package.jdo
@@ -27,10 +27,10 @@
 -->
 <jdo>
   <package name="org.apache.hadoop.hive.metastore.model">
-    <class name="MDatabase" identity-type="datastore" table="DBS" detachable="true">  
-      <datastore-identity>
-        <column name="DB_ID"/>
-      </datastore-identity>
+    <class name="MDatabase" identity-type="application" table="DBS" detachable="true">
+      <field name="id" primary-key="true" value-strategy="native">
+        <column name="DB_ID" jdbc-type="BIGINT" />
+      </field>
       <index name="UniqueDatabase" unique="true">
         <column name="NAME"/>
         <column name="CTLG_NAME"/>
@@ -75,10 +75,10 @@
 
     </class>
 
-    <class name="MCatalog" identity-type="datastore" table="CTLGS" detachable="true">
-      <datastore-identity>
-        <column name="CTLG_ID"/>
-      </datastore-identity>
+    <class name="MCatalog" identity-type="application" table="CTLGS" detachable="true">
+      <field name="id" primary-key="true" value-strategy="native">
+        <column name="CTLG_ID" jdbc-type="BIGINT" />
+      </field>
       <field name="name">
         <column name="NAME" length="256" jdbc-type="VARCHAR"/>
         <index name="UniqueCatalog" unique="true"/>
@@ -468,14 +468,14 @@
       </field>
     </class>
 
-    <class name="MPartition" table="PARTITIONS" identity-type="datastore" detachable="true">
+    <class name="MPartition" table="PARTITIONS" identity-type="application" detachable="true">
+      <field name="id" primary-key="true" value-strategy="native">
+        <column name="PART_ID" jdbc-type="BIGINT" />
+      </field>
       <index name="UniquePartition" unique="true">
         <column name="PART_NAME"/>
         <column name="TBL_ID"/>
       </index>
-      <datastore-identity>
-        <column name="PART_ID"/>
-      </datastore-identity>
       <field name="partitionName">
         <column name="PART_NAME" length="767" jdbc-type="VARCHAR"/>
       </field>

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/MetaStoreTestUtils.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hive.common.ZooKeeperHiveHelper;
+import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
 import org.apache.hadoop.hive.metastore.events.EventCleanerTask;
@@ -44,6 +45,7 @@ import org.apache.hadoop.hive.metastore.security.HadoopThriftAuthBridge;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreServerUtils;
 import org.apache.thrift.TException;
+import org.junit.Assert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -383,6 +385,37 @@ public class MetaStoreTestUtils {
         client.dropDatabase(catName, db, true, false, true);
       }
       client.dropCatalog(catName);
+    }
+  }
+
+
+  /**
+   * Util method to compare two partition objects except for their ids.
+   */
+  public static void comparePartitionIgnoreId(Partition expected, Partition actual) {
+    Partition expectedCopy = expected.deepCopy();
+    Partition actualCopy = actual.deepCopy();
+    expectedCopy.unsetId();
+    actualCopy.unsetId();
+    Assert.assertEquals(expectedCopy, actualCopy);
+  }
+
+  /**
+   * Util method to compare two partition objects except for their ids with a error message.
+   */
+  public static void comparePartitionIgnoreId(String msg, Partition expected, Partition actual) {
+    Partition expectedCopy = expected.deepCopy();
+    Partition actualCopy = actual.deepCopy();
+    expectedCopy.unsetId();
+    actualCopy.unsetId();
+    Assert.assertEquals(msg, expectedCopy, actualCopy);
+  }
+
+  public static void comparePartitionsIgnoreId(String msg, List<Partition> expected,
+      List<Partition> actual) {
+    Assert.assertEquals(msg, expected.size(), actual.size());
+    for (int i=0; i<expected.size(); i++) {
+      comparePartitionIgnoreId(msg, expected.get(i), actual.get(i));
     }
   }
 }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestGetPartitionsUsingProjectionAndFilterSpecs.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hive.metastore;
 
+import java.util.Comparator;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
@@ -774,6 +775,12 @@ public class TestGetPartitionsUsingProjectionAndFilterSpecs {
       Assert.assertNotNull(partitionSpecWithSharedSD);
       Assert.assertEquals("Invalid number of partitions returned", expectedPartitions,
           partitionSpecWithSharedSD.getPartitionsSize());
+      // in case of listPartitions, the partitions are not sorted by name and hence
+      // the order it non-determistic. To reduce flakiness we sort the partitions by
+      // locations before comparing.
+      Collections.sort(partitions, Comparator.comparing(o -> o.getSd().getLocation()));
+      Collections.sort(partitionSpecWithSharedSD.getPartitions(),
+          Comparator.comparing(o -> o.getRelativePath()));
       verifyLocations(partitions, partitionSpecWithSharedSD.getSd(),
           partitionSpecWithSharedSD.getPartitions());
     } else {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -269,8 +269,10 @@ public abstract class TestHiveMetaStore {
       assertNotNull("Unable to create partition " + part3, retp3);
       Partition retp4 = client.add_partition(part4);
       assertNotNull("Unable to create partition " + part4, retp4);
+      assertTrue(retp.getId() > 0);
 
       Partition part_get = client.getPartition(dbName, tblName, part.getValues());
+      assertTrue(part_get.getId() > 0);
       // since we are using thrift, 'part' will not have the create time and
       // last DDL time set since it does not get updated in the add_partition()
       // call - likewise part2 and part3 - set it correctly so that equals check
@@ -295,6 +297,7 @@ public abstract class TestHiveMetaStore {
           LOG.info("Found partition " + p + " having null field schema");
           foundPart = true;
         }
+        assertTrue(p.getId() > 0);
       }
       assertTrue(foundPart);
 
@@ -317,7 +320,9 @@ public abstract class TestHiveMetaStore {
           (short) -1);
       assertTrue("Should have returned 2 partitions", partial.size() == 2);
       assertTrue("Not all parts returned", partial.containsAll(parts));
-
+      for (Partition p : partial) {
+        assertTrue(p.getId() > 0);
+      }
       Set<String> partNames = new HashSet<>();
       partNames.add(partName);
       partNames.add(part2Name);
@@ -378,6 +383,7 @@ public abstract class TestHiveMetaStore {
       assertTrue("Append partition by name failed", part5.getValues().equals(vals));
       Path part5Path = new Path(part5.getSd().getLocation());
       assertTrue(fs.exists(part5Path));
+      assertTrue(part5.getId() > 0);
 
       // Test drop_partition_by_name
       assertTrue("Drop partition by name failed",
@@ -591,6 +597,9 @@ public abstract class TestHiveMetaStore {
     // Requesting less partitions than allowed should work
     maxParts = DEFAULT_LIMIT_PARTITION_REQUEST / 2;
     partitions = client.listPartitions(dbName, tblName, maxParts);
+    for (Partition p : partitions) {
+      assertTrue(p.getId() > 0);
+    }
     assertNotNull("should have returned partitions", partitions);
     assertEquals(" should have returned 50 partitions", maxParts, partitions.size());
   }
@@ -753,6 +762,7 @@ public abstract class TestHiveMetaStore {
           returnedPartitionWithoutSD.isSetCreateTime());
       Assert.assertTrue("Partition parameters were requested but are not set",
           returnedPartitionWithoutSD.isSetParameters());
+      assertTrue(returnedPartitionWithoutSD.isSetId());
       // first partition has parameters set
       if (i == 0) {
         Assert.assertTrue("partition parameters not set",
@@ -990,6 +1000,7 @@ public abstract class TestHiveMetaStore {
           .getParameters().get("abc"), "1");
       assertEquals("couldn't alter partition", part3.getSd().getNumBuckets(),
           12);
+      assertTrue(part3.isSetId());
 
       client.dropTable(dbName, tblName);
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListener.java
@@ -127,7 +127,7 @@ public class TestMetaStoreEventListener {
   }
 
   private void validateAddPartition(Partition expectedPartition, Partition actualPartition) {
-    assertEquals(expectedPartition, actualPartition);
+    MetaStoreTestUtils.comparePartitionIgnoreId(expectedPartition, actualPartition);
   }
 
   private void validateTableInAddPartition(Table expectedTable, Table actualTable) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/cache/TestCachedStore.java
@@ -413,6 +413,9 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
     localDb1 = cachedStore.getDatabase(DEFAULT_CATALOG_NAME, dbName1);
     // Read db via ObjectStore
     dbRead = objectStore.getDatabase(DEFAULT_CATALOG_NAME, dbName1);
+    // cachedStore doesn't expose the fields which are set by the backing db.
+    // we unset the id so that comparison ignores it.
+    dbRead.unsetId();
     Assert.assertEquals(localDb1, dbRead);
     allDatabases = cachedStore.getAllDatabases(DEFAULT_CATALOG_NAME);
     Assert.assertEquals(4, allDatabases.size());
@@ -457,6 +460,9 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
     localDb1 = cachedStore.getDatabase(DEFAULT_CATALOG_NAME, dbName1);
     // Read db via ObjectStore
     dbRead = objectStore.getDatabase(DEFAULT_CATALOG_NAME, dbName1);
+    // cachedStore doesn't expose the fields which are set by the backing db.
+    // we unset the id so that comparison ignores it.
+    dbRead.unsetId();
     Assert.assertEquals(localDb1, dbRead);
     allDatabases = cachedStore.getAllDatabases(DEFAULT_CATALOG_NAME);
     Assert.assertEquals(3, allDatabases.size());
@@ -492,6 +498,9 @@ import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
     db = cachedStore.getDatabase(DEFAULT_CATALOG_NAME, dbName);
     // Read db via ObjectStore
     Database dbRead = objectStore.getDatabase(DEFAULT_CATALOG_NAME, dbName);
+    // cachedStore doesn't expose the fields which are set by the backing db.
+    // we unset the id so that comparison ignores it.
+    dbRead.unsetId();
     Assert.assertEquals(db, dbRead);
     // Alter db via ObjectStore
     dbOwner = "user3";

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAppendPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAppendPartitions.java
@@ -150,7 +150,7 @@ public class TestAppendPartitions extends MetaStoreClientTest {
         client.getPartition(table.getDbName(), table.getTableName(), partitionValues);
     appendedPart.setWriteId(partition.getWriteId());
     partition.setWriteIdIsSet(true);
-    Assert.assertEquals(partition, appendedPart);
+    MetaStoreTestUtils.comparePartitionIgnoreId(partition, appendedPart);
     verifyPartition(partition, table, partitionValues, "year=2017/month=may");
     verifyPartitionNames(table, Lists.newArrayList("year=2017/month=march", "year=2017/month=april",
         "year=2018/month=march", "year=2017/month=may"));
@@ -170,7 +170,7 @@ public class TestAppendPartitions extends MetaStoreClientTest {
         client.getPartition(table.getDbName(), table.getTableName(), partitionValues);
     appendedPart.setWriteId(partition.getWriteId());
     partition.setWriteIdIsSet(true);
-    Assert.assertEquals(partition, appendedPart);
+    MetaStoreTestUtils.comparePartitionIgnoreId(partition, appendedPart);
     verifyPartition(partition, table, partitionValues, "year=2017/month=may");
     verifyPartitionNames(table, Lists.newArrayList("year=2017/month=may"));
   }
@@ -326,7 +326,7 @@ public class TestAppendPartitions extends MetaStoreClientTest {
         getPartitionValues(partitionName));
     appendedPart.setWriteId(partition.getWriteId());
     partition.setWriteIdIsSet(true);
-    Assert.assertEquals(partition, appendedPart);
+    MetaStoreTestUtils.comparePartitionIgnoreId(partition, appendedPart);
     verifyPartition(partition, table, getPartitionValues(partitionName), partitionName);
     verifyPartitionNames(table, Lists.newArrayList("year=2017/month=march", "year=2017/month=april",
         "year=2018/month=march", partitionName));
@@ -346,7 +346,7 @@ public class TestAppendPartitions extends MetaStoreClientTest {
         getPartitionValues(partitionName));
     appendedPart.setWriteId(partition.getWriteId());
     partition.setWriteIdIsSet(true);
-    Assert.assertEquals(partition, appendedPart);
+    MetaStoreTestUtils.comparePartitionIgnoreId(partition, appendedPart);
     verifyPartition(partition, table, getPartitionValues(partitionName), partitionName);
     verifyPartitionNames(table, Lists.newArrayList(partitionName));
   }
@@ -512,7 +512,7 @@ public class TestAppendPartitions extends MetaStoreClientTest {
     Partition fetched =
         client.getPartition(catName, dbName, tableName, Collections.singletonList("a1"));
     created.setWriteId(fetched.getWriteId());
-    Assert.assertEquals(created, fetched);
+    MetaStoreTestUtils.comparePartitionIgnoreId(created, fetched);
 
     created = client.appendPartition(catName, dbName, tableName, "partcol=a2");
     Assert.assertEquals(1, created.getValuesSize());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCatalogs.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestCatalogs.java
@@ -168,6 +168,7 @@ public class TestCatalogs extends MetaStoreClientTest {
     fetchedNewCat = client.getCatalog(catNames[1]);
     Assert.assertEquals(location[1], fetchedNewCat.getLocationUri());
     Assert.assertEquals(newDescription, fetchedNewCat.getDescription());
+    Assert.assertTrue(fetchedNewCat.getId() > 0);
 
     for (int i = 0; i < catNames.length; i++) {
       client.dropCatalog(catNames[i]);

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -127,6 +127,9 @@ public class TestDatabases extends MetaStoreClientTest {
 
     // The createTime will be set on the server side, so the comparison should skip it
     database.setCreateTime(createdDatabase.getCreateTime());
+    Assert.assertTrue(createdDatabase.getId() > 0);
+    // unset id to compare
+    createdDatabase.unsetId();
     Assert.assertEquals("Comparing databases", database, createdDatabase);
     Assert.assertTrue("The directory should be created", metaStore.isPathExists(
         new Path(database.getLocationUri())));
@@ -158,6 +161,7 @@ public class TestDatabases extends MetaStoreClientTest {
     Assert.assertEquals("Comparing owner name", SecurityUtils.getUser(),
         createdDatabase.getOwnerName());
     Assert.assertEquals("Comparing owner type", PrincipalType.USER, createdDatabase.getOwnerType());
+    Assert.assertTrue(createdDatabase.getId() > 0);
   }
 
   @Test
@@ -224,6 +228,7 @@ public class TestDatabases extends MetaStoreClientTest {
     Assert.assertNull("Default database privileges", database.getPrivileges());
     Assert.assertTrue("database create time should be set", database.isSetCreateTime());
     Assert.assertTrue("Database create time should be non-zero", database.getCreateTime() > 0);
+    Assert.assertTrue(database.getId() > 0);
   }
 
   @Test
@@ -477,6 +482,9 @@ public class TestDatabases extends MetaStoreClientTest {
 
     client.alterDatabase(originalDatabase.getName(), newDatabase);
     Database alteredDatabase = client.getDatabase(newDatabase.getName());
+    Assert.assertTrue(alteredDatabase.getId() > 0);
+    // unset id for comparison
+    alteredDatabase.unsetId();
     Assert.assertEquals("Comparing Databases", newDatabase, alteredDatabase);
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestExchangePartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestExchangePartitions.java
@@ -25,6 +25,7 @@ import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.Warehouse;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreCheckinTest;
@@ -1312,7 +1313,7 @@ public class TestExchangePartitions extends MetaStoreClientTest {
       partition.getSd().setLocation(resultPart.getSd().getLocation());
       partition.setDbName(destTable.getDbName());
       partition.setTableName(destTable.getTableName());
-      Assert.assertEquals(partition, resultPart);
+      MetaStoreTestUtils.comparePartitionIgnoreId(partition, resultPart);
     }
   }
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetPartitions.java
@@ -193,6 +193,13 @@ public class TestGetPartitions extends MetaStoreClientTest {
     assertEquals(Lists.newArrayList("1997", "05", "16"), partition.getValues());
   }
 
+  @Test
+  public void testPartitionId() throws Exception {
+    createTable3PartCols1Part(client);
+    Partition partition = client.getPartition(DB_NAME, TABLE_NAME, "yyyy=1997/mm=05/dd=16");
+    assertTrue(partition.getId() > 0);
+  }
+
   @Test(expected = NoSuchObjectException.class)
   public void testGetPartitionCaseSensitive() throws Exception {
     createTable3PartCols1Part(client);
@@ -372,6 +379,9 @@ public class TestGetPartitions extends MetaStoreClientTest {
     partitions = client.getPartitionsByNames(DB_NAME, TABLE_NAME,
         Lists.newArrayList("yyyy=2017", "yyyy=1999/mm=01/dd=02"));
     assertEquals(testValues.get(0), partitions.get(0).getValues());
+    for (Partition p : partitions) {
+      assertTrue(p.getId() > 0);
+    }
   }
 
   @Test
@@ -451,6 +461,7 @@ public class TestGetPartitions extends MetaStoreClientTest {
         "1997", "05", "16"), "", Lists.newArrayList());
     assertNotNull(partition);
     assertNull(partition.getPrivileges());
+    assertTrue(partition.getId() > 0);
   }
 
   @Test
@@ -460,6 +471,7 @@ public class TestGetPartitions extends MetaStoreClientTest {
         Lists.newArrayList("1997", "05", "16"), "user0", Lists.newArrayList("group0"));
     assertNotNull(partition);
     assertAuthInfoReturned("user0", "group0", partition);
+    assertTrue(partition.getId() > 0);
   }
 
   @Test
@@ -594,7 +606,10 @@ public class TestGetPartitions extends MetaStoreClientTest {
         Arrays.asList("partcol=a0", "partcol=a1"));
     Assert.assertEquals(2, fetchedParts.size());
     Set<String> vals = new HashSet<>(fetchedParts.size());
-    for (Partition part : fetchedParts) vals.add(part.getValues().get(0));
+    for (Partition part : fetchedParts) {
+      assertTrue(part.getId() > 0);
+      vals.add(part.getValues().get(0));
+    }
     Assert.assertTrue(vals.contains("a0"));
     Assert.assertTrue(vals.contains("a1"));
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestGetPartitions.java
@@ -191,13 +191,14 @@ public class TestGetPartitions extends MetaStoreClientTest {
     Partition partition = client.getPartition(DB_NAME, TABLE_NAME, "yyyy=1997/mm=05/dd=16");
     assertNotNull(partition);
     assertEquals(Lists.newArrayList("1997", "05", "16"), partition.getValues());
+    assertPartitionId(partition);
   }
 
   @Test
   public void testPartitionId() throws Exception {
     createTable3PartCols1Part(client);
     Partition partition = client.getPartition(DB_NAME, TABLE_NAME, "yyyy=1997/mm=05/dd=16");
-    assertTrue(partition.getId() > 0);
+    assertPartitionId(partition);
   }
 
   @Test(expected = NoSuchObjectException.class)
@@ -297,6 +298,7 @@ public class TestGetPartitions extends MetaStoreClientTest {
     Partition partition = client.getPartition(DB_NAME, TABLE_NAME, parts);
     assertNotNull(partition);
     assertEquals(parts, partition.getValues());
+    assertPartitionId(partition);
   }
 
   @Test(expected = NoSuchObjectException.class)
@@ -380,8 +382,12 @@ public class TestGetPartitions extends MetaStoreClientTest {
         Lists.newArrayList("yyyy=2017", "yyyy=1999/mm=01/dd=02"));
     assertEquals(testValues.get(0), partitions.get(0).getValues());
     for (Partition p : partitions) {
-      assertTrue(p.getId() > 0);
+      assertPartitionId(p);
     }
+  }
+
+  protected void assertPartitionId(Partition p) {
+    assertTrue(p.isSetId());
   }
 
   @Test
@@ -461,7 +467,7 @@ public class TestGetPartitions extends MetaStoreClientTest {
         "1997", "05", "16"), "", Lists.newArrayList());
     assertNotNull(partition);
     assertNull(partition.getPrivileges());
-    assertTrue(partition.getId() > 0);
+    assertPartitionId(partition);
   }
 
   @Test

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
@@ -249,9 +249,13 @@ public class TestListPartitions extends MetaStoreClientTest {
     assertEquals(testValues.size(), partitions.size());
 
     for (int i = 0; i < partitions.size(); ++i) {
-      assertTrue(partitions.get(i).getId() > 0);
+      assertPartitionId(partitions.get(i));
       assertEquals(testValues.get(i), partitions.get(i).getValues());
     }
+  }
+
+  protected void assertPartitionId(Partition p) {
+    assertTrue(p.isSetId());
   }
 
   private void assertCorrectPartitionValuesResponse(List<List<String>> testValues,

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestListPartitions.java
@@ -249,6 +249,7 @@ public class TestListPartitions extends MetaStoreClientTest {
     assertEquals(testValues.size(), partitions.size());
 
     for (int i = 0; i < partitions.size(); ++i) {
+      assertTrue(partitions.get(i).getId() > 0);
       assertEquals(testValues.get(i), partitions.get(i).getValues());
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
This changes exposes a id field to Database, Catalog and Partition thrift objects. The id was always present internally in the metastore but now we start exposing it in the thrift interface. This could be very useful to unique identify a table or database. For example, a database which is dropped and recreated with the same name, will have a different id. Id field is already present in the table objects. This PR adds them to Database, Partition and Catalogs as well.

### Why are the changes needed?
This is a enhancement which could be useful for clients who want to know if the object they have is same as the table which is present in the metastore. Currently, if another client drops and recreates the object with the same name, there is no way of the client to know the difference.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Modified existing tests which assert that id is present in the Database, Catalog and Partitions.
