### PR TITLE
HIVE-24860: Shut down DbTxnManager heartbeatExecutorService at session close

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -874,6 +874,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       if (lockMgr != null) {
         lockMgr.close();
       }
+      shutdownHeartbeatExecutorService();
     } catch (Exception e) {
       LOG.error("Caught exception " + e.getClass().getName() + " with message <" + e.getMessage()
       + ">, swallowing as there is nothing we can do with it.");
@@ -912,6 +913,7 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     if (heartbeatExecutorService != null && !heartbeatExecutorService.isShutdown()) {
       LOG.info("Shutting down Heartbeater thread pool.");
       heartbeatExecutorService.shutdown();
+      heartbeatExecutorService = null;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -874,7 +874,6 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
       if (lockMgr != null) {
         lockMgr.close();
       }
-      shutdownHeartbeatExecutorService();
     } catch (Exception e) {
       LOG.error("Caught exception " + e.getClass().getName() + " with message <" + e.getMessage()
       + ">, swallowing as there is nothing we can do with it.");
@@ -913,7 +912,6 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
     if (heartbeatExecutorService != null && !heartbeatExecutorService.isShutdown()) {
       LOG.info("Shutting down Heartbeater thread pool.");
       heartbeatExecutorService.shutdown();
-      heartbeatExecutorService = null;
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DbTxnManager.java
@@ -901,7 +901,12 @@ public final class DbTxnManager extends HiveTxnManagerImpl {
 
                 @Override
                 public Thread newThread(Runnable r) {
-                  return new HeartbeaterThread(r, "Heartbeater-" + threadCounter.getAndIncrement());
+                  ClassLoader originalClassLoader = Thread.currentThread().getContextClassLoader();
+                  Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+                  HeartbeaterThread heartbeaterThread =
+                          new HeartbeaterThread(r, "Heartbeater-" + threadCounter.getAndIncrement());
+                  Thread.currentThread().setContextClassLoader(originalClassLoader);
+                  return heartbeaterThread;
                 }
               });
       ((ScheduledThreadPoolExecutor) heartbeatExecutorService).setRemoveOnCancelPolicy(true);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Shut down thread pool HeartbeatExecutorService upon session close.

### Why are the changes needed?
If the HeartBeaterExecutorService isn't shut down, UDF classes belonging to the session's UDFClassLoader (which was the session thread's context classloader at HeartBeaterExecutorService creation) could pile up and cause Metaspace OOM.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Manually