### PR TITLE
HIVE-24783: Store currentNotificationID on target during repl load op.

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -186,7 +186,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
   }
 
   private long fetchNotificationIDFromDump(Path dumpLocation) throws Exception{
-    Path loadMetadataFilePath = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + "/" + ReplAck.LOAD_METADATA);
+    Path loadMetadataFilePath = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + File.separator + ReplAck.LOAD_METADATA);
     FileSystem fs = dumpLocation.getFileSystem(conf);
     BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(loadMetadataFilePath)));
     String line = reader.readLine();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -91,7 +91,6 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
       Class clazz) throws Exception {
 
     conf = new HiveConf(clazz);
-    conf.set(MetastoreConf.ConfVars.EVENT_DB_NOTIFICATION_API_AUTH.getVarname(), "false");
     conf.set("dfs.client.use.datanode.hostname", "true");
     conf.set("metastore.warehouse.tenant.colocation", "true");
     conf.set("hadoop.proxyuser." + Utils.getUGI().getShortUserName() + ".hosts", "*");

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -163,6 +163,23 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
   }
 
   @Test
+  public void testNotificationAck() throws Throwable{
+    long previousNotificationID = 0;
+    WarehouseInstance.Tuple bootstrapDump = primary.run("use " + primaryDbName)
+            .run("CREATE TABLE t1(a string) STORED AS TEXTFILE")
+            .dump(primaryDbName);
+    previousNotificationID = replica.load(replicatedDbName, primaryDbName)
+            .verifyResults(new String[] {})
+            .verifyNotificationAck(bootstrapDump.dumpLocation, previousNotificationID);
+    WarehouseInstance.Tuple incrementalDump1 = primary.run("use " + primaryDbName)
+            .run("insert into t1 values (1)")
+            .dump(primaryDbName);
+    previousNotificationID = replica.load(replicatedDbName, primaryDbName)
+            .verifyResults(new String[] {})
+            .verifyNotificationAck(incrementalDump1.dumpLocation, previousNotificationID);
+  }
+
+  @Test
   /**
    * Testcase for getting immutable dataset dump, and its corresponding repl load.
    */

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -53,7 +53,6 @@ import javax.annotation.Nullable;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
@@ -166,7 +165,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
   }
 
   @Test
-  public void testNotificationAck() throws Throwable{
+  public void testNotificationFromLoadMetadataAck() throws Throwable{
     long previousLoadNotificationID = 0, currentLoadNotificationID, currentNotificationID;
     WarehouseInstance.Tuple bootstrapDump = primary.run("use " + primaryDbName)
             .run("CREATE TABLE t1(a string) STORED AS TEXTFILE")
@@ -189,8 +188,7 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
   private long fetchNotificationIDFromDump(Path dumpLocation) throws Exception{
     Path loadMetadataFilePath = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + "/" + ReplAck.LOAD_METADATA);
     FileSystem fs = dumpLocation.getFileSystem(conf);
-    InputStream inputstream = fs.open(loadMetadataFilePath);
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputstream));
+    BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(loadMetadataFilePath)));
     String line = reader.readLine();
     assertTrue(line != null && reader.readLine() == null);
     if(reader != null)  reader.close();

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -51,7 +51,6 @@ import org.junit.BeforeClass;
 
 import javax.annotation.Nullable;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -188,9 +187,9 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
   }
 
   private long fetchNotificationIDFromDump(Path dumpLocation) throws Exception{
-    Path notificationAckFile = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + "/" + ReplAck.LOAD_METADATA);
+    Path loadMetadataFilePath = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + "/" + ReplAck.LOAD_METADATA);
     FileSystem fs = dumpLocation.getFileSystem(conf);
-    InputStream inputstream = fs.open(notificationAckFile);
+    InputStream inputstream = fs.open(loadMetadataFilePath);
     BufferedReader reader = new BufferedReader(new InputStreamReader(inputstream));
     String line = reader.readLine();
     assertTrue(line != null && reader.readLine() == null);

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -194,7 +194,9 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
     BufferedReader reader = new BufferedReader(new InputStreamReader(fs.open(loadMetadataFilePath)));
     String line = reader.readLine();
     assertTrue(line != null && reader.readLine() == null);
-    if(reader != null)  reader.close();
+    if (reader != null) {
+      reader.close();
+    }
     return Long.parseLong(line);
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -51,7 +51,6 @@ import org.apache.hadoop.hive.metastore.api.UniqueConstraintsRequest;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
-import org.apache.hadoop.hive.ql.exec.repl.ReplAck;
 import org.apache.hadoop.hive.ql.exec.repl.ReplDumpWork;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.parse.repl.PathBuilder;
