### PR TITLE
HIVE-24201: WorkloadManager can support delayed move if destination pool does not have enough sessions

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3760,7 +3760,7 @@ public class HiveConf extends Configuration {
         "A value of 0 indicates no timeout"),
     HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval", "60",
         new TimeValidator(TimeUnit.SECONDS),
-        "Interval for checking for expired delayed moves and retries."),
+        "Interval for checking for expired delayed moves."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +
         "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3749,6 +3749,10 @@ public class HiveConf extends Configuration {
         new TimeValidator(TimeUnit.SECONDS),
         "The timeout for AM registry registration, after which (on attempting to use the\n" +
         "session), we kill it and try to get another one."),
+    HIVE_SERVER2_WM_DELAYED_MOVE("hive.server2.wm.delayed.move", false,
+        "Determines behavior of the wm move trigger when destination pool is full.\n"+
+        "If true, the query will run in source pool as long as possible if destination pool is full;\n"+
+        "if false, the query will be killed if destination pool is full."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +
         "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3753,11 +3753,12 @@ public class HiveConf extends Configuration {
         "Determines behavior of the wm move trigger when destination pool is full.\n" +
         "If true, the query will run in source pool as long as possible if destination pool is full;\n" +
         "if false, the query will be killed if destination pool is full."),
-    HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT("hive.server2.wm.delayed.move.timeout", "600",
+    HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT("hive.server2.wm.delayed.move.timeout", "3600",
         new TimeValidator(TimeUnit.SECONDS),
         "The amount of time a delayed move is allowed to run in the source pool,\n" +
-        "when a delayed move session times out, the session is moved to the destination pool.\n"),
-    HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval", "10",
+        "when a delayed move session times out, the session is moved to the destination pool.\n" +
+        "A value of 0 indicates no timeout"),
+    HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval", "60",
         new TimeValidator(TimeUnit.SECONDS),
         "Interval for checking for expired delayed moves and retries. Value of 0 indicates no checks."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3750,9 +3750,18 @@ public class HiveConf extends Configuration {
         "The timeout for AM registry registration, after which (on attempting to use the\n" +
         "session), we kill it and try to get another one."),
     HIVE_SERVER2_WM_DELAYED_MOVE("hive.server2.wm.delayed.move", false,
-        "Determines behavior of the wm move trigger when destination pool is full.\n"+
-        "If true, the query will run in source pool as long as possible if destination pool is full;\n"+
+        "Determines behavior of the wm move trigger when destination pool is full.\n" +
+        "If true, the query will run in source pool as long as possible if destination pool is full;\n" +
         "if false, the query will be killed if destination pool is full."),
+    HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT(
+        "hive.server2.wm.delayed.move.timeout", "0",
+        new TimeValidator(TimeUnit.SECONDS),
+        "The amount of time a delayed move is allowed to run in the source pool,\n" +
+            "when a delayed move session times out, the session is moved to the destination pool,\n" +
+            "a value of 0 indicates no timeout"),
+    HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval",
+        "0", new TimeValidator(TimeUnit.SECONDS),
+        "Interval for checking for expired delayed moves and retries. Value of 0 indicates no checks."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +
         "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3760,7 +3760,7 @@ public class HiveConf extends Configuration {
         "A value of 0 indicates no timeout"),
     HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval", "60",
         new TimeValidator(TimeUnit.SECONDS),
-        "Interval for checking for expired delayed moves and retries. Value of 0 indicates no checks."),
+        "Interval for checking for expired delayed moves and retries."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +
         "When HiveServer2 is launched in Tez mode, this configuration needs to be set\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3754,13 +3754,12 @@ public class HiveConf extends Configuration {
         "If true, the query will run in source pool as long as possible if destination pool is full;\n" +
         "if false, the query will be killed if destination pool is full."),
     HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT(
-        "hive.server2.wm.delayed.move.timeout", "0",
+        "hive.server2.wm.delayed.move.timeout", "600",
         new TimeValidator(TimeUnit.SECONDS),
         "The amount of time a delayed move is allowed to run in the source pool,\n" +
-            "when a delayed move session times out, the session is moved to the destination pool,\n" +
-            "a value of 0 indicates no timeout"),
+            "when a delayed move session times out, the session is moved to the destination pool.\n"),
     HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval",
