### PR TITLE
Hive 24764: insert overwrite on a partition resets row count stats in other partitions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
@@ -135,10 +135,10 @@ public class FSStatsAggregator implements StatsAggregator {
       }
       counter += Long.parseLong(statVal);
     }
-    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}, {}: ",
-        partID, statType, statsPresent, counter);
+    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}, {}, {}: ",
+        partID, statType, statsPresent, counter, statsList.isEmpty());
 
-    return (statsPresent ? String.valueOf(counter) : null);
+    return ((statsPresent || statsList.isEmpty()) ? String.valueOf(counter) : null);
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
@@ -128,14 +128,15 @@ public class FSStatsAggregator implements StatsAggregator {
       if (null == partStat) { // not all partitions are scanned in all mappers, so this could be null.
         continue;
       }
+      statsPresent = true;
       String statVal = partStat.get(statType);
       if (null == statVal) { // partition was found, but was empty.
         continue;
       }
-      statsPresent = true;
       counter += Long.parseLong(statVal);
     }
-    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}: ", partID, statType, counter);
+    Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}, {}: ",
+        partID, statType, statsPresent, counter);
 
     return (statsPresent ? String.valueOf(counter) : null);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/fs/FSStatsAggregator.java
@@ -122,6 +122,7 @@ public class FSStatsAggregator implements StatsAggregator {
   public String aggregateStats(String partID, String statType) {
     long counter = 0;
     Utilities.FILE_OP_LOGGER.debug("Part ID: {}, {}", partID, statType);
+    boolean statsPresent = false;
     for (Map<String,Map<String,String>> statsMap : statsList) {
       Map<String,String> partStat = statsMap.get(partID);
       if (null == partStat) { // not all partitions are scanned in all mappers, so this could be null.
@@ -131,11 +132,12 @@ public class FSStatsAggregator implements StatsAggregator {
       if (null == statVal) { // partition was found, but was empty.
         continue;
       }
+      statsPresent = true;
       counter += Long.parseLong(statVal);
     }
     Utilities.FILE_OP_LOGGER.info("Read stats for {}, {}, {}: ", partID, statType, counter);
 
-    return String.valueOf(counter);
+    return (statsPresent ? String.valueOf(counter) : null);
   }
 
   @Override

--- a/ql/src/test/queries/clientpositive/insert_overwrite_stats.q
+++ b/ql/src/test/queries/clientpositive/insert_overwrite_stats.q
@@ -1,0 +1,33 @@
+set hive.stats.dbclass=fs;
+set hive.stats.fetch.column.stats=true;
+set datanucleus.cache.collections=false;
+
+set hive.merge.mapfiles=false;
+set hive.merge.mapredfiles=false;
+
+set hive.stats.autogather=true;
+set hive.stats.column.autogather=true;
+set hive.compute.query.using.stats=true;
+set hive.mapred.mode=nonstrict;
+set hive.explain.user=false;
+
+set hive.fetch.task.conversion=none;
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.query.results.cache.enabled=false;
+
+DROP TABLE IF EXISTS test_stats;
+DROP TABLE IF EXISTS test_stats_2;
+
+CREATE TABLE test_stats(i int, j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only");
+CREATE TABLE test_stats_2(i int) PARTITIONED BY (j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only");
+
+INSERT INTO test_stats VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, NULL);
+SELECT * FROM test_stats;
+
+
+INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NOT NULL;
+INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NULL;
+
+-- stats should be COMPLETE
+EXPLAIN SELECT i, count(*) as c FROM test_stats_2 GROUP BY i ORDER BY c DESC LIMIT 10;

--- a/ql/src/test/results/clientpositive/llap/insert_overwrite_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_overwrite_stats.q.out
@@ -1,0 +1,181 @@
+PREHOOK: query: DROP TABLE IF EXISTS test_stats
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS test_stats
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: DROP TABLE IF EXISTS test_stats_2
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS test_stats_2
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE test_stats(i int, j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: CREATE TABLE test_stats(i int, j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_stats
+PREHOOK: query: CREATE TABLE test_stats_2(i int) PARTITIONED BY (j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_stats_2
+POSTHOOK: query: CREATE TABLE test_stats_2(i int) PARTITIONED BY (j bigint) STORED AS ORC tblproperties ("transactional"="true", "transactional_properties"="insert_only")
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_stats_2
+PREHOOK: query: INSERT INTO test_stats VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_stats
+POSTHOOK: query: INSERT INTO test_stats VALUES (1, 1), (2, 2), (3, 3), (4, 4), (5, NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_stats
+POSTHOOK: Lineage: test_stats.i SCRIPT []
+POSTHOOK: Lineage: test_stats.j SCRIPT []
+PREHOOK: query: SELECT * FROM test_stats
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM test_stats
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+#### A masked pattern was here ####
+1	1
+2	2
+3	3
+4	4
+5	NULL
+PREHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NOT NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+PREHOOK: Output: default@test_stats_2
+POSTHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NOT NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+POSTHOOK: Output: default@test_stats_2@j=1
+POSTHOOK: Output: default@test_stats_2@j=2
+POSTHOOK: Output: default@test_stats_2@j=3
+POSTHOOK: Output: default@test_stats_2@j=4
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=1).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=2).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=3).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=4).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+PREHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NULL
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats
+PREHOOK: Output: default@test_stats_2
+POSTHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NULL
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats
+POSTHOOK: Output: default@test_stats_2@j=1
+POSTHOOK: Output: default@test_stats_2@j=2
+POSTHOOK: Output: default@test_stats_2@j=3
+POSTHOOK: Output: default@test_stats_2@j=4
+POSTHOOK: Output: default@test_stats_2@j=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=1).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=2).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=3).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=4).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+POSTHOOK: Lineage: test_stats_2 PARTITION(j=__HIVE_DEFAULT_PARTITION__).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
+PREHOOK: query: EXPLAIN SELECT i, count(*) as c FROM test_stats_2 GROUP BY i ORDER BY c DESC LIMIT 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_stats_2
+PREHOOK: Input: default@test_stats_2@j=1
+PREHOOK: Input: default@test_stats_2@j=2
+PREHOOK: Input: default@test_stats_2@j=3
+PREHOOK: Input: default@test_stats_2@j=4
+PREHOOK: Input: default@test_stats_2@j=__HIVE_DEFAULT_PARTITION__
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT i, count(*) as c FROM test_stats_2 GROUP BY i ORDER BY c DESC LIMIT 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_stats_2
+POSTHOOK: Input: default@test_stats_2@j=1
+POSTHOOK: Input: default@test_stats_2@j=2
+POSTHOOK: Input: default@test_stats_2@j=3
+POSTHOOK: Input: default@test_stats_2@j=4
+POSTHOOK: Input: default@test_stats_2@j=__HIVE_DEFAULT_PARTITION__
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: test_stats_2
+                  Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: i (type: int)
+                    outputColumnNames: i
+                    Statistics: Num rows: 5 Data size: 20 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: count()
+                      keys: i (type: int)
+                      minReductionHashAggr: 0.6
+                      mode: hash
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Top N Key Operator
+                  sort order: -
+                  keys: _col1 (type: bigint)
+                  null sort order: z
+                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  top n: 10
+                  Reduce Output Operator
+                    key expressions: _col1 (type: bigint)
+                    null sort order: z
+                    sort order: -
+                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    TopN Hash Memory Usage: 0.1
+                    value expressions: _col0 (type: int)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: bigint)
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Limit
+                  Number of rows: 10
+                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: 10
+      Processor Tree:
+        ListSink
+

