### PR TITLE
HIVE-24887: HMSHandler.getDatabase() with no capabilities to call tra…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/security/authorization/StorageBasedAuthorizationProvider.java
@@ -288,7 +288,7 @@ public class StorageBasedAuthorizationProvider extends HiveAuthorizationProvider
     }
   }
 
-  private void checkDeletePermission(Path dataLocation, Configuration conf, String userName)
+  protected void checkDeletePermission(Path dataLocation, Configuration conf, String userName)
       throws HiveException {
     try {
       FileUtils.checkDeletePermission(dataLocation, conf, userName);

--- a/ql/src/test/results/clientpositive/beeline/escape_comments.q.out
+++ b/ql/src/test/results/clientpositive/beeline/escape_comments.q.out
@@ -42,14 +42,14 @@ PREHOOK: Input: database:escape_comments_db
 POSTHOOK: query: describe database extended escape_comments_db
 POSTHOOK: type: DESCDATABASE
 POSTHOOK: Input: database:escape_comments_db
-#### A masked pattern was here ####
+escape_comments_db	a\nb	location/in/test		user	USER	
 PREHOOK: query: describe database escape_comments_db
 PREHOOK: type: DESCDATABASE
 PREHOOK: Input: database:escape_comments_db
 POSTHOOK: query: describe database escape_comments_db
 POSTHOOK: type: DESCDATABASE
 POSTHOOK: Input: database:escape_comments_db
-#### A masked pattern was here ####
+escape_comments_db	a\nb	location/in/test		user	USER
 PREHOOK: query: show create table escape_comments_tbl1
 PREHOOK: type: SHOW_CREATETABLE
 PREHOOK: Input: escape_comments_db@escape_comments_tbl1

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1644,7 +1644,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     try {
       db = getMS().getDatabase(request.getCatalogName(), request.getName());
       firePreEvent(new PreReadDatabaseEvent(db, this));
-      if (processorCapabilities != null && transformer != null) {
+      if (transformer != null && !isInTest) {
         db = transformer.transformDatabase(db, processorCapabilities, processorId);
       }
     } catch (MetaException | NoSuchObjectException e) {
@@ -2150,6 +2150,9 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     List<String> processorCapabilities = req.getProcessorCapabilities();
     String processorId = req.getProcessorIdentifier();
 
+    if (!tbl.isSetCatName()) {
+      tbl.setCatName(getDefaultCatalog(conf));
+    }
     if (transformer != null && !isInTest) {
       tbl = transformer.transformCreateTable(tbl, processorCapabilities, processorId);
     }
@@ -2208,9 +2211,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     Database db = null;
     boolean isReplicated = false;
     try {
-      if (!tbl.isSetCatName()) {
-        tbl.setCatName(getDefaultCatalog(conf));
-      }
       firePreEvent(new PreCreateTableEvent(tbl, this));
 
       ms.openTransaction();

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestMetaStoreEventListener.java
@@ -104,6 +104,14 @@ public class TestMetaStoreEventListener {
     MetaStoreTestUtils.setConfForStandloneMode(conf);
     MetaStoreTestUtils.startMetaStoreWithRetry(HadoopThriftAuthBridge.getBridge(), conf);
 
+    HiveMetaStoreClient.setProcessorIdentifier("test@TestMetaStoreEventListener");
+    HiveMetaStoreClient.setProcessorCapabilities(new String[] {
+        "HIVEFULLACIDREAD",
+        "EXTWRITE",
+        "EXTREAD",
+        "HIVEBUCKET2"
+    });
+
     msc = new HiveMetaStoreClient(conf);
 
     msc.dropDatabase(dbName, true, true, true);
@@ -131,6 +139,8 @@ public class TestMetaStoreEventListener {
   }
 
   private void validateTableInAddPartition(Table expectedTable, Table actualTable) {
+    // AccessType is not set on the table object from the event. We want to compare everything else.
+    actualTable.setAccessType(expectedTable.getAccessType());
     assertEquals(expectedTable, actualTable);
   }
 
@@ -262,7 +272,7 @@ public class TestMetaStoreEventListener {
     hmsClient.add_partitions(Arrays.asList(partition1, partition2, partition3));
     ++listSize;
     AddPartitionEvent multiplePartitionEvent = (AddPartitionEvent)(notifyList.get(listSize-1));
-    assertEquals("Unexpected table value.", table, multiplePartitionEvent.getTable());
+    validateTableInAddPartition(table, multiplePartitionEvent.getTable());
     List<Partition> multiParts = Lists.newArrayList(multiplePartitionEvent.getPartitionIterator());
     assertEquals("Unexpected number of partitions in event!", 3, multiParts.size());
     assertEquals("Unexpected partition value.", partition1.getValues(), multiParts.get(0).getValues());

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestDatabases.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.metastore.client;
 
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.MetaStoreTestUtils;
 import org.apache.hadoop.hive.metastore.Warehouse;
@@ -76,6 +77,14 @@ public class TestDatabases extends MetaStoreClientTest {
 
   @Before
   public void setUp() throws Exception {
+    HiveMetaStoreClient.setProcessorIdentifier("UnitTest@TestDatabases");
+    HiveMetaStoreClient.setProcessorCapabilities(new String[] {
+        "HIVEFULLACIDREAD",
+        "EXTWRITE",
+        "EXTREAD",
+        "HIVEBUCKET2"
+    } );
+
     // Get new client
     client = metaStore.getClient();
 
@@ -468,7 +477,7 @@ public class TestDatabases extends MetaStoreClientTest {
             .setName(originalDatabase.getName())
             .setOwnerType(PrincipalType.GROUP)
             .setOwnerName("owner2")
-            .setLocation(metaStore.getWarehouseRoot() + "/database_location_2")
+            .setLocation(metaStore.getExternalWarehouseRoot() + "/database_location_2")
             .setDescription("dummy description 2")
             .addParam("param_key_1", "param_value_1_2")
             .addParam("param_key_2_3", "param_value_2_3")
@@ -665,7 +674,7 @@ public class TestDatabases extends MetaStoreClientTest {
                .setName("dummy")
                .setOwnerType(PrincipalType.ROLE)
                .setOwnerName("owner")
-               .setLocation(metaStore.getWarehouseRoot() + "/database_location")
+               .setLocation(metaStore.getExternalWarehouseRoot() + "/database_location")
                .setDescription("dummy description")
                .addParam("param_key_1", "param_value_1")
                .addParam("param_key_2", "param_value_2")


### PR DESCRIPTION
…nslation (Naveen Gangam)

### What changes were proposed in this pull request?
A minor change to have getDatabase() call call the translation layer even when client does not set the capabilities.
Another change is to make checkDeletePermissions in the storage based authorizer to be package visibility, much like the other check* methods on this class. This allows the subclasses to use this method as well.

### Why are the changes needed?
Mostly consistency with other methods like createTable() etc.

### Does this PR introduce _any_ user-facing change?
Potentially, clients can see a different locationUri if their original database object had location from the managed warehouse. This old location will now be set as managedLocationUri.

### How was this patch tested?
Manually.
Failed unit tests.