### PR TITLE
HIVE-24778: Unify hive.strict.timestamp.conversion and hive.strict.checks.type.safety properties

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1773,15 +1773,15 @@ public class HiveConf extends Configuration {
         "Enabling strict type safety checks disallows the following:\n" +
         "  Comparing bigints and strings/(var)chars.\n" +
         "  Comparing bigints and doubles.\n" +
-        "  Comparing decimals and strings/(var)chars."),
+        "  Comparing decimals and strings/(var)chars.\n" +
+        "  Casting dates/timestamps to numeric.\n" +
+        "  Casting numeric to timestamps."),
     HIVE_STRICT_CHECKS_CARTESIAN("hive.strict.checks.cartesian.product", false,
         "Enabling strict Cartesian join checks disallows the following:\n" +
         "  Cartesian product (cross join)."),
     HIVE_STRICT_CHECKS_BUCKETING("hive.strict.checks.bucketing", true,
         "Enabling strict bucketing checks disallows the following:\n" +
         "  Load into bucketed tables."),
-    HIVE_STRICT_TIMESTAMP_CONVERSION("hive.strict.timestamp.conversion", true,
-        "Restricts unsafe numeric to timestamp conversions"),
     HIVE_LOAD_DATA_OWNER("hive.load.data.owner", "",
         "Set the owner of files loaded using load data in managed tables."),
 

--- a/data/conf/hive-site.xml
+++ b/data/conf/hive-site.xml
@@ -383,11 +383,6 @@
 </property>
 
 <property>
-  <name>hive.strict.timestamp.conversion</name>
-  <value>false</value>
-</property>
-
-<property>
   <name>hive.cbo.fallback.strategy</name>
   <value>TEST</value>
 </property>

--- a/data/conf/llap/hive-site.xml
+++ b/data/conf/llap/hive-site.xml
@@ -403,11 +403,6 @@
 </property>
 
 <property>
-  <name>hive.strict.timestamp.conversion</name>
-  <value>false</value>
-</property>
-
-<property>
   <name>hive.cbo.fallback.strategy</name>
   <value>TEST</value>
 </property>

--- a/hbase-handler/src/test/queries/positive/hbase_timestamp.q
+++ b/hbase-handler/src/test/queries/positive/hbase_timestamp.q
@@ -1,4 +1,5 @@
 --! qt:dataset:src
+SET hive.strict.checks.type.safety=false;
 DROP TABLE hbase_table;
 CREATE EXTERNAL TABLE hbase_table (key string, value string, `time` timestamp)
   STORED BY 'org.apache.hadoop.hive.hbase.HBaseStorageHandler'

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/TimestampCastRestrictorResolver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/TimestampCastRestrictorResolver.java
@@ -45,7 +45,7 @@ public class TimestampCastRestrictorResolver implements UDFMethodResolver {
   public TimestampCastRestrictorResolver(UDFMethodResolver parentResolver) {
     this.parentResolver = parentResolver;
     SessionState ss = SessionState.get();
-    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION)) {
+    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY)) {
       strictTsConversion = true;
     }
   }
@@ -60,7 +60,7 @@ public class TimestampCastRestrictorResolver implements UDFMethodResolver {
         PrimitiveGrouping group = PrimitiveObjectInspectorUtils.getPrimitiveGrouping(category);
         if (group == PrimitiveGrouping.DATE_GROUP) {
           throw new UDFArgumentException(
-              "Casting DATE/TIMESTAMP types to NUMERIC is prohibited (" + ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION
+              "Casting DATE/TIMESTAMP types to NUMERIC is prohibited (" + ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY
                   + ")");
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBaseCompare.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFBaseCompare.java
@@ -166,10 +166,10 @@ public abstract class GenericUDFBaseCompare extends GenericUDFBaseBinary {
       return;
     }
     SessionState ss = SessionState.get();
-    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION)) {
+    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY)) {
       if (primitiveGroupOf(compareOI) == PrimitiveGrouping.NUMERIC_GROUP) {
         throw new UDFArgumentException(
-            "Casting DATE/TIMESTAMP to NUMERIC is prohibited (" + ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION + ")");
+            "Casting DATE/TIMESTAMP to NUMERIC is prohibited (" + ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY + ")");
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTimestamp.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFTimestamp.java
@@ -84,12 +84,12 @@ public class GenericUDFTimestamp extends GenericUDF {
           "The function TIMESTAMP takes only primitive types");
     }
 
