### PR TITLE
HIVE-24522: Support the Kudu DATE and VARCHAR column type

### DIFF
--- a/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
+++ b/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
@@ -132,7 +132,7 @@ public final class KuduHiveUtils {
     case UNIXTIME_MICROS:
       return TypeInfoFactory.timestampTypeInfo;
     case DATE:
-        return TypeInfoFactory.dateTypeInfo;
+      return TypeInfoFactory.dateTypeInfo;
     case DECIMAL:
       return TypeInfoFactory.getDecimalTypeInfo(attributes.getPrecision(), attributes.getScale());
     case FLOAT:
@@ -142,7 +142,7 @@ public final class KuduHiveUtils {
     case STRING:
       return TypeInfoFactory.stringTypeInfo;
     case VARCHAR:
-       return TypeInfoFactory.getVarcharTypeInfo(attributes.getLength());
+      return TypeInfoFactory.getVarcharTypeInfo(attributes.getLength());
     case BINARY:
       return TypeInfoFactory.binaryTypeInfo;
     default:

--- a/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
+++ b/kudu-handler/src/java/org/apache/hadoop/hive/kudu/KuduHiveUtils.java
@@ -131,6 +131,8 @@ public final class KuduHiveUtils {
       return TypeInfoFactory.longTypeInfo;
     case UNIXTIME_MICROS:
       return TypeInfoFactory.timestampTypeInfo;
+    case DATE:
+        return TypeInfoFactory.dateTypeInfo;
     case DECIMAL:
       return TypeInfoFactory.getDecimalTypeInfo(attributes.getPrecision(), attributes.getScale());
     case FLOAT:
@@ -139,6 +141,8 @@ public final class KuduHiveUtils {
       return TypeInfoFactory.doubleTypeInfo;
     case STRING:
       return TypeInfoFactory.stringTypeInfo;
+    case VARCHAR:
+       return TypeInfoFactory.getVarcharTypeInfo(attributes.getLength());
     case BINARY:
       return TypeInfoFactory.binaryTypeInfo;
     default:

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/KuduTestUtils.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/KuduTestUtils.java
@@ -42,8 +42,13 @@ public final class KuduTestUtils {
         new ColumnSchema.ColumnSchemaBuilder("float", Type.FLOAT).build(),
         new ColumnSchema.ColumnSchemaBuilder("double", Type.DOUBLE).build(),
         new ColumnSchema.ColumnSchemaBuilder("string", Type.STRING).build(),
+        new ColumnSchema.ColumnSchemaBuilder("varchar", Type.VARCHAR)
+            .typeAttributes(new ColumnTypeAttributes.ColumnTypeAttributesBuilder()
+                .length(10).build())
+            .build(),
         new ColumnSchema.ColumnSchemaBuilder("binary", Type.BINARY).build(),
         new ColumnSchema.ColumnSchemaBuilder("timestamp", Type.UNIXTIME_MICROS).build(),
+        new ColumnSchema.ColumnSchemaBuilder("date", Type.DATE).build(),
         new ColumnSchema.ColumnSchemaBuilder("decimal", Type.DECIMAL)
             .typeAttributes(new ColumnTypeAttributes.ColumnTypeAttributesBuilder()
                 .precision(5).scale(3).build())

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduInputFormat.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduInputFormat.java
@@ -49,7 +49,9 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -92,8 +94,10 @@ public class TestKuduInputFormat {
     ROW.addFloat("float", 1.1f);
     ROW.addDouble("double", 1.1d);
     ROW.addString("string", "one");
+    ROW.addVarchar("varchar", "one");
     ROW.addBinary("binary", "one".getBytes(UTF_8));
     ROW.addTimestamp("timestamp", new Timestamp(NOW_MS));
+    ROW.addDate("date", new Date(NOW_MS));
     ROW.addDecimal("decimal", new BigDecimal("1.111"));
     ROW.setNull("null");
     // Not setting the "default" column.
@@ -268,8 +272,10 @@ public class TestKuduInputFormat {
     row.addFloat("float", 2.2f);
     row.addDouble("double", 2.2d);
     row.addString("string", "two");
+    row.addVarchar("varchar", "two");
     row.addBinary("binary", "two".getBytes(UTF_8));
     row.addTimestamp("timestamp", new Timestamp(NOW_MS + 1));
+    row.addDate("date", new Date(NOW_MS + Duration.ofDays(1).toMillis()));
     row.addDecimal("decimal", new BigDecimal("2.222"));
     row.setNull("null");
     // Not setting the "default" column.
@@ -327,10 +333,12 @@ public class TestKuduInputFormat {
     assertEquals(ROW.getFloat(5), value.getFloat(5), 0);
     assertEquals(ROW.getDouble(6), value.getDouble(6), 0);
     assertEquals(ROW.getString(7), value.getString(7));
-    assertArrayEquals(ROW.getBinaryCopy(8), value.getBinaryCopy(8));
-    assertEquals(ROW.getTimestamp(9), value.getTimestamp(9));
-    assertEquals(ROW.getDecimal(10), value.getDecimal(10));
-    assertTrue(value.isNull(11));
-    assertEquals(1, value.getInt(12)); // default.
+    assertEquals(ROW.getVarchar(8), value.getVarchar(8));
+    assertArrayEquals(ROW.getBinaryCopy(9), value.getBinaryCopy(9));
+    assertEquals(ROW.getTimestamp(10), value.getTimestamp(10));
+    assertEquals(ROW.getDate(11), value.getDate(11));
+    assertEquals(ROW.getDecimal(12), value.getDecimal(12));
+    assertTrue(value.isNull(13));
+    assertEquals(1, value.getInt(14)); // default.
   }
 }

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduOutputFormat.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduOutputFormat.java
@@ -29,6 +29,7 @@ import org.apache.kudu.client.KuduTable;
 import org.apache.kudu.client.PartialRow;
 import org.apache.kudu.client.RowResult;
 import org.apache.kudu.test.KuduTestHarness;
+import org.apache.kudu.util.DateUtil;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -36,6 +37,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -100,8 +102,10 @@ public class TestKuduOutputFormat {
       row.addFloat("float", 1.1f);
       row.addDouble("double", 1.1d);
       row.addString("string", "one");
+      row.addVarchar("varchar", "one");
       row.addBinary("binary", "one".getBytes(UTF_8));
       row.addTimestamp("timestamp", new Timestamp(NOW_MS));
+      row.addDate("date", new Date(NOW_MS));
       row.addDecimal("decimal", new BigDecimal("1.111"));
       row.setNull("null");
       // Not setting the "default" column.
@@ -131,11 +135,13 @@ public class TestKuduOutputFormat {
     assertEquals(1.1f, result.getFloat(5), 0);
     assertEquals(1.1d, result.getDouble(6), 0);
     assertEquals("one", result.getString(7));
-    assertEquals("one", new String(result.getBinaryCopy(8), UTF_8));
-    assertEquals(NOW_MS, result.getTimestamp(9).getTime());
-    assertEquals(new BigDecimal("1.111"), result.getDecimal(10));
-    assertTrue(result.isNull(11));
-    assertEquals(1, result.getInt(12)); // default.
+    assertEquals("one", result.getVarchar(8));
+    assertEquals("one", new String(result.getBinaryCopy(9), UTF_8));
+    assertEquals(NOW_MS, result.getTimestamp(10).getTime());
+    assertEquals(DateUtil.sqlDateToEpochDays(new Date(NOW_MS)),  DateUtil.sqlDateToEpochDays(result.getDate(11)));
+    assertEquals(new BigDecimal("1.111"), result.getDecimal(12));
+    assertTrue(result.isNull(13));
+    assertEquals(1, result.getInt(14)); // default.
   }
 
   @Test

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduPredicateHandler.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduPredicateHandler.java
@@ -58,6 +58,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
@@ -96,8 +97,10 @@ public class TestKuduPredicateHandler {
     ROW.addFloat("float", 1.1f);
     ROW.addDouble("double", 1.1d);
     ROW.addString("string", "one");
+    ROW.addVarchar("varchar", "one");
     ROW.addBinary("binary", "one".getBytes(UTF_8));
     ROW.addTimestamp("timestamp", new Timestamp(NOW_MS));
+    ROW.addDate("date", new Date(NOW_MS));
     ROW.addDecimal("decimal", new BigDecimal("1.111"));
     ROW.setNull("null");
     // Not setting the "default" column.

--- a/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduSerDe.java
+++ b/kudu-handler/src/test/org/apache/hadoop/hive/kudu/TestKuduSerDe.java
@@ -36,6 +36,7 @@ import org.junit.Test;
 import com.google.common.collect.ImmutableList;
 
 import java.math.BigDecimal;
+import java.sql.Date;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.List;
@@ -95,8 +96,10 @@ public class TestKuduSerDe {
     before.addFloat("float", 1.1f);
     before.addDouble("double", 1.1d);
     before.addString("string", "one");
+    before.addVarchar("varchar", "one");
     before.addBinary("binary", "one".getBytes(UTF_8));
     before.addTimestamp("timestamp", new Timestamp(NOW_MS));
+    before.addDate("date", new Date(NOW_MS));
     before.addDecimal("decimal", new BigDecimal("1.111"));
     before.setNull("null");
     before.addInt("default", 1);
@@ -106,7 +109,8 @@ public class TestKuduSerDe {
 
     // Capitalized `key` field to check for field case insensitivity.
     List<String> fieldNames = Arrays.asList("KEY", "int16", "int32", "int64", "bool", "float",
-        "double", "string", "binary", "timestamp", "decimal", "null", "default");
+        "double", "string", "varchar", "binary", "timestamp", "date", "decimal", "null",
+        "default");
     List<ObjectInspector> ois = Arrays.asList(
         PrimitiveObjectInspectorFactory.writableByteObjectInspector,
         PrimitiveObjectInspectorFactory.writableShortObjectInspector,
@@ -116,8 +120,10 @@ public class TestKuduSerDe {
         PrimitiveObjectInspectorFactory.writableFloatObjectInspector,
         PrimitiveObjectInspectorFactory.writableDoubleObjectInspector,
         PrimitiveObjectInspectorFactory.writableStringObjectInspector,
+        PrimitiveObjectInspectorFactory.writableHiveVarcharObjectInspector,
         PrimitiveObjectInspectorFactory.writableBinaryObjectInspector,
         PrimitiveObjectInspectorFactory.writableTimestampObjectInspector,
+        PrimitiveObjectInspectorFactory.writableDateObjectInspector,
         PrimitiveObjectInspectorFactory.writableHiveDecimalObjectInspector,
         PrimitiveObjectInspectorFactory.writableStringObjectInspector,
         PrimitiveObjectInspectorFactory.writableIntObjectInspector

--- a/kudu-handler/src/test/queries/positive/kudu_queries.q
+++ b/kudu-handler/src/test/queries/positive/kudu_queries.q
@@ -31,8 +31,8 @@ TBLPROPERTIES ("kudu.table_name" = "default.kudu_all_types");
 DESCRIBE EXTENDED all_types_table;
 
 INSERT INTO TABLE all_types_table VALUES
-(1, 1, 1, 1, true, 1.1, 1.1, "one", 'one', '2001-01-01 01:11:11', 1.111, null, 1),
-(2, 2, 2, 2, false, 2.2, 2.2, "two", 'two', '2001-01-01 01:12:12', 2.222, "not null", 2);
+(1, 1, 1, 1, true, 1.1, 1.1, "one", "one", 'one', '2001-01-01 01:11:11', '2001-01-01', 1.111, null, 1),
+(2, 2, 2, 2, false, 2.2, 2.2, "two", "two", 'two', '2001-01-01 01:12:12', '2001-01-02', 2.222, "not null", 2);
 
 SELECT * FROM all_types_table;
 SELECT count(*) FROM all_types_table;
@@ -92,6 +92,16 @@ SELECT key FROM all_types_table WHERE `string` >= "one";
 SELECT key FROM all_types_table WHERE `string` < "two";
 SELECT key FROM all_types_table WHERE `string` <= "two";
 
+-- Verify comparison predicates on varchar.
+-- Note: varchar is escaped because it's a reserved word.
+EXPLAIN SELECT key FROM all_types_table WHERE `string` = "one";
+SELECT key FROM all_types_table WHERE `varchar` = "one";
+SELECT key FROM all_types_table WHERE `varchar` != "one";
+SELECT key FROM all_types_table WHERE `varchar` > "one";
+SELECT key FROM all_types_table WHERE `varchar` >= "one";
+SELECT key FROM all_types_table WHERE `varchar` < "two";
+SELECT key FROM all_types_table WHERE `varchar` <= "two";
+
 -- Verify comparison predicates on binary.
 -- Note: binary is escaped because it's a reserved word.
 EXPLAIN SELECT key FROM all_types_table WHERE `binary` = cast ('one' as binary);
@@ -111,6 +121,16 @@ SELECT key FROM all_types_table WHERE `timestamp` > '2001-01-01 01:11:11';
 SELECT key FROM all_types_table WHERE `timestamp` >= '2001-01-01 01:11:11';
 SELECT key FROM all_types_table WHERE `timestamp` < '2001-01-01 01:12:12';
 SELECT key FROM all_types_table WHERE `timestamp` <= '2001-01-01 01:12:12';
+
+-- Verify comparison predicates on date.
+-- Note: date is escaped because it's a reserved word.
+EXPLAIN SELECT key FROM all_types_table WHERE `timestamp` = '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` = '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` != '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` > '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` >= '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` < '2001-01-01';
+SELECT key FROM all_types_table WHERE `date` <= '2001-01-01';
 
 -- Verify comparison predicates on float.
 -- Note: float is escaped because it's a reserved word.

--- a/kudu-handler/src/test/results/positive/kudu_queries.q.out
+++ b/kudu-handler/src/test/results/positive/kudu_queries.q.out
@@ -119,22 +119,24 @@ bool                	boolean
 float               	float               	                    
 double              	double              	                    
 string              	string              	                    
+varchar             	varchar(10)         	                    
 binary              	binary              	                    
 timestamp           	timestamp           	                    
+date                	date                	                    
 decimal             	decimal(5,3)        	                    
 null                	string              	                    
 default             	int                 	                    
 	 	 
 #### A masked pattern was here ####
 PREHOOK: query: INSERT INTO TABLE all_types_table VALUES
-(1, 1, 1, 1, true, 1.1, 1.1, "one", 'one', '2001-01-01 01:11:11', 1.111, null, 1),
-(2, 2, 2, 2, false, 2.2, 2.2, "two", 'two', '2001-01-01 01:12:12', 2.222, "not null", 2)
+(1, 1, 1, 1, true, 1.1, 1.1, "one", "one", 'one', '2001-01-01 01:11:11', '2001-01-01', 1.111, null, 1),
+(2, 2, 2, 2, false, 2.2, 2.2, "two", "two", 'two', '2001-01-01 01:12:12', '2001-01-02', 2.222, "not null", 2)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@all_types_table
 POSTHOOK: query: INSERT INTO TABLE all_types_table VALUES
-(1, 1, 1, 1, true, 1.1, 1.1, "one", 'one', '2001-01-01 01:11:11', 1.111, null, 1),
-(2, 2, 2, 2, false, 2.2, 2.2, "two", 'two', '2001-01-01 01:12:12', 2.222, "not null", 2)
+(1, 1, 1, 1, true, 1.1, 1.1, "one", "one", 'one', '2001-01-01 01:11:11', '2001-01-01', 1.111, null, 1),
+(2, 2, 2, 2, false, 2.2, 2.2, "two", "two", 'two', '2001-01-01 01:12:12', '2001-01-02', 2.222, "not null", 2)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@all_types_table
@@ -146,8 +148,8 @@ POSTHOOK: query: SELECT * FROM all_types_table
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@all_types_table
 #### A masked pattern was here ####
-2	2	2	2	false	2.2	2.2	two	two	2001-01-01 01:12:12	2.222	not null	2
-1	1	1	1	true	1.1	1.1	one	one	2001-01-01 01:11:11	1.111	NULL	1
+2	2	2	2	false	2.2	2.2	two	two	two	2001-01-01 01:12:12	2001-01-02	2.222	not null	2
+1	1	1	1	true	1.1	1.1	one	one	one	2001-01-01 01:11:11	2001-01-01	1.111	NULL	1
 PREHOOK: query: SELECT count(*) FROM all_types_table
 PREHOOK: type: QUERY
 PREHOOK: Input: default@all_types_table
@@ -634,6 +636,86 @@ POSTHOOK: Input: default@all_types_table
 #### A masked pattern was here ####
 2
 1
+PREHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `string` = "one"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `string` = "one"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: all_types_table
+          filterExpr: (string = 'one') (type: boolean)
+          Select Operator
+            expressions: key (type: tinyint)
+            outputColumnNames: _col0
+            ListSink
+
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` = "one"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` = "one"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+1
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` != "one"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` != "one"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` > "one"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` > "one"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` >= "one"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` >= "one"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+1
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` < "two"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` < "two"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+1
+PREHOOK: query: SELECT key FROM all_types_table WHERE `varchar` <= "two"
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `varchar` <= "two"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+1
 PREHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `binary` = cast ('one' as binary)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@all_types_table
@@ -795,6 +877,84 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@all_types_table
 #### A masked pattern was here ####
 2
+1
+PREHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `timestamp` = '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `timestamp` = '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-0 is a root stage
+
+STAGE PLANS:
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        TableScan
+          alias: all_types_table
+          filterExpr: (timestamp = TIMESTAMP'2001-01-01 00:00:00') (type: boolean)
+          Select Operator
+            expressions: key (type: tinyint)
+            outputColumnNames: _col0
+            ListSink
+
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` = '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` = '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+1
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` != '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` != '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` > '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` > '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` >= '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` >= '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+2
+1
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` < '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` < '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+PREHOOK: query: SELECT key FROM all_types_table WHERE `date` <= '2001-01-01'
+PREHOOK: type: QUERY
+PREHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT key FROM all_types_table WHERE `date` <= '2001-01-01'
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@all_types_table
+#### A masked pattern was here ####
 1
 PREHOOK: query: EXPLAIN SELECT key FROM all_types_table WHERE `float` = 1.1
 PREHOOK: type: QUERY
@@ -1243,8 +1403,8 @@ STAGE PLANS:
         TableScan
           alias: all_types_table
           Select Operator
-            expressions: key (type: tinyint), int16 (type: smallint), int32 (type: int), int64 (type: bigint), bool (type: boolean), float (type: float), double (type: double), string (type: string), binary (type: binary), timestamp (type: timestamp), decimal (type: decimal(5,3)), null (type: string), default (type: int)
-            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+            expressions: key (type: tinyint), int16 (type: smallint), int32 (type: int), int64 (type: bigint), bool (type: boolean), float (type: float), double (type: double), string (type: string), varchar (type: varchar(10)), binary (type: binary), timestamp (type: timestamp), date (type: date), decimal (type: decimal(5,3)), null (type: string), default (type: int)
+            outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
             ListSink
 
 PREHOOK: query: SHOW CREATE TABLE all_types_table
@@ -1262,8 +1422,10 @@ CREATE EXTERNAL TABLE `all_types_table`(
   `float` float COMMENT '', 
   `double` double COMMENT '', 
   `string` string COMMENT '', 
+  `varchar` varchar(10) COMMENT '', 
   `binary` binary COMMENT '', 
   `timestamp` timestamp COMMENT '', 
+  `date` date COMMENT '', 
   `decimal` decimal(5,3) COMMENT '', 
   `null` string COMMENT '', 
   `default` int COMMENT '')
@@ -1293,8 +1455,10 @@ bool                	boolean
 float               	float               	                    
 double              	double              	                    
 string              	string              	                    
+varchar             	varchar(10)         	                    
 binary              	binary              	                    
 timestamp           	timestamp           	                    
+date                	date                	                    
 decimal             	decimal(5,3)        	                    
 null                	string              	                    
 default             	int                 	                    
@@ -1313,8 +1477,10 @@ bool                	boolean
 float               	float               	                    
 double              	double              	                    
 string              	string              	                    
+varchar             	varchar(10)         	                    
 binary              	binary              	                    
 timestamp           	timestamp           	                    
+date                	date                	                    
 decimal             	decimal(5,3)        	                    
 null                	string              	                    
 default             	int                 	                    
@@ -1326,7 +1492,7 @@ Retention:          	0
 #### A masked pattern was here ####
 Table Type:         	EXTERNAL_TABLE      	 
 Table Parameters:	 	 
-	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"binary\":\"true\",\"bool\":\"true\",\"decimal\":\"true\",\"default\":\"true\",\"double\":\"true\",\"float\":\"true\",\"int16\":\"true\",\"int32\":\"true\",\"int64\":\"true\",\"key\":\"true\",\"null\":\"true\",\"string\":\"true\",\"timestamp\":\"true\"}}
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"binary\":\"true\",\"bool\":\"true\",\"date\":\"true\",\"decimal\":\"true\",\"default\":\"true\",\"double\":\"true\",\"float\":\"true\",\"int16\":\"true\",\"int32\":\"true\",\"int64\":\"true\",\"key\":\"true\",\"null\":\"true\",\"string\":\"true\",\"timestamp\":\"true\",\"varchar\":\"true\"}}
 	EXTERNAL            	TRUE                
 	bucketing_version   	2                   
 	kudu.table_name     	default.kudu_all_types

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,7 @@
     <kryo.version>5.0.3</kryo.version>
     <kryo4.version>4.0.2</kryo4.version> <!-- old kryo, for spark-client, might be removed in HIVE-23885 -->
     <reflectasm.version>1.11.9</reflectasm.version>
-    <kudu.version>1.12.0</kudu.version>
+    <kudu.version>1.14.0</kudu.version>
     <!-- Leaving libfb303 at 0.9.3 regardless of libthrift: As per THRIFT-4613 The Apache Thrift project does not publish items related to fb303 at this point -->
     <libfb303.version>0.9.3</libfb303.version>
     <libthrift.version>0.13.0</libthrift.version>


### PR DESCRIPTION
This patch updates the Kudu version to the latest and adds
support for the new DATE and VARCHAR column types.