### PR TITLE
HIVE-24834: Support submit comment for kafka table

### DIFF
--- a/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
+++ b/kafka-handler/src/java/org/apache/hadoop/hive/kafka/KafkaSerDe.java
@@ -53,6 +53,7 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.rmi.server.UID;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 import java.util.stream.Collectors;
@@ -120,7 +121,16 @@ import java.util.stream.Collectors;
     inspectors.addAll(delegateDeserializerOI.getAllStructFieldRefs().stream().map(StructField::getFieldObjectInspector)
         .collect(Collectors.toList()));
     inspectors.addAll(MetadataColumn.KAFKA_METADATA_INSPECTORS);
-    objectInspector = ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, inspectors);
+    //Build comments
+    String commentStr = tableProperties.getProperty("columns.comments");
+    List<String> colComments =  new ArrayList<>(Collections.nCopies(columnNames.size(), null));
+    if (commentStr != null) {
+      String[] commentArr = commentStr.split("\0", columnNames.size());
+      for (int i = 0; i < commentArr.length; i++) {
+        colComments.set(i, commentArr[i]);
+      }
+    }
+    objectInspector = ObjectInspectorFactory.getStandardStructObjectInspector(columnNames, inspectors, colComments);
     metadataStartIndex = columnNames.size() - MetadataColumn.values().length;
     // Setup Read and Write Path From/To Kafka
     if (delegateSerDe.getSerializedClass() == Text.class) {


### PR DESCRIPTION
When using kafka-handler to create a kafka table, no matter whether the user specifies column comment or not, the comment will become 'from deserializer' when the 'show create table' command is used to view the table structure.
jira: https://issues.apache.org/jira/browse/HIVE-24834