### PR TITLE
HIVE-24809: Build failure while resolving javax.el dependency

### DIFF
--- a/itests/pom.xml
+++ b/itests/pom.xml
@@ -416,12 +416,24 @@
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
         <version>${hbase.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-server</artifactId>
         <version>${hbase.version}</version>
         <classifier>tests</classifier>
+        <exclusions>
+          <exclusion>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>

--- a/standalone-metastore/metastore-tools/pom.xml
+++ b/standalone-metastore/metastore-tools/pom.xml
@@ -70,6 +70,10 @@
             <groupId>org.apache.curator</groupId>
             <artifactId>curator-recipes</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.glassfish.web</groupId>
+            <artifactId>javax.servlet.jsp</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Exclude javax.servlet.jsp dependency from metastore-tools and itests
to avoid pulling transitively javax.el (similar approach to HIVE-19579).

Exclusion should take place in top-level dependency management sections.

### Why are the changes needed?
Build may fail since [javax.servlet.jsp|https://repo1.maven.org/maven2/org/glassfish/web/javax.servlet.jsp/2.3.2/javax.servlet.jsp-2.3.2.pom] defines the following

```
<dependency>
<groupId>org.glassfish</groupId>
<artifactId>javax.el</artifactId>
<version>[3.0.0,)</version>
</dependency>
```
and this might create problems due to https://issues.apache.org/jira/browse/MNG-3092.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Add the following snippet to ~/.m2/settings.xml

```
<repositories>
        <repository>
          <id>mvn.central</id>
          <url>https://repo1.maven.org/maven2/</url>
        </repository>
        <repository>
          <id>hortonworks</id>
          <url>https://nexus-private.hortonworks.com/nexus/content/groups/public</url>
          <snapshots>
            <enabled>true</enabled>
          </snapshots>
        </repository>
      </repositories>
```
and run `mvn clean install -DskipTests`.

Without these changes the build will fail.