### PR TITLE
HIVE-24822: Materialized View rebuild loses materializationTime property value

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -4728,6 +4728,7 @@ public class ObjectStore implements RawStore, Configurable {
       mcm.setTxnList(newMcm.getTxnList());
       // commit the changes
       success = commitTransaction();
+      cm.setMaterializationTime(newMcm.getMaterializationTime());
     } finally {
       if (!success) {
         rollbackTransaction();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.metastore;
 import com.codahale.metrics.Counter;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import org.apache.hadoop.hive.metastore.ObjectStore.RetryingExecutor;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.metastore.annotation.MetastoreUnitTest;
@@ -29,6 +30,7 @@ import org.apache.hadoop.hive.metastore.api.ColumnStatistics;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsData;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsDesc;
 import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
+import org.apache.hadoop.hive.metastore.api.CreationMetadata;
 import org.apache.hadoop.hive.metastore.api.CurrentNotificationEventId;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -110,6 +112,8 @@ import static java.util.concurrent.Executors.newFixedThreadPool;
 import static org.apache.hadoop.hive.metastore.Warehouse.DEFAULT_CATALOG_NAME;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
 
 @Category(MetastoreUnitTest.class)
 public class TestObjectStore {
@@ -1251,6 +1255,43 @@ public class TestObjectStore {
     result = objectStore.getAllStoredProcedures(req);
     Assert.assertEquals(1, result.size());
     assertThat(result, hasItems("proc1"));
+  }
+
+  @Test
+  public void testUpdateCreationMetadataSetsMaterializationTime() throws Exception {
+    Database db1 = new DatabaseBuilder()
+            .setName(DB1)
+            .setDescription("description")
+            .setLocation("locationurl")
+            .build(conf);
+    objectStore.createDatabase(db1);
+
+    StorageDescriptor sd1 =
+            new StorageDescriptor(ImmutableList.of(new FieldSchema("pk_col", "double", null)),
+                    "location", null, null, false, 0, new SerDeInfo("SerDeName", "serializationLib", null),
+                    null, null, null);
+    HashMap<String, String> params = new HashMap<>();
+    params.put("EXTERNAL", "false");
+    Table tbl1 = new Table(TABLE1, DB1, "owner", 1, 2, 3, sd1, null, params, null, null, "MANAGED_TABLE");
+    tbl1.setCatName(db1.getCatalogName());
+    objectStore.createTable(tbl1);
+
+    Table matView1 = new Table("mat1", DB1, "owner", 1, 2, 3, sd1, null, params, null, null, "MATERIALIZED_VIEW");
+    matView1.setCatName(db1.getCatalogName());
+
+    CreationMetadata creationMetadata = new CreationMetadata();
+    creationMetadata.setCatName(db1.getCatalogName());
+    creationMetadata.setDbName(matView1.getDbName());
+    creationMetadata.setTblName(matView1.getTableName());
+    creationMetadata.setTablesUsed(Collections.singleton(tbl1.getDbName() + "." + tbl1.getTableName()));
+    matView1.setCreationMetadata(creationMetadata);
+    objectStore.createTable(matView1);
+
+    CreationMetadata newCreationMetadata = new CreationMetadata(matView1.getCatName(), matView1.getDbName(),
+            matView1.getTableName(), ImmutableSet.copyOf(creationMetadata.getTablesUsed()));
+    objectStore.updateCreationMetadata(matView1.getCatName(), matView1.getDbName(), matView1.getTableName(), newCreationMetadata);
+
+    assertThat(creationMetadata.getMaterializationTime(), is(not(0)));
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Set `materializationTime` when updating `CreationMetadata` using `ObjectStore.updateCreationMetadata`

### Why are the changes needed?
When Rebuilding a MaterializedView a new `CreationMetadata` instance is created for the view which contains updated information like `ValidTxnList`. Initially this object has a `materializationTime` value with `0` and this is going to be stored in the `HiveMaterializedViewsRegistry` wrapped by the `RelOptMaterialization` object represents the view. However the `materializationTime` value stored in the MetaStore is recalculated and stored during the update hence MS and the registry has different values. This can lead unnecessary registry refresh or even `NullPointerException` as the jira explains.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest=TestObjectStore#testUpdateCreationMetadataSetsMaterializationTime -pl standalone-metastore/metastore-server
```
