### PR TITLE
HIVE-24876: Disable /logconf.jsp page in HS2 web UI if the user doesn…

### DIFF
--- a/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
@@ -134,7 +134,7 @@
 
                 <button id="log-level-submit" type="button" class="btn btn-primary">Submit</button>
             </form>
-            <% } %>
+            <% } else {%>
                 <p>Cannot configure logging rules unless user <%= hiveSession.getUserName() %> has admin privileges</p>
             <% }
              } %>

--- a/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
@@ -112,7 +112,9 @@
                     </tbody>
                 </table>
             </div>
-
+            <% Collection<HiveSession> hiveSessions = sessionManager.getSessions();
+            for (HiveSession hiveSession: hiveSessions) {
+            if( hiveSessions.size() > 0 && HttpServer.hasAccess(remoteUser, hiveSession.getUserName(), ctx, request) ) { %>
             <h2>Set new logging rules</h2>
 
             <form class="form-inline">
@@ -132,7 +134,10 @@
 
                 <button id="log-level-submit" type="button" class="btn btn-primary">Submit</button>
             </form>
-
+            <% } else { %>
+                <p>Cannot configure logging rules unless you user <%= hiveSession.getUserName() %></p>
+            <% }
+             } %>
         </div>
     </div>
 

--- a/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
@@ -134,8 +134,8 @@
 
                 <button id="log-level-submit" type="button" class="btn btn-primary">Submit</button>
             </form>
-            <% } else { %>
-                <p>Cannot configure logging rules unless you user <%= hiveSession.getUserName() %></p>
+            <% } %>
+                <p>Cannot configure logging rules unless user <%= hiveSession.getUserName() %> has admin privileges</p>
             <% }
              } %>
         </div>


### PR DESCRIPTION
…'t belong to admin role

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Disbale the logger configuration page for non-admin users.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Otherwise normal users can flood log files with unrequired information.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
Yes. If a user needs to access this log config page, he should be configured as admin in hive-site.xml with the config hive.user.in.admin.role property can have comma separated values.
<property>
    <name>hive.user.in.admin.role</name>
    <value>bob,adam</value>
</property>
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Local machine. Remote cluster.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
