### PR TITLE
HIVE-24911: Metastore: Create index on SDS.CD_ID for Postgres

### DIFF
--- a/standalone-metastore/metastore-server/src/main/sql/postgres/hive-schema-4.0.0.postgres.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/postgres/hive-schema-4.0.0.postgres.sql
@@ -1236,6 +1236,11 @@ CREATE INDEX "ROLE_MAP_N49" ON "ROLE_MAP" USING btree ("ROLE_ID");
 
 CREATE INDEX "SDS_N49" ON "SDS" USING btree ("SERDE_ID");
 
+--
+-- Name: SDS_N50; Type: INDEX; Schema: public; Owner: hiveuser; Tablespace:
+--
+
+CREATE INDEX "SDS_N50" ON "SDS" USING btree ("CD_ID");
 
 --
 -- Name: SD_PARAMS_N49; Type: INDEX; Schema: public; Owner: hiveuser; Tablespace:

--- a/standalone-metastore/metastore-server/src/main/sql/postgres/upgrade-3.2.0-to-4.0.0.postgres.sql
+++ b/standalone-metastore/metastore-server/src/main/sql/postgres/upgrade-3.2.0-to-4.0.0.postgres.sql
@@ -303,6 +303,9 @@ ALTER TABLE "DBS" ADD "DATACONNECTOR_NAME" character varying(128);
 ALTER TABLE "DBS" ADD "REMOTE_DBNAME" character varying(128);
 UPDATE "DBS" SET "TYPE"= 'NATIVE' WHERE "TYPE" IS NULL;
 
+-- HIVE-24911
+CREATE INDEX "SDS_N50" ON "SDS" USING btree ("CD_ID");
+
 -- These lines need to be last. Insert any changes above.
 UPDATE "VERSION" SET "SCHEMA_VERSION"='4.0.0', "VERSION_COMMENT"='Hive release version 4.0.0' where "VER_ID"=1;
 SELECT 'Finished upgrading MetaStore schema from 3.2.0 to 4.0.0';


### PR DESCRIPTION
### What changes were proposed in this pull request?
Create index on SDS.CD_ID for Postgres.

### Why are the changes needed?
Performance improvment. The index is already present for other RDBMS vendors.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Manually, on customer side.