-    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION)) {
+    if (ss != null && ss.getConf().getBoolVar(ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY)) {
       PrimitiveCategory category = argumentOI.getPrimitiveCategory();
       PrimitiveGrouping group = PrimitiveObjectInspectorUtils.getPrimitiveGrouping(category);
       if (group == PrimitiveGrouping.NUMERIC_GROUP) {
         throw new UDFArgumentException(
-            "Casting NUMERIC types to TIMESTAMP is prohibited (" + ConfVars.HIVE_STRICT_TIMESTAMP_CONVERSION + ")");
+            "Casting NUMERIC types to TIMESTAMP is prohibited (" + ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY + ")");
       }
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorFilterCompare.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorFilterCompare.java
@@ -84,6 +84,7 @@ public class TestVectorFilterCompare {
     // Arithmetic operations rely on getting conf from SessionState, need to initialize here.
     SessionState ss = new SessionState(new HiveConf());
     ss.getConf().setVar(HiveConf.ConfVars.HIVE_COMPAT, "latest");
+    ss.getConf().setBoolVar(HiveConf.ConfVars.HIVE_STRICT_CHECKS_TYPE_SAFETY, false);
     SessionState.setCurrentSessionState(ss);
   }
 

--- a/ql/src/test/queries/clientnegative/script_broken_pipe2.q
+++ b/ql/src/test/queries/clientnegative/script_broken_pipe2.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.llap.execution.mode=auto;
 set hive.exec.script.allow.partial.consumption = false;
+set hive.strict.checks.type.safety=false;
 -- Tests exception in ScriptOperator.processOp() by passing extra data needed to fill pipe buffer
 SELECT TRANSFORM(key, value, key, value, key, value, key, value, key, value, key, value, key, value, key, value, key, value, key, value, key, value, key, value) USING 'true' as a,b,c,d FROM src;

--- a/ql/src/test/queries/clientnegative/strict_numeric_to_timestamp.q
+++ b/ql/src/test/queries/clientnegative/strict_numeric_to_timestamp.q
@@ -1,2 +1,2 @@
-set hive.strict.timestamp.conversion=true;
+set hive.strict.checks.type.safety=true;
 select cast(123 as timestamp);

--- a/ql/src/test/queries/clientnegative/strict_numeric_to_timestamp2.q
+++ b/ql/src/test/queries/clientnegative/strict_numeric_to_timestamp2.q
@@ -1,3 +1,3 @@
-set hive.strict.timestamp.conversion=true;
+set hive.strict.checks.type.safety=true;
 create table t (a integer);
 select cast(a as timestamp) from t;

--- a/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric.q
+++ b/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric.q
@@ -1,2 +1,2 @@
-set hive.strict.timestamp.conversion=true;
-select cast(cast('2011-11-11' as timestamp) as integer);
+set hive.strict.checks.type.safety=true;
+select cast(cast('2011-11-11' as date) as integer);

--- a/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric2.q
+++ b/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric2.q
@@ -1,3 +1,3 @@
-set hive.strict.timestamp.conversion=true;
+set hive.strict.checks.type.safety=true;
 create table t(a timestamp);
 select cast(a as integer) from t;

--- a/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric3.q
+++ b/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric3.q
@@ -1,3 +1,3 @@
-set hive.strict.timestamp.conversion=true;
+set hive.strict.checks.type.safety=true;
 create table t(a struct<t:timestamp>);
 select cast(a.t as integer) from t;

--- a/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric4.q
+++ b/ql/src/test/queries/clientnegative/strict_timestamp_to_numeric4.q
@@ -1,3 +1,3 @@
-set hive.strict.timestamp.conversion=true;
+set hive.strict.checks.type.safety=true;
 create table t(a timestamp);
 select 1 from t where a=1000;

--- a/ql/src/test/queries/clientpositive/constprog_type.q
+++ b/ql/src/test/queries/clientpositive/constprog_type.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.optimize.constant.propagation=true;
+set hive.strict.checks.type.safety=false;
 
 CREATE TABLE dest1_n26(d date, t timestamp);
 

--- a/ql/src/test/queries/clientpositive/date_1.q
+++ b/ql/src/test/queries/clientpositive/date_1.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table date_1;
 

--- a/ql/src/test/queries/clientpositive/decimal_1.q
+++ b/ql/src/test/queries/clientpositive/decimal_1.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table if exists decimal_1_n0;
 

--- a/ql/src/test/queries/clientpositive/druidmini_test_insert.q
+++ b/ql/src/test/queries/clientpositive/druidmini_test_insert.q
@@ -1,6 +1,7 @@
 --! qt:dataset:alltypesorc
 SET hive.ctas.external.tables=true;
 SET hive.external.table.purge.default = true;
+SET hive.strict.checks.type.safety=false;
 CREATE EXTERNAL TABLE druid_alltypesorc
 STORED BY 'org.apache.hadoop.hive.druid.DruidStorageHandler'
 TBLPROPERTIES ("druid.segment.granularity" = "HOUR", "druid.query.granularity" = "MINUTE")

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_13.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_13.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_2.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_2.q
@@ -1,6 +1,7 @@
 --! qt:dataset:alltypesparquet
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_3.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_3.q
@@ -2,6 +2,7 @@
 set hive.mapred.mode=nonstrict;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_7.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_7.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_8.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_8.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/parquet_vectorization_decimal_date.q
+++ b/ql/src/test/queries/clientpositive/parquet_vectorization_decimal_date.q
@@ -1,6 +1,7 @@
 --! qt:dataset:alltypesparquet
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 CREATE TABLE date_decimal_test_parquet STORED AS PARQUET AS SELECT cint, cdouble, CAST (CAST (cint AS TIMESTAMP) AS DATE) AS cdate, CAST (((cdouble*22.1)/37) AS DECIMAL(20,10)) AS cdecimal FROM alltypesparquet;
 SET hive.vectorized.execution.enabled=true;

--- a/ql/src/test/queries/clientpositive/timestamp_1.q
+++ b/ql/src/test/queries/clientpositive/timestamp_1.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table timestamp_1;
 

--- a/ql/src/test/queries/clientpositive/timestamp_2.q
+++ b/ql/src/test/queries/clientpositive/timestamp_2.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table timestamp_2;
 

--- a/ql/src/test/queries/clientpositive/timestamp_3.q
+++ b/ql/src/test/queries/clientpositive/timestamp_3.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table timestamp_3;
 

--- a/ql/src/test/queries/clientpositive/timestamp_comparison2.q
+++ b/ql/src/test/queries/clientpositive/timestamp_comparison2.q
@@ -1,5 +1,7 @@
 --! qt:dataset:alltypesorc
 -- Test timestamp-to-numeric comparison
+set hive.strict.checks.type.safety=false;
+
 select count(*) 
 FROM   alltypesorc
 WHERE  

--- a/ql/src/test/queries/clientpositive/timestamptz_3.q
+++ b/ql/src/test/queries/clientpositive/timestamptz_3.q
@@ -1,4 +1,5 @@
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 drop table tstz1_n1;
 

--- a/ql/src/test/queries/clientpositive/udf_from_utc_timestamp.q
+++ b/ql/src/test/queries/clientpositive/udf_from_utc_timestamp.q
@@ -1,5 +1,6 @@
 DESCRIBE FUNCTION from_utc_timestamp;
 DESC FUNCTION EXTENDED from_utc_timestamp;
+set hive.strict.checks.type.safety=false;
 
 explain select from_utc_timestamp('2012-02-11 10:30:00', 'PST');
 

--- a/ql/src/test/queries/clientpositive/udf_to_boolean.q
+++ b/ql/src/test/queries/clientpositive/udf_to_boolean.q
@@ -1,5 +1,6 @@
 --! qt:dataset:src
 set hive.fetch.task.conversion=more;
+set hive.strict.checks.type.safety=false;
 
 -- 'true' cases:
 

--- a/ql/src/test/queries/clientpositive/vector_between_in.q
+++ b/ql/src/test/queries/clientpositive/vector_between_in.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 CREATE TABLE decimal_date_test STORED AS ORC AS SELECT cdouble, CAST (((cdouble*22.1)/37) AS DECIMAL(20,10)) AS cdecimal1, CAST (((cdouble*9.3)/13) AS DECIMAL(23,14)) AS cdecimal2, CAST(CAST((CAST(cint AS BIGINT) *ctinyint) AS TIMESTAMP) AS DATE) AS cdate FROM alltypesorc ORDER BY cdate;
 

--- a/ql/src/test/queries/clientpositive/vector_case_when_2.q
+++ b/ql/src/test/queries/clientpositive/vector_case_when_2.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
 set hive.vectorized.execution.enabled=true;
+set hive.strict.checks.type.safety=false;
 
 create table timestamps_txt (tsval timestamp) STORED AS TEXTFILE;
 

--- a/ql/src/test/queries/clientpositive/vector_decimal_1.q
+++ b/ql/src/test/queries/clientpositive/vector_decimal_1.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 drop table if exists decimal_1;
 

--- a/ql/src/test/queries/clientpositive/vector_decimal_expressions.q
+++ b/ql/src/test/queries/clientpositive/vector_decimal_expressions.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
 set hive.stats.column.autogather=false;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vector_reuse_scratchcols.q
+++ b/ql/src/test/queries/clientpositive/vector_reuse_scratchcols.q
@@ -1,5 +1,6 @@
 --! qt:dataset:alltypesorc
 set hive.vectorized.execution.enabled=true;
+set hive.strict.checks.type.safety=false;
 
 
 EXPLAIN VECTORIZATION DETAIL

--- a/ql/src/test/queries/clientpositive/vectorization_13.q
+++ b/ql/src/test/queries/clientpositive/vectorization_13.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorization_2.q
+++ b/ql/src/test/queries/clientpositive/vectorization_2.q
@@ -1,6 +1,7 @@
 --! qt:dataset:alltypesorc
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorization_3.q
+++ b/ql/src/test/queries/clientpositive/vectorization_3.q
@@ -2,6 +2,7 @@
 set hive.mapred.mode=nonstrict;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorization_7.q
+++ b/ql/src/test/queries/clientpositive/vectorization_7.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorization_8.q
+++ b/ql/src/test/queries/clientpositive/vectorization_8.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorization_decimal_date.q
+++ b/ql/src/test/queries/clientpositive/vectorization_decimal_date.q
@@ -1,6 +1,7 @@
 --! qt:dataset:alltypesorc
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 CREATE TABLE date_decimal_test STORED AS ORC AS SELECT cint, cdouble, CAST (CAST (cint AS TIMESTAMP) AS DATE) AS cdate, CAST (((cdouble*22.1)/37) AS DECIMAL(20,10)) AS cdecimal FROM alltypesorc;
 SET hive.vectorized.execution.enabled=true;

--- a/ql/src/test/queries/clientpositive/vectorization_short_regress.q
+++ b/ql/src/test/queries/clientpositive/vectorization_short_regress.q
@@ -5,6 +5,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 SET hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorized_casts.q
+++ b/ql/src/test/queries/clientpositive/vectorized_casts.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
 SET hive.vectorized.execution.enabled = true;
+set hive.strict.checks.type.safety=false;
 
 -- SORT_QUERY_RESULTS
 

--- a/ql/src/test/queries/clientpositive/vectorized_timestamp.q
+++ b/ql/src/test/queries/clientpositive/vectorized_timestamp.q
@@ -1,6 +1,7 @@
 set hive.fetch.task.conversion=none;
 set hive.explain.user=false;
 set hive.vectorized.execution.reduce.enabled=true;
+set hive.strict.checks.type.safety=false;
 
 DROP TABLE IF EXISTS test_n2;
 CREATE TABLE test_n2(ts TIMESTAMP) STORED AS ORC;

--- a/ql/src/test/queries/clientpositive/vectorized_timestamp_funcs.q
+++ b/ql/src/test/queries/clientpositive/vectorized_timestamp_funcs.q
@@ -4,6 +4,7 @@ set hive.mapred.mode=nonstrict;
 set hive.explain.user=false;
 set hive.fetch.task.conversion=none;
 SET hive.vectorized.execution.enabled = false;
+set hive.strict.checks.type.safety=false;
 
 -- Test timestamp functions in vectorized mode to verify they run correctly end-to-end.
 -- Turning on vectorization has been temporarily moved after filling the test table

--- a/ql/src/test/queries/clientpositive/vectorized_timestamp_ints_casts.q
+++ b/ql/src/test/queries/clientpositive/vectorized_timestamp_ints_casts.q
@@ -3,6 +3,7 @@ set hive.mapred.mode=nonstrict;
 SET hive.vectorized.execution.enabled = true;
 SET hive.int.timestamp.conversion.in.seconds=false;
 set hive.fetch.task.conversion=none;
+set hive.strict.checks.type.safety=false;
 
 explain vectorization expression
 select

--- a/ql/src/test/results/clientnegative/strict_numeric_to_timestamp.q.out
+++ b/ql/src/test/results/clientnegative/strict_numeric_to_timestamp.q.out
@@ -1,1 +1,1 @@
-FAILED: SemanticException Line 0:-1 Wrong arguments '123': Casting NUMERIC types to TIMESTAMP is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException Line 0:-1 Wrong arguments '123': Casting NUMERIC types to TIMESTAMP is prohibited (hive.strict.checks.type.safety)

--- a/ql/src/test/results/clientnegative/strict_numeric_to_timestamp2.q.out
+++ b/ql/src/test/results/clientnegative/strict_numeric_to_timestamp2.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table t (a integer)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t
-FAILED: SemanticException Line 0:-1 Wrong arguments 'a': Casting NUMERIC types to TIMESTAMP is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException Line 0:-1 Wrong arguments 'a': Casting NUMERIC types to TIMESTAMP is prohibited (hive.strict.checks.type.safety)

--- a/ql/src/test/results/clientnegative/strict_timestamp_to_numeric.q.out
+++ b/ql/src/test/results/clientnegative/strict_timestamp_to_numeric.q.out
@@ -1,1 +1,1 @@
-FAILED: SemanticException Line 0:-1 Wrong arguments ''2011-11-11'': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException Line 0:-1 Wrong arguments ''2011-11-11'': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.checks.type.safety)

