### PR TITLE
HIVE-24840: Materialized View incremental rebuild produces wrong result set after compaction

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/CompactorOnTezTest.java
@@ -22,12 +22,17 @@ import org.apache.hadoop.hive.cli.CliSessionState;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.ShowCompactRequest;
+import org.apache.hadoop.hive.metastore.api.ShowCompactResponseElement;
+import org.apache.hadoop.hive.metastore.txn.TxnUtils;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.io.HiveInputFormat;
 import org.apache.hadoop.hive.ql.session.SessionState;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -126,6 +131,21 @@ public class CompactorOnTezTest {
       driver.close();
     }
     conf = null;
+  }
+
+  /**
+   * Verify that the expected number of transactions have run, and their state is "succeeded".
+   *
+   * @param expectedSuccessfulCompactions number of compactions already run
+   * @throws MetaException
+   */
+  protected void verifySuccessfulCompaction(int expectedSuccessfulCompactions) throws MetaException {
+    List<ShowCompactResponseElement> compacts =
+        TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
+    Assert.assertEquals("Completed compaction queue must contain " + expectedSuccessfulCompactions + " element(s)",
+        expectedSuccessfulCompactions, compacts.size());
+    compacts.forEach(
+        c -> Assert.assertEquals("Compaction state is not succeeded", "succeeded", c.getState()));
   }
 
   protected class TestDataProvider {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -2337,8 +2337,8 @@ public class TestCompactor {
     try {
       executeStatementOnDriver(cmd, driver);
     }
-    catch (Exception ignore) {
-
+    catch (Exception ex) {
+      LOG.warn("Error while executing query: " + cmd, ex);
     }
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -2315,7 +2315,7 @@ public class TestCompactor {
   /**
    * convenience method to execute a select stmt and dump results to log file
    */
-  private static List<String> execSelectAndDumpData(String selectStmt, IDriver driver, String msg)
+  public static List<String> execSelectAndDumpData(String selectStmt, IDriver driver, String msg)
     throws Exception {
     executeStatementOnDriver(selectStmt, driver);
     ArrayList<String> valuesReadFromHiveDriver = new ArrayList<String>();
@@ -2326,6 +2326,20 @@ public class TestCompactor {
       LOG.debug(" rowIdx=" + rowIdx++ + ":" + row);
     }
     return valuesReadFromHiveDriver;
+  }
+
+  /**
+   * Execute Hive CLI statement and ignore any exception thrown.
+   *
+   * @param cmd arbitrary statement to execute
+   */
+  static void executeStatementOnDriverSiletnly(String cmd, IDriver driver) {
+    try {
+      executeStatementOnDriver(cmd, driver);
+    }
+    catch (Exception ignore) {
+
+    }
   }
 
   /**

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCompactor.java
@@ -2333,7 +2333,7 @@ public class TestCompactor {
    *
    * @param cmd arbitrary statement to execute
    */
-  static void executeStatementOnDriverSiletnly(String cmd, IDriver driver) {
+  static void executeStatementOnDriverSilently(String cmd, IDriver driver) {
     try {
       executeStatementOnDriver(cmd, driver);
     }

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCrudCompactorOnTez.java
@@ -1708,21 +1708,6 @@ public class TestCrudCompactorOnTez extends CompactorOnTezTest {
   }
 
   /**
-   * Verify that the expected number of transactions have run, and their state is "succeeded".
-   *
-   * @param expectedSuccessfulCompactions number of compactions already run
-   * @throws MetaException
-   */
-  private void verifySuccessfulCompaction(int expectedSuccessfulCompactions) throws MetaException {
-    List<ShowCompactResponseElement> compacts =
-        TxnUtils.getTxnStore(conf).showCompact(new ShowCompactRequest()).getCompacts();
-    Assert.assertEquals("Completed compaction queue must contain " + expectedSuccessfulCompactions + " element(s)",
-        expectedSuccessfulCompactions, compacts.size());
-    compacts.forEach(
-        c -> Assert.assertEquals("Compaction state is not succeeded", "succeeded", c.getState()));
-  }
-
-  /**
    * Read file, and
    * 1. make sure that the bucket property in each row matches the file name.
    * For example, if the bucketId is 0, we check file bucket_00000 to make sure that the third

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMaterializedViewRebuild.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMaterializedViewRebuild.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.txn.compactor;
+
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.hadoop.hive.metastore.api.CompactionType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriverSiletnly;
+
+public class TestMaterializedViewRebuild extends CompactorOnTezTest {
+
+  private static final String TABLE1 = "t1";
+  private static final String MV1 = "mat1";
+
+  private static final List<String> FULL_REBUILD_PLAN = Arrays.asList(
+      "CBO PLAN:",
+      "HiveProject(a=[$0], b=[$1], c=[$2])",
+      "  HiveFilter(condition=[OR(IS NULL($0), >($0, 0))])",
+      "    HiveTableScan(table=[[default, t1]], table:alias=[t1])",
+      ""
+  );
+
+  private static final List<String> INCREMENTAL_REBUILD_PLAN = Arrays.asList(
+      "CBO PLAN:",
+      "HiveProject(a=[$0], b=[$1], c=[$2])",
+      "  HiveFilter(condition=[AND(<(2, $5.writeid), OR(>($0, 0), IS NULL($0)))])",
+      "    HiveTableScan(table=[[default, t1]], table:alias=[t1])",
+      ""
+  );
+
+  private static final List<String> EXPECTED_RESULT = Arrays.asList(
+      "1\tone\t1.1",
+      "2\ttwo\t2.2",
+      "3\tthree\t3.3",
+      "NULL\tNULL\tNULL"
+  );
+
+
+  @Override
+  public void setup() throws Exception {
+    super.setup();
+
+    executeStatementOnDriver("create table " + TABLE1 + "(a int, b varchar(128), c float) stored as orc TBLPROPERTIES ('transactional'='true')", driver);
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b, c) values (1, 'one', 1.1), (2, 'two', 2.2), (NULL, NULL, NULL)", driver);
+    executeStatementOnDriver("create materialized view " + MV1 + " stored as orc TBLPROPERTIES ('transactional'='true') as " +
+        "select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver);
+  }
+
+  @Override
+  public void tearDown() {
+    executeStatementOnDriverSiletnly("drop materialized view " + MV1, driver);
+    executeStatementOnDriverSiletnly("drop table " + TABLE1 , driver);
+
+    super.tearDown();
+  }
+
+  @Test
+  public void testWhenMajorCompactionThenIncrementalMVRebuildNotUsed() throws Exception {
+
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b,c) values (3, 'three', 3.3)", driver);
+
+    CompactorTestUtil.runCompaction(conf, "default",  TABLE1 , CompactionType.MAJOR, true);
+    CompactorTestUtil.runCleaner(conf);
+    verifySuccessfulCompaction(1);
+
+    List<String> result = execSelectAndDumpData("explain cbo alter materialized view " + MV1 + " rebuild", driver, "");
+    Assert.assertEquals(FULL_REBUILD_PLAN, result);
+    executeStatementOnDriver("alter materialized view " + MV1 + " rebuild", driver);
+
+    result = execSelectAndDumpData("select * from " + MV1 , driver, "");
+    assertResult(EXPECTED_RESULT, result);
+
+    result = execSelectAndDumpData("explain cbo select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver, "");
+    Assert.assertEquals(Arrays.asList("CBO PLAN:", "HiveTableScan(table=[[default, " + MV1 + "]], table:alias=[default." + MV1 + "])", ""), result);
+  }
+
+  @Test
+  public void testSecondRebuildCanBeIncrementalAfterMajorCompaction() throws Exception {
+
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b,c) values (3, 'three', 3.3)", driver);
+
+    CompactorTestUtil.runCompaction(conf, "default",  TABLE1 , CompactionType.MAJOR, true);
+    CompactorTestUtil.runCleaner(conf);
+    verifySuccessfulCompaction(1);
+
+    executeStatementOnDriver("alter materialized view " + MV1 + " rebuild", driver);
+
+    // Insert after first rebuild.
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b,c) values (4, 'four', 4.4)", driver);
+
+    List<String> result = execSelectAndDumpData("explain cbo alter materialized view " + MV1 + " rebuild", driver, "");
+    Assert.assertEquals(INCREMENTAL_REBUILD_PLAN, result);
+    executeStatementOnDriver("alter materialized view " + MV1 + " rebuild", driver);
+
+    result = execSelectAndDumpData("select * from " + MV1 , driver, "");
+    List<String> expected = new ArrayList(EXPECTED_RESULT);
+    expected.add("4\tfour\t4.4");
+    assertResult(expected, result);
+
+    result = execSelectAndDumpData("explain cbo select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver, "");
+    Assert.assertEquals(Arrays.asList("CBO PLAN:", "HiveTableScan(table=[[default, " + MV1 + "]], table:alias=[default." + MV1 + "])", ""), result);
+  }
+
+  @Test
+  public void testWhenCleanUpOfMajorCompactionHasNotFinishedIncrementalMVRebuildNotUsed() throws Exception {
+    executeStatementOnDriver("insert into " + TABLE1 + "(a,b,c) values (3, 'three', 3.3)", driver);
+
+    CompactorTestUtil.runCompaction(conf, "default",  TABLE1 , CompactionType.MAJOR, true);
+
+    List<String> result = execSelectAndDumpData("explain cbo alter materialized view " + MV1 + " rebuild", driver, "");
+    Assert.assertEquals(FULL_REBUILD_PLAN, result);
+    executeStatementOnDriver("alter materialized view " + MV1 + " rebuild", driver);
+
+    result = execSelectAndDumpData("select * from " + MV1 , driver, "");
+    assertResult(EXPECTED_RESULT, result);
+
+    result = execSelectAndDumpData("explain cbo select a,b,c from " + TABLE1 + " where a > 0 or a is null", driver, "");
+    Assert.assertEquals(Arrays.asList("CBO PLAN:", "HiveTableScan(table=[[default, " + MV1 + "]], table:alias=[default." + MV1 + "])", ""), result);
+  }
+
+  private void assertResult(List<String> expected, List<String> actual) {
+    Assert.assertEquals(expected.size(), actual.size());
+
+    Collections.sort(expected);
+    Collections.sort(actual);
+    Assert.assertEquals(expected, actual);
+  }
+
+}

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMaterializedViewRebuild.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestMaterializedViewRebuild.java
@@ -28,7 +28,7 @@ import org.junit.Test;
 
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriver;
 import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.execSelectAndDumpData;
-import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriverSiletnly;
+import static org.apache.hadoop.hive.ql.txn.compactor.TestCompactor.executeStatementOnDriverSilently;
 
 public class TestMaterializedViewRebuild extends CompactorOnTezTest {
 
@@ -71,8 +71,8 @@ public class TestMaterializedViewRebuild extends CompactorOnTezTest {
 
   @Override
   public void tearDown() {
-    executeStatementOnDriverSiletnly("drop materialized view " + MV1, driver);
-    executeStatementOnDriverSiletnly("drop table " + TABLE1 , driver);
+    executeStatementOnDriverSilently("drop materialized view " + MV1, driver);
+    executeStatementOnDriverSilently("drop table " + TABLE1 , driver);
 
     super.tearDown();
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1917,7 +1917,8 @@ public class Hive {
             // We will not try partial rewriting if there were update/delete operations on source tables
             Materialization invalidationInfo = getMSC().getMaterializationInvalidationInfo(
                 creationMetadata, conf.get(ValidTxnList.VALID_TXNS_KEY));
-            ignore = invalidationInfo == null || invalidationInfo.isSourceTablesUpdateDeleteModified();
+            ignore = invalidationInfo == null || invalidationInfo.isSourceTablesCompacted() ||
+                invalidationInfo.isSourceTablesUpdateDeleteModified();
           }
           if (ignore) {
             LOG.debug("Materialized view " + materializedViewTable.getFullyQualifiedName() +

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1821,7 +1821,8 @@ public class Hive {
               // We will not try partial rewriting if there were update/delete operations on source tables
               Materialization invalidationInfo = getMSC().getMaterializationInvalidationInfo(
                   materializedViewTable.getCreationMetadata(), conf.get(ValidTxnList.VALID_TXNS_KEY));
-              if (invalidationInfo == null || invalidationInfo.isSourceTablesUpdateDeleteModified()) {
+              if (invalidationInfo == null || invalidationInfo.isSourceTablesUpdateDeleteModified() ||
+                  invalidationInfo.isSetSourceTablesCompacted()) {
                 // We ignore (as it did not meet the requirements), but we do not need to update it in the
                 // registry, since it is up-to-date
                 result = false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1818,7 +1818,7 @@ public class Hive {
               result = false;
             } else {
               // Obtain additional information if we should try incremental rewriting / rebuild
-              // We will not try partial rewriting if there were update/delete operations on source tables
+              // We will not try partial rewriting if there were update/delete/compaction operations on source tables
               Materialization invalidationInfo = getMSC().getMaterializationInvalidationInfo(
                   materializedViewTable.getCreationMetadata(), conf.get(ValidTxnList.VALID_TXNS_KEY));
               if (invalidationInfo == null || invalidationInfo.isSourceTablesUpdateDeleteModified() ||
@@ -1915,7 +1915,7 @@ public class Hive {
             ignore = true;
           } else {
             // Obtain additional information if we should try incremental rewriting / rebuild
-            // We will not try partial rewriting if there were update/delete operations on source tables
+            // We will not try partial rewriting if there were update/delete/compaction operations on source tables
             Materialization invalidationInfo = getMSC().getMaterializationInvalidationInfo(
                 creationMetadata, conf.get(ValidTxnList.VALID_TXNS_KEY));
             ignore = invalidationInfo == null || invalidationInfo.isSourceTablesCompacted() ||

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -32416,6 +32416,14 @@ uint32_t TableMeta::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_BOOL) {
+          xfer += iprot->readBool(this->sourceTablesCompacted);
+          isset_sourceTablesCompacted = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -32512,6 +32520,10 @@ Materialization::~Materialization() noexcept {
 void Materialization::__set_sourceTablesUpdateDeleteModified(const bool val) {
   this->sourceTablesUpdateDeleteModified = val;
 }
+
+void Materialization::__set_sourceTablesCompacted(const bool val) {
+  this->sourceTablesCompacted = val;
+}
 std::ostream& operator<<(std::ostream& out, const Materialization& obj)
 {
   obj.printTo(out);
@@ -32532,6 +32544,7 @@ uint32_t Materialization::read(::apache::thrift::protocol::TProtocol* iprot) {
   using ::apache::thrift::protocol::TProtocolException;
 
   bool isset_sourceTablesUpdateDeleteModified = false;
+  bool isset_sourceTablesCompacted = false;
 
   while (true)
   {
@@ -32560,6 +32573,8 @@ uint32_t Materialization::read(::apache::thrift::protocol::TProtocol* iprot) {
 
   if (!isset_sourceTablesUpdateDeleteModified)
     throw TProtocolException(TProtocolException::INVALID_DATA);
+  if (!isset_sourceTablesCompacted)
+    throw TProtocolException(TProtocolException::INVALID_DATA);
   return xfer;
 }
 
@@ -32572,6 +32587,10 @@ uint32_t Materialization::write(::apache::thrift::protocol::TProtocol* oprot) co
   xfer += oprot->writeBool(this->sourceTablesUpdateDeleteModified);
   xfer += oprot->writeFieldEnd();
 
+  xfer += oprot->writeFieldBegin("sourceTablesCompacted", ::apache::thrift::protocol::T_BOOL, 2);
+  xfer += oprot->writeBool(this->sourceTablesCompacted);
+  xfer += oprot->writeFieldEnd();
+
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -32580,19 +32599,23 @@ uint32_t Materialization::write(::apache::thrift::protocol::TProtocol* oprot) co
 void swap(Materialization &a, Materialization &b) {
   using ::std::swap;
   swap(a.sourceTablesUpdateDeleteModified, b.sourceTablesUpdateDeleteModified);
+  swap(a.sourceTablesCompacted, b.sourceTablesCompacted);
 }
 
 Materialization::Materialization(const Materialization& other1210) {
   sourceTablesUpdateDeleteModified = other1210.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1210.sourceTablesCompacted;
 }
 Materialization& Materialization::operator=(const Materialization& other1211) {
   sourceTablesUpdateDeleteModified = other1211.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1211.sourceTablesCompacted;
   return *this;
 }
 void Materialization::printTo(std::ostream& out) const {
   using ::apache::thrift::to_string;
   out << "Materialization(";
   out << "sourceTablesUpdateDeleteModified=" << to_string(sourceTablesUpdateDeleteModified);
+  out << ", " << "sourceTablesCompacted=" << to_string(sourceTablesCompacted);
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -12017,17 +12017,22 @@ class Materialization : public virtual ::apache::thrift::TBase {
 
   Materialization(const Materialization&);
   Materialization& operator=(const Materialization&);
-  Materialization() : sourceTablesUpdateDeleteModified(0) {
+  Materialization() : sourceTablesUpdateDeleteModified(0), sourceTablesCompacted(0) {
   }
 
   virtual ~Materialization() noexcept;
   bool sourceTablesUpdateDeleteModified;
+  bool sourceTablesCompacted;
 
   void __set_sourceTablesUpdateDeleteModified(const bool val);
+
+  void __set_sourceTablesCompacted(const bool val);
 
   bool operator == (const Materialization & rhs) const
   {
     if (!(sourceTablesUpdateDeleteModified == rhs.sourceTablesUpdateDeleteModified))
+      return false;
+    if (!(sourceTablesCompacted == rhs.sourceTablesCompacted))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Materialization.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/Materialization.java
@@ -12,15 +12,18 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TStruct STRUCT_DESC = new org.apache.thrift.protocol.TStruct("Materialization");
 
   private static final org.apache.thrift.protocol.TField SOURCE_TABLES_UPDATE_DELETE_MODIFIED_FIELD_DESC = new org.apache.thrift.protocol.TField("sourceTablesUpdateDeleteModified", org.apache.thrift.protocol.TType.BOOL, (short)1);
+  private static final org.apache.thrift.protocol.TField SOURCE_TABLES_COMPACTED_FIELD_DESC = new org.apache.thrift.protocol.TField("sourceTablesCompacted", org.apache.thrift.protocol.TType.BOOL, (short)2);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new MaterializationStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new MaterializationTupleSchemeFactory();
 
   private boolean sourceTablesUpdateDeleteModified; // required
+  private boolean sourceTablesCompacted; // required
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
-    SOURCE_TABLES_UPDATE_DELETE_MODIFIED((short)1, "sourceTablesUpdateDeleteModified");
+    SOURCE_TABLES_UPDATE_DELETE_MODIFIED((short)1, "sourceTablesUpdateDeleteModified"),
+    SOURCE_TABLES_COMPACTED((short)2, "sourceTablesCompacted");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -38,6 +41,8 @@ package org.apache.hadoop.hive.metastore.api;
       switch(fieldId) {
         case 1: // SOURCE_TABLES_UPDATE_DELETE_MODIFIED
           return SOURCE_TABLES_UPDATE_DELETE_MODIFIED;
+        case 2: // SOURCE_TABLES_COMPACTED
+          return SOURCE_TABLES_COMPACTED;
         default:
           return null;
       }
@@ -80,11 +85,14 @@ package org.apache.hadoop.hive.metastore.api;
 
   // isset id assignments
   private static final int __SOURCETABLESUPDATEDELETEMODIFIED_ISSET_ID = 0;
+  private static final int __SOURCETABLESCOMPACTED_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
     tmpMap.put(_Fields.SOURCE_TABLES_UPDATE_DELETE_MODIFIED, new org.apache.thrift.meta_data.FieldMetaData("sourceTablesUpdateDeleteModified", org.apache.thrift.TFieldRequirementType.REQUIRED, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.SOURCE_TABLES_COMPACTED, new org.apache.thrift.meta_data.FieldMetaData("sourceTablesCompacted", org.apache.thrift.TFieldRequirementType.REQUIRED, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(Materialization.class, metaDataMap);
@@ -94,11 +102,14 @@ package org.apache.hadoop.hive.metastore.api;
   }
 
   public Materialization(
-    boolean sourceTablesUpdateDeleteModified)
+    boolean sourceTablesUpdateDeleteModified,
+    boolean sourceTablesCompacted)
   {
     this();
     this.sourceTablesUpdateDeleteModified = sourceTablesUpdateDeleteModified;
     setSourceTablesUpdateDeleteModifiedIsSet(true);
+    this.sourceTablesCompacted = sourceTablesCompacted;
+    setSourceTablesCompactedIsSet(true);
   }
 
   /**
@@ -107,6 +118,7 @@ package org.apache.hadoop.hive.metastore.api;
   public Materialization(Materialization other) {
     __isset_bitfield = other.__isset_bitfield;
     this.sourceTablesUpdateDeleteModified = other.sourceTablesUpdateDeleteModified;
+    this.sourceTablesCompacted = other.sourceTablesCompacted;
   }
 
   public Materialization deepCopy() {
@@ -117,6 +129,8 @@ package org.apache.hadoop.hive.metastore.api;
   public void clear() {
     setSourceTablesUpdateDeleteModifiedIsSet(false);
     this.sourceTablesUpdateDeleteModified = false;
+    setSourceTablesCompactedIsSet(false);
+    this.sourceTablesCompacted = false;
   }
 
   public boolean isSourceTablesUpdateDeleteModified() {
@@ -141,6 +155,28 @@ package org.apache.hadoop.hive.metastore.api;
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __SOURCETABLESUPDATEDELETEMODIFIED_ISSET_ID, value);
   }
 
+  public boolean isSourceTablesCompacted() {
+    return this.sourceTablesCompacted;
+  }
+
+  public void setSourceTablesCompacted(boolean sourceTablesCompacted) {
+    this.sourceTablesCompacted = sourceTablesCompacted;
+    setSourceTablesCompactedIsSet(true);
+  }
+
+  public void unsetSourceTablesCompacted() {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.clearBit(__isset_bitfield, __SOURCETABLESCOMPACTED_ISSET_ID);
+  }
+
+  /** Returns true if field sourceTablesCompacted is set (has been assigned a value) and false otherwise */
+  public boolean isSetSourceTablesCompacted() {
+    return org.apache.thrift.EncodingUtils.testBit(__isset_bitfield, __SOURCETABLESCOMPACTED_ISSET_ID);
+  }
+
+  public void setSourceTablesCompactedIsSet(boolean value) {
+    __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __SOURCETABLESCOMPACTED_ISSET_ID, value);
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case SOURCE_TABLES_UPDATE_DELETE_MODIFIED:
@@ -148,6 +184,14 @@ package org.apache.hadoop.hive.metastore.api;
         unsetSourceTablesUpdateDeleteModified();
       } else {
         setSourceTablesUpdateDeleteModified((java.lang.Boolean)value);
+      }
+      break;
+
+    case SOURCE_TABLES_COMPACTED:
+      if (value == null) {
+        unsetSourceTablesCompacted();
+      } else {
+        setSourceTablesCompacted((java.lang.Boolean)value);
       }
       break;
 
@@ -159,6 +203,9 @@ package org.apache.hadoop.hive.metastore.api;
     switch (field) {
     case SOURCE_TABLES_UPDATE_DELETE_MODIFIED:
       return isSourceTablesUpdateDeleteModified();
+
+    case SOURCE_TABLES_COMPACTED:
+      return isSourceTablesCompacted();
 
     }
     throw new java.lang.IllegalStateException();
@@ -173,6 +220,8 @@ package org.apache.hadoop.hive.metastore.api;
     switch (field) {
     case SOURCE_TABLES_UPDATE_DELETE_MODIFIED:
       return isSetSourceTablesUpdateDeleteModified();
+    case SOURCE_TABLES_COMPACTED:
+      return isSetSourceTablesCompacted();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -201,6 +250,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_sourceTablesCompacted = true;
+    boolean that_present_sourceTablesCompacted = true;
+    if (this_present_sourceTablesCompacted || that_present_sourceTablesCompacted) {
+      if (!(this_present_sourceTablesCompacted && that_present_sourceTablesCompacted))
+        return false;
+      if (this.sourceTablesCompacted != that.sourceTablesCompacted)
+        return false;
+    }
+
     return true;
   }
 
@@ -209,6 +267,8 @@ package org.apache.hadoop.hive.metastore.api;
     int hashCode = 1;
 
     hashCode = hashCode * 8191 + ((sourceTablesUpdateDeleteModified) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((sourceTablesCompacted) ? 131071 : 524287);
 
     return hashCode;
   }
@@ -227,6 +287,16 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetSourceTablesUpdateDeleteModified()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sourceTablesUpdateDeleteModified, other.sourceTablesUpdateDeleteModified);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetSourceTablesCompacted()).compareTo(other.isSetSourceTablesCompacted());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetSourceTablesCompacted()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.sourceTablesCompacted, other.sourceTablesCompacted);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -255,6 +325,10 @@ package org.apache.hadoop.hive.metastore.api;
     sb.append("sourceTablesUpdateDeleteModified:");
     sb.append(this.sourceTablesUpdateDeleteModified);
     first = false;
+    if (!first) sb.append(", ");
+    sb.append("sourceTablesCompacted:");
+    sb.append(this.sourceTablesCompacted);
+    first = false;
     sb.append(")");
     return sb.toString();
   }
@@ -263,6 +337,10 @@ package org.apache.hadoop.hive.metastore.api;
     // check for required fields
     if (!isSetSourceTablesUpdateDeleteModified()) {
       throw new org.apache.thrift.protocol.TProtocolException("Required field 'sourceTablesUpdateDeleteModified' is unset! Struct:" + toString());
+    }
+
+    if (!isSetSourceTablesCompacted()) {
+      throw new org.apache.thrift.protocol.TProtocolException("Required field 'sourceTablesCompacted' is unset! Struct:" + toString());
     }
 
     // check for sub-struct validity
@@ -312,6 +390,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 2: // SOURCE_TABLES_COMPACTED
+            if (schemeField.type == org.apache.thrift.protocol.TType.BOOL) {
+              struct.sourceTablesCompacted = iprot.readBool();
+              struct.setSourceTablesCompactedIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -327,6 +413,9 @@ package org.apache.hadoop.hive.metastore.api;
       oprot.writeStructBegin(STRUCT_DESC);
       oprot.writeFieldBegin(SOURCE_TABLES_UPDATE_DELETE_MODIFIED_FIELD_DESC);
       oprot.writeBool(struct.sourceTablesUpdateDeleteModified);
+      oprot.writeFieldEnd();
+      oprot.writeFieldBegin(SOURCE_TABLES_COMPACTED_FIELD_DESC);
+      oprot.writeBool(struct.sourceTablesCompacted);
       oprot.writeFieldEnd();
       oprot.writeFieldStop();
       oprot.writeStructEnd();
@@ -346,6 +435,7 @@ package org.apache.hadoop.hive.metastore.api;
     public void write(org.apache.thrift.protocol.TProtocol prot, Materialization struct) throws org.apache.thrift.TException {
       org.apache.thrift.protocol.TTupleProtocol oprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       oprot.writeBool(struct.sourceTablesUpdateDeleteModified);
+      oprot.writeBool(struct.sourceTablesCompacted);
     }
 
     @Override
@@ -353,6 +443,8 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       struct.sourceTablesUpdateDeleteModified = iprot.readBool();
       struct.setSourceTablesUpdateDeleteModifiedIsSet(true);
+      struct.sourceTablesCompacted = iprot.readBool();
+      struct.setSourceTablesCompactedIsSet(true);
     }
   }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Materialization.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/Materialization.php