-        "0", new TimeValidator(TimeUnit.SECONDS),
+        "10", new TimeValidator(TimeUnit.SECONDS),
         "Interval for checking for expired delayed moves and retries. Value of 0 indicates no checks."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3753,13 +3753,12 @@ public class HiveConf extends Configuration {
         "Determines behavior of the wm move trigger when destination pool is full.\n" +
         "If true, the query will run in source pool as long as possible if destination pool is full;\n" +
         "if false, the query will be killed if destination pool is full."),
-    HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT(
-        "hive.server2.wm.delayed.move.timeout", "600",
+    HIVE_SERVER2_WM_DELAYED_MOVE_TIMEOUT("hive.server2.wm.delayed.move.timeout", "600",
         new TimeValidator(TimeUnit.SECONDS),
         "The amount of time a delayed move is allowed to run in the source pool,\n" +
-            "when a delayed move session times out, the session is moved to the destination pool.\n"),
-    HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval",
-        "10", new TimeValidator(TimeUnit.SECONDS),
+        "when a delayed move session times out, the session is moved to the destination pool.\n"),
+    HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL("hive.server2.wm.delayed.move.validator.interval", "10",
+        new TimeValidator(TimeUnit.SECONDS),
         "Interval for checking for expired delayed moves and retries. Value of 0 indicates no checks."),
     HIVE_SERVER2_TEZ_DEFAULT_QUEUES("hive.server2.tez.default.queues", "",
         "A list of comma separated values corresponding to YARN queues of the same name.\n" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillMoveTriggerActionHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/KillMoveTriggerActionHandler.java
@@ -47,8 +47,10 @@ public class KillMoveTriggerActionHandler implements TriggerActionHandler<WmTezS
           break;
         case MOVE_TO_POOL:
           String destPoolName = entry.getValue().getAction().getPoolName();
-          Future<Boolean> moveFuture = wm.applyMoveSessionAsync(wmTezSession, destPoolName);
-          moveFutures.put(wmTezSession, moveFuture);
+          if (!wmTezSession.isDelayedMove()) {
+            Future<Boolean> moveFuture = wm.applyMoveSessionAsync(wmTezSession, destPoolName);
+            moveFutures.put(wmTezSession, moveFuture);
+          }
           break;
         default:
           throw new RuntimeException("Unsupported action: " + entry.getValue());

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TriggerValidatorRunnable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TriggerValidatorRunnable.java
@@ -95,7 +95,7 @@ public class TriggerValidatorRunnable implements Runnable {
 
           Trigger chosenTrigger = violatedSessions.get(sessionState);
           if (chosenTrigger != null) {
-            LOG.info("Query: {}. {}. Applying action.", sessionState.getWmContext().getQueryId(),
+            LOG.debug("Query: {}. {}. Applying action.", sessionState.getWmContext().getQueryId(),
               chosenTrigger.getViolationMsg());
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TriggerValidatorRunnable.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TriggerValidatorRunnable.java
@@ -95,7 +95,7 @@ public class TriggerValidatorRunnable implements Runnable {
 
           Trigger chosenTrigger = violatedSessions.get(sessionState);
           if (chosenTrigger != null) {
-            LOG.debug("Query: {}. {}. Applying action.", sessionState.getWmContext().getQueryId(),
+            LOG.info("Query: {}. {}. Applying action.", sessionState.getWmContext().getQueryId(),
               chosenTrigger.getViolationMsg());
           }
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WmTezSession.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WmTezSession.java
@@ -55,6 +55,7 @@ public class WmTezSession extends TezSessionPoolSession implements AmPluginNode 
   @JsonProperty("queryId")
   private String queryId;
   private SettableFuture<Boolean> returnFuture = null;
+  private boolean isDelayedMove;
 
   private final WorkloadManager wmParent;
 
@@ -72,6 +73,7 @@ public class WmTezSession extends TezSessionPoolSession implements AmPluginNode 
       SessionExpirationTracker expiration, HiveConf conf) {
     super(sessionId, parent, expiration, conf);
     wmParent = parent;
+    isDelayedMove = false;
   }
 
   @VisibleForTesting
@@ -79,6 +81,7 @@ public class WmTezSession extends TezSessionPoolSession implements AmPluginNode 
       SessionExpirationTracker expiration, HiveConf conf) {
     super(sessionId, testParent, expiration, conf);
     wmParent = null;
+    isDelayedMove = false;
   }
 
   public ListenableFuture<WmTezSession> waitForAmRegistryAsync(
@@ -168,6 +171,14 @@ public class WmTezSession extends TezSessionPoolSession implements AmPluginNode 
     return poolName;
   }
 
+  public void setDelayedMove(boolean isDelayedMove) {
+    this.isDelayedMove = isDelayedMove;
+  }
+
+  public boolean isDelayedMove() {
+    return isDelayedMove;
+  }
+
   void setClusterFraction(double fraction) {
     this.clusterFraction = fraction;
   }
@@ -175,6 +186,7 @@ public class WmTezSession extends TezSessionPoolSession implements AmPluginNode 
   void clearWm() {
     this.poolName = null;
     this.clusterFraction = null;
+    this.isDelayedMove = false;
   }
 
   public boolean hasClusterFraction() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -1363,9 +1363,9 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
         LOG.info("Processing delayed move {} for pool {}", moveSession, poolName);
         result = handleMoveSessionOnMasterThread(moveSession, syncWork, poolsToRedistribute, toReuse, recordMoveEvents,
             false);
+        LOG.info("Result of processing delayed move {} for pool {}: {}", moveSession, poolName, result);
         iter.remove();
         if ((result == MoveSessionResult.OK) || (result == MoveSessionResult.KILLED)) {
-          LOG.info("Attempt to process delayed move {} for pool {} was successful", moveSession, poolName);
           movedCount++;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -650,7 +650,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
       int failedEndpointVersion = entry.getValue();
       LOG.info("Update failed for {}", sessionWithUpdateError);
       handleUpdateErrorOnMasterThread(
-        sessionWithUpdateError, failedEndpointVersion, e.toReuse, syncWork, poolsToRedistribute);
+          sessionWithUpdateError, failedEndpointVersion, e.toReuse, syncWork, poolsToRedistribute);
     }
     e.updateErrors.clear();
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -863,9 +863,10 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
         if (srcPoolName != null) {
           PoolState srcPool = pools.get(srcPoolName);
           if (srcPool != null) {
-            LOG.info("Move: {} is a delayed move.Since destination pool {} is full, running in source pool "
-                + "as long as possible.", moveSession, destPoolName);
-            srcPool.delayedMoveSessions.add(moveSession);
+            if (srcPool.delayedMoveSessions.add(moveSession)) {
+              LOG.info("Move: {} is a delayed move. Since destination pool {} is full, running in source pool "
+                  + "as long as possible.", moveSession, destPoolName);
+            }
           }
         }
         moveSession.future.set(false);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -247,10 +247,13 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
     delayedMoveValidationIntervalMs =
         (int) HiveConf.getTimeVar(conf, ConfVars.HIVE_SERVER2_WM_DELAYED_MOVE_VALIDATOR_INTERVAL, TimeUnit.SECONDS)
             * 1000;
-    delayedMoveThread = new Thread(() -> runDelayedMoveThread(), "Workload management delayed move");
-    delayedMoveThread.setDaemon(true);
+
     if ((delayedMoveTimeOutMs > 0) && (delayedMoveValidationIntervalMs > 0)) {
+      delayedMoveThread = new Thread(() -> runDelayedMoveThread(), "Workload management delayed move");
+      delayedMoveThread.setDaemon(true);
       delayedMoveThread.start();
+    } else {
+      delayedMoveThread = null;
     }
 
     updateResourcePlanAsync(plan).get(); // Wait for the initial resource plan to be applied.
@@ -310,6 +313,11 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
     if (wmThread != null) {
       wmThread.interrupt();
     }
+
+    if (delayedMoveThread != null) {
+      delayedMoveThread.interrupt();
+    }
+
     if (amComm != null) {
       amComm.stop();
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -684,9 +684,10 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
     // May be change command to support ... DELAYED MOVE TO etl ... which will run under src cluster fraction as long
     // as possible
     Map<WmTezSession, WmEvent> recordMoveEvents = new HashMap<>();
+    boolean convertToDelayedMove = HiveConf.getBoolVar(conf, ConfVars.HIVE_SERVER2_WM_DELAYED_MOVE);
     for (MoveSession moveSession : e.moveSessions) {
       handleMoveSessionOnMasterThread(moveSession, syncWork, poolsToRedistribute, e.toReuse,
-          recordMoveEvents, HiveConf.getBoolVar(conf, ConfVars.HIVE_SERVER2_WM_DELAYED_MOVE));
+          recordMoveEvents, convertToDelayedMove);
     }
     e.moveSessions.clear();
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -569,7 +569,8 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
     for (Map.Entry<WmTezSession, Boolean> entry : e.killQueryResults.entrySet()) {
       WmTezSession killQuerySession = entry.getKey();
       boolean killResult = entry.getValue();
-      LOG.debug("Processing KillQuery {} for {}", killResult ? "success" : "failure", killQuerySession);
+      LOG.debug("Processing KillQuery {} for {}",
+          killResult ? "success" : "failure", killQuerySession);
       // Note: do not cancel any user actions here; user actions actually interact with kills.
       KillQueryContext killCtx = killQueryInProgress.get(killQuerySession);
       if (killCtx == null) {
@@ -586,7 +587,8 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
         LOG.warn("The session was both destroyed and returned by the user; destroying");
       }
       LOG.info("Destroying {}", sessionToDestroy);
-      RemoveSessionResult rr = handleReturnedInUseSessionOnMasterThread(e, sessionToDestroy, poolsToRedistribute, false);
+      RemoveSessionResult rr = handleReturnedInUseSessionOnMasterThread(
+          e, sessionToDestroy, poolsToRedistribute, false);
       if (rr == RemoveSessionResult.OK || rr == RemoveSessionResult.NOT_FOUND) {
         // Restart even if there's an internal error.
         syncWork.toRestartInUse.add(sessionToDestroy);
@@ -595,9 +597,10 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
     e.toDestroy.clear();
 
     // 3. Now handle actual returns. Sessions may be returned to the pool or may trigger expires.
-    for (WmTezSession sessionToReturn : e.toReturn) {
+    for (WmTezSession sessionToReturn: e.toReturn) {
       LOG.info("Returning {}", sessionToReturn);
-      RemoveSessionResult rr = handleReturnedInUseSessionOnMasterThread(e, sessionToReturn, poolsToRedistribute, true);
+      RemoveSessionResult rr = handleReturnedInUseSessionOnMasterThread(
+          e, sessionToReturn, poolsToRedistribute, true);
       switch (rr) {
       case OK:
         WmEvent wmEvent = new WmEvent(WmEvent.EventType.RETURN);
@@ -616,8 +619,7 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
         break;
       case IGNORE:
         break;
-      default:
-        throw new AssertionError("Unknown state " + rr);
+      default: throw new AssertionError("Unknown state " + rr);
       }
     }
     e.toReturn.clear();

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/WorkloadManager.java
@@ -862,7 +862,6 @@ public class WorkloadManager extends TezSessionPoolSession.AbstractTriggerValida
       String srcPoolName = moveSession.srcSession.getPoolName();
       PoolState srcPool = pools.get(srcPoolName);
       boolean capacityAvailableInDest = capacityAvailable(destPoolName);
-
       // If delayed move is set to true and if destination pool doesn't have enough capacity, don't kill the query.
       // Let the query run in source pool. Add the session to the source pool's delayed move sessions.
       if (convertToDelayedMove && !capacityAvailableInDest) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestWorkloadManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestWorkloadManager.java
@@ -1161,7 +1161,7 @@ public class TestWorkloadManager {
     // [A: 1, B: 1]
     future = wm.applyMoveSessionAsync(sessionA2, "B");
     assertNotNull(future.get());
-    assertTrue(future.get());
+    assertFalse(future.get());
     wm.addTestEvent().get();
     allSessionProviders = wm.getAllSessionTriggerProviders();
     assertEquals(1, allSessionProviders.get("A").getSessions().size());


### PR DESCRIPTION
### What changes were proposed in this pull request?
 Currently, the Workload management move trigger kills the query being moved to a different pool if destination pool does not have enough capacity. This PR introduces a "delayed move" configuration which doesn't immediately kill the query when the destination pool is full but lets the query run in the source pool as long as possible. Workload manager will attempt the move to destination pool only when there is claim upon the source pool.  Also, introduces additional options for retrying delayed moves periodically and moving the session to the destination pool after a specified amount of time (delayed move timeout).
Design Doc- 
[DelayedMoveDesign.docx](https://github.com/apache/hive/files/6394264/DelayedMoveDesign.docx)


### Why are the changes needed?
For better utilization of cluster resources. 

### Does this PR introduce _any_ user-facing change?
 No

### How was this patch tested? 
Unit test
