### PR TITLE
HIVE-24834 support submit comment for kafka table

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/serde2/TestSerdeWithFieldComments.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/serde2/TestSerdeWithFieldComments.java
@@ -73,6 +73,6 @@ public class TestSerdeWithFieldComments {
     assertEquals("first", result.get(0).getName());
     assertEquals("this is a comment", result.get(0).getComment());
     assertEquals("second", result.get(1).getName());
-    assertEquals("from deserializer", result.get(1).getComment());
+    assertEquals(null, result.get(1).getComment());
   }
 }

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreUtils.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreUtils.java
@@ -201,7 +201,7 @@ public class HiveMetaStoreUtils {
 
   private static final String FROM_SERIALIZER = "from deserializer";
   private static String determineFieldComment(String comment) {
-    return (comment == null) ? FROM_SERIALIZER : comment;
+    return ("".equals(comment)) ? null : comment;
   }
 
   /**


### PR DESCRIPTION
When using kafka-handler to create a kafka table, no matter whether the user specifies column comment or not, the comment will become 'from deserializer' when the 'show create table' command is used to view the table structure.
jira: https://issues.apache.org/jira/browse/HIVE-24834
It is worth noting that I am not very familiar with hive. Can someone help me review whether the modification of HiveMetaStoreUtils.java has any side effects?