@@ -65,9 +64,6 @@ import org.slf4j.Logger;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -416,24 +412,6 @@ public class WarehouseInstance implements Closeable {
     assertEquals(data.size(), results.size());
     assertTrue(results.containsAll(data));
     return this;
-  }
-
-  long verifyNotificationAck(String dumpLocation, long prevNotificationID) throws Exception {
-    FileSystem fs = new Path(dumpLocation).getFileSystem(hiveConf);
-    Path notificationAckFile = new Path(dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR + "/" + ReplAck.NOTIFICATION_FILE);
-    assertTrue(fs.exists(notificationAckFile));
-    long currentNotificationID = getCurrentNotificationEventId().getEventId();
-    long previousLoadNotificationID = fetchNotificationIDFromDump(notificationAckFile, fs);
-    assertTrue(previousLoadNotificationID > prevNotificationID && currentNotificationID > previousLoadNotificationID);
-    return previousLoadNotificationID;
-  }
-
-  long fetchNotificationIDFromDump(Path notificationAckFile, FileSystem fs) throws Exception{
-    InputStream inputstream = fs.open(notificationAckFile);
-    BufferedReader reader = new BufferedReader(new InputStreamReader(inputstream));
-    String line = reader.readLine();
-    assertTrue(line!=null && reader.readLine()==null);
-    return Long.parseLong(line);
   }
 
   public List<String> getOutput() throws IOException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
