### PR TITLE
HIVE-24710: Optimise PTF iteration for count(*) to reduce CPU and IO …

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/PTFPartition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/PTFPartition.java
@@ -125,6 +125,10 @@ public class PTFPartition {
     return new PItr(start, end);
   }
 
+  public PTFPartitionIterator<Object> range(int start, int end, boolean optimisedIteration) {
+    return (optimisedIteration) ? new OptimisedPItr(start, end) : range(start, end);
+  }
+
   public void close() {
     try {
       elems.close();
@@ -215,7 +219,31 @@ public class PTFPartition {
     public void reset() {
       idx = start;
     }
+
+    @Override
+    public long count() {
+      return (end - start);
+    }
   };
+
+  /**
+   * This can be used for functions with no parameters.
+   * next() function in this impl does not fetch anything from rowContainer, thus saving IO.
+   * It just increments the pointer to maintain iterator contract.
+   */
+  class OptimisedPItr extends PItr {
+
+    OptimisedPItr(int start, int end) {
+      super(start, end);
+    }
+
+    @Override
+    public Object next() {
+      checkForComodification();
+      idx++;
+      return null;
+    }
+  }
 
   /*
    * provide an Iterator on the rows in a Partition.
@@ -239,6 +267,8 @@ public class PTFPartition {
     PTFPartition getPartition();
 
     void reset() throws HiveException;
+
+    long count();
   }
 
   public static PTFPartition create(Configuration cfg,

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/PTFRollingPartition.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/PTFRollingPartition.java
@@ -186,5 +186,10 @@ public class PTFRollingPartition extends PTFPartition {
     public void reset() throws HiveException {
     }
 
+    @Override
+    public long count() {
+      throw new UnsupportedOperationException();
+    }
+
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24710

{noformat}
select x, y, count(*) over (partition by x order by y range between 86400 PRECEDING and CURRENT ROW) r0 from foo
{noformat}

When there are duplicates "y",  window frame becomes really large and internal implementation of PTFOperator ends up running for O(n^2) times. E.g in some queries, we had 2.5 M entries in the window and that caused it to run forever in single task.  Along with this, there is high amount of IO due to reading and discarding rows from RowContainers (note that we just need the count and nothing from materizlied row).

1. In such cases, there is no need to iterate over the rowcontainers often (internally it does O(n^2) operations taking forever when window frame is really large). This can be optimised to reduce CPU burn and IO.
2. BasePartitionEvaluator::calcFunctionValue need not materialize ROW when parameters are empty. This codepath can also be optimised.

### What changes were proposed in this pull request?
- For count(*), PR follows a fast path and just takes up the count of PTFPartitionIterator.
- When parameters are empty/null, it tries to run via optimised iterator which does not materialize anything in ROW. This helps in reducing IO cost. 

### How was this patch tested?
small internal cluster