--- a/ql/src/test/results/clientnegative/strict_timestamp_to_numeric2.q.out
+++ b/ql/src/test/results/clientnegative/strict_timestamp_to_numeric2.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table t(a timestamp)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t
-FAILED: SemanticException Line 0:-1 Wrong arguments 'a': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException Line 0:-1 Wrong arguments 'a': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.checks.type.safety)

--- a/ql/src/test/results/clientnegative/strict_timestamp_to_numeric3.q.out
+++ b/ql/src/test/results/clientnegative/strict_timestamp_to_numeric3.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table t(a struct<t:timestamp>)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t
-FAILED: SemanticException Line 0:-1 Wrong arguments 't': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException Line 0:-1 Wrong arguments 't': Casting DATE/TIMESTAMP types to NUMERIC is prohibited (hive.strict.checks.type.safety)

--- a/ql/src/test/results/clientnegative/strict_timestamp_to_numeric4.q.out
+++ b/ql/src/test/results/clientnegative/strict_timestamp_to_numeric4.q.out
@@ -6,4 +6,4 @@ POSTHOOK: query: create table t(a timestamp)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t
-FAILED: SemanticException [Error 10014]: Line 2:22 Wrong arguments '1000': Casting DATE/TIMESTAMP to NUMERIC is prohibited (hive.strict.timestamp.conversion)
+FAILED: SemanticException [Error 10014]: Line 2:22 Wrong arguments '1000': Casting DATE/TIMESTAMP to NUMERIC is prohibited (hive.strict.checks.type.safety)


### PR DESCRIPTION
### What changes were proposed in this pull request?
The majority of strict type checks can be controlled by hive.strict.checks.type.safety property. HIVE-24157 introduced another property, namely hive.strict.timestamp.conversion, to control the implicit comparisons between numerics and timestamps.
The name and description of hive.strict.checks.type.safety imply that the property covers all strict checks so having others for specific cases appears confusing and can easily lead to unexpected behavior.

This PR unifies those properties to facilitate configuration and improve code reuse.

### Why are the changes needed?
Reduce conf complexity

### Does this PR introduce _any_ user-facing change?
Unifies hive.strict.timestamp.conversion and hive.strict.checks.type.safety properties


### How was this patch tested?
Existing tests
