### PR TITLE
HIVE-24866: FileNotFoundException during alter table concat

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFileStripeMergeRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcFileStripeMergeRecordReader.java
@@ -38,7 +38,7 @@ import java.util.Map;
 public class OrcFileStripeMergeRecordReader implements
     RecordReader<OrcFileKeyWrapper, OrcFileValueWrapper> {
   public static final Logger LOG = LoggerFactory.getLogger(OrcFileStripeMergeRecordReader.class);
-  private final Reader reader;
+  private Reader reader;
   private final Path path;
   protected Iterator<StripeInformation> iter;
   protected List<OrcProto.StripeStatistics> stripeStatistics;
@@ -51,11 +51,13 @@ public class OrcFileStripeMergeRecordReader implements
     // if the combined split has only part of the file split, the entire file will be handled by the mapper that
     // owns the start of file split.
     skipFile = start > 0; // skip the file if start is not 0
-    FileSystem fs = path.getFileSystem(conf);
-    this.reader = OrcFile.createReader(path, OrcFile.readerOptions(conf).filesystem(fs));
-    this.iter = reader.getStripes().iterator();
-    this.stripeIdx = 0;
-    this.stripeStatistics = ((ReaderImpl) reader).getOrcProtoStripeStatistics();
+    if (!skipFile) {
+      FileSystem fs = path.getFileSystem(conf);
+      this.reader = OrcFile.createReader(path, OrcFile.readerOptions(conf).filesystem(fs));
+      this.iter = reader.getStripes().iterator();
+      this.stripeIdx = 0;
+      this.stripeStatistics = ((ReaderImpl) reader).getOrcProtoStripeStatistics();
+    }
     LOG.info("Processing file {}. skipFile: {}", path, skipFile);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFileStripeMergeRecordReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/orc/TestOrcFileStripeMergeRecordReader.java
@@ -63,8 +63,19 @@ public class TestOrcFileStripeMergeRecordReader {
     FileSplit split = new FileSplit(tmpPath, offset, length, (String[])null);
     OrcFileStripeMergeRecordReader reader = new OrcFileStripeMergeRecordReader(conf, split);
     reader.next(key, value);
+    // since offset is non-zero this file will not be processed.
+    Assert.assertNull(key.getInputPath());
+    split = new FileSplit(tmpPath, 0, length, (String[])null);
+    reader = new OrcFileStripeMergeRecordReader(conf, split);
+    // both stripes will be processed, first stripe has 5000 rows and second stripe has 1 row
+    reader.next(key, value);
+    Assert.assertEquals("InputPath", tmpPath, key.getInputPath());
+    Assert.assertEquals("NumberOfValues", 5000L, value.getStripeStatistics().getColStats(0).getNumberOfValues());
+    reader.next(key, value);
     Assert.assertEquals("InputPath", tmpPath, key.getInputPath());
     Assert.assertEquals("NumberOfValues", 1L, value.getStripeStatistics().getColStats(0).getNumberOfValues());
+    // we are done with the file, so expect null path
+    Assert.assertEquals(false, reader.next(key, value));
     reader.close();
   }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
There has been a bug lurking in alter table concatenate for ORC for a while which is typically observed when orc files are bigger and are spread across different nodes and racks. Because of the way CombineFileInputFormat groups the files together based on node/rack locality (and based on default max split size of 256MB), if the orc file size is >256MB and if the file spans multiple nodes/rack then CombineIF splits the file and groups then into different splits. Now when these different splits are processed by the mappers of merge task, the first task will initiate the concatenate and the task commit will move the source file to scratch dir. Now when the same file is processed by a different split, the file will be non-existent as it was moved by the prior mapper. This can cause failures in alter table concat task and also can results in stripes being lost because of this partial concatenation. 
This PR addresses this issue by letting the mapper that gets the start of the split to own the entire orc file for concatenation. It will process all the stripes, concatenate them to destination file and move the source file. Mappers that does not get start of the split will simply skip as the file is already handled or will be handled by different mapper.

### Why are the changes needed?
To avoid concatenation failures and stripe loss issues. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in internal repro cluster which had bigger orc files that spans multiple nodes and racks. 