### PR TITLE
HIVE-24863: Wrong property value in UDAF percentile_cont/disc description

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileCont.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileCont.java
@@ -57,7 +57,7 @@ import org.apache.hadoop.io.LongWritable;
  * GenericUDAFPercentileCont.
  */
 @Description(
-        name = "dense_rank",
+        name = "percentile_cont",
         value = "_FUNC_(input, pc) "
                 + "- Returns the percentile of expr at pc (range: [0,1]).")
 @WindowFunctionDescription(

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileDisc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFPercentileDisc.java
@@ -32,7 +32,7 @@ import org.apache.hadoop.io.LongWritable;
  * GenericUDAFPercentileDisc.
  */
 @Description(
-        name = "dense_rank",
+        name = "percentile_disc",
         value = "_FUNC_(input, pc) - "
                 + "Returns the percentile of expr at pc (range: [0,1]) without interpolation.")
 @WindowFunctionDescription(


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix constant values in `GenericUDAFPercentileCont/Disc` description.

### Why are the changes needed?
Values were copy/pasted from `GenericUDAFDenseRank`

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=udaf_percentile_disc.q,udaf_percentile_cont.q -pl itests/qtest -Pitests
```