### PR TITLE
HIVE-24820: MaterializedViewCache enables adding multiple entries of the same Materialization instance

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/update/MaterializedViewUpdateOperation.java
@@ -61,7 +61,7 @@ public class MaterializedViewUpdateOperation extends DDLOperation<MaterializedVi
         cm.setValidTxnList(context.getConf().get(ValidTxnWriteIdList.VALID_TABLES_WRITEIDS_KEY));
         context.getDb().updateCreationMetadata(mvTable.getDbName(), mvTable.getTableName(), cm);
         mvTable.setCreationMetadata(cm);
-        HiveMaterializedViewsRegistry.get().createMaterializedView(context.getDb().getConf(), mvTable);
+        HiveMaterializedViewsRegistry.get().refreshMaterializedView(context.getDb().getConf(), mvTable);
       }
     } catch (HiveException e) {
       LOG.debug("Exception during materialized view cache update", e);

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1795,7 +1795,8 @@ public class Hive {
         if (materializedViewTable == null || !materializedViewTable.isRewriteEnabled()) {
           // This could happen if materialized view has been deleted or rewriting has been disabled.
           // We remove it from the registry and set result to false.
-          HiveMaterializedViewsRegistry.get().dropMaterializedView(cachedMaterializedViewTable);
+          HiveMaterializedViewsRegistry.get().dropMaterializedView(
+                  cachedMaterializedViewTable.getDbName(), cachedMaterializedViewTable.getTableName());
           result = false;
         } else {
           final Boolean outdated = isOutdatedMaterializedView(cachedMaterializedViewTable, tablesUsed, false, txnMgr);
@@ -1814,7 +1815,7 @@ public class Hive {
           if (outdated) {
             if (!cachedMaterializedViewTable.equals(materializedViewTable)) {
               // We ignore and update the registry
-              HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, cachedMaterializedViewTable, materializedViewTable);
+              HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, materializedViewTable);
               result = false;
             } else {
               // Obtain additional information if we should try incremental rewriting / rebuild
@@ -1829,7 +1830,7 @@ public class Hive {
             }
           } else if (!cachedMaterializedViewTable.equals(materializedViewTable)) {
             // Update the registry
-            HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, cachedMaterializedViewTable, materializedViewTable);
+            HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, materializedViewTable);
           }
         }
       }
@@ -1960,7 +1961,7 @@ public class Hive {
                 HiveMaterializedViewsRegistry.get().createMaterialization(conf, materializedViewTable);
         if (hiveRelOptMaterialization != null && hiveRelOptMaterialization.isSupported(scope)) {
           relOptMaterialization = hiveRelOptMaterialization;
-          HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, null, materializedViewTable);
+          HiveMaterializedViewsRegistry.get().refreshMaterializedView(conf, materializedViewTable);
           if (outdated) {
             // We will rewrite it to include the filters on transaction list
             // so we can produce partial rewritings

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/MaterializedViewsCache.java
@@ -56,7 +56,7 @@ public class MaterializedViewsCache {
     ConcurrentMap<String, HiveRelOptMaterialization> dbMap = ensureDbMap(materializedViewTable);
 
     // You store the materialized view
-    dbMap.compute(materializedViewTable.getTableName(), (mvTableName, aMaterialization) -> {
+    dbMap.computeIfAbsent(materializedViewTable.getTableName(), (mvTableName) -> {
       List<HiveRelOptMaterialization> materializationList = sqlToMaterializedView.computeIfAbsent(
               materializedViewTable.getViewExpandedText(), s -> new ArrayList<>());
       materializationList.add(materialization);

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
@@ -124,6 +124,18 @@ class TestMaterializedViewsCache {
     assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1));
   }
 
+  @Test
+  void testAddSameMVTwice() {
+    materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
+    materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
+
+    assertThat(materializedViewsCache.get(defaultMV1.getDbName(), defaultMV1.getTableName()), is(defaultMaterialization1));
+    assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).size(), is(1));
+    assertThat(materializedViewsCache.get(defaultMV1.getViewExpandedText()).get(0), is(defaultMaterialization1));
+    assertThat(materializedViewsCache.values().size(), is(1));
+    assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1));
+  }
+
   private Table getTable(String db, String tableName, String definition) {
     Table table = new Table(new org.apache.hadoop.hive.metastore.api.Table());
     table.setDbName(db);

--- a/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/metadata/TestMaterializedViewsCache.java
@@ -238,6 +238,18 @@ class TestMaterializedViewsCache {
   }
 
   @Test
+  void testMultipleRefresh() {
+    Table defaultMV1SameTable2 = getTable(defaultMV1.getDbName(), defaultMV1.getTableName(), defaultMV1.getViewExpandedText(), 30);
+    HiveRelOptMaterialization defaultMaterialization1SameTable2 = createMaterialization(defaultMV1SameTable2);
+
+    materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
+    materializedViewsCache.refresh(defaultMV1SameTable, defaultMaterialization1SameTable);
+    materializedViewsCache.refresh(defaultMV1SameTable2, defaultMaterialization1SameTable2);
+
+    assertThat(materializedViewsCache.values().get(0), is(defaultMaterialization1SameTable2));
+  }
+
+  @Test
   void testRemoveByTableName() {
     materializedViewsCache.putIfAbsent(defaultMV1, defaultMaterialization1);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Replace `ConcurrentMap.compute` to `computeIfAbsent` in `MaterializedViewsCache.putIfAbsent`
2. Rewrite MaterializedViewsCache.refresh to a remove and putIfAbsent.
3. Removing from cache is based on `MaterializedViewsCache.refresh(dbName, viewName)` only.

### Why are the changes needed?
Using `ConcurrentMap.compute` enabled adding multiple entries of the same Materialization instance to the sqlText -> materialization map.
`MaterializedViewsCache.refresh(oldTable, newTable)` did not removed outdated cache entry since a newer version of the passed table object was loaded from MetaStore. `CreationMetadata` objects does not match however this is the main purpose of refresh 


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestMaterializedViewsCache -pl ql
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite_4.q,materialized_view_create_rewrite_5.q,materialized_view_create_rewrite_nulls.q,materialized_view_rewrite_by_text_4.q -pl itests/qtest -Pitests
```