### PR TITLE
HIVE-24882: Compaction task reattempt fails with FileAlreadyExistsException for DeleteEventWriter

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorMR.java
@@ -894,7 +894,9 @@ public class CompactorMR {
           AcidOutputFormat<WritableComparable, V> aof =
           instantiate(AcidOutputFormat.class, jobConf.get(OUTPUT_FORMAT_CLASS_NAME));
 
-      deleteEventWriter = aof.getRawRecordWriter(new Path(jobConf.get(TMP_LOCATION)), options);
+      Path rootDir = new Path(jobConf.get(TMP_LOCATION));
+      cleanupTmpLocationOnTaskRetry(options, rootDir);
+      deleteEventWriter = aof.getRawRecordWriter(rootDir, options);
 
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Compaction reattempt should clear the old attempt files before running the current attempt

### Why are the changes needed?
Compaction task can be pre-empted by yarn for resource or some network issue could cause hdfs read failures, which when re-attempted to new NM can succeed. This re-attempt is failing because of stale files from old failed attempt.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
No testcase is included.
