### PR TITLE
HIVE-24416: Optimise HiveCharWritable::getStrippedValue

### DIFF
--- a/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/serde/HiveCharBench.java
+++ b/itests/hive-jmh/src/main/java/org/apache/hive/benchmark/serde/HiveCharBench.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hive.benchmark.serde;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.hive.serde2.io.HiveCharWritable;
+import org.apache.hadoop.io.Text;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+@State(Scope.Benchmark)
+public class HiveCharBench {
+
+  @BenchmarkMode(Mode.AverageTime)
+  @Fork(1)
+  @State(Scope.Thread)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public static class BaseBench {
+
+    private Text value;
+
+    @Setup
+    public void setup() throws Exception {
+      value = new Text("    asdfghjk    ");
+    }
+
+    @Benchmark
+    @Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+    public void testStrippedValueOld() {
+      for (int i = 0; i < 10000; i++) {
+        HiveChar hiveChar = new HiveChar(value.toString(), -1);
+        new Text(StringUtils.stripEnd(hiveChar.getValue(), " "));
+      }
+    }
+
+    @Benchmark
+    @Warmup(iterations = 2, time = 2, timeUnit = TimeUnit.SECONDS)
+    @Measurement(iterations = 10, time = 2, timeUnit = TimeUnit.SECONDS)
+    public void testStrippedValueNew() {
+      for (int j = 0; j < 10000; j++) {
+        byte[] input = value.getBytes();
+        int i = input.length;
+        while (i-- > 0 && (input[i] == 32 || input[i] == 0)) {
+        }
+        byte[] output = new byte[i + 1];
+        System.arraycopy(input, 0, output, 0, i + 1);
+        new Text(output);
+      }
+    }
+  }
+
+  public static void main(String[] args) throws RunnerException {
+    Options opt =
+        new OptionsBuilder().include(".*" + HiveCharBench.class.getSimpleName() + ".*").build();
+    new Runner(opt).run();
+  }
+}

--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/HiveCharWritable.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hive.serde2.io;
 
 import org.apache.hadoop.hive.common.type.HiveBaseChar;
 import org.apache.hadoop.hive.common.type.HiveChar;
-import org.apache.hadoop.hive.shims.ShimLoader;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hive.common.util.HiveStringUtils;
@@ -82,9 +81,7 @@ public class HiveCharWritable extends HiveBaseCharWritable
     if (value.charAt(value.getLength() - 1) != ' ') {
       return value;
     }
-    // A lot of these methods could be done more efficiently by operating on the Text value
-    // directly, rather than converting to HiveChar.
-    return new Text(getHiveChar().getStrippedValue());
+    return new Text(HiveCharWritable.stripTrailingWhitespace(value));
   }
 
   public Text getPaddedValue() {
@@ -120,5 +117,16 @@ public class HiveCharWritable extends HiveBaseCharWritable
   @Override
   public String toString() {
     return getPaddedValue().toString();
+  }
+
+  public static byte[] stripTrailingWhitespace(Text valueToStrip) {
+    byte[] input = valueToStrip.getBytes();
+    int i = input.length;
+    // iterate from end while we see space or 0x character
+    while (i-- > 0 && (input[i] == 32 || input[i] == 0)) {
+    }
+    byte[] output = new byte[i + 1];
+    System.arraycopy(input, 0, output, 0, i + 1);
+    return output;
   }
 }

--- a/serde/src/test/org/apache/hadoop/hive/serde2/io/TestHiveCharWritable.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/io/TestHiveCharWritable.java
@@ -24,6 +24,7 @@ import org.junit.*;
 
 import static org.junit.Assert.*;
 import org.apache.hadoop.hive.common.type.HiveChar;
+import org.apache.hadoop.io.Text;
 
 public class TestHiveCharWritable {
   @Rule public ConcurrentRule concurrentRule = new ConcurrentRule();
@@ -153,5 +154,48 @@ public class TestHiveCharWritable {
     assertFalse(hcw2.equals(hcw1));
     assertFalse(0 == hcw1.compareTo(hcw2));
     assertFalse(0 == hcw2.compareTo(hcw1));
+  }
+
+  @Test
+  public void testStrippedValue() {
+    // stripped end
+    HiveCharWritable hcw = new HiveCharWritable();
+    HiveChar hc = new HiveChar("abcd", 8);
+    hcw.set(hc);
+    assertEquals(4, hcw.getCharacterLength());
+    assertEquals("abcd    ", hcw.toString());
+    assertEquals(new Text("abcd    "), hcw.getTextValue());
+    assertEquals(new Text("abcd"), hcw.getStrippedValue());
+    assertEquals("abcd", hcw.getStrippedValue().toString());
+
+    // stripped end, untouched start
+    hcw = new HiveCharWritable();
+    hc = new HiveChar("  abcd  ", 8);
+    hcw.set(hc);
+    assertEquals(6, hcw.getCharacterLength()); //stripped 2 trailing whitespace
+    assertEquals("  abcd  ", hcw.toString());
+    assertEquals(new Text("  abcd  "), hcw.getTextValue());
+    assertEquals(new Text("  abcd"), hcw.getStrippedValue());
+    assertEquals("  abcd", hcw.getStrippedValue().toString());
+
+    // empty
+    hcw = new HiveCharWritable();
+    hc = new HiveChar("   ", 8);
+    hcw.set(hc);
+    assertEquals(0, hcw.getCharacterLength());
+    assertEquals("        ", hcw.toString());
+    assertEquals(new Text("        "), hcw.getTextValue());
+    assertEquals(new Text(""), hcw.getStrippedValue());
+    assertEquals("", hcw.getStrippedValue().toString());
+
+    // truncated
+    hcw = new HiveCharWritable();
+    hc = new HiveChar("abcdefghij", 8); // will be truncated to 8 chars
+    hcw.set(hc);
+    assertEquals(8, hcw.getCharacterLength()); // truncated
+    assertEquals("abcdefgh", hcw.toString());
+    assertEquals(new Text("abcdefgh"), hcw.getTextValue());
+    assertEquals(new Text("abcdefgh"), hcw.getStrippedValue());
+    assertEquals("abcdefgh", hcw.getStrippedValue().toString());
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Addressing a performance optimization in HiveCharWritable::getStrippedValue:
```
-    // A lot of these methods could be done more efficiently by operating on the Text value
-    // directly, rather than converting to HiveChar.
-    return new Text(getHiveChar().getStrippedValue());
```

### Why are the changes needed?
Performance.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
New unit tests are included.