--- a/ql/src/test/results/clientpositive/llap/insert_overwrite_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_overwrite_stats.q.out
@@ -52,6 +52,7 @@ PREHOOK: Output: default@test_stats_2
 POSTHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NOT NULL
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_stats
+POSTHOOK: Output: default@test_stats_2
 POSTHOOK: Output: default@test_stats_2@j=1
 POSTHOOK: Output: default@test_stats_2@j=2
 POSTHOOK: Output: default@test_stats_2@j=3
@@ -67,15 +68,8 @@ PREHOOK: Output: default@test_stats_2
 POSTHOOK: query: INSERT OVERWRITE TABLE test_stats_2 partition(j) SELECT i, j FROM test_stats WHERE j IS NULL
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_stats
-POSTHOOK: Output: default@test_stats_2@j=1
-POSTHOOK: Output: default@test_stats_2@j=2
-POSTHOOK: Output: default@test_stats_2@j=3
-POSTHOOK: Output: default@test_stats_2@j=4
+POSTHOOK: Output: default@test_stats_2
 POSTHOOK: Output: default@test_stats_2@j=__HIVE_DEFAULT_PARTITION__
-POSTHOOK: Lineage: test_stats_2 PARTITION(j=1).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
-POSTHOOK: Lineage: test_stats_2 PARTITION(j=2).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
-POSTHOOK: Lineage: test_stats_2 PARTITION(j=3).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
-POSTHOOK: Lineage: test_stats_2 PARTITION(j=4).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
 POSTHOOK: Lineage: test_stats_2 PARTITION(j=__HIVE_DEFAULT_PARTITION__).i SIMPLE [(test_stats)test_stats.FieldSchema(name:i, type:int, comment:null), ]
 PREHOOK: query: EXPLAIN SELECT i, count(*) as c FROM test_stats_2 GROUP BY i ORDER BY c DESC LIMIT 10
 PREHOOK: type: QUERY
@@ -120,16 +114,16 @@ STAGE PLANS:
                     Group By Operator
                       aggregations: count()
                       keys: i (type: int)
-                      minReductionHashAggr: 0.6
+                      minReductionHashAggr: 0.4
                       mode: hash
                       outputColumnNames: _col0, _col1
-                      Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                         value expressions: _col1 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -141,19 +135,18 @@ STAGE PLANS:
                 keys: KEY._col0 (type: int)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                 Top N Key Operator
                   sort order: -
                   keys: _col1 (type: bigint)
-                  null sort order: z
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  null sort order: a
+                  Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                   top n: 10
                   Reduce Output Operator
                     key expressions: _col1 (type: bigint)
-                    null sort order: z
+                    null sort order: a
                     sort order: -
-                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    TopN Hash Memory Usage: 0.1
+                    Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col0 (type: int)
         Reducer 3 
             Execution mode: vectorized, llap
@@ -161,13 +154,13 @@ STAGE PLANS:
               Select Operator
                 expressions: VALUE._col0 (type: int), KEY.reducesinkkey0 (type: bigint)
                 outputColumnNames: _col0, _col1
-                Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                 Limit
                   Number of rows: 10
-                  Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                   File Output Operator
                     compressed: false
-                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 5 Data size: 60 Basic stats: COMPLETE Column stats: COMPLETE
                     table:
                         input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24764
insert overwrite on a partition resets row count stats in other partitions. This causes partitions to return PARTIAL value and in some cases, it ends up generating suboptimal plan.
What changes were proposed in this pull request?

FSStatsAggregator::aggregateStats should return the value when the partitions are present in its statslist. Otherwise, it should return empty or null value. This would prevent stats from being overwritten in BasicStatsTask::updateStats for other partitions during 'insert overwrite' operation.