### PR TITLE
HIVE-24762: StringValueBoundaryScanner ignores boundary which leads to incorrect results

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/ValueBoundaryScanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/ValueBoundaryScanner.java
@@ -1195,7 +1195,7 @@ class StringValueBoundaryScanner extends SingleValueBoundaryScanner {
         (PrimitiveObjectInspector) expressionDef.getOI());
     String s2 = PrimitiveObjectInspectorUtils.getString(v2,
         (PrimitiveObjectInspector) expressionDef.getOI());
-    return s1 != null && s2 != null && s1.compareTo(s2) > 0;
+    return s1 != null && s2 != null && s1.compareTo(s2) > amt;
   }
 
   @Override
@@ -1216,7 +1216,7 @@ class StringPrimitiveValueBoundaryScanner extends SinglePrimitiveValueBoundarySc
 
   @Override
   public boolean isDistanceGreaterPrimitive(String s1, String s2, int amt) {
-    return s1 != null && s2 != null && s1.compareTo(s2) > 0;
+    return s1 != null && s2 != null && s1.compareTo(s2) > amt;
   }
 
   @Override

--- a/ql/src/test/queries/clientpositive/ptf.q
+++ b/ql/src/test/queries/clientpositive/ptf.q
@@ -25,6 +25,16 @@ from noop(on part
   order by p_name
   );
 
+-- string based range
+select
+count(*) over(partition by p_mfgr order by p_name range between 1 preceding and current row) as count1,
+count(*) over(partition by p_mfgr order by p_name range between 3 preceding and current row) as count3,
+p_mfgr, p_name
+from noop(on part
+  partition by p_mfgr
+  order by p_name
+  );
+
 -- 2. testJoinWithNoop
 explain
 select p_mfgr, p_name,

--- a/ql/src/test/results/clientpositive/llap/ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf.q.out
@@ -184,6 +184,54 @@ Manufacturer#5	almond antique medium spring khaki	6	2	2	3401.35
 Manufacturer#5	almond antique sky peru orange	2	3	3	5190.08
 Manufacturer#5	almond aquamarine dodger light gainsboro	46	4	4	6208.18
 Manufacturer#5	almond azure blanched chiffon midnight	23	5	5	7672.66
+PREHOOK: query: select
+count(*) over(partition by p_mfgr order by p_name range between 1 preceding and current row) as count1,
+count(*) over(partition by p_mfgr order by p_name range between 3 preceding and current row) as count3,
+p_mfgr, p_name
+from noop(on part
+  partition by p_mfgr
+  order by p_name
+  )
+PREHOOK: type: QUERY
+PREHOOK: Input: default@part
+#### A masked pattern was here ####
+POSTHOOK: query: select
+count(*) over(partition by p_mfgr order by p_name range between 1 preceding and current row) as count1,
+count(*) over(partition by p_mfgr order by p_name range between 3 preceding and current row) as count3,
+p_mfgr, p_name
+from noop(on part
+  partition by p_mfgr
+  order by p_name
+  )
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@part
+#### A masked pattern was here ####
+1	1	Manufacturer#1	almond antique salmon chartreuse burlywood
+1	1	Manufacturer#1	almond aquamarine pink moccasin thistle
+1	1	Manufacturer#2	almond antique violet chocolate turquoise
+1	1	Manufacturer#2	almond antique violet turquoise frosted
+1	1	Manufacturer#2	almond aquamarine rose maroon antique
+1	1	Manufacturer#3	almond antique chartreuse khaki white
+1	1	Manufacturer#3	almond antique metallic orange dim
+1	1	Manufacturer#3	almond antique misty red olive
+1	1	Manufacturer#4	almond antique gainsboro frosted violet
+1	1	Manufacturer#4	almond antique violet mint lemon
+1	1	Manufacturer#4	almond aquamarine yellow dodger mint
+1	1	Manufacturer#4	almond azure aquamarine papaya violet
+1	1	Manufacturer#5	almond antique blue firebrick mint
+1	1	Manufacturer#5	almond antique medium spring khaki
+1	1	Manufacturer#5	almond antique sky peru orange
+1	1	Manufacturer#5	almond azure blanched chiffon midnight
+1	2	Manufacturer#3	almond antique forest lavender goldenrod
+1	3	Manufacturer#2	almond aquamarine midnight light salmon
+1	3	Manufacturer#3	almond antique olive coral navajo
+1	3	Manufacturer#4	almond aquamarine floral ivory bisque
+1	4	Manufacturer#5	almond aquamarine dodger light gainsboro
+1	5	Manufacturer#1	almond aquamarine burnished black steel
+2	2	Manufacturer#1	almond antique burnished rose metallic
+2	2	Manufacturer#1	almond antique burnished rose metallic
+2	2	Manufacturer#2	almond aquamarine sandy cyan gainsboro
+3	3	Manufacturer#1	almond antique chartreuse lavender yellow
 PREHOOK: query: explain
 select p_mfgr, p_name,
 p_size, p_size - lag(p_size,1,p_size) over (partition by p_mfgr order by p_name) as deltaSz


### PR DESCRIPTION
### What changes were proposed in this pull request?
StringValueBoundaryScanner.isDistanceGreater to take amt into account.


### Why are the changes needed?
Described in jira.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added string based range window to ptf.q.
