### PR TITLE
HIVE-24748: The result of TimestampWritableV2.toString() is wrong whe…

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritableV2.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/io/TimestampWritableV2.java
@@ -374,16 +374,6 @@ public class TimestampWritableV2 implements WritableComparable<TimestampWritable
       return timestamp.toString();
     }
 
-    String timestampString = timestamp.toString();
-    if (timestampString.length() > 19) {
-      if (timestampString.length() == 21) {
-        if (timestampString.substring(19).compareTo(".0") == 0) {
-          return timestamp.format(DATE_TIME_FORMAT);
-        }
-      }
-      return timestamp.format(DATE_TIME_FORMAT) + timestampString.substring(19);
-    }
-
     return timestamp.format(DATE_TIME_FORMAT);
   }
 

--- a/serde/src/test/org/apache/hadoop/hive/serde2/io/TestTimestampWritableV2.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/io/TestTimestampWritableV2.java
@@ -508,6 +508,15 @@ public class TestTimestampWritableV2 {
     verifySetTimestamp((long) Integer.MAX_VALUE * 1000 + 1234);
   }
 
+
+  @Test
+  public void testTimestampWritableV2toString() {
+    TimestampWritableV2 timestampWritableV2 = new TimestampWritableV2(
+        Timestamp.valueOf("10001-01-01 01:01:23"));
+
+    assertEquals("+10001-01-01 01:01:23", timestampWritableV2.toString());
+  }
+
   private static void verifySetTimestamp(long time) {
     Timestamp t1 = Timestamp.ofEpochMilli(time);
     TimestampWritableV2 writable = new TimestampWritableV2(t1);


### PR DESCRIPTION
…n year is larger than 9999.





Hi, I found that `TimestampWritableV2.toString()` can be wrong when year is larger than 9999. Here is what I get:
- test code:
```java
  @Test
  public void testTimestampWritableV2toString() {
    TimestampWritableV2 timestampWritableV2 = new TimestampWritableV2(
        Timestamp.valueOf("10001-01-01 01:01:23"));
    assertEquals("+10001-01-01 01:01:23", timestampWritableV2.toString());
  }
```
- output:
```
org.junit.ComparisonFailure: 
Expected :+10001-01-01 01:01:23
Actual   :+10001-01-01 01:01:2323
```

The patch below removes some 'wrong' code in `TimestampWritableV2.toString()`, for the reason that the length of `org.apache.hadoop.hive.common.type.Timestamp#toString` can be larger than 19, even its nano-of-second is zero.


<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->

`TimestampWritableV2.toString()` 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->

The result of TimestampWritableV2.toString() is wrong when year is larger than 9999.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit Test.



