### PR TITLE
HIVE-23779: BasicStatsTask Info is not getting printed in beeline console

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppender.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/log/LogDivertAppender.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hive.ql.Driver;
 import org.apache.hadoop.hive.ql.exec.Task;
 import org.apache.hadoop.hive.ql.exec.tez.TezTask;
 import org.apache.hadoop.hive.ql.session.OperationLog;
+import org.apache.hadoop.hive.ql.stats.BasicStatsTask;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -82,7 +83,7 @@ public class LogDivertAppender {
     private static final Pattern executionIncludeNamePattern = Pattern.compile(Joiner.on("|").
         join(new String[]{"org.apache.hadoop.mapreduce.JobSubmitter",
           "org.apache.hadoop.mapreduce.Job", "SessionState", "ReplState", Task.class.getName(),
-          TezTask.class.getName(), Driver.class.getName(),
+          TezTask.class.getName(), Driver.class.getName(), BasicStatsTask.class.getName(),
           "org.apache.hadoop.hive.ql.exec.spark.status.SparkJobMonitor"}));
 
     /* Patterns that are included in performance logging level.


### PR DESCRIPTION
### What changes were proposed in this pull request?
ETL flow prints Partition Basic Stats in beeline or client console. After HIVE-16061, this stats are not getting printed on the client.

### Why are the changes needed?
As there are multiple clients connecting to HS2 & running ETL, it was difficult for end user to search for stats in HS2 logs. This feature will help to know data loaded per partition.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
I did manual testing by including this fix in my local cluster & validated client console shows the logs.
