### PR TITLE
HIVE-24775: Incorrect null handling when rebuilding Materialized view incrementally

### DIFF
--- a/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_nulls.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_create_rewrite_nulls.q
@@ -1,0 +1,61 @@
+SET hive.vectorized.execution.enabled=false;
+SET hive.support.concurrency=true;
+SET hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+SET hive.materializedview.rewriting.sql=false;
+set hive.cli.print.header=true;
+
+CREATE TABLE t1 (a int, b varchar(256), c decimal(10,2), d int) STORED AS orc TBLPROPERTIES ('transactional'='true');
+
+INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.77, 7),
+ (1, 'calvin', 978.76, 3),
+ (1, 'charlie', 9.8, 1);
+
+CREATE MATERIALIZED VIEW mat1 TBLPROPERTIES ('transactional'='true') AS
+  SELECT a, b, sum(d)
+  FROM t1
+  WHERE c > 10.0
+  GROUP BY a, b;
+
+INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.88, 8),
+ (NULL, NULL, 20.2, 200),
+ (9, 'bob', 40.2, 400),
+ (1, 'charlie', 15.8, 1);
+
+explain cbo
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+explain
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+
+EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b;
+
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b;
+
+SELECT * FROM mat1
+ORDER BY a, b;
+
+DROP MATERIALIZED VIEW mat1;
+
+EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b;
+
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_4.q.out
@@ -743,22 +743,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n5
-                  filterExpr: ((c > 10) and a is not null) (type: boolean)
                   Statistics: Num rows: 2 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((c > 10) and a is not null) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), c (type: decimal(10,2)), _c2 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0, _col1, _col2, _col3
+                  Select Operator
+                    expressions: a (type: int), c (type: decimal(10,2)), _c2 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
                       Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
-                        Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      value expressions: _col2 (type: bigint), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -813,13 +809,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int), _col1 (type: decimal(10,2))
                   1 _col0 (type: int), _col1 (type: decimal(10,2))
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col0 is null and _col1 is null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col3 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN ((_col0 is null and _col1 is null)) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    expressions: _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -847,10 +844,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: decimal(10,2)), _col6 (type: decimal(10,2)), _col7 (type: bigint), _col8 (type: binary), _col9 (type: bigint), _col10 (type: bigint), _col11 (type: bigint), _col12 (type: binary)
                 Filter Operator
-                  predicate: ((_col0 = _col4) and (_col1 = _col5)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col3 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN ((_col0 is null and _col1 is null)) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
                     outputColumnNames: _col0, _col1, _col2, _col3
                     Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -993,7 +990,7 @@ POSTHOOK: Input: default@cmv_basetable_n5
 POSTHOOK: Input: default@cmv_mat_view_n5
 POSTHOOK: Output: default@cmv_mat_view_n5
 POSTHOOK: Output: default@cmv_mat_view_n5
-POSTHOOK: Lineage: cmv_mat_view_n5._c2 EXPRESSION [(cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:a, type:int, comment:null), (cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:c, type:decimal(10,2), comment:null), (cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:d, type:int, comment:null), (cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:_c2, type:bigint, comment:null), ]
+POSTHOOK: Lineage: cmv_mat_view_n5._c2 EXPRESSION [(cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:_c2, type:bigint, comment:null), (cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:d, type:int, comment:null), ]
 POSTHOOK: Lineage: cmv_mat_view_n5.a SIMPLE [(cmv_basetable_n5)cmv_basetable_n5.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: cmv_mat_view_n5.c SIMPLE [(cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:c, type:decimal(10,2), comment:null), ]
 PREHOOK: query: DESCRIBE FORMATTED cmv_mat_view_n5
@@ -1767,22 +1764,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n5
-                  filterExpr: ((c > 10) and a is not null) (type: boolean)
                   Statistics: Num rows: 2 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: ((c > 10) and a is not null) (type: boolean)
-                    Statistics: Num rows: 2 Data size: 248 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), c (type: decimal(10,2)), _c2 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0, _col1, _col2, _col3
+                  Select Operator
+                    expressions: a (type: int), c (type: decimal(10,2)), _c2 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
                       Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int), _col1 (type: decimal(10,2))
-                        null sort order: zz
-                        sort order: ++
-                        Map-reduce partition columns: _col0 (type: int), _col1 (type: decimal(10,2))
-                        Statistics: Num rows: 2 Data size: 400 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col2 (type: bigint), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      value expressions: _col2 (type: bigint), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -1837,13 +1830,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int), _col1 (type: decimal(10,2))
                   1 _col0 (type: int), _col1 (type: decimal(10,2))
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
-                Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: (_col0 is null and _col1 is null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col3 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN ((_col0 is null and _col1 is null)) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    expressions: _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 1 Data size: 124 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -1871,10 +1865,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 712 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: decimal(10,2)), _col6 (type: decimal(10,2)), _col7 (type: bigint), _col8 (type: binary), _col9 (type: bigint), _col10 (type: bigint), _col11 (type: bigint), _col12 (type: binary)
                 Filter Operator
