### PR TITLE
HIVE-24892: Replace getContentSummary::getLength with listStatus(recu…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
@@ -33,7 +33,9 @@ import java.util.concurrent.Future;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;

--- a/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/stats/BasicStats.java
@@ -216,7 +216,12 @@ public class BasicStats {
 
     private long getFileSizeForPath(Path path) throws IOException {
       FileSystem fs = path.getFileSystem(conf);
-      return fs.getContentSummary(path).getLength();
+      RemoteIterator<LocatedFileStatus> it = fs.listFiles(path, true);
+      long size = 0;
+      while (it.hasNext()) {
+        size += it.next().getLen();
+      }
+      return size;
     }
 
   }


### PR DESCRIPTION
HIVE-24892: Replace getContentSummary::getLength with listStatus(recursive) for blobstores


### What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/HIVE-24892
getContentSummary is super slow for blobstores and makes lots of network calls. Replacing it with listStatus(path, recursive) which is a lot more performant (e.g in consistent s3). 

### Why are the changes needed?

### Does this PR introduce _any_ user-facing change?
No