### PR TITLE
HIVE-24785: Fix HIVE_COMPACTOR_COMPACT_MM property

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -469,6 +469,12 @@ public class Initiator extends MetaStoreCompactorThread {
             "=true so we will not compact it.");
         return false;
       }
+      if (AcidUtils.isInsertOnlyTable(t.getParameters()) && !HiveConf
+          .getBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM)) {
+        LOG.info("Table " + tableName(t) + " is insert only and " + HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM.varname
+            + "=false so we will not compact it.");
+        return false;
+      }
       if (isDynPartIngest(t, ci)) {
         return false;
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactorFactory.java
@@ -21,6 +21,7 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.txn.CompactionInfo;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,7 +54,8 @@ final class QueryCompactorFactory {
    * @param compactionInfo provides insight about the type of compaction, must be not null.
    * @return {@link QueryCompactor} or null.
    */
-  static QueryCompactor getQueryCompactor(Table table, HiveConf configuration, CompactionInfo compactionInfo) {
+  static QueryCompactor getQueryCompactor(Table table, HiveConf configuration, CompactionInfo compactionInfo)
+      throws HiveException {
     if (!AcidUtils.isInsertOnlyTable(table.getParameters())
         && HiveConf.getBoolVar(configuration, HiveConf.ConfVars.COMPACTOR_CRUD_QUERY_BASED)) {
       if (!"tez".equalsIgnoreCase(HiveConf.getVar(configuration, HiveConf.ConfVars.HIVE_EXECUTION_ENGINE))) {
@@ -66,8 +68,11 @@ final class QueryCompactorFactory {
         return new MinorQueryCompactor();
       }
     }
-
     if (AcidUtils.isInsertOnlyTable(table.getParameters())) {
+      if (!configuration.getBoolVar(HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM)) {
+        throw new HiveException(
+            "Insert only compaction is disabled. Set hive.compactor.compact.insert.only to true to enable it.");
+      }
       if (compactionInfo.isMajorCompaction()) {
         return new MmMajorQueryCompactor();
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactorFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/QueryCompactorFactory.java
@@ -67,8 +67,7 @@ final class QueryCompactorFactory {
       }
     }
 
-    if (AcidUtils.isInsertOnlyTable(table.getParameters()) && HiveConf
-        .getBoolVar(configuration, HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM)) {
+    if (AcidUtils.isInsertOnlyTable(table.getParameters())) {
       if (compactionInfo.isMajorCompaction()) {
         return new MmMajorQueryCompactor();
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -533,10 +533,6 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         todo Find a more generic approach to collecting files in the same logical bucket to compact within the same
         task (currently we're using Tez split grouping).
         */
-        if (AcidUtils.isInsertOnlyTable(t.getParameters()) && !HiveConf
-            .getBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM)) {
-          throw new HiveException("Insert only compaction is disabled. Set hive.compactor.compact.insert.only to true to enable it.");
-        }
         QueryCompactor queryCompactor = QueryCompactorFactory.getQueryCompactor(t, conf, ci);
         if (queryCompactor != null) {
           LOG.info("Will compact id: " + ci.id + " with query-based compactor class: "

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -533,6 +533,10 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
         todo Find a more generic approach to collecting files in the same logical bucket to compact within the same
         task (currently we're using Tez split grouping).
         */
+        if (AcidUtils.isInsertOnlyTable(t.getParameters()) && !HiveConf
+            .getBoolVar(conf, HiveConf.ConfVars.HIVE_COMPACTOR_COMPACT_MM)) {
+          throw new HiveException("Insert only compaction is disabled. Set hive.compactor.compact.insert.only to true to enable it.");
+        }
         QueryCompactor queryCompactor = QueryCompactorFactory.getQueryCompactor(t, conf, ci);
         if (queryCompactor != null) {
           LOG.info("Will compact id: " + ci.id + " with query-based compactor class: "


### PR DESCRIPTION


### What changes were proposed in this pull request?
Fix how HIVE_COMPACTOR_COMPACT_MM will disable compaction for insert only tables.


### Why are the changes needed?
Currently if this property is disabled, compaction will be initiated for insert_only tables and fail in MR based compaction


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Current unit tests