-                  predicate: ((_col0 = _col4) and (_col1 = _col5)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 324 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col3 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN ((_col0 is null and _col1 is null)) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col5 (type: decimal(10,2)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
                     outputColumnNames: _col0, _col1, _col2, _col3
                     Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
@@ -2017,7 +2011,7 @@ POSTHOOK: Input: default@cmv_basetable_n5
 POSTHOOK: Input: default@cmv_mat_view_n5
 POSTHOOK: Output: default@cmv_mat_view_n5
 POSTHOOK: Output: default@cmv_mat_view_n5
-POSTHOOK: Lineage: cmv_mat_view_n5._c2 EXPRESSION [(cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:a, type:int, comment:null), (cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:c, type:decimal(10,2), comment:null), (cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:d, type:int, comment:null), (cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:_c2, type:bigint, comment:null), ]
+POSTHOOK: Lineage: cmv_mat_view_n5._c2 EXPRESSION [(cmv_mat_view_n5)default.cmv_mat_view_n5.FieldSchema(name:_c2, type:bigint, comment:null), (cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:d, type:int, comment:null), ]
 POSTHOOK: Lineage: cmv_mat_view_n5.a SIMPLE [(cmv_basetable_n5)cmv_basetable_n5.FieldSchema(name:a, type:int, comment:null), ]
 POSTHOOK: Lineage: cmv_mat_view_n5.c SIMPLE [(cmv_basetable_2_n2)cmv_basetable_2_n2.FieldSchema(name:c, type:decimal(10,2), comment:null), ]
 PREHOOK: query: DESCRIBE FORMATTED cmv_mat_view_n5

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_nulls.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_nulls.q.out
@@ -1,0 +1,465 @@
+PREHOOK: query: CREATE TABLE t1 (a int, b varchar(256), c decimal(10,2), d int) STORED AS orc TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1 (a int, b varchar(256), c decimal(10,2), d int) STORED AS orc TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.77, 7),
+ (1, 'calvin', 978.76, 3),
+ (1, 'charlie', 9.8, 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.77, 7),
+ (1, 'calvin', 978.76, 3),
+ (1, 'charlie', 9.8, 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
+_col0	_col1	_col2	_col3
+PREHOOK: query: CREATE MATERIALIZED VIEW mat1 TBLPROPERTIES ('transactional'='true') AS
+  SELECT a, b, sum(d)
+  FROM t1
+  WHERE c > 10.0
+  GROUP BY a, b
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+POSTHOOK: query: CREATE MATERIALIZED VIEW mat1 TBLPROPERTIES ('transactional'='true') AS
+  SELECT a, b, sum(d)
+  FROM t1
+  WHERE c > 10.0
+  GROUP BY a, b
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+a	b	_c2
+PREHOOK: query: INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.88, 8),
+ (NULL, NULL, 20.2, 200),
+ (9, 'bob', 40.2, 400),
+ (1, 'charlie', 15.8, 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1 VALUES
+ (NULL, 'null_value', 100.88, 8),
+ (NULL, NULL, 20.2, 200),
+ (9, 'bob', 40.2, 400),
+ (1, 'charlie', 15.8, 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
+_col0	_col1	_col2	_col3
+PREHOOK: query: explain cbo
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: explain cbo
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+Explain
+CBO PLAN:
+HiveProject($f0=[$3], $f1=[$4], $f2=[CASE(IS NULL($2), $5, +($5, $2))])
+  HiveFilter(condition=[OR(IS NULL($2), AND(=($0, $3), =($1, $4)))])
+    HiveJoin(condition=[AND(=($0, $3), =($1, $4))], joinType=[right], algorithm=[none], cost=[not available])
+      HiveProject(a=[$0], b=[$1], _c2=[$2])
+        HiveFilter(condition=[AND(IS NOT NULL($0), IS NOT NULL($1))])
+          HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+      HiveProject(a=[$0], b=[$1], $f2=[$2])
+        HiveAggregate(group=[{0, 1}], agg#0=[sum($3)])
+          HiveFilter(condition=[AND(<(1, $6.writeid), >($2, 10))])
+            HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: explain
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+Explain
+STAGE DEPENDENCIES:
+  Stage-2 is a root stage
+  Stage-3 depends on stages: Stage-2
+  Stage-0 depends on stages: Stage-3
+  Stage-4 depends on stages: Stage-0
+  Stage-6 depends on stages: Stage-4, Stage-5
+  Stage-1 depends on stages: Stage-3
+  Stage-5 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-2
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (CUSTOM_SIMPLE_EDGE)
+        Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: default.mat1
+                  Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), b (type: varchar(256)), _c2 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: varchar(256))
+                      null sort order: zz
+                      sort order: ++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: varchar(256))
+                      Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col2 (type: bigint), _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: ((ROW__ID.writeid > 1L) and (c > 10)) (type: boolean)
+                  Statistics: Num rows: 7 Data size: 1476 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: ((ROW__ID.writeid > 1L) and (c > 10)) (type: boolean)
+                    Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: varchar(256)), d (type: int)
+                      outputColumnNames: a, b, d
+                      Statistics: Num rows: 2 Data size: 424 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(d)
+                        keys: a (type: int), b (type: varchar(256))
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: varchar(256))
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: varchar(256))
+                          Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col2 (type: bigint)
+            Execution mode: llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Right Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: int), _col1 (type: varchar(256))
+                  1 _col0 (type: int), _col1 (type: varchar(256))
+                nullSafes: [true, true]
+                outputColumnNames: _col2, _col3, _col4, _col5, _col6
+                Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: _col3 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col4 (type: int), _col5 (type: varchar(256)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 1 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                          serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                          name: default.mat1
+                      Write Type: INSERT
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: varchar(256)), _col2 (type: bigint)
+                      outputColumnNames: a, b, _c2
+                      Statistics: Num rows: 1 Data size: 104 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(a), max(a), count(1), count(a), compute_bit_vector_hll(a), max(length(b)), avg(COALESCE(length(b),0)), count(b), compute_bit_vector_hll(b), min(_c2), max(_c2), count(_c2), compute_bit_vector_hll(_c2)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                        Statistics: Num rows: 1 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Statistics: Num rows: 1 Data size: 568 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: int), _col6 (type: struct<count:bigint,sum:double,input:int>), _col7 (type: bigint), _col8 (type: binary), _col9 (type: bigint), _col10 (type: bigint), _col11 (type: bigint), _col12 (type: binary)
+                Filter Operator
+                  predicate: _col3 is not null (type: boolean)
+                  Statistics: Num rows: 2 Data size: 376 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col4 (type: int), _col5 (type: varchar(256)), CASE WHEN (_col2 is null) THEN (_col6) ELSE ((_col6 + _col2)) END (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      null sort order: a
+                      sort order: +
+                      Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                      Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col1 (type: int), _col2 (type: varchar(256)), _col3 (type: bigint)
+        Reducer 3 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), max(VALUE._col5), avg(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8), min(VALUE._col9), max(VALUE._col10), count(VALUE._col11), compute_bit_vector_hll(VALUE._col12)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                Statistics: Num rows: 1 Data size: 500 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'LONG' (type: string), UDFToLong(_col0) (type: bigint), UDFToLong(_col1) (type: bigint), (_col2 - _col3) (type: bigint), COALESCE(ndv_compute_bit_vector(_col4),0) (type: bigint), _col4 (type: binary), 'STRING' (type: string), UDFToLong(COALESCE(_col5,0)) (type: bigint), COALESCE(_col6,0) (type: double), (_col2 - _col7) (type: bigint), COALESCE(ndv_compute_bit_vector(_col8),0) (type: bigint), _col8 (type: binary), 'LONG' (type: string), _col9 (type: bigint), _col10 (type: bigint), (_col2 - _col11) (type: bigint), COALESCE(ndv_compute_bit_vector(_col12),0) (type: bigint), _col12 (type: binary)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17
+                  Statistics: Num rows: 1 Data size: 794 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 794 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 4 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: varchar(256)), VALUE._col2 (type: bigint)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 2 Data size: 360 Basic stats: COMPLETE Column stats: COMPLETE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.mat1
+                  Write Type: UPDATE
+        Reducer 6 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: varchar(256))
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                Reduce Output Operator
+                  key expressions: _col0 (type: int), _col1 (type: varchar(256))
+                  null sort order: zz
+                  sort order: ++
+                  Map-reduce partition columns: _col0 (type: int), _col1 (type: varchar(256))
+                  Statistics: Num rows: 2 Data size: 208 Basic stats: COMPLETE Column stats: COMPLETE
+                  value expressions: _col2 (type: bigint)
+
+  Stage: Stage-3
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mat1
+          Write Type: INSERT
+
+  Stage: Stage-4
+    Stats Work
+      Basic Stats Work:
+
+  Stage: Stage-6
+    Materialized View Update
+      name: default.mat1
+      update creation metadata: true
+
+  Stage: Stage-1
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mat1
+          Write Type: UPDATE
+
+  Stage: Stage-5
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: a, b, _c2
+          Column Types: int, varchar(256), bigint
+          Table: default.mat1
+
+PREHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Lineage: mat1._c2 EXPRESSION [(mat1)default.mat1.FieldSchema(name:_c2, type:bigint, comment:null), (t1)t1.FieldSchema(name:d, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1.a SIMPLE [(t1)t1.FieldSchema(name:a, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1.b SIMPLE [(t1)t1.FieldSchema(name:b, type:varchar(256), comment:null), ]
+$hdt$_0.row__id	t1.a	t1.b	_c2
+PREHOOK: query: EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveSortLimit(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])
+  HiveProject(a=[$0], b=[$1], _c2=[$2])
+    HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+a	b	_c2
+1	calvin	3
+1	charlie	1
+9	bob	400
+NULL	null_value	15
+NULL	NULL	200
+PREHOOK: query: SELECT * FROM mat1
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT * FROM mat1
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+#### A masked pattern was here ####
+mat1.a	mat1.b	mat1._c2
+1	calvin	3
+1	charlie	1
+9	bob	400
+NULL	null_value	15
+NULL	NULL	200
+PREHOOK: query: DROP MATERIALIZED VIEW mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: DROP MATERIALIZED VIEW mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN CBO
+SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+Explain
+CBO PLAN:
+HiveSortLimit(sort0=[$0], sort1=[$1], dir0=[ASC], dir1=[ASC])
+  HiveProject(a=[$0], b=[$1], $f2=[$2])
+    HiveAggregate(group=[{0, 1}], agg#0=[sum($3)])
+      HiveFilter(condition=[>($2, 10)])
+        HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, b, sum(d)
+FROM t1
+WHERE c > 10.0
+GROUP BY a, b
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+a	b	_c2
+1	calvin	3
+1	charlie	1
+9	bob	400
+NULL	null_value	15
+NULL	NULL	200

--- a/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_one_key_gby.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_create_rewrite_one_key_gby.q.out
@@ -127,22 +127,18 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.cmv_mat_view_n5
-                  filterExpr: a is not null (type: boolean)
                   Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                  Filter Operator
-                    predicate: a is not null (type: boolean)
-                    Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
-                    Select Operator
-                      expressions: a (type: int), _c1 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0, _col1, _col2
+                  Select Operator
+                    expressions: a (type: int), _c1 (type: bigint), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 2 Data size: 176 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: bigint), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      value expressions: _col1 (type: bigint), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
             Execution mode: llap
             LLAP IO: may be used (ACID table)
         Map 5 
@@ -197,13 +193,14 @@ STAGE PLANS:
                 keys:
                   0 _col0 (type: int)
                   1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4
-                Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                nullSafes: [true]
+                outputColumnNames: _col1, _col2, _col3, _col4
+                Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
-                  predicate: _col0 is null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col2 is null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col3 (type: int), CASE WHEN (_col0 is null) THEN (_col4) ELSE ((_col4 + _col1)) END (type: bigint)
+                    expressions: _col3 (type: int), CASE WHEN (_col1 is null) THEN (_col4) ELSE ((_col4 + _col1)) END (type: bigint)
                     outputColumnNames: _col0, _col1
                     Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
@@ -231,10 +228,10 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
                           value expressions: _col0 (type: int), _col1 (type: int), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: binary), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: binary)
                 Filter Operator
-                  predicate: (_col0 = _col3) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 100 Basic stats: COMPLETE Column stats: COMPLETE
+                  predicate: _col2 is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), CASE WHEN (_col0 is null) THEN (_col4) ELSE ((_col4 + _col1)) END (type: bigint)
+                    expressions: _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col3 (type: int), CASE WHEN (_col1 is null) THEN (_col4) ELSE ((_col4 + _col1)) END (type: bigint)
                     outputColumnNames: _col0, _col1, _col2
                     Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator


### PR DESCRIPTION
See #1995

### What changes were proposed in this pull request?
When transforming plan of materialized view rebuild to incremental rebuild in case of the view definition has aggregate:
* Instead of checking the aggregate key is null check the aggregated columns are null or not. Example:
```
HiveProject($f0=[$3], $f1=[$4], $f2=[CASE(IS NULL($2), $5, +($5, $2))])
```
where `$2` is coming from the Materialized view and `$5` is coming from the delta result set (The rows inserted after the last MV refresh)
* When transforming the `newAST` generated from the CBO plan from an insert overwrite plan to a multi insert plan by `CalcitePlanner.fixUpASTAggregateIncrementalRebuild` replace equality operators with null safe equality operators in join condition
* The CBO plan contains a Filter on top of the MV scan checking all the aggregate key columns should be not null. Remove this in `fixUpASTAggregateIncrementalRebuild` since we need all rows from the view.
* Split the result of the Right outer join to the insert and update branches of the "multi insert statement" plan by checking that the RowId coming from the materialized view is null or not.

### Why are the changes needed?
Rows with null aggregate keys was not handled by incremental MV rebuild and it could lead to data corruption.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
vn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite_4.q,materialized_view_create_rewrite_nulls.q -pl itests/qtest -Pitests
```