@@ -26,18 +26,30 @@ class Materialization
             'isRequired' => true,
             'type' => TType::BOOL,
         ),
+        2 => array(
+            'var' => 'sourceTablesCompacted',
+            'isRequired' => true,
+            'type' => TType::BOOL,
+        ),
     );
 
     /**
      * @var bool
      */
     public $sourceTablesUpdateDeleteModified = null;
+    /**
+     * @var bool
+     */
+    public $sourceTablesCompacted = null;
 
     public function __construct($vals = null)
     {
         if (is_array($vals)) {
             if (isset($vals['sourceTablesUpdateDeleteModified'])) {
                 $this->sourceTablesUpdateDeleteModified = $vals['sourceTablesUpdateDeleteModified'];
+            }
+            if (isset($vals['sourceTablesCompacted'])) {
+                $this->sourceTablesCompacted = $vals['sourceTablesCompacted'];
             }
         }
     }
@@ -68,6 +80,13 @@ class Materialization
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 2:
+                    if ($ftype == TType::BOOL) {
+                        $xfer += $input->readBool($this->sourceTablesCompacted);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -85,6 +104,11 @@ class Materialization
         if ($this->sourceTablesUpdateDeleteModified !== null) {
             $xfer += $output->writeFieldBegin('sourceTablesUpdateDeleteModified', TType::BOOL, 1);
             $xfer += $output->writeBool($this->sourceTablesUpdateDeleteModified);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->sourceTablesCompacted !== null) {
+            $xfer += $output->writeFieldBegin('sourceTablesCompacted', TType::BOOL, 2);
+            $xfer += $output->writeBool($this->sourceTablesCompacted);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -18634,12 +18634,14 @@ class Materialization(object):
     """
     Attributes:
      - sourceTablesUpdateDeleteModified
+     - sourceTablesCompacted
 
     """
 
 
-    def __init__(self, sourceTablesUpdateDeleteModified=None,):
+    def __init__(self, sourceTablesUpdateDeleteModified=None, sourceTablesCompacted=None,):
         self.sourceTablesUpdateDeleteModified = sourceTablesUpdateDeleteModified
+        self.sourceTablesCompacted = sourceTablesCompacted
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -18653,6 +18655,11 @@ class Materialization(object):
             if fid == 1:
                 if ftype == TType.BOOL:
                     self.sourceTablesUpdateDeleteModified = iprot.readBool()
+                else:
+                    iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.BOOL:
+                    self.sourceTablesCompacted = iprot.readBool()
                 else:
                     iprot.skip(ftype)
             else:
@@ -18669,12 +18676,18 @@ class Materialization(object):
             oprot.writeFieldBegin('sourceTablesUpdateDeleteModified', TType.BOOL, 1)
             oprot.writeBool(self.sourceTablesUpdateDeleteModified)
             oprot.writeFieldEnd()
+        if self.sourceTablesCompacted is not None:
+            oprot.writeFieldBegin('sourceTablesCompacted', TType.BOOL, 2)
+            oprot.writeBool(self.sourceTablesCompacted)
+            oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
 
     def validate(self):
         if self.sourceTablesUpdateDeleteModified is None:
             raise TProtocolException(message='Required field sourceTablesUpdateDeleteModified is unset!')
+        if self.sourceTablesCompacted is None:
+            raise TProtocolException(message='Required field sourceTablesCompacted is unset!')
         return
 
     def __repr__(self):
@@ -28849,6 +28862,7 @@ all_structs.append(Materialization)
 Materialization.thrift_spec = (
     None,  # 0
     (1, TType.BOOL, 'sourceTablesUpdateDeleteModified', None, None, ),  # 1
+    (2, TType.BOOL, 'sourceTablesCompacted', None, None, ),  # 2
 )
 all_structs.append(WMResourcePlan)
 WMResourcePlan.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -5264,15 +5264,18 @@ end
 class Materialization
   include ::Thrift::Struct, ::Thrift::Struct_Union
   SOURCETABLESUPDATEDELETEMODIFIED = 1
+  SOURCETABLESCOMPACTED = 2
 
   FIELDS = {
-    SOURCETABLESUPDATEDELETEMODIFIED => {:type => ::Thrift::Types::BOOL, :name => 'sourceTablesUpdateDeleteModified'}
+    SOURCETABLESUPDATEDELETEMODIFIED => {:type => ::Thrift::Types::BOOL, :name => 'sourceTablesUpdateDeleteModified'},
+    SOURCETABLESCOMPACTED => {:type => ::Thrift::Types::BOOL, :name => 'sourceTablesCompacted'}
   }
 
   def struct_fields; FIELDS; end
 
   def validate
     raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field sourceTablesUpdateDeleteModified is unset!') if @sourceTablesUpdateDeleteModified.nil?
+    raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field sourceTablesCompacted is unset!') if @sourceTablesCompacted.nil?
   end
 
   ::Thrift::Struct.generate_accessors self

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -1550,6 +1550,7 @@ struct TableMeta {
 
 struct Materialization {
   1: required bool sourceTablesUpdateDeleteModified;
+  2: required bool sourceTablesCompacted;
 }
 
 // Data types for workload management.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -2364,91 +2364,129 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
 
     // We are composing a query that returns a single row if an update happened after
     // the materialization was created. Otherwise, query returns 0 rows.
+
+    // Parse validReaderWriteIdList from creation metadata
+    final ValidTxnWriteIdList validReaderWriteIdList =
+            new ValidTxnWriteIdList(creationMetadata.getValidTxnList());
+
+    // Parse validTxnList
+    final ValidReadTxnList currentValidTxnList = new ValidReadTxnList(validTxnListStr);
+    // Get the valid write id list for the tables in current state
+    final List<TableValidWriteIds> currentTblValidWriteIdsList = new ArrayList<>();
+    Connection dbConn = null;
+      for (String fullTableName : creationMetadata.getTablesUsed()) {
+        try {
+          dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
+          currentTblValidWriteIdsList.add(getValidWriteIdsForTable(dbConn, fullTableName, currentValidTxnList));
+        } catch (SQLException ex) {
+          String errorMsg = "Unable to query Valid writeIds of table " + fullTableName;
+          LOG.warn(errorMsg, ex);
+          throw new MetaException(errorMsg + " " + StringUtils.stringifyException(ex));
+        } finally {
+          closeDbConn(dbConn);
+        }
+      }
+    final ValidTxnWriteIdList currentValidReaderWriteIdList = TxnCommonUtils.createValidTxnWriteIdList(
+            currentValidTxnList.getHighWatermark(), currentTblValidWriteIdsList);
+
+    List<String> params = new ArrayList<>();
+    StringBuilder queryUpdateDelete = new StringBuilder();
+    StringBuilder queryCompletedCompactions = new StringBuilder();
+    StringBuilder queryCompactionQueue = new StringBuilder();
+    // compose a query that select transactions containing an update...
+    queryUpdateDelete.append("SELECT \"CTC_UPDATE_DELETE\" FROM \"COMPLETED_TXN_COMPONENTS\" WHERE \"CTC_UPDATE_DELETE\" ='Y' AND (");
+    queryCompletedCompactions.append("SELECT 1 FROM \"COMPLETED_COMPACTIONS\" WHERE (");
+    queryCompactionQueue.append("SELECT 1 FROM \"COMPACTION_QUEUE\" WHERE (");
+    int i = 0;
+    for (String fullyQualifiedName : creationMetadata.getTablesUsed()) {
+      ValidWriteIdList tblValidWriteIdList =
+              validReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
+      if (tblValidWriteIdList == null) {
+        LOG.warn("ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
+        return null;
+      }
+
+      // First, we check whether the low watermark has moved for any of the tables.
+      // If it has, we return true, since it is not incrementally refreshable, e.g.,
+      // one of the commits that are not available may be an update/delete.
+      ValidWriteIdList currentTblValidWriteIdList =
+              currentValidReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
+      if (currentTblValidWriteIdList == null) {
+        LOG.warn("Current ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
+        return null;
+      }
+      if (!Objects.equals(currentTblValidWriteIdList.getMinOpenWriteId(), tblValidWriteIdList.getMinOpenWriteId())) {
+        LOG.debug("Minimum open write id do not match for table {}", fullyQualifiedName);
+        return null;
+      }
+
+      // ...for each of the tables that are part of the materialized view,
+      // where the transaction had to be committed after the materialization was created...
+      if (i != 0) {
+        queryUpdateDelete.append("OR");
+        queryCompletedCompactions.append("OR");
+        queryCompactionQueue.append("OR");
+      }
+      String[] names = TxnUtils.getDbTableName(fullyQualifiedName);
+      assert (names.length == 2);
+      queryUpdateDelete.append(" (\"CTC_DATABASE\"=? AND \"CTC_TABLE\"=?");
+      queryCompletedCompactions.append(" (\"CC_DATABASE\"=? AND \"CC_TABLE\"=?");
+      queryCompactionQueue.append(" (\"CQ_DATABASE\"=? AND \"CQ_TABLE\"=?");
+      params.add(names[0]);
+      params.add(names[1]);
+      queryUpdateDelete.append(" AND (\"CTC_WRITEID\" > " + tblValidWriteIdList.getHighWatermark());
+      queryCompletedCompactions.append(" AND (\"CC_HIGHEST_WRITE_ID\" > " + tblValidWriteIdList.getHighWatermark());
+      queryUpdateDelete.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
+              " OR \"CTC_WRITEID\" IN(" + StringUtils.join(",",
+                      Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ");
+      queryCompletedCompactions.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
+              " OR \"CC_HIGHEST_WRITE_ID\" IN(" + StringUtils.join(",",
+                      Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ");
+      queryUpdateDelete.append(") ");
+      queryCompletedCompactions.append(") ");
+      queryCompactionQueue.append(") ");
+      i++;
+    }
+    // ... and where the transaction has already been committed as per snapshot taken
+    // when we are running current query
+    queryUpdateDelete.append(") AND \"CTC_TXNID\" <= " + currentValidTxnList.getHighWatermark());
+    queryUpdateDelete.append(currentValidTxnList.getInvalidTransactions().length == 0 ? " " :
+            " AND \"CTC_TXNID\" NOT IN(" + StringUtils.join(",",
+                    Arrays.asList(ArrayUtils.toObject(currentValidTxnList.getInvalidTransactions()))) + ") ");
+    queryCompletedCompactions.append(")");
+    queryCompactionQueue.append(") ");
+
+    boolean hasUpdateDelete = executeBoolean(queryUpdateDelete.toString(), params,
+            "Unable to retrieve materialization invalidation information: completed transaction components.");
+
+    // Execute query
+    queryCompletedCompactions.append(" UNION ");
+    queryCompletedCompactions.append(queryCompactionQueue.toString());
+    List<String> paramsTwice = new ArrayList<>(params);
+    paramsTwice.addAll(params);
+    boolean hasCompaction = executeBoolean(queryCompletedCompactions.toString(), paramsTwice,
+            "Unable to retrieve materialization invalidation information: compactions");
+
+    return new Materialization(hasUpdateDelete, hasCompaction);
+  }
+
+  private boolean executeBoolean(String queryText, List<String> params, String errorMessage) throws MetaException {
     Connection dbConn = null;
     PreparedStatement pst = null;
     ResultSet rs = null;
     try {
       dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
-
-      // Parse validReaderWriteIdList from creation metadata
-      final ValidTxnWriteIdList validReaderWriteIdList =
-          new ValidTxnWriteIdList(creationMetadata.getValidTxnList());
-
-      // Parse validTxnList
-      final ValidReadTxnList currentValidTxnList = new ValidReadTxnList(validTxnListStr);
-      // Get the valid write id list for the tables in current state
-      final List<TableValidWriteIds> currentTblValidWriteIdsList = new ArrayList<>();
-      for (String fullTableName : creationMetadata.getTablesUsed()) {
-        currentTblValidWriteIdsList.add(getValidWriteIdsForTable(dbConn, fullTableName, currentValidTxnList));
-      }
-      final ValidTxnWriteIdList currentValidReaderWriteIdList = TxnCommonUtils.createValidTxnWriteIdList(
-          currentValidTxnList.getHighWatermark(), currentTblValidWriteIdsList);
-
-      List<String> params = new ArrayList<>();
-      StringBuilder query = new StringBuilder();
-      // compose a query that select transactions containing an update...
-      query.append("SELECT \"CTC_UPDATE_DELETE\" FROM \"COMPLETED_TXN_COMPONENTS\" WHERE \"CTC_UPDATE_DELETE\" ='Y' AND (");
-      int i = 0;
-      for (String fullyQualifiedName : creationMetadata.getTablesUsed()) {
-        ValidWriteIdList tblValidWriteIdList =
-            validReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
-        if (tblValidWriteIdList == null) {
-          LOG.warn("ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
-          return null;
-        }
-
-        // First, we check whether the low watermark has moved for any of the tables.
-        // If it has, we return true, since it is not incrementally refreshable, e.g.,
-        // one of the commits that are not available may be an update/delete.
-        ValidWriteIdList currentTblValidWriteIdList =
-            currentValidReaderWriteIdList.getTableValidWriteIdList(fullyQualifiedName);
-        if (currentTblValidWriteIdList == null) {
-          LOG.warn("Current ValidWriteIdList for table {} not present in creation metadata, this should not happen", fullyQualifiedName);
-          return null;
-        }
-        if (!Objects.equals(currentTblValidWriteIdList.getMinOpenWriteId(), tblValidWriteIdList.getMinOpenWriteId())) {
-          LOG.debug("Minimum open write id do not match for table {}", fullyQualifiedName);
-          return null;
-        }
-
-        // ...for each of the tables that are part of the materialized view,
-        // where the transaction had to be committed after the materialization was created...
-        if (i != 0) {
-          query.append("OR");
-        }
-        String[] names = TxnUtils.getDbTableName(fullyQualifiedName);
-        assert(names.length == 2);
-        query.append(" (\"CTC_DATABASE\"=? AND \"CTC_TABLE\"=?");
-        params.add(names[0]);
-        params.add(names[1]);
-        query.append(" AND (\"CTC_WRITEID\" > " + tblValidWriteIdList.getHighWatermark());
-        query.append(tblValidWriteIdList.getInvalidWriteIds().length == 0 ? ") " :
-            " OR \"CTC_WRITEID\" IN(" + StringUtils.join(",",
-                Arrays.asList(ArrayUtils.toObject(tblValidWriteIdList.getInvalidWriteIds()))) + ") ");
-        query.append(") ");
-        i++;
-      }
-      // ... and where the transaction has already been committed as per snapshot taken
-      // when we are running current query
-      query.append(") AND \"CTC_TXNID\" <= " + currentValidTxnList.getHighWatermark());
-      query.append(currentValidTxnList.getInvalidTransactions().length == 0 ? " " :
-          " AND \"CTC_TXNID\" NOT IN(" + StringUtils.join(",",
-              Arrays.asList(ArrayUtils.toObject(currentValidTxnList.getInvalidTransactions()))) + ") ");
-
-      // Execute query
-      String s = query.toString();
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Going to execute query <" + s + ">");
+        LOG.debug("Going to execute query <" + queryText + ">");
       }
-      pst = sqlGenerator.prepareStmtWithParameters(dbConn, s, params);
+      pst = sqlGenerator.prepareStmtWithParameters(dbConn, queryText, params);
       pst.setMaxRows(1);
       rs = pst.executeQuery();
 
-      return new Materialization(rs.next());
+      return rs.next();
     } catch (SQLException ex) {
-      LOG.warn("getMaterializationInvalidationInfo failed due to " + getMessage(ex), ex);
-      throw new MetaException("Unable to retrieve materialization invalidation information due to " +
-          StringUtils.stringifyException(ex));
+      LOG.warn(errorMessage, ex);
+      throw new MetaException(errorMessage + " " + StringUtils.stringifyException(ex));
     } finally {
       close(rs, pst, dbConn);
     }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -2348,8 +2348,8 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   }
 
   /**
-   * Get invalidation info for the materialization. Currently, the materialization information
-   * only contains information about whether there was update/delete operations on the source
+   * Get invalidation info for the materialization. Materialization information
+   * contains information about whether there was update/delete/compaction operations on the source
    * tables used by the materialization since it was created.
    */
   @Override

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -2374,18 +2374,18 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     // Get the valid write id list for the tables in current state
     final List<TableValidWriteIds> currentTblValidWriteIdsList = new ArrayList<>();
     Connection dbConn = null;
-      for (String fullTableName : creationMetadata.getTablesUsed()) {
-        try {
-          dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
-          currentTblValidWriteIdsList.add(getValidWriteIdsForTable(dbConn, fullTableName, currentValidTxnList));
-        } catch (SQLException ex) {
-          String errorMsg = "Unable to query Valid writeIds of table " + fullTableName;
-          LOG.warn(errorMsg, ex);
-          throw new MetaException(errorMsg + " " + StringUtils.stringifyException(ex));
-        } finally {
-          closeDbConn(dbConn);
-        }
+    for (String fullTableName : creationMetadata.getTablesUsed()) {
+      try {
+        dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
+        currentTblValidWriteIdsList.add(getValidWriteIdsForTable(dbConn, fullTableName, currentValidTxnList));
+      } catch (SQLException ex) {
+        String errorMsg = "Unable to query Valid writeIds of table " + fullTableName;
+        LOG.warn(errorMsg, ex);
+        throw new MetaException(errorMsg + " " + StringUtils.stringifyException(ex));
+      } finally {
+        closeDbConn(dbConn);
       }
+    }
     final ValidTxnWriteIdList currentValidReaderWriteIdList = TxnCommonUtils.createValidTxnWriteIdList(
             currentValidTxnList.getHighWatermark(), currentTblValidWriteIdsList);
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
When checking a Materialized view validity check whether any of the source tables compacted since the last materialized view rebuild.

### Why are the changes needed?
During Materialized view rebuild we choose from incremental or full rebuild. 
To make this choice existing implementation searches for delete transactions affect the source tables of the MV in `COMPLETED_TXN_COMPONENTS` table (Metastore) since the last rebuild. However these records are deleted during compaction. This leads to corrupted materialized view datasets since incremental rebuild will be used which does not handle deleted records.

### Does this PR introduce _any_ user-facing change?
Yes. Query the materialized view and queries which plan is rewritten to scan the materialized view may produce different results.
Only transactional materialized views are affected.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite_4.q -pl itests/qtest -Pitests
mvn test -Dtest=TestMaterializedViewRebuild -pl itests/hive-unit -Pitests
```