### PR TITLE
HIVE-24764: insert overwrite on a partition resets row count stats in…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
@@ -128,14 +128,15 @@ public class FSStatsAggregator implements StatsAggregator {
       if (null == partStat) { // not all partitions are scanned in all mappers, so this could be null.
         continue;
       }
+      statsPresent = true;
       String statVal = partStat.get(statType);
       if (null == statVal) { // partition was found, but was empty.
         continue;
       }
-      statsPresent = true;
       counter += Long.parseLong(statVal);
     }
-    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}: ", partID, statType, counter);
+    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}, {}: ",
+        partID, statType, statsPresent, counter);
 
     return (statsPresent ? String.valueOf(counter) : null);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
@@ -122,6 +122,7 @@ public class FSStatsAggregator implements StatsAggregator {
   public String aggregateStats(String partID, String statType) {
     long counter = 0;
     Utilities.FILE_OP_LOGGER.debug("Part ID: {}, {}", partID, statType);
+    boolean statsPresent = false;
     for (Map<String,Map<String,String>> statsMap : statsList) {
       Map<String,String> partStat = statsMap.get(partID);
       if (null == partStat) { // not all partitions are scanned in all mappers, so this could be null.
@@ -131,11 +132,12 @@ public class FSStatsAggregator implements StatsAggregator {
       if (null == statVal) { // partition was found, but was empty.
         continue;
       }
+      statsPresent = true;
       counter += Long.parseLong(statVal);
     }
     Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}: ", partID, statType, counter);
 
-    return String.valueOf(counter);
+    return (statsPresent ? String.valueOf(counter) : null);
   }
 
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24764
insert overwrite on a partition resets row count stats in other partitions. This causes partitions to return PARTIAL value and in some cases, it ends up generating suboptimal plan.

### What changes were proposed in this pull request?
FSStatsAggregator::aggregateStats should return the value when the partitions are present in its statslist. Otherwise, it should return empty or null value. This would prevent stats from being overwritten in BasicStatsTask::updateStats for other partitions during 'insert overwrite' operation. 
