### PR TITLE
HIVE-24753: Non blocking DROP PARTITION implementation

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2996,6 +2996,9 @@ public class HiveConf extends Configuration {
 
     HIVE_TXN_READONLY_ENABLED("hive.txn.readonly.enabled", false,
       "Enables read-only transaction classification and related optimizations"),
+//    HIVE_TXN_LOCKLESS_READS_ENABLED("hive.txn.lockless.reads.enabled", false,
+//        "Feature flag for enabling lockless read"),
+
 
     /**
      * @deprecated Use MetastoreConf.TXN_TIMEOUT

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AbstractDropPartitionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AbstractDropPartitionAnalyzer.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
 import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.hooks.ReadEntity;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.metadata.InvalidTableException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
@@ -105,6 +106,10 @@ abstract class AbstractDropPartitionAnalyzer extends AbstractAlterTableAnalyzer 
 
     AlterTableDropPartitionDesc desc =
         new AlterTableDropPartitionDesc(tableName, partitionSpecs, mustPurge, replicationSpec);
+    if (AcidUtils.isTransactionalTable(table)) {
+      setAcidDdlDesc(desc);
+    }
+
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AlterTableDropPartitionDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AlterTableDropPartitionDesc.java
@@ -117,4 +117,5 @@ public class AlterTableDropPartitionDesc implements DDLDescWithWriteId, Serializ
     return true;
   }
 
+  public Long getWriteId() { return this.writeId; }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TxnCommandsBaseForTests.java
@@ -70,6 +70,7 @@ public abstract class TxnCommandsBaseForTests {
   public enum Table {
     ACIDTBL("acidTbl"),
     ACIDTBLPART("acidTblPart"),
+    ACIDTBLNESTEDPART("acidTblNestedPart"),
     ACIDTBL2("acidTbl2"),
     NONACIDORCTBL("nonAcidOrcTbl"),
     NONACIDORCTBL2("nonAcidOrcTbl2"),
@@ -141,6 +142,7 @@ public abstract class TxnCommandsBaseForTests {
     dropTables();
     runStatementOnDriver("create table " + Table.ACIDTBL + "(a int, b int) clustered by (a) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='true')");
     runStatementOnDriver("create table " + Table.ACIDTBLPART + "(a int, b int) partitioned by (p string) clustered by (a) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='true')");
+    runStatementOnDriver("create table " + Table.ACIDTBLNESTEDPART + "(a int, b int) partitioned by (p1 string, p2 string, p3 string) clustered by (a) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='true')");
     runStatementOnDriver("create table " + Table.NONACIDORCTBL + "(a int, b int) clustered by (a) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='false')");
     runStatementOnDriver("create table " + Table.NONACIDORCTBL2 + "(a int, b int) clustered by (a) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='false')");
     runStatementOnDriver("create temporary  table " + Table.ACIDTBL2 + "(a int, b int, c int) clustered by (c) into " + BUCKET_COUNT + " buckets stored as orc TBLPROPERTIES ('transactional'='true')");

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1619,7 +1619,9 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
                                         List<Pair<Integer, byte[]>> partExprs,
                                         PartitionDropOptions options) throws TException {
     RequestPartsSpec rps = new RequestPartsSpec();
+    boolean locklessReadsEnabled = MetastoreConf.getBoolVar(conf, ConfVars.LOCKLESS_READS_ENABLED);
     List<DropPartitionsExpr> exprs = new ArrayList<>(partExprs.size());
+    EnvironmentContext environmentContext;
     for (Pair<Integer, byte[]> partExpr : partExprs) {
       DropPartitionsExpr dpe = new DropPartitionsExpr();
       dpe.setExpr(partExpr.getRight());
@@ -1627,14 +1629,28 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
       exprs.add(dpe);
     }
     rps.setExprs(exprs);
+
     DropPartitionsRequest req = new DropPartitionsRequest(dbName, tblName, rps);
     req.setCatName(catName);
     req.setDeleteData(options.deleteData);
     req.setNeedResult(options.returnResults);
     req.setIfExists(options.ifExists);
+
     if (options.purgeData) {
       LOG.info("Dropped partitions will be purged!");
-      req.setEnvironmentContext(getEnvironmentContextWithIfPurgeSet());
+      environmentContext = getEnvironmentContextWithIfPurgeSet();
+      if (locklessReadsEnabled) {
+        environmentContext.putToProperties("writeId", options.writeId.toString());
+      }
+      req.setEnvironmentContext(environmentContext);
+    } else {
+      if (locklessReadsEnabled) {
+        Map<String, String> warehouseOptions = new HashMap<>();
+        warehouseOptions.put("writeId", options.writeId.toString());
+        environmentContext = new EnvironmentContext(warehouseOptions);
+
+        req.setEnvironmentContext(environmentContext);
+      }
     }
     return client.drop_partitions_req(req).getPartitions();
   }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/PartitionDropOptions.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/PartitionDropOptions.java
@@ -27,6 +27,8 @@ public class PartitionDropOptions {
   public boolean ifExists = false;
   public boolean returnResults = true;
   public boolean purgeData = false;
+  public String validWriteIds;
+  public Long writeId;
 
   public static PartitionDropOptions instance() { return new PartitionDropOptions(); }
 
@@ -47,6 +49,16 @@ public class PartitionDropOptions {
 
   public PartitionDropOptions purgeData(boolean purgeData) {
     this.purgeData = purgeData;
+    return this;
+  }
+
+  public PartitionDropOptions setValidWriteIds(String validWriteIds) {
+    this.validWriteIds = validWriteIds;
+    return this;
+  }
+
+  public PartitionDropOptions setWriteId(Long writeId) {
+    this.writeId = writeId;
     return this;
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -687,6 +687,8 @@ public class MetastoreConf {
         "hive-metastore/_HOST@EXAMPLE.COM",
         "The service principal for the metastore Thrift server. \n" +
             "The special string _HOST will be replaced automatically with the correct host name."),
+    LOCKLESS_READS_ENABLED("metastore.lockless.reads.enabled", "metastore.lockless.reads.enabled",
+        false, "Feature flag for enabling lockless read"),
     THRIFT_METASTORE_AUTHENTICATION("metastore.authentication", "hive.metastore.authentication",
             "NOSASL",
       new StringSetValidator("NOSASL", "NONE", "LDAP", "KERBEROS", "CUSTOM"),


### PR DESCRIPTION
Change-Id: Ie989ced8a1ef88e397d4d310628143cdb53ee8ca

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This changes the drop partition operation to asynchronous. The data files of transactional tables will not be deleted, but a truncated basefile will be written, which is going to be later cleaned up by the Compactor/Cleaner. 

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This along with a few other changes will enable us to not use read locks, which provides perf boost to the transactional tables.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Added tests to the TestTxnCommands
