### PR TITLE
HIVE-24240: Implement missing features in UDTFStatsRule

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/stats/annotation/StatsRulesProcFactory.java
@@ -2912,19 +2912,15 @@ public class StatsRulesProcFactory {
       if (parentStats != null) {
         Statistics st = parentStats.clone();
 
-        float udtfFactor=HiveConf.getFloatVar(aspCtx.getConf(), HiveConf.ConfVars.HIVE_STATS_UDTF_FACTOR);
-        long numRows = (long) (parentStats.getNumRows() * udtfFactor);
+        float udtfFactor = HiveConf.getFloatVar(aspCtx.getConf(), HiveConf.ConfVars.HIVE_STATS_UDTF_FACTOR);
+        long numRows = Math.max(StatsUtils.safeMult(parentStats.getNumRows(), udtfFactor), 1);
         long dataSize = StatsUtils.safeMult(parentStats.getDataSize(), udtfFactor);
         st.setNumRows(numRows);
         st.setDataSize(dataSize);
 
         List<ColStatistics> colStatsList = st.getColumnStats();
         if(colStatsList != null) {
-          for (ColStatistics colStats : colStatsList) {
-            colStats.setNumFalses((long) (colStats.getNumFalses() * udtfFactor));
-            colStats.setNumTrues((long) (colStats.getNumTrues() * udtfFactor));
-            colStats.setNumNulls((long) (colStats.getNumNulls() * udtfFactor));
-          }
+          StatsUtils.scaleColStatistics(colStatsList, udtfFactor);
           st.setColumnStats(colStatsList);
         }
 
@@ -2932,7 +2928,7 @@ public class StatsRulesProcFactory {
           LOG.debug("[0] STATS-" + uop.toString() + ": " + st.extendedToString());
         }
 
-        uop.setStatistics(st);
+        uop.setStatistics(applyRuntimeStats(aspCtx.getParseContext().getContext(), st, uop));
       }
       return null;
     }

--- a/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
+++ b/ql/src/test/results/clientpositive/llap/annotate_stats_lateral_view_join.q.out
@@ -772,7 +772,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
@@ -823,7 +823,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
@@ -913,7 +913,7 @@ STAGE PLANS:
                                   outputColumnNames: _col0
                                   Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -934,7 +934,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                              Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
@@ -964,7 +964,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -1024,7 +1024,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -1045,7 +1045,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
@@ -1075,7 +1075,7 @@ STAGE PLANS:
                                       outputColumnNames: _col0
                                       Statistics: Num rows: 1 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                                        Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -2356,7 +2356,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
@@ -2407,7 +2407,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
@@ -2497,7 +2497,7 @@ STAGE PLANS:
                                   outputColumnNames: _col0
                                   Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                   UDTF Operator
-                                    Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                    Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                     function name: explode
                                     Lateral View Join Operator
                                       outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -2518,7 +2518,7 @@ STAGE PLANS:
                             outputColumnNames: _col0
                             Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                             UDTF Operator
-                              Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                              Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                               function name: explode
                               Lateral View Join Operator
                                 outputColumnNames: _col0, _col1, _col5, _col6
@@ -2548,7 +2548,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -2608,7 +2608,7 @@ STAGE PLANS:
                                     outputColumnNames: _col0
                                     Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                     UDTF Operator
-                                      Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                      Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                       function name: explode
                                       Lateral View Join Operator
                                         outputColumnNames: _col0, _col1, _col5, _col6, _col7
@@ -2629,7 +2629,7 @@ STAGE PLANS:
                               outputColumnNames: _col0
                               Statistics: Num rows: 1 Data size: 55 Basic stats: COMPLETE Column stats: NONE
                               UDTF Operator
-                                Statistics: Num rows: 0 Data size: 27 Basic stats: COMPLETE Column stats: NONE
+                                Statistics: Num rows: 1 Data size: 27 Basic stats: COMPLETE Column stats: NONE
                                 function name: explode
                                 Lateral View Join Operator
                                   outputColumnNames: _col0, _col1, _col5, _col6
@@ -2659,7 +2659,7 @@ STAGE PLANS:
                                       outputColumnNames: _col0
                                       Statistics: Num rows: 1 Data size: 82 Basic stats: COMPLETE Column stats: NONE
                                       UDTF Operator
-                                        Statistics: Num rows: 0 Data size: 41 Basic stats: COMPLETE Column stats: NONE
+                                        Statistics: Num rows: 1 Data size: 41 Basic stats: COMPLETE Column stats: NONE
                                         function name: explode
                                         Lateral View Join Operator
                                           outputColumnNames: _col0, _col1, _col5, _col6, _col7


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24240

### What changes were proposed in this pull request?
Fix incorrect computations to estimate UDTF size.

- Put 1 when numRows becomes zero because Hive expects it will be non-zero in regular cases
- Use `StatsUtils .scaleColStatistics` to update col stats so as to update # of distinct values
- Wrap the final stats with `applyRuntimeStats`

This is a follow-up of https://github.com/apache/hive/pull/1531.

### Why are the changes needed?
This PR would help Hive to compute more precise stats for UDTF.

### Does this PR introduce _any_ user-facing change?
Compatible from the point of view of users.

### How was this patch tested?
Revised one unit test.