### PR TITLE
HIVE-24770: Change classname for MultiDelimiterSerDe during upgrade (…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/sql/derby/upgrade-3.2.0-to-4.0.0.derby.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/derby/upgrade-3.2.0-to-4.0.0.derby.sql
@@ -120,5 +120,8 @@ ALTER TABLE COMPACTION_QUEUE ADD CQ_TXN_ID bigint;
 -- HIVE-24275
 ALTER TABLE COMPACTION_QUEUE ADD CQ_COMMIT_TIME bigint;
 
+-- HIVE-24770
+UPDATE "APP".SERDES SET SLIB='org.apache.hadoop.hive.serde2.MultiDelimitSerDe' where SLIB='org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe';
+
 -- This needs to be the last thing done.  Insert any changes above this line.
 UPDATE "APP".VERSION SET SCHEMA_VERSION='4.0.0', VERSION_COMMENT='Hive release version 4.0.0' where VER_ID=1;

--- a/standalone-metastore/metastore-server/src/main/sql/mssql/upgrade-3.2.0-to-4.0.0.mssql.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/mssql/upgrade-3.2.0-to-4.0.0.mssql.sql
@@ -156,6 +156,9 @@ ALTER TABLE COMPACTION_QUEUE ADD CQ_TXN_ID bigint NULL;
 -- HIVE-24275
 ALTER TABLE COMPACTION_QUEUE ADD CQ_COMMIT_TIME bigint NULL;
 
+-- HIVE-24770
+UPDATE SERDES SET SLIB='org.apache.hadoop.hive.serde2.MultiDelimitSerDe' where SLIB='org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe';
+
 -- These lines need to be last.  Insert any changes above.
 UPDATE VERSION SET SCHEMA_VERSION='4.0.0', VERSION_COMMENT='Hive release version 4.0.0' where VER_ID=1;
 SELECT 'Finished upgrading MetaStore schema from 3.2.0 to 4.0.0' AS MESSAGE;

--- a/standalone-metastore/metastore-server/src/main/sql/mysql/upgrade-3.2.0-to-4.0.0.mysql.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/mysql/upgrade-3.2.0-to-4.0.0.mysql.sql
@@ -128,6 +128,9 @@ ALTER TABLE COMPACTION_QUEUE ADD CQ_TXN_ID bigint;
 -- HIVE-24275
 ALTER TABLE COMPACTION_QUEUE ADD CQ_COMMIT_TIME bigint;
 
+-- HIVE-24770
+UPDATE SERDES SET SLIB='org.apache.hadoop.hive.serde2.MultiDelimitSerDe' where SLIB='org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe';
+
 -- These lines need to be last.  Insert any changes above.
 UPDATE VERSION SET SCHEMA_VERSION='4.0.0', VERSION_COMMENT='Hive release version 4.0.0' where VER_ID=1;
 SELECT 'Finished upgrading MetaStore schema from 3.2.0 to 4.0.0' AS MESSAGE;

--- a/standalone-metastore/metastore-server/src/main/sql/oracle/upgrade-3.2.0-to-4.0.0.oracle.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/oracle/upgrade-3.2.0-to-4.0.0.oracle.sql
@@ -128,6 +128,9 @@ ALTER TABLE COMPACTION_QUEUE ADD CQ_COMMIT_TIME NUMBER(19);
 -- HIVE-24589
 CREATE INDEX CTLG_NAME_DBS ON DBS(CTLG_NAME);
 
+-- HIVE-24770
+UPDATE SERDES SET SLIB='org.apache.hadoop.hive.serde2.MultiDelimitSerDe' where SLIB='org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe';
+
 -- These lines need to be last.  Insert any changes above.
 UPDATE VERSION SET SCHEMA_VERSION='4.0.0', VERSION_COMMENT='Hive release version 4.0.0' where VER_ID=1;
 SELECT 'Finished upgrading MetaStore schema from 3.2.0 to 4.0.0' AS Status from dual;

--- a/standalone-metastore/metastore-server/src/main/sql/postgres/upgrade-3.2.0-to-4.0.0.postgres.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/postgres/upgrade-3.2.0-to-4.0.0.postgres.sql
@@ -252,6 +252,9 @@ ALTER TABLE "COMPACTION_QUEUE" ADD "CQ_TXN_ID" bigint;
 -- HIVE-24275
 ALTER TABLE "COMPACTION_QUEUE" ADD "CQ_COMMIT_TIME" bigint;
 
+-- HIVE-24770
+UPDATE "SERDES" SET "SLIB"='org.apache.hadoop.hive.serde2.MultiDelimitSerDe' where "SLIB"='org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe';
+
 -- These lines need to be last. Insert any changes above.
 UPDATE "VERSION" SET "SCHEMA_VERSION"='4.0.0', "VERSION_COMMENT"='Hive release version 4.0.0' where "VER_ID"=1;
 SELECT 'Finished upgrading MetaStore schema from 3.2.0 to 4.0.0';


### PR DESCRIPTION
…Naveen Gangam)
HIVE-20619 makes MultiDelimiterSerDe a first class serde in hive moving it from hive-contrib into hive-exec jar. Part of the change includes removing "contrib" from its full qualified package+class name. Although, this does not introduce a backward incompatibility, it still requires users to manually add hive-contrib.jar to the classpath to make it work after the upgrade. (This is no different than what a user would do after upgrade without this change as well). However, we can make the user experience better by automatically changing the hive table metadata to rename the class.

### What changes were proposed in this pull request?
Schema upgrade scripts update the SLIB column value in SERDES table to update it from "org.apache.hadoop.hive.contrib.serde2.MultiDelimitSerDe" to "org.apache.hadoop.hive.serde2.MultiDelimitSerDe"

### Why are the changes needed?
Better user experience to getting MultiDelimiterSerDe to work out of the box after the upgrade.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Manually.
