### PR TITLE
HIVE-24730: Shims classes override values from hive-site.xml and tez-site.xml silently

### DIFF
--- a/data/conf/llap/tez-site.xml
+++ b/data/conf/llap/tez-site.xml
@@ -9,6 +9,22 @@
     <name>tez.am.resource.memory.mb</name>
     <value>128</value>
   </property>
+  <property>
+    <name>tez.task.resource.memory.mb</name>
+    <value>128</value>
+  </property>
+  <property>
+    <name>tez.runtime.io.sort.mb</name>
+    <value>24</value>
+  </property>
+  <property>
+    <name>tez.runtime.unordered.output.buffer.size-mb</name>
+    <value>10</value>
+  </property>
+  <property>
+    <name>tez.runtime.shuffle.fetch.buffer.percent</name>
+    <value>0.4</value>
+  </property>
 
   <!-- Fail fast during tests -->
   <property>

--- a/data/conf/tez/tez-site.xml
+++ b/data/conf/tez/tez-site.xml
@@ -4,6 +4,22 @@
     <value>128</value>
   </property>
   <property>
+    <name>tez.task.resource.memory.mb</name>
+    <value>128</value>
+  </property>
+  <property>
+    <name>tez.runtime.io.sort.mb</name>
+    <value>24</value>
+  </property>
+  <property>
+    <name>tez.runtime.unordered.output.buffer.size-mb</name>
+    <value>10</value>
+  </property>
+  <property>
+    <name>tez.runtime.shuffle.fetch.buffer.percent</name>
+    <value>0.4</value>
+  </property>
+  <property>
     <name>tez.am.dag.scheduler.class</name>
     <value>org.apache.tez.dag.app.dag.impl.DAGSchedulerNaturalOrderControlled</value>
   </property>

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/UtilsForTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/UtilsForTest.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hive;
 
+import java.io.File;
+import java.net.URL;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -55,6 +57,15 @@ public class UtilsForTest {
       String key = iter.next().getKey();
       hiveConf.set(key, hiveConf.get(key));
     }
