### PR TITLE
HIVE-24797: Disable validate default values when parsing Avro schemas

### DIFF
--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -278,18 +278,20 @@ public class AvroSerdeUtils {
     return dec;
   }
 
-  public static Schema getSchemaFor(String str) {
+  private static Schema.Parser getSchemaParser() {
     // HIVE-24797: Disable validate default values when parsing Avro schemas.
-    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
-    Schema schema = parser.parse(str);
+    return new Schema.Parser().setValidateDefaults(false);
+  }
+
+  public static Schema getSchemaFor(String str) {
+    Schema schema = getSchemaParser().parse(str);
     return schema;
   }
 
   public static Schema getSchemaFor(File file) {
-    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
     Schema schema;
     try {
-      schema = parser.parse(file);
+      schema = getSchemaParser().parse(file);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Avro schema from " + file.getName(), e);
     }
@@ -297,10 +299,9 @@ public class AvroSerdeUtils {
   }
 
   public static Schema getSchemaFor(InputStream stream) {
-    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
     Schema schema;
     try {
-      schema = parser.parse(stream);
+      schema = getSchemaParser().parse(stream);
     } catch (IOException e) {
       throw new RuntimeException("Failed to parse Avro schema", e);
     }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerdeUtils.java
@@ -279,13 +279,14 @@ public class AvroSerdeUtils {
   }
 
   public static Schema getSchemaFor(String str) {
-    Schema.Parser parser = new Schema.Parser();
+    // HIVE-24797: Disable validate default values when parsing Avro schemas.
+    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
     Schema schema = parser.parse(str);
     return schema;
   }
 
   public static Schema getSchemaFor(File file) {
-    Schema.Parser parser = new Schema.Parser();
+    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
     Schema schema;
     try {
       schema = parser.parse(file);
@@ -296,7 +297,7 @@ public class AvroSerdeUtils {
   }
 
   public static Schema getSchemaFor(InputStream stream) {
-    Schema.Parser parser = new Schema.Parser();
+    Schema.Parser parser = new Schema.Parser().setValidateDefaults(false);
     Schema schema;
     try {
       schema = parser.parse(stream);


### PR DESCRIPTION
### What changes were proposed in this pull request?

This pr disable validate default values when parsing Avro schemas.

### Why are the changes needed?

It will throw exception when upgrading Avro to 1.10.1 for this schema::
```json
{
    "type": "record",
    "name": "EventData",
    "doc": "event data",
    "fields": [
        {"name": "ARRAY_WITH_DEFAULT", "type": {"type": "array", "items": "string"}, "default": null }
    ]
}
```
```
org.apache.avro.AvroTypeException: Invalid default for field ARRAY_WITH_DEFAULT: null not a {"type":"array","items":"string"}
	at org.apache.avro.Schema.validateDefault(Schema.java:1571)
	at org.apache.avro.Schema.access$500(Schema.java:87)
	at org.apache.avro.Schema$Field.<init>(Schema.java:544)
	at org.apache.avro.Schema.parse(Schema.java:1678)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1425)
	at org.apache.avro.Schema$Parser.parse(Schema.java:1396)
	at org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.getSchemaFor(AvroSerdeUtils.java:287)
	at org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.getSchemaFromFS(AvroSerdeUtils.java:170)
	at org.apache.hadoop.hive.serde2.avro.AvroSerdeUtils.determineSchemaOrThrowException(AvroSerdeUtils.java:139)
	at org.apache.hadoop.hive.serde2.avro.AvroSerDe.determineSchemaOrReturnErrorSchema(AvroSerDe.java:187)
	at org.apache.hadoop.hive.serde2.avro.AvroSerDe.initialize(AvroSerDe.java:107)
	at org.apache.hadoop.hive.serde2.avro.AvroSerDe.initialize(AvroSerDe.java:83)
	at org.apache.hadoop.hive.serde2.SerDeUtils.initializeSerDe(SerDeUtils.java:533)
	at org.apache.hadoop.hive.metastore.MetaStoreUtils.getDeserializer(MetaStoreUtils.java:493)
	at org.apache.hadoop.hive.ql.metadata.Partition.getDeserializer(Partition.java:225)
```

Related Avro ticket: https://issues.apache.org/jira/browse/AVRO-2035

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Manual test.