### PR TITLE
HIVE-24881: Abort old open replication txns

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -504,7 +504,8 @@ public class TestDbTxnManager {
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TIMEDOUT_TXN_REAPER_START, 0, TimeUnit.SECONDS);
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TXN_TIMEOUT, 10, TimeUnit.SECONDS);
     houseKeeperService = new AcidHouseKeeperService();
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 1, TimeUnit.MINUTES);
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 30, TimeUnit.SECONDS);
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL, 30, TimeUnit.SECONDS);
     houseKeeperService.setConf(conf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -429,7 +429,8 @@ public class TestDbTxnManager {
 
   /**
    * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
-   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 1 minute for testing purposes
+   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 1 minute and hive.repl.event.db.listener.timetolive
+   * is set to 0 for testing purposes (the sum of these is the actual timeout)
    */
   @Test
   public void testHeartbeaterReplicationTxn() throws Exception {
@@ -504,8 +505,8 @@ public class TestDbTxnManager {
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TIMEDOUT_TXN_REAPER_START, 0, TimeUnit.SECONDS);
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TXN_TIMEOUT, 10, TimeUnit.SECONDS);
     houseKeeperService = new AcidHouseKeeperService();
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 30, TimeUnit.SECONDS);
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.EVENT_DB_LISTENER_TTL, 30, TimeUnit.SECONDS);
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 1, TimeUnit.MINUTES);
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL, 0, TimeUnit.SECONDS);
     houseKeeperService.setConf(conf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -429,7 +429,7 @@ public class TestDbTxnManager {
 
   /**
    * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
-   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 1 minute and hive.repl.event.db.listener.timetolive
+   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 30s and hive.repl.event.db.listener.timetolive
    * is set to 0 for testing purposes (the sum of these is the actual timeout)
    */
   @Test
@@ -438,7 +438,7 @@ public class TestDbTxnManager {
   };
 
   /**
-   * @param txnType e.g. TxnType.DEFAULT or TxnType.REPL_CREATED. There's a similar but different mechanism for
+   * @param txnType e.g. TxnType.DEFAULT or TxnType.REPL_CREATED. There's a different timeout for
    *                cleaning replication txns vs. non-replication txns
    */
   private void testHeartbeater(TxnType txnType, MetastoreConf.ConfVars timeThresholdConfVar) throws Exception {

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -505,7 +505,7 @@ public class TestDbTxnManager {
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TIMEDOUT_TXN_REAPER_START, 0, TimeUnit.SECONDS);
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TXN_TIMEOUT, 10, TimeUnit.SECONDS);
     houseKeeperService = new AcidHouseKeeperService();
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 1, TimeUnit.MINUTES);
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 30, TimeUnit.SECONDS);
     MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL, 0, TimeUnit.SECONDS);
     houseKeeperService.setConf(conf);
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -429,11 +429,12 @@ public class TestDbTxnManager {
 
   /**
    * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
+   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 1 minute for testing purposes
    */
   @Test
   public void testHeartbeaterReplicationTxn() throws Exception {
     testHeartbeater(TxnType.REPL_CREATED, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT);
-  }
+  };
 
   /**
    * @param txnType e.g. TxnType.DEFAULT or TxnType.REPL_CREATED. There's a similar but different mechanism for
@@ -447,7 +448,7 @@ public class TestDbTxnManager {
     QueryPlan qp = new MockQueryPlan(this, HiveOperation.QUERY);
 
     // Case 1: If there's no delay for the heartbeat, txn should be able to commit
-    txnMgr.openTxn(ctx, "u0", txnType);
+    txnMgr.openTxn(ctx, "fred", txnType);
     txnMgr.acquireLocks(qp, ctx, "fred"); // heartbeat started..
     runReaper();
     try {
@@ -503,6 +504,7 @@ public class TestDbTxnManager {
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TIMEDOUT_TXN_REAPER_START, 0, TimeUnit.SECONDS);
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TXN_TIMEOUT, 10, TimeUnit.SECONDS);
     houseKeeperService = new AcidHouseKeeperService();
+    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 1, TimeUnit.MINUTES);
     houseKeeperService.setConf(conf);
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -429,8 +429,7 @@ public class TestDbTxnManager {
 
   /**
    * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
-   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 30s and hive.repl.event.db.listener.timetolive
-   * is set to 0 for testing purposes (the sum of these is the actual timeout)
+   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 30s for testing purposes.
    */
   @Test
   public void testHeartbeaterReplicationTxn() throws Exception {
@@ -506,7 +505,6 @@ public class TestDbTxnManager {
     conf.setTimeVar(HiveConf.ConfVars.HIVE_TXN_TIMEOUT, 10, TimeUnit.SECONDS);
     houseKeeperService = new AcidHouseKeeperService();
     MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT, 30, TimeUnit.SECONDS);
-    MetastoreConf.setTimeVar(conf, MetastoreConf.ConfVars.REPL_EVENT_DB_LISTENER_TTL, 0, TimeUnit.SECONDS);
     houseKeeperService.setConf(conf);
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1031,9 +1031,10 @@ public class MetastoreConf {
     REPL_METRICS_MAX_AGE("metastore.repl.metrics.max.age",
       "hive.metastore.repl.metrics.max.age", 7, TimeUnit.DAYS,
       "Maximal age of a replication metrics entry before it is removed."),
-    REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 1, TimeUnit.DAYS,
-      "Time after hive.repl.event.db.listener.timetolive after which replication transactions are declared" +
-              "aborted if the client has not sent a heartbeat."),
+    REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 11, TimeUnit.DAYS,
+      "Time after which replication transactions are declared aborted if the client has not sent a " +
+              "heartbeat. If this is a target cluster, value must be greater than" +
+              "hive.repl.event.db.listener.timetolive on the source cluster (!), ideally by 1 day."),
     SCHEMA_INFO_CLASS("metastore.schema.info.class", "hive.metastore.schema.info.class",
         "org.apache.hadoop.hive.metastore.MetaStoreSchemaInfo",
         "Fully qualified class name for the metastore schema information class \n"

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1031,9 +1031,9 @@ public class MetastoreConf {
     REPL_METRICS_MAX_AGE("metastore.repl.metrics.max.age",
       "hive.metastore.repl.metrics.max.age", 7, TimeUnit.DAYS,
       "Maximal age of a replication metrics entry before it is removed."),
-    REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 24, TimeUnit.HOURS,
-      "Time after which replication transactions are declared aborted if the client has not" +
-      "sent a heartbeat."),
+    REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 1, TimeUnit.DAYS,
+      "Time after hive.repl.event.db.listener.timetolive after which replication transactions are declared" +
+              "aborted if the client has not sent a heartbeat."),
     SCHEMA_INFO_CLASS("metastore.schema.info.class", "hive.metastore.schema.info.class",
         "org.apache.hadoop.hive.metastore.MetaStoreSchemaInfo",
         "Fully qualified class name for the metastore schema information class \n"

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1032,7 +1032,7 @@ public class MetastoreConf {
       "hive.metastore.repl.metrics.max.age", 7, TimeUnit.DAYS,
       "Maximal age of a replication metrics entry before it is removed."),
     REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 24, TimeUnit.HOURS,
-      "time after which replication transactions are declared aborted if the client has not" +
+      "Time after which replication transactions are declared aborted if the client has not" +
       "sent a heartbeat."),
     SCHEMA_INFO_CLASS("metastore.schema.info.class", "hive.metastore.schema.info.class",
         "org.apache.hadoop.hive.metastore.MetaStoreSchemaInfo",

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -1031,6 +1031,9 @@ public class MetastoreConf {
     REPL_METRICS_MAX_AGE("metastore.repl.metrics.max.age",
       "hive.metastore.repl.metrics.max.age", 7, TimeUnit.DAYS,
       "Maximal age of a replication metrics entry before it is removed."),
+    REPL_TXN_TIMEOUT("metastore.repl.txn.timeout", "hive.repl.txn.timeout", 24, TimeUnit.HOURS,
+      "time after which replication transactions are declared aborted if the client has not" +
+      "sent a heartbeat."),
     SCHEMA_INFO_CLASS("metastore.schema.info.class", "hive.metastore.schema.info.class",
         "org.apache.hadoop.hive.metastore.MetaStoreSchemaInfo",
         "Fully qualified class name for the metastore schema information class \n"

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -302,7 +302,6 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   // (End user) Transaction timeout, in milliseconds.
   private long timeout;
   private long replicationTxnTimeout;
-  // Timeout for opening a transaction
 
   private int maxBatchSize;
   private String identifierQuoteString; // quotes to use for quoting tables, where necessary
@@ -378,7 +377,8 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     numOpenTxns = Metrics.getOrCreateGauge(MetricsConstants.NUM_OPEN_TXNS);
 
     timeout = MetastoreConf.getTimeVar(conf, ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS);
-    replicationTxnTimeout = MetastoreConf.getTimeVar(conf, ConfVars.REPL_TXN_TIMEOUT, TimeUnit.MILLISECONDS);
+    replicationTxnTimeout = MetastoreConf.getTimeVar(conf, ConfVars.REPL_EVENT_DB_LISTENER_TTL, TimeUnit.MILLISECONDS) +
+            MetastoreConf.getTimeVar(conf, ConfVars.REPL_TXN_TIMEOUT, TimeUnit.MILLISECONDS);
     retryInterval = MetastoreConf.getTimeVar(conf, ConfVars.HMS_HANDLER_INTERVAL,
         TimeUnit.MILLISECONDS);
     retryLimit = MetastoreConf.getIntVar(conf, ConfVars.HMS_HANDLER_ATTEMPTS);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -377,8 +377,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     numOpenTxns = Metrics.getOrCreateGauge(MetricsConstants.NUM_OPEN_TXNS);
 
     timeout = MetastoreConf.getTimeVar(conf, ConfVars.TXN_TIMEOUT, TimeUnit.MILLISECONDS);
-    replicationTxnTimeout = MetastoreConf.getTimeVar(conf, ConfVars.REPL_EVENT_DB_LISTENER_TTL, TimeUnit.MILLISECONDS) +
-            MetastoreConf.getTimeVar(conf, ConfVars.REPL_TXN_TIMEOUT, TimeUnit.MILLISECONDS);
+    replicationTxnTimeout = MetastoreConf.getTimeVar(conf, ConfVars.REPL_TXN_TIMEOUT, TimeUnit.MILLISECONDS);
     retryInterval = MetastoreConf.getTimeVar(conf, ConfVars.HMS_HANDLER_INTERVAL,
         TimeUnit.MILLISECONDS);
     retryLimit = MetastoreConf.getIntVar(conf, ConfVars.HMS_HANDLER_ATTEMPTS);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -5091,7 +5091,7 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
           " AND (" +
                 "\"TXN_TYPE\" != " + TxnType.REPL_CREATED.getValue() +
                 " AND \"TXN_LAST_HEARTBEAT\" <  " + getEpochFn(dbProduct) + "-" + timeout +
-             ") OR (" +
+             " OR " +
                 " \"TXN_TYPE\" = " + TxnType.REPL_CREATED.getValue() +
                 " AND \"TXN_LAST_HEARTBEAT\" <  " + getEpochFn(dbProduct) + "-" + replicationTxnTimeout +
              ")";


### PR DESCRIPTION
We should auto-abort/remove open replication txns that are older than a time threshold (default: 24h).

### How was this patch tested?
Unit test