+  }
+
+  public static HiveConf getHiveOnTezConfFromDir(String confDir) throws Exception {
+    HiveConf.setHiveSiteLocation(
+        new URL("file://" + new File(confDir).toURI().getPath() + "/hive-site.xml"));
+    HiveConf hiveConf = new HiveConf();
+    hiveConf
+        .addResource(new URL("file://" + new File(confDir).toURI().getPath() + "/tez-site.xml"));
+    return hiveConf;
   }
 
 }

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestBeeLineWithArgs.java
@@ -47,6 +47,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.UtilsForTest;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hive.jdbc.Utils;
@@ -89,7 +90,7 @@ import org.junit.Test;
    */
   @BeforeClass
   public static void preTests() throws Exception {
-    HiveConf hiveConf = new HiveConf();
+    HiveConf hiveConf = UtilsForTest.getHiveOnTezConfFromDir("../../data/conf/tez/");
     hiveConf.setVar(HiveConf.ConfVars.HIVE_LOCK_MANAGER,
         "org.apache.hadoop.hive.ql.lockmgr.EmbeddedLockManager");
     hiveConf.setBoolVar(HiveConf.ConfVars.HIVEOPTIMIZEMETADATAQUERIES, false);
@@ -908,6 +909,8 @@ import org.junit.Test;
     // Set to non-zk lock manager to avoid trying to connect to zookeeper
     final String SCRIPT_TEXT = "set hive.lock.manager=org.apache.hadoop.hive.ql.lockmgr.EmbeddedLockManager;\n"
         + "set hive.compute.query.using.stats=false;\n"
+        // Embedded BeeLine test does not work with tez engine, so reset it to mr - TODO: fix this in HIVE-25097
+        + "set hive.execution.engine=mr;"
         + "create table if not exists embeddedBeelineOutputs(d int);\n"
         + "set a=1;\nselect count(*) from embeddedBeelineOutputs;\n"
         + "drop table embeddedBeelineOutputs;\n";

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
@@ -34,6 +34,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.hadoop.hive.UtilsForTest;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.jdbc.miniHS2.MiniHS2;
 import org.junit.AfterClass;
@@ -49,7 +50,7 @@ public class TestHplSqlViaBeeLine {
    */
   @BeforeClass
   public static void preTests() throws Exception {
-    HiveConf hiveConf = new HiveConf();
+    HiveConf hiveConf = UtilsForTest.getHiveOnTezConfFromDir("../../data/conf/tez/");
     hiveConf.setVar(HiveConf.ConfVars.HIVE_LOCK_MANAGER,
             "org.apache.hadoop.hive.ql.lockmgr.EmbeddedLockManager");
     hiveConf.setIntVar(HiveConf.ConfVars.HIVE_SERVER2_THRIFT_RESULTSET_DEFAULT_FETCH_SIZE, 10);

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/TestHiveServer2Acid.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/miniHS2/TestHiveServer2Acid.java
@@ -18,6 +18,7 @@
 
 package org.apache.hive.jdbc.miniHS2;
 
+import org.apache.hadoop.hive.UtilsForTest;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
@@ -47,7 +48,7 @@ public class TestHiveServer2Acid {
 
   @BeforeClass
   public static void beforeTest() throws Exception {
-    HiveConf conf = new HiveConf();
+    HiveConf conf = UtilsForTest.getHiveOnTezConfFromDir("../../data/conf/tez/");
     TestTxnDbUtil.setConfValues(conf);
     TestTxnDbUtil.prepDb(conf);
     miniHS2 = new MiniHS2(conf, MiniHS2.MiniClusterType.TEZ);

--- a/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/service/cli/operation/TestOperationLoggingAPIWithTez.java
@@ -19,7 +19,7 @@ package org.apache.hive.service.cli.operation;
 
 import java.util.HashMap;
 
-import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.UtilsForTest;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hive.jdbc.miniHS2.MiniHS2;
 import org.apache.hive.jdbc.miniHS2.MiniHS2.MiniClusterType;
@@ -55,7 +55,7 @@ public class TestOperationLoggingAPIWithTez extends OperationLoggingAPITestBase 
       "TOTAL_LAUNCHED_TASKS",
       "CPU_MILLISECONDS"
     };
-    hiveConf = new HiveConf();
+    hiveConf = UtilsForTest.getHiveOnTezConfFromDir("../../data/conf/tez/");
     hiveConf.set(ConfVars.HIVE_SERVER2_LOGGING_OPERATION_LEVEL.varname, "verbose");
     // Set tez execution summary to false.
     hiveConf.setBoolVar(ConfVars.TEZ_EXEC_SUMMARY, false);

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -409,14 +409,7 @@ public class Hadoop23Shims extends HadoopShimsSecure {
       conf.setInt(YarnConfiguration.YARN_MINICLUSTER_NM_PMEM_MB, 512);
       conf.setInt(YarnConfiguration.RM_SCHEDULER_MINIMUM_ALLOCATION_MB, 128);
       conf.setInt(YarnConfiguration.RM_SCHEDULER_MAXIMUM_ALLOCATION_MB, 512);
-      // Overrides values from the hive/tez-site.
-      conf.setInt("hive.tez.container.size", 128);
-      conf.setInt(TezConfiguration.TEZ_AM_RESOURCE_MEMORY_MB, 128);
-      conf.setInt(TezConfiguration.TEZ_TASK_RESOURCE_MEMORY_MB, 128);
-      conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 24);
-      conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB, 10);
-      conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.4f);
-      conf.setInt(TezConfiguration.TEZ_COUNTERS_MAX, 1024);
+
       conf.set("fs.defaultFS", nameNode);
       conf.set("tez.am.log.level", "DEBUG");
       conf.set(MRJobConfig.MR_AM_STAGING_DIR, "/apps_staging_dir");
@@ -446,16 +439,9 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     @Override
     public void setupConfiguration(Configuration conf) {
       Configuration config = mr.getConfig();
-      for (Map.Entry<String, String> pair: config) {
+      for (Map.Entry<String, String> pair : config) {
         conf.set(pair.getKey(), pair.getValue());
       }
-      // Overrides values from the hive/tez-site.
-      conf.setInt("hive.tez.container.size", 128);
-      conf.setInt(TezConfiguration.TEZ_AM_RESOURCE_MEMORY_MB, 128);
-      conf.setInt(TezConfiguration.TEZ_TASK_RESOURCE_MEMORY_MB, 128);
-      conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_IO_SORT_MB, 24);
-      conf.setInt(TezRuntimeConfiguration.TEZ_RUNTIME_UNORDERED_OUTPUT_BUFFER_SIZE_MB, 10);
-      conf.setFloat(TezRuntimeConfiguration.TEZ_RUNTIME_SHUFFLE_FETCH_BUFFER_PERCENT, 0.4f);
       if (isLlap) {
         conf.set("hive.llap.execution.mode", "all");
       }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Prevent tez minicluster's settings to be overriden silently by hadoop shim.


### Why are the changes needed?
It confuses developer who changes values in data/conf/*/hive-site.xml and data/conf/*/tez-site.xml 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?

```
mvn clean test -Dtest.output.overwrite=true -Pitests -Denforcer.skip=true -pl itests/qtest -pl ./shims/0.23  -Dtest=TestMiniLlapCliDriver -Dqfile=varchar_join1.q
```

Checked logs, and it works as expected (./itests/qtest/target/tmp/log/hive.log)

1. original xmls, e.g. hive.tez.container.size=128 (same behavior as without the patch, but now shim doesn't override because there is an explicit value in the xml, which happens to be the same btw)

```
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims doesn't touch 'hive.tez.container.size' value 128
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims doesn't touch 'tez.am.resource.memory.mb' value 128
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.task.resource.memory.mb' from 1024 to 128
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.io.sort.mb' from 100 to 24
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.unordered.output.buffer.size-mb' from 100 to 10
2021-02-04T01:06:43,986  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.shuffle.fetch.buffer.percent' from 0.9 to 0.4

```

2. with an explicit setting below in data/conf/llap/hive-site.xml (shim will still not override 256)

```
<property>
  <name>hive.tez.container.size</name>
  <value>256</value>
  <description></description>
</property>

```

```
2021-02-04T01:09:26,219  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims doesn't touch 'hive.tez.container.size' value 256
2021-02-04T01:09:26,219  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims doesn't touch 'tez.am.resource.memory.mb' value 128
2021-02-04T01:09:26,219  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.task.resource.memory.mb' from 1024 to 128
2021-02-04T01:09:26,219  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.io.sort.mb' from 100 to 24
2021-02-04T01:09:26,219  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.unordered.output.buffer.size-mb' from 100 to 10
2021-02-04T01:09:26,220  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.shuffle.fetch.buffer.percent' from 0.9 to 0.4
```



3. if I remove hive.tez.container.size completely from data/conf/llap/hive-site.xml (makes it default)

```
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'hive.tez.container.size' from -1 to 128
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims doesn't touch 'tez.am.resource.memory.mb' value 128
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.task.resource.memory.mb' from 1024 to 128
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.io.sort.mb' from 100 to 24
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.unordered.output.buffer.size-mb' from 100 to 10
2021-02-04T01:10:28,428  INFO [main] shims.HadoopShimsSecure: Hadoop23Shims overrides 'tez.runtime.shuffle.fetch.buffer.percent' from 0.9 to 0.4
```
