### PR TITLE
HIVE-24804: RANGE with offset PRECEDING/FOLLOWING requires at least one ORDER BY column

### DIFF
--- a/ql/src/test/queries/clientnegative/ptf_window_boundaries_range_without_order.q
+++ b/ql/src/test/queries/clientnegative/ptf_window_boundaries_range_without_order.q
@@ -1,0 +1,4 @@
+--! qt:dataset:part
+select p_mfgr, p_name, p_size,
+sum(p_retailprice) over (partition by p_mfgr range between 1 preceding and current row) as s1
+from part;

--- a/ql/src/test/results/clientnegative/ptf_window_boundaries_range_without_order.q.out
+++ b/ql/src/test/results/clientnegative/ptf_window_boundaries_range_without_order.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException RANGE with offset PRECEDING/FOLLOWING requires at least one ORDER BY column


### PR DESCRIPTION
### What changes were proposed in this pull request?
I just wanted to own the 2000th PR so created this. :)
Btw, throwing an exception if the user tries to use bounded range window without ORDER BY clause, similarly to Postgres.

the patch is basically only a check and throw:
```
        if (windowFrame.getWindowType() == WindowType.RANGE
            && (windowFrame.getStart().isBoundedNotCurrent()
                || windowFrame.getEnd().isBoundedNotCurrent())) {
          throw new SemanticException(
              "RANGE with offset PRECEDING/FOLLOWING requires exactly one ORDER BY column");
        }
```
all other changes are only formatting...WindowingSpec class was in very bad shape from formatting point of view, I think this was a good opportunity to clean it

### Why are the changes needed?
Described in JIRA.


### Does this PR introduce _any_ user-facing change?
The exception in the mentioned use-case.


### How was this patch tested?
Manually and with a negative test.
