### PR TITLE
HIVE-22601 Some columns will be lost when a UDTF has multiple aliases in some cases

### DIFF
--- a/ql/src/test/queries/clientnegative/udf_multiple_aliases.q
+++ b/ql/src/test/queries/clientnegative/udf_multiple_aliases.q
@@ -1,0 +1,1 @@
+SELECT isnull(null) AS (c1, c2);

--- a/ql/src/test/queries/clientpositive/udtf_multiple_aliases.q
+++ b/ql/src/test/queries/clientpositive/udtf_multiple_aliases.q
@@ -1,0 +1,8 @@
+EXPLAIN
+SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3);
+
+SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3);

--- a/ql/src/test/results/clientnegative/udf_multiple_aliases.q.out
+++ b/ql/src/test/results/clientnegative/udf_multiple_aliases.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException 1:28 AS clause has an invalid number of aliases. Error encountered near token 'c2'

--- a/ql/src/test/results/clientpositive/llap/udtf_multiple_aliases.q.out
+++ b/ql/src/test/results/clientpositive/llap/udtf_multiple_aliases.q.out
@@ -1,0 +1,102 @@
+PREHOOK: query: EXPLAIN
+SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: EXPLAIN
+SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Map 1 <- Union 2 (CONTAINS)
+        Map 3 <- Union 2 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: _dummy_table
+                  Row Limit Per Split: 1
+                  Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: 1 (type: int), 'a' (type: string), 'b' (type: string), 'c' (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 259 Basic stats: COMPLETE Column stats: COMPLETE
+                    UDTF Operator
+                      Statistics: Num rows: 1 Data size: 259 Basic stats: COMPLETE Column stats: COMPLETE
+                      function name: stack
+                      Select Operator
+                        expressions: col0 (type: string), col1 (type: string), col2 (type: string)
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        File Output Operator
+                          compressed: false
+                          Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: no inputs
+        Map 3 
+            Map Operator Tree:
+                TableScan
+                  alias: _dummy_table
+                  Row Limit Per Split: 1
+                  Statistics: Num rows: 1 Data size: 10 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: 1 (type: int), 'd' (type: string), 'e' (type: string), 'f' (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 259 Basic stats: COMPLETE Column stats: COMPLETE
+                    UDTF Operator
+                      Statistics: Num rows: 1 Data size: 259 Basic stats: COMPLETE Column stats: COMPLETE
+                      function name: stack
+                      Select Operator
+                        expressions: col0 (type: string), col1 (type: string), col2 (type: string)
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        File Output Operator
+                          compressed: false
+                          Statistics: Num rows: 2 Data size: 16 Basic stats: COMPLETE Column stats: COMPLETE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+            Execution mode: llap
+            LLAP IO: no inputs
+        Union 2 
+            Vertex: Union 2
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT stack(1, 'a', 'b', 'c') AS (c1, c2, c3)
+UNION ALL
+SELECT stack(1, 'd', 'e', 'f') AS (c1, c2, c3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+a	b	c
+d	e	f


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-22601

### What changes were proposed in this pull request?
A bug fix. Hive can't handle multiple aliases now.
See also the JIRA ticket for the detail.

See also: https://issues.apache.org/jira/browse/HIVE-22601?focusedCommentId=16993783&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16993783

### Why are the changes needed?
This bug causes incorrect results. It's inconvenient especially when we use Hivemall. It has a number of UDTFs that return multiple columns.

### Does this PR introduce _any_ user-facing change?
Yes, but the current behavior is apparently buggy.

### How was this patch tested?
Add 2 test cases.