### PR TITLE
HIVE-23036: [TEST] ORC PPD eval with sub-millisecond timestamps

### DIFF
--- a/ql/src/test/queries/clientpositive/orc_ppd_timestamp_precision.q
+++ b/ql/src/test/queries/clientpositive/orc_ppd_timestamp_precision.q
@@ -1,18 +1,30 @@
 SET hive.input.format=org.apache.hadoop.hive.ql.io.HiveInputFormat;
 
 create table tsstat (ts timestamp) stored as orc;
-insert into tsstat values ("1970-01-01 00:00:00.0005");
+insert into tsstat values ("1970-01-01 00:00:00.00005");
 
 SET hive.vectorized.execution.enabled=false;
 set hive.optimize.index.filter=false;
-select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+select * from tsstat where ts = "1970-01-01 00:00:00.00005";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050000";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050001";
 
 set hive.optimize.index.filter=true;
-select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+select * from tsstat where ts = "1970-01-01 00:00:00.00005";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050000";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050001";
 
 SET hive.vectorized.execution.enabled=true;
 set hive.optimize.index.filter=false;
-select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+select * from tsstat where ts = "1970-01-01 00:00:00.00005";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050000";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050001";
 
 set hive.optimize.index.filter=true;
-select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+select * from tsstat where ts = "1970-01-01 00:00:00.00005";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050000";
+select * from tsstat where ts = "1970-01-01 00:00:00.000050001";

--- a/ql/src/test/queries/clientpositive/orc_ppd_timestamp_precision.q
+++ b/ql/src/test/queries/clientpositive/orc_ppd_timestamp_precision.q
@@ -1,0 +1,18 @@
+SET hive.input.format=org.apache.hadoop.hive.ql.io.HiveInputFormat;
+
+create table tsstat (ts timestamp) stored as orc;
+insert into tsstat values ("1970-01-01 00:00:00.0005");
+
+SET hive.vectorized.execution.enabled=false;
+set hive.optimize.index.filter=false;
+select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+
+set hive.optimize.index.filter=true;
+select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+
+SET hive.vectorized.execution.enabled=true;
+set hive.optimize.index.filter=false;
+select * from tsstat where ts = "1970-01-01 00:00:00.0005";
+
+set hive.optimize.index.filter=true;
+select * from tsstat where ts = "1970-01-01 00:00:00.0005";

--- a/ql/src/test/results/clientpositive/llap/orc_ppd_timestamp_precision.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_ppd_timestamp_precision.q.out
@@ -6,48 +6,152 @@ POSTHOOK: query: create table tsstat (ts timestamp) stored as orc
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@tsstat
-PREHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.0005")
+PREHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.00005")
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@tsstat
-POSTHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.0005")
+POSTHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.00005")
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@tsstat
 POSTHOOK: Lineage: tsstat.ts SCRIPT []
-PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-1970-01-01 00:00:00.0005
-PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-1970-01-01 00:00:00.0005
-PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-1970-01-01 00:00:00.0005
-PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tsstat
 #### A masked pattern was here ####
-1970-01-01 00:00:00.0005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.00005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050000"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.00005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.000050001"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/orc_ppd_timestamp_precision.q.out
+++ b/ql/src/test/results/clientpositive/llap/orc_ppd_timestamp_precision.q.out
@@ -1,0 +1,53 @@
+PREHOOK: query: create table tsstat (ts timestamp) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tsstat
+POSTHOOK: query: create table tsstat (ts timestamp) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tsstat
+PREHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.0005")
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@tsstat
+POSTHOOK: query: insert into tsstat values ("1970-01-01 00:00:00.0005")
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@tsstat
+POSTHOOK: Lineage: tsstat.ts SCRIPT []
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.0005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.0005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.0005
+PREHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+POSTHOOK: query: select * from tsstat where ts = "1970-01-01 00:00:00.0005"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tsstat
+#### A masked pattern was here ####
+1970-01-01 00:00:00.0005


### PR DESCRIPTION
### What changes were proposed in this pull request?
Timestamp PPD Test with nanosecond precision


### Why are the changes needed?
Nanosecond precision timestamps where not supported prior to ORC-1.6 thus we need to add some tests

### Does this PR introduce _any_ user-facing change?
Np


### How was this patch tested?
orc_ppd_timestamp_precision.q
