### PR TITLE
HIVE-24817: A "not in" clause returns incorrect data when there is co…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -980,14 +980,8 @@ public class TypeCheckProcFactory<T> {
 
           final PrimitiveTypeInfo colTypeInfo = TypeInfoFactory.getPrimitiveTypeInfo(
               exprFactory.getTypeInfo(columnChild).getTypeName().toLowerCase());
-          T newChild = interpretNodeAsConstant(colTypeInfo, constChild,
-              exprFactory.isEqualFunction(fi));
-          if (newChild == null) {
-            // non-interpretable as target type...
-            if (!exprFactory.isNSCompareFunction(fi)) {
-              return exprFactory.createBooleanConstantExpr(null);
-            }
-          } else {
+          T newChild = interpretNodeAsConstant(colTypeInfo, constChild);
+          if (newChild != null) {
             children.set(constIdx, newChild);
           }
         }
@@ -1007,17 +1001,12 @@ public class TypeCheckProcFactory<T> {
             T columnDesc = children.get(0);
             T valueDesc = interpretNode(columnDesc, children.get(i));
             if (valueDesc == null) {
-              if (hasNullValue) {
-                // Skip if null value has already been added
-                continue;
-              }
-              TypeInfo targetType = exprFactory.getTypeInfo(columnDesc);
+              // Keep original
+              TypeInfo targetType = exprFactory.getTypeInfo(children.get(i));
               if (!expressions.containsKey(targetType)) {
                 expressions.put(targetType, columnDesc);
               }
-              T nullConst = exprFactory.createConstantExpr(targetType, null);
-              expressions.put(targetType, nullConst);
-              hasNullValue = true;
+              expressions.put(targetType, children.get(i));
             } else {
               TypeInfo targetType = exprFactory.getTypeInfo(valueDesc);
               if (!expressions.containsKey(targetType)) {

--- a/ql/src/test/queries/clientpositive/in_coercion.q
+++ b/ql/src/test/queries/clientpositive/in_coercion.q
@@ -1,0 +1,14 @@
+DROP TABLE src_table;
+CREATE TABLE src_table (key int);
+LOAD DATA LOCAL INPATH '../../data/files/kv6.txt' INTO TABLE src_table;
+
+-- verify table has data
+select count(*) from src_table; 
+-- should coerce key (int) and 355.8 to be comparable types
+select count(*) from src_table where key in (355.8);
+-- should coerce key (int) and 1.0 to be comparable types, but 1 exists in the table
+select count(*) from src_table where key in (1.0, 0.0);
+-- should coerce key (int) and 355.8 to be comparable types
+select count(*) from src_table where key not in (355.8);
+-- should coerce key (int) and 1.0 to be comparable types, but 1 exists in the table
+select count(*) from src_table where key not in (1.0, 0.0);

--- a/ql/src/test/results/clientpositive/llap/in_coercion.q.out
+++ b/ql/src/test/results/clientpositive/llap/in_coercion.q.out
@@ -1,0 +1,65 @@
+PREHOOK: query: DROP TABLE src_table
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE src_table
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE src_table (key int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@src_table
+POSTHOOK: query: CREATE TABLE src_table (key int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@src_table
+PREHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/kv6.txt' INTO TABLE src_table
+PREHOOK: type: LOAD
+#### A masked pattern was here ####
+PREHOOK: Output: default@src_table
+POSTHOOK: query: LOAD DATA LOCAL INPATH '../../data/files/kv6.txt' INTO TABLE src_table
+POSTHOOK: type: LOAD
+#### A masked pattern was here ####
+POSTHOOK: Output: default@src_table
+PREHOOK: query: select count(*) from src_table
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_table
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from src_table
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_table
+#### A masked pattern was here ####
+100
+PREHOOK: query: select count(*) from src_table where key in (355.8)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_table
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from src_table where key in (355.8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_table
+#### A masked pattern was here ####
+0
+PREHOOK: query: select count(*) from src_table where key in (1.0, 0.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_table
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from src_table where key in (1.0, 0.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_table
+#### A masked pattern was here ####
+100
+PREHOOK: query: select count(*) from src_table where key not in (355.8)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_table
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from src_table where key not in (355.8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_table
+#### A masked pattern was here ####
+100
+PREHOOK: query: select count(*) from src_table where key not in (1.0, 0.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@src_table
+#### A masked pattern was here ####
+POSTHOOK: query: select count(*) from src_table where key not in (1.0, 0.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@src_table
+#### A masked pattern was here ####
+0


### PR DESCRIPTION
…ercion

When the query has a where clause that has an integer column checking against
being "not in" a decimal column, the decimal column is being changed to null,
causing incorrect results.

This is a sample query of a failure:
select count from my_tbl where int_col not in (355.8);

Since the int_col can never be 355.8, one would expect all the rows to be
returned, but it is changing the 355.8 into a null value causing no rows
to be returned.

The fix is that when the value is attempted to be interpreted and it fails,
the original type should be used rather than null.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