@@ -44,8 +44,7 @@ public class AckTask extends Task<AckWork> implements Serializable {
   @Override
   public int execute() {
     try {
-      List<Runnable> preAckTasks = work.getPreAckTasks();
-      for(Runnable task:preAckTasks){
+      for( preAckTask task : work.getPreAckTasks() ){
         task.run();
       }
       Path ackPath = work.getAckFilePath();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
-import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.repl.dump.Utils;
 import org.apache.hadoop.hive.ql.plan.api.StageType;
 import org.slf4j.Logger;
@@ -43,7 +42,7 @@ public class AckTask extends Task<AckWork> implements Serializable {
   @Override
   public int execute() {
     try {
-      for( preAckTask task : work.getPreAckTasks() ){
+      for(PreAckTask task : work.getPreAckTasks()) {
         task.run();
       }
       Path ackPath = work.getAckFilePath();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
@@ -29,6 +29,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * AckTask.
@@ -43,6 +44,10 @@ public class AckTask extends Task<AckWork> implements Serializable {
   @Override
   public int execute() {
     try {
+      List<Runnable> preAckTasks = work.getPreAckTasks();
+      for(Runnable task:preAckTasks){
+        task.run();
+      }
       Path ackPath = work.getAckFilePath();
       Utils.create(ackPath, conf);
       LOG.info("Created ack file : {} ", ackPath);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckTask.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
-import java.util.List;
 
 /**
  * AckTask.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
@@ -36,7 +36,7 @@ public class AckWork implements Serializable {
   private static final long serialVersionUID = 1L;
   private Path ackFilePath;
   private transient ReplicationMetricCollector metricCollector;
-  private List<Runnable> tasks;
+  private List<preAckTask> preAcktasks;
 
   public Path getAckFilePath() {
     return ackFilePath;
@@ -50,13 +50,13 @@ public class AckWork implements Serializable {
     this.ackFilePath = ackFilePath;
   }
 
-  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector, List<Runnable> preAckTasks) {
+  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector, List<preAckTask> preAckTasks) {
     this.ackFilePath = ackFilePath;
     this.metricCollector = metricCollector;
-    this.tasks = preAckTasks;
+    this.preAcktasks = preAckTasks;
   }
 
-  public List<Runnable> getPreAckTasks(){
-    return this.tasks;
+  public List<preAckTask> getPreAckTasks(){
+    return this.preAcktasks;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.exec.repl;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
 import org.apache.hadoop.hive.ql.parse.repl.metric.ReplicationMetricCollector;
 import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
@@ -36,7 +37,7 @@ public class AckWork implements Serializable {
   private static final long serialVersionUID = 1L;
   private Path ackFilePath;
   private transient ReplicationMetricCollector metricCollector;
-  private List<preAckTask> preAcktasks;
+  private List<PreAckTask> preAckTasks;
 
   public Path getAckFilePath() {
     return ackFilePath;
@@ -50,13 +51,17 @@ public class AckWork implements Serializable {
     this.ackFilePath = ackFilePath;
   }
 
-  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector, List<preAckTask> preAckTasks) {
+  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector, List<PreAckTask> preAckTasks) {
     this.ackFilePath = ackFilePath;
     this.metricCollector = metricCollector;
-    this.preAcktasks = preAckTasks;
+    this.preAckTasks = preAckTasks;
   }
 
-  public List<preAckTask> getPreAckTasks(){
-    return this.preAcktasks;
+  public List<PreAckTask> getPreAckTasks(){
+    return this.preAckTasks;
   }
 }
+
+interface PreAckTask {
+  void run() throws SemanticException;
+};

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.ql.plan.Explain;
 import org.apache.hadoop.hive.ql.plan.Explain.Level;
 
 import java.io.Serializable;
+import java.util.List;
 
 /**
  * AckWork.
@@ -35,6 +36,7 @@ public class AckWork implements Serializable {
   private static final long serialVersionUID = 1L;
   private Path ackFilePath;
   private transient ReplicationMetricCollector metricCollector;
+  private List<Runnable> tasks;
 
   public Path getAckFilePath() {
     return ackFilePath;
@@ -48,8 +50,13 @@ public class AckWork implements Serializable {
     this.ackFilePath = ackFilePath;
   }
 
-  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector) {
+  public AckWork(Path ackFilePath, ReplicationMetricCollector metricCollector, List<Runnable> preAckTasks) {
     this.ackFilePath = ackFilePath;
     this.metricCollector = metricCollector;
+    this.tasks = preAckTasks;
+  }
+
+  public List<Runnable> getPreAckTasks(){
+    return this.tasks;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/AckWork.java
@@ -57,7 +57,7 @@ public class AckWork implements Serializable {
     this.preAckTasks = preAckTasks;
   }
 
-  public List<PreAckTask> getPreAckTasks(){
+  public List<PreAckTask> getPreAckTasks() {
     return this.preAckTasks;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
@@ -25,7 +25,7 @@ public enum ReplAck {
     EVENTS_DUMP("_events_dump"),
     LOAD_ACKNOWLEDGEMENT("_finished_load"),
     NON_RECOVERABLE_MARKER("_non_recoverable"),
-    NOTIFICATION_FILE("_notification_id");
+    LOAD_METADATA("_load_metadata");
   private String ack;
   ReplAck(String ack) {
     this.ack = ack;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
@@ -24,7 +24,8 @@ public enum ReplAck {
     DUMP_ACKNOWLEDGEMENT("_finished_dump"),
     EVENTS_DUMP("_events_dump"),
     LOAD_ACKNOWLEDGEMENT("_finished_load"),
-    NON_RECOVERABLE_MARKER("_non_recoverable");
+    NON_RECOVERABLE_MARKER("_non_recoverable"),
+    NOTIFICATION_FILE("_notification_id");
   private String ack;
   ReplAck(String ack) {
     this.ack = ack;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -72,7 +72,13 @@ import org.apache.hadoop.hive.ql.plan.api.StageType;
 
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.LinkedList;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_SKIP_IMMUTABLE_DATA_COPY;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.NOTIFICATION_FILE;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
-import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.utils.SecurityUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.DDLWork;
@@ -81,7 +80,7 @@ import java.util.Map;
 import java.util.LinkedList;
 
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.REPL_DUMP_SKIP_IMMUTABLE_DATA_COPY;
-import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.NOTIFICATION_FILE;
+import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_METADATA;
 import static org.apache.hadoop.hive.ql.exec.repl.bootstrap.load.LoadDatabase.AlterDatabase;
 import static org.apache.hadoop.hive.ql.exec.repl.ReplAck.LOAD_ACKNOWLEDGEMENT;
 import static org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils.RANGER_AUTHORIZER;
@@ -513,11 +512,11 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
           try{
             HiveMetaStoreClient metaStoreClient = new HiveMetaStoreClient(conf);
             long currentNotificationID = metaStoreClient.getCurrentNotificationEventId().getEventId();
-            Path notificationFilePath = new Path(work.dumpDirectory, NOTIFICATION_FILE.toString());
+            Path notificationFilePath = new Path(work.dumpDirectory, LOAD_METADATA.toString());
             Utils.writeOutput(String.valueOf(currentNotificationID), notificationFilePath, conf);
             LOG.info("Created NotificationACK file : {} with NotificationID : {}", notificationFilePath, currentNotificationID);
           }catch (Exception e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
           }
         }
       });


### PR DESCRIPTION
What changes were proposed in this pull request?
Storing last notificationID of target cluster while executing repl load command.

Why are the changes needed?
Does this PR introduce any user-facing change?
No

How was this patch tested?
Added one test => TestReplicationScenariosAcidTables#testNotificationFromLoadMetadataAck