### PR TITLE
HIVE-24715 Increase bucketId range (amagyar)

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2130,6 +2130,8 @@ public class HiveConf extends Configuration {
     TESTMODE_BUCKET_CODEC_VERSION("hive.test.bucketcodec.version", 1,
       "For testing only.  Will make ACID subsystem write RecordIdentifier.bucketId in specified\n" +
         "format", false),
+    HIVE_EXTEND_BUCKET_ID_RANGE("hive.extend.bucketid.range", true,
+            "Dynamically allocate some bits from statement id when bucket id overflows. This allows having more than 4096 buckets."),
     HIVETESTMODEACIDKEYIDXSKIP("hive.test.acid.key.index.skip", false, "For testing only. OrcRecordUpdater will skip "
         + "generation of the hive.acid.key.index", false),
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -67,7 +67,6 @@ import org.apache.hadoop.hive.ql.session.SessionState;
 import org.apache.hadoop.hive.ql.session.SessionState.LogHelper;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hive.common.util.ShutdownHookManager;
-import org.apache.hive.common.util.TxnIdUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -286,8 +285,10 @@ class DriverTxnHandler {
               " is not supported due to OVERWRITE and UNION ALL.  Please use truncate + insert");
         }
       }
-      for (FileSinkDesc each : acidSinks) {
-        each.setMaxStmtId(maxStmtId);
+      if (HiveConf.getBoolVar(driverContext.getConf(), ConfVars.HIVE_EXTEND_BUCKET_ID_RANGE)) {
+        for (FileSinkDesc each : acidSinks) {
+          each.setMaxStmtId(maxStmtId);
+        }
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -264,6 +264,7 @@ class DriverTxnHandler {
         acidSinks.sort((FileSinkDesc fsd1, FileSinkDesc fsd2) -> fsd1.getMoveTaskId().compareTo(fsd2.getMoveTaskId()));
       }
 
+      int maxStmtId = -1;
       for (FileSinkDesc acidSink : acidSinks) {
         TableDesc tableInfo = acidSink.getTableInfo();
         TableName tableName = HiveTableName.of(tableInfo.getTableName());
@@ -277,12 +278,16 @@ class DriverTxnHandler {
          * {@link org.apache.hadoop.hive.ql.exec.AbstractFileMergeOperator#UNION_SUDBIR_PREFIX}
          */
         acidSink.setStatementId(driverContext.getTxnManager().getStmtIdAndIncrement());
+        maxStmtId = Math.max(acidSink.getStatementId(), maxStmtId);
         String unionAllSubdir = "/" + AbstractFileMergeOperator.UNION_SUDBIR_PREFIX;
         if (acidSink.getInsertOverwrite() && acidSink.getDirName().toString().contains(unionAllSubdir) &&
             acidSink.isFullAcidTable()) {
           throw new UnsupportedOperationException("QueryId=" + driverContext.getPlan().getQueryId() +
               " is not supported due to OVERWRITE and UNION ALL.  Please use truncate + insert");
         }
+      }
+      for (FileSinkDesc each : acidSinks) {
+        each.setMaxStmtId(maxStmtId);
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4509,7 +4509,6 @@ public final class Utilities {
         fs.mkdirs(specPath);
       }
     }
-
     Set<String> dynamicPartitionSpecs = new HashSet<>();
     Set<Path> committed = Collections.newSetFromMap(new ConcurrentHashMap<>());
     Set<Path> directInsertDirectories = new HashSet<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4509,6 +4509,7 @@ public final class Utilities {
         fs.mkdirs(specPath);
       }
     }
+
     Set<String> dynamicPartitionSpecs = new HashSet<>();
     Set<Path> committed = Collections.newSetFromMap(new ConcurrentHashMap<>());
     Set<Path> directInsertDirectories = new HashSet<>();

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/AcidOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/AcidOutputFormat.java
@@ -72,6 +72,7 @@ public interface AcidOutputFormat<K extends WritableComparable, V> extends HiveO
     private boolean temporary = false;
 
     private final boolean writeVersionFile;
+    private int maxStmtId = -1;
 
     /**
      * Create the options object.
@@ -345,6 +346,15 @@ public interface AcidOutputFormat<K extends WritableComparable, V> extends HiveO
 
     public boolean isTemporary() {
       return temporary;
+    }
+
+    public Options maxStmtId(int maxStmtId) {
+      this.maxStmtId = maxStmtId;
+      return this;
+    }
+
+    public int getMaxStmtId() {
+      return maxStmtId;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/BucketCodec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/BucketCodec.java
@@ -88,15 +88,31 @@ public enum BucketCodec {
     }
     @Override
     public int encode(AcidOutputFormat.Options options) {
-      final int statementId = options.getStatementId();
-      final int bucketId = options.getBucketId();
+      int statementId = Math.max(0, options.getStatementId());
+      int bucketId = options.getBucketId();
+      int maxStatementId = options.getMaxStmtId();
+      if (maxStatementId < 0) {              // uninitialized, use the default
+        maxStatementId = MAX_STATEMENT_ID;
+      } else if (maxStatementId == 0) {      // single statement tx, id starts from zero, set it to one to make the below logic work
+        maxStatementId = 1;
+      }
+      Preconditions.checkArgument(maxStatementId >= 0 && maxStatementId <= MAX_STATEMENT_ID,
+              "Max Statement ID out of range: " + bucketId);
+      Preconditions.checkArgument(statementId >= 0 && statementId <= MAX_STATEMENT_ID,
+              "Statement ID out of range: " + statementId);
+      Preconditions.checkArgument(bucketId >= 0, "Bucket ID out of range: " + bucketId);
 
-      Preconditions.checkArgument(bucketId >= 0 && bucketId <= MAX_BUCKET_ID, "Bucket ID out of range: " + bucketId);
-      Preconditions.checkArgument(statementId >= -1 && statementId <= MAX_STATEMENT_ID,
-          "Statement ID out of range: " + statementId);
+      if (bucketId > MAX_BUCKET_ID) {
+        int extraBits = NUM_STATEMENT_ID_BITS - (32 - Integer.numberOfLeadingZeros(maxStatementId)); // allocate some bits from the stmt id
+        int overflowedParts = bucketId >>> NUM_BUCKET_ID_BITS; // this part doesn't fit to 12bit, move it to stmt
+        int maxBucketId = (1 << (NUM_BUCKET_ID_BITS + extraBits)) -1; // this is the max we can handle using 12bit + extra bits from stmt id
+        Preconditions.checkArgument(bucketId >= 0 && bucketId <= maxBucketId, "Bucket ID out of range: " + bucketId + " max: " + maxBucketId);
+        statementId = (overflowedParts << (NUM_STATEMENT_ID_BITS - extraBits)) | statementId;
+        bucketId = bucketId & MAX_BUCKET_ID;
+      }
 
       return this.version << (1 + NUM_BUCKET_ID_BITS + 4 + NUM_STATEMENT_ID_BITS)
-          | options.getBucketId() << (4 + NUM_STATEMENT_ID_BITS) | Math.max(0, statementId);
+          | bucketId << (4 + NUM_STATEMENT_ID_BITS) | Math.max(0, statementId);
     }
   };
   private static final int TOP3BITS_MASK = 0b1110_0000_0000_0000_0000_0000_0000_0000;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveFileFormatUtils.java
@@ -353,6 +353,7 @@ public final class HiveFileFormatUtils {
         .inspector(inspector)
         .recordIdColumn(rowIdColNum)
         .statementId(conf.getStatementId())
+        .maxStmtId(conf.getMaxStmtId())
         .finalDestination(conf.getDestPath())
         .attemptId(attemptId)
         .temporary(conf.isTemporary()));

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
@@ -285,6 +285,8 @@ public class OrcRecordUpdater implements RecordUpdater {
       }
     }
     this.bucket.set(bucketCodec.encode(options));
+    options.statementId(bucketCodec.decodeStatementId(this.bucket.get()));
+    options.bucket(bucketCodec.decodeWriterId(this.bucket.get()));
     this.path = AcidUtils.createFilename(partitionRoot, options);
     this.deleteEventWriter = null;
     this.deleteEventPath = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcRecordUpdater.java
@@ -284,8 +284,10 @@ public class OrcRecordUpdater implements RecordUpdater {
             BucketCodec.V1.getVersion()));
       }
     }
-    this.bucket.set(bucketCodec.encode(options));
-    options.statementId(bucketCodec.decodeStatementId(this.bucket.get()));
+    this.bucket.set(bucketCodec.encode(options)); // encode might chang bucketId/stmtId, use the new one for file name generation
+    if (options.getStatementId() != -1) { // -1 is treated specially in createFilename during compaction
+      options.statementId(bucketCodec.decodeStatementId(this.bucket.get()));
+    }
     options.bucket(bucketCodec.decodeWriterId(this.bucket.get()));
     this.path = AcidUtils.createFilename(partitionRoot, options);
     this.deleteEventWriter = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/FileSinkDesc.java
@@ -96,6 +96,7 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
   private AcidUtils.Operation writeType = AcidUtils.Operation.NOT_ACID;
   private long tableWriteId = 0;  // table write id for this operation
   private int statementId = -1;
+  private int maxStmtId = -1;
 
   private transient Table table;
   private Path destPath;
@@ -597,6 +598,15 @@ public class FileSinkDesc extends AbstractOperatorDesc implements IStatsGatherDe
   public int getStatementId() {
     return statementId;
   }
+
+  public void setMaxStmtId(int maxStmtId) {
+    this.maxStmtId = maxStmtId;
+  }
+
+  public int getMaxStmtId() {
+    return maxStmtId;
+  }
+
   public Path getDestPath() {
     return destPath;
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestBucketCodec.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestBucketCodec.java
@@ -77,13 +77,13 @@ public class TestBucketCodec {
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetBucketCodecVersion1EncodeNegativeBucketId() {
-    BucketCodec.getCodec(1).encode(new AcidOutputFormat.Options(null).bucket(-1).statementId(16).maxStmtId(BucketCodec.MAX_STATEMENT_ID));
+    BucketCodec.getCodec(1).encode(new AcidOutputFormat.Options(null).bucket(-1).statementId(16));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetBucketCodecVersion1EncodeMaxBucketId() {
     BucketCodec.getCodec(1)
-        .encode(new AcidOutputFormat.Options(null).bucket(BucketCodec.MAX_BUCKET_ID + 1).statementId(16).maxStmtId(BucketCodec.MAX_STATEMENT_ID));
+        .encode(new AcidOutputFormat.Options(null).bucket(BucketCodec.MAX_BUCKET_ID + 1).statementId(16));
   }
 
   @Test(expected = IllegalArgumentException.class)

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/TestBucketCodec.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/TestBucketCodec.java
@@ -77,13 +77,13 @@ public class TestBucketCodec {
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetBucketCodecVersion1EncodeNegativeBucketId() {
-    BucketCodec.getCodec(1).encode(new AcidOutputFormat.Options(null).bucket(-1).statementId(16));
+    BucketCodec.getCodec(1).encode(new AcidOutputFormat.Options(null).bucket(-1).statementId(16).maxStmtId(BucketCodec.MAX_STATEMENT_ID));
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testGetBucketCodecVersion1EncodeMaxBucketId() {
     BucketCodec.getCodec(1)
-        .encode(new AcidOutputFormat.Options(null).bucket(BucketCodec.MAX_BUCKET_ID + 1).statementId(16));
+        .encode(new AcidOutputFormat.Options(null).bucket(BucketCodec.MAX_BUCKET_ID + 1).statementId(16).maxStmtId(BucketCodec.MAX_STATEMENT_ID));
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -98,4 +98,56 @@ public class TestBucketCodec {
         .encode(new AcidOutputFormat.Options(null).bucket(7).statementId(BucketCodec.MAX_STATEMENT_ID + 1));
   }
 
+  @Test
+  public void testBucketIdTakesExtra8BitsFromStmtId() {
+    AcidOutputFormat.Options options = new AcidOutputFormat
+            .Options(null)
+            .bucket(5000)             // 1|001110001000
+            .statementId(12)          //   000000001100
+            .maxStmtId(100); //        1100100
+    int encode = BucketCodec.getCodec(1).encode(options);
+    assertEquals("10001100", Integer.toString(BucketCodec.V1.decodeStatementId(encode), 2));
+    assertEquals("1110001000", Integer.toString(BucketCodec.V1.decodeWriterId(encode), 2));
+  }
+
+  @Test
+  public void testBucketIdTakesExtra4BitsFromStmtId() {
+    AcidOutputFormat.Options options = new AcidOutputFormat
+            .Options(null)
+            .bucket(65535)
+            .statementId(150)         //   000010010110
+            .maxStmtId(150); //       10010110
+    int encode = BucketCodec.getCodec(1).encode(options);
+    assertEquals("111110010110", Integer.toString(BucketCodec.V1.decodeStatementId(encode), 2));
+    assertEquals("111111111111", Integer.toString(BucketCodec.V1.decodeWriterId(encode), 2));
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testNoRoomToOverflowBucketId() {
+    BucketCodec.getCodec(1).encode(new AcidOutputFormat
+            .Options(null)
+            .bucket(65536)
+            .statementId(1)
+            .maxStmtId(150));   //   000010010110
+  }
+
+  @Test
+  public void testBucketIdRollOver() {
+    for (int i = 0; i < 16384; i++) {
+      int encode = BucketCodec.getCodec(1).encode(new AcidOutputFormat
+              .Options(null)
+              .bucket(i)
+              .statementId(10)
+              .maxStmtId(0b001000000000)); // 2 bit free
+      assertEquals(i % 4096, BucketCodec.getCodec(1).decodeWriterId(encode));
+      if (i < 4096)
+        assertEquals(10, BucketCodec.getCodec(1).decodeStatementId(encode));
+      else if (i < 8192)
+        assertEquals(0b010000001010, BucketCodec.getCodec(1).decodeStatementId(encode));
+      else if (i < 12288)
+        assertEquals(0b100000001010, BucketCodec.getCodec(1).decodeStatementId(encode));
+      else
+        assertEquals(0b110000001010, BucketCodec.getCodec(1).decodeStatementId(encode));
+    }
+  }
 }


### PR DESCRIPTION
Currently the bucketId field is stored on 12 bits. When TEZ starts more tasks than 4095 it overflows.

The proposed solution is to let the bucket id overflow into the statement id. Depending on the maximum statement id (we  know that at compile time) we can dynamically allocate bits for the bucket id from the statement id field.

For example in a single statement operation only one bit is needed for the statement id and 11 extra bits can be allocated for the bucket id.

In case of a multi insert where the max statement id lets say 100 (0b000001100100), five extra bits can be allocated for the bucket Id.

Compaction ignores statement ids therefore the same buckets (delta_1_1_0/bucket_00904_0 and delta_1_1_178/bucket_00904_0) will be merged together after running a major compaction, so we won’t end up having more than 4096 files in the end.


After running an INSERT with 6000 parallel tasks we end up having 2 delta directories:

```
/warehouse/tablespace/managed/hive/cdr5bi/delta_0000039_0000039_0000
/warehouse/tablespace/managed/hive/cdr5bi/delta_0000039_0000039_0002  
```

Where in the first we have buckets from 0 .. 4095 and in the second we have buckets from 0 .. 1903.
After running compaction we expect having a single base directory with buckets from 0 .. 4095.

```
/warehouse/tablespace/managed/hive/cdr5bi/base_0000039_v0003975
```

The same buckets from different statements are merged together.

See more info in the attached pdf in the Jira.