### PR TITLE
HIVE-24843: Remove unnecessary throw-catch in Deadline

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Deadline.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/Deadline.java
@@ -155,18 +155,14 @@ public class Deadline {
   private static final long NO_DEADLINE = Long.MIN_VALUE;
 
   private void check() throws MetaException{
-    try {
-      if (startTime == NO_DEADLINE) {
-        throw new DeadlineException("Should execute startTimer() method before " +
-            "checkTimeout. Error happens in method: " + method);
-      }
-      long elapsedTime = System.nanoTime() - startTime;
-      if (elapsedTime > timeoutNanos) {
-        throw new DeadlineException("Timeout when executing method: " + method + "; "
-            + (elapsedTime / 1000000L) + "ms exceeds " + (timeoutNanos / 1000000L)  + "ms");
-      }
-    } catch (DeadlineException e) {
-      throw MetaStoreUtils.newMetaException(e);
+    if (startTime == NO_DEADLINE) {
+      throw MetaStoreUtils.newMetaException(new DeadlineException("Should execute startTimer() method before " +
+              "checkTimeout. Error happens in method: " + method));
+    }
+    long elapsedTime = System.nanoTime() - startTime;
+    if (elapsedTime > timeoutNanos) {
+      throw MetaStoreUtils.newMetaException(new DeadlineException("Timeout when executing method: " + method + "; "
+              + (elapsedTime / 1000000L) + "ms exceeds " + (timeoutNanos / 1000000L)  + "ms"));
     }
   }
 }


### PR DESCRIPTION
Remove an unnecessary throw-catch in the Deadline.java

### What changes were proposed in this pull request?
- Removing the unnecessary throw-catch -> throw the MetaException directly

### Why are the changes needed?
- Thowing and catching - then re-throwing is an additional overhead

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in a local cluster
