### PR TITLE
HIVE-24742: Support router path or viewfs path in Hive table location

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -26,7 +26,6 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.security.AccessControlException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
@@ -54,6 +53,8 @@ import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.Trash;
 import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.viewfs.ViewFileSystem;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.shims.HadoopShims;
 import org.apache.hadoop.hive.shims.ShimLoader;
@@ -740,18 +741,33 @@ public final class FileUtils {
   }
 
   /**
-   * @param fs1
-   * @param fs2
+   * Check if path1 and path2 are on the same file system
+   * @param fs1   file system
+   * @param path1 path on file system fs1
+   * @param fs2   file system
+   * @param path2 path on file system fs2
    * @return return true if both file system arguments point to same file system
    */
-  public static boolean equalsFileSystem(FileSystem fs1, FileSystem fs2) {
+  public static boolean equalsFileSystem(FileSystem fs1, Path path1,
+                                         FileSystem fs2, Path path2)
+          throws IOException {
     //When file system cache is disabled, you get different FileSystem objects
     // for same file system, so '==' can't be used in such cases
     //FileSystem api doesn't have a .equals() function implemented, so using
     //the uri for comparison. FileSystem already uses uri+Configuration for
     //equality in its CACHE .
     //Once equality has been added in HDFS-9159, we should make use of it
-    return fs1.getUri().equals(fs2.getUri());
+    URI resolvedPath1 =
+            (fs1 instanceof DistributedFileSystem || fs1 instanceof ViewFileSystem) ?
+                    fs1.resolvePath(path1).toUri() : fs1.getUri();
+    URI resolvedPath2 =
+            (fs2 instanceof DistributedFileSystem || fs2 instanceof ViewFileSystem) ?
+                    fs2.resolvePath(path2).toUri() : fs2.getUri();
+
+    return org.apache.commons.lang3.StringUtils.
+            equalsIgnoreCase(resolvedPath1.getScheme(), resolvedPath2.getScheme()) &&
+           org.apache.commons.lang3.StringUtils.
+            equalsIgnoreCase(resolvedPath1.getAuthority(), resolvedPath2.getAuthority());
   }
 
   /**

--- a/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
@@ -30,11 +30,13 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
@@ -263,5 +265,38 @@ public class TestFileUtils {
       Assert.assertTrue(e.getMessage().
               equalsIgnoreCase("Distcp is called with doAsUser and delete source set as true"));
     }
+  }
+
+  @Test
+  public void testEqualsFileSystem() throws IOException {
+    FileSystem mockFs1 = mock(FileSystem.class);
+    FileSystem mockFs2 = mock(FileSystem.class);
+    Path path1 = new Path("viewfs://ns/path1");
+    Path path2 = new Path("viewfs://ns/path2");
+
+    when(mockFs1.resolvePath(path1))
+            .thenReturn(new Path("hdfs://ns1/path1"));
+    when(mockFs2.resolvePath(path2))
+            .thenReturn(new Path("hdfs://ns1/path2"));
+
+    Assert.assertTrue(FileUtils.equalsFileSystem(mockFs1, path1, mockFs2, path2));
+
+    when(mockFs1.resolvePath(path1))
+            .thenReturn(new Path("hdfs://ns1/path1"));
+    when(mockFs2.resolvePath(path2))
+            .thenReturn(new Path("hdfs://ns2/path2"));
+
+    Assert.assertFalse(FileUtils.equalsFileSystem(mockFs1, path1, mockFs2, path2));
+
+    // Test local paths
+    path1 = new Path("file:/tmp/path1");
+    path2 = new Path("file:/tmp/path2");
+    FileSystem localFS = mock(FileSystem.class);
+    when(localFS.resolvePath(path1)).thenReturn(path1);
+    when(localFS.resolvePath(path2)).thenReturn(path2);
+
+    Assert.assertTrue(FileUtils.equalsFileSystem(localFS, path1, localFS, path2));
+
+
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2340,7 +2340,7 @@ public class Hive {
            */
           FileSystem oldPartPathFS = oldPartPath.getFileSystem(getConf());
           FileSystem loadPathFS = loadPath.getFileSystem(getConf());
-          if (FileUtils.equalsFileSystem(oldPartPathFS,loadPathFS)) {
+          if (FileUtils.equalsFileSystem(oldPartPathFS, oldPartPath,loadPathFS, loadPath)) {
             newPartPath = oldPartPath;
           }
         }
@@ -4650,8 +4650,12 @@ private void constructOneLBLocationMap(FileStatus fSta,
   static private boolean needToCopy(final HiveConf conf, Path srcf, Path destf, FileSystem srcFs,
                                       FileSystem destFs, String configuredOwner, boolean isManaged) throws HiveException {
     //Check if different FileSystems
-    if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-      return true;
+    try {
+      if (!FileUtils.equalsFileSystem(srcFs, srcf, destFs, destf)) {
+        return true;
+      }
+    } catch(IOException e) {
+      throw new HiveException(e);
     }
 
     if (isManaged && !configuredOwner.isEmpty() && srcFs instanceof DistributedFileSystem) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigration.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigration.java
@@ -594,7 +594,7 @@ public class HiveStrictManagedMigration {
           FileSystem curWhRootFs = targetPath.getFileSystem(conf);
           oldWhRootPath = oldWhRootFs.makeQualified(oldWhRootPath);
           targetPath = curWhRootFs.makeQualified(targetPath);
-          if (!FileUtils.equalsFileSystem(oldWhRootFs, curWhRootFs)) {
+          if (!FileUtils.equalsFileSystem(oldWhRootFs, oldWhRootPath, curWhRootFs, targetPath)) {
             LOG.info("oldWarehouseRoot {} has a different FS than the target path {}."
                 + " Disabling shouldModifyManagedTableLocation and shouldMoveExternal",
               runOptions.oldWarehouseRoot, currentPathString);

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/FileUtils.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.fs.Trash;
+import org.apache.hadoop.fs.viewfs.ViewFileSystem;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf.ConfVars;
@@ -192,7 +194,7 @@ public class FileUtils {
          + "path already exists.");
    }
 
-   if (equalsFileSystem(srcFs, destFs)) {
+   if (equalsFileSystem(srcFs, srcPath, destFs, destPath)) {
        //just rename the directory
        return srcFs.rename(srcPath, destPath);
      } else {
@@ -407,19 +409,33 @@ public class FileUtils {
   }
 
   /**
-   * Determine if two objects reference the same file system.
-   * @param fs1 first file system
-   * @param fs2 second file system
+   * Check if path1 and path2 are on the same file system
+   * @param fs1   file system
+   * @param path1 path on file system fs1
+   * @param fs2   file system
+   * @param path2 path on file system fs2
    * @return return true if both file system arguments point to same file system
    */
-  public static boolean equalsFileSystem(FileSystem fs1, FileSystem fs2) {
+  public static boolean equalsFileSystem(FileSystem fs1, Path path1,
+                                         FileSystem fs2, Path path2)
+          throws IOException {
     //When file system cache is disabled, you get different FileSystem objects
     // for same file system, so '==' can't be used in such cases
     //FileSystem api doesn't have a .equals() function implemented, so using
     //the uri for comparison. FileSystem already uses uri+Configuration for
     //equality in its CACHE .
     //Once equality has been added in HDFS-9159, we should make use of it
-    return fs1.getUri().equals(fs2.getUri());
+    URI resolvedPath1 =
+            (fs1 instanceof DistributedFileSystem || fs1 instanceof ViewFileSystem) ?
+              fs1.resolvePath(path1).toUri() : fs1.getUri();
+    URI resolvedPath2 =
+            (fs2 instanceof DistributedFileSystem || fs2 instanceof ViewFileSystem) ?
+              fs2.resolvePath(path2).toUri() : fs2.getUri();
+
+    return org.apache.commons.lang3.StringUtils.
+            equalsIgnoreCase(resolvedPath1.getScheme(), resolvedPath2.getScheme()) &&
+           org.apache.commons.lang3.StringUtils.
+            equalsIgnoreCase(resolvedPath1.getAuthority(), resolvedPath2.getAuthority());
   }
 
   /**

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -266,10 +266,17 @@ public class HiveAlterHandler implements AlterHandler {
             // check that destination does not exist otherwise we will be
             // overwriting data
             // check that src and dest are on the same file system
-            if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-              throw new InvalidOperationException("table new location " + destPath
-                      + " is on a different file system than the old location "
-                      + srcPath + ". This operation is not supported");
+            try {
+              if (!FileUtils.equalsFileSystem(srcFs, srcPath, destFs, destPath)) {
+                throw new InvalidOperationException("table new location " + destPath
+                        + " is on a different file system than the old location "
+                        + srcPath + ". This operation is not supported");
+              }
+            } catch(IOException e) {
+              LOG.error("Failed to check if " + srcPath + "," + destPath
+                      + "are on same file system", e);
+              throw new InvalidOperationException("Alter Table operation for " + dbname + "." + name +
+                      " failed due to: '" + getSimpleMessage(e) +"'");
             }
 
             try {
@@ -654,10 +661,17 @@ public class HiveAlterHandler implements AlterHandler {
           srcFs = wh.getFs(srcPath);
           destFs = wh.getFs(destPath);
           // check that src and dest are on the same file system
-          if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-            throw new InvalidOperationException("New table location " + destPath
-              + " is on a different file system than the old location "
-              + srcPath + ". This operation is not supported.");
+          try {
+            if (!FileUtils.equalsFileSystem(srcFs, srcPath, destFs, destPath)) {
+              throw new InvalidOperationException("New table location " + destPath
+                      + " is on a different file system than the old location "
+                      + srcPath + ". This operation is not supported.");
+            }
+          } catch(IOException e) {
+            LOG.error("Failed to check if " + srcPath + "," + destPath
+                    + "are on same file system", e);
+            throw new InvalidOperationException("Alter partition operation for " + dbname + "." + name +
+                    " failed due to: '" + getSimpleMessage(e) +"'");
           }
 
           try {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Support router path or viewfs path in Hive table location by resolving the path to the physical cluster path and comparing them to determine if source or destination are on the same cluster.

### Why are the changes needed?
HDFS router or viewfs is for file system federation and the path is not the physical path. Currently Hive uses the scheme and authority to check if the source and destination are on the same cluster and decides to rename the path or copy the data. That would cause issue for router or viewfs path since the physical paths could be on different clusters. 

### Does this PR introduce any user-facing change?
No

### How was this patch tested?
New UT