### PR TITLE
HIVE-24908: Adding Respect/Ignore nulls as a UDAF parameter is ambiguous

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
+++ b/common/src/java/org/apache/hadoop/hive/ql/ErrorMsg.java
@@ -471,6 +471,7 @@ public enum ErrorMsg {
   AMBIGUOUS_STRUCT_ATTRIBUTE(10423, "Attribute \"{0}\" specified more than once in structured type.", true),
   OFFSET_NOT_SUPPORTED_IN_SUBQUERY(10424, "OFFSET is not supported in subquery of exists", true),
   WITH_COL_LIST_NUM_OVERFLOW(10425, "WITH-clause query {0} returns {1} columns, but {2} labels were specified. The number of column labels must be smaller or equal to the number of expressions returned by the query.", true),
+  NULL_TREATMENT_NOT_SUPPORTED(10426, "Function {0} does not support null treatment.", true),
 
   //========================== 20000 range starts here ========================//
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FunctionRegistry.java
@@ -1079,12 +1079,12 @@ public final class FunctionRegistry {
 
   public static GenericUDAFEvaluator getGenericWindowingEvaluator(String name,
       List<ObjectInspector> argumentOIs, boolean isDistinct,
-      boolean isAllColumns) throws SemanticException {
+      boolean isAllColumns, boolean respectNulls) throws SemanticException {
     Registry registry = SessionState.getRegistry();
     GenericUDAFEvaluator evaluator = registry == null ? null :
-        registry.getGenericWindowingEvaluator(name, argumentOIs, isDistinct, isAllColumns);
+        registry.getGenericWindowingEvaluator(name, argumentOIs, isDistinct, isAllColumns, respectNulls);
     return evaluator != null ? evaluator :
-        system.getGenericWindowingEvaluator(name, argumentOIs, isDistinct, isAllColumns);
+        system.getGenericWindowingEvaluator(name, argumentOIs, isDistinct, isAllColumns, respectNulls);
   }
 
   public static GenericUDAFResolver getGenericUDAFResolver(String functionName)

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Registry.java
@@ -477,7 +477,7 @@ public class Registry {
   @SuppressWarnings("deprecation")
   public GenericUDAFEvaluator getGenericUDAFEvaluator(String name,
       List<ObjectInspector> argumentOIs, boolean isWindowing, boolean isDistinct,
-      boolean isAllColumns) throws SemanticException {
+      boolean isAllColumns, boolean respectNulls) throws SemanticException {
 
     GenericUDAFResolver udafResolver = getGenericUDAFResolver(name);
     if (udafResolver == null) {
@@ -494,7 +494,7 @@ public class Registry {
 
     GenericUDAFParameterInfo paramInfo =
         new SimpleGenericUDAFParameterInfo(
-            args, isWindowing, isDistinct, isAllColumns);
+            args, isWindowing, isDistinct, isAllColumns, respectNulls);
     if (udafResolver instanceof GenericUDAFResolver2) {
       udafEvaluator =
           ((GenericUDAFResolver2) udafResolver).getEvaluator(paramInfo);
@@ -505,7 +505,7 @@ public class Registry {
   }
 
   public GenericUDAFEvaluator getGenericWindowingEvaluator(String functionName,
-      List<ObjectInspector> argumentOIs, boolean isDistinct, boolean isAllColumns)
+      List<ObjectInspector> argumentOIs, boolean isDistinct, boolean isAllColumns, boolean respectNulls)
       throws SemanticException {
     functionName = functionName.toLowerCase();
     WindowFunctionInfo info = getWindowFunctionInfo(functionName);
@@ -514,7 +514,7 @@ public class Registry {
     }
     if (!functionName.equals(FunctionRegistry.LEAD_FUNC_NAME) &&
         !functionName.equals(FunctionRegistry.LAG_FUNC_NAME)) {
-      return getGenericUDAFEvaluator(functionName, argumentOIs, true, isDistinct, isAllColumns);
+      return getGenericUDAFEvaluator(functionName, argumentOIs, true, isDistinct, isAllColumns, respectNulls);
     }
 
     // this must be lead/lag UDAF

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/WindowFunctionDescription.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/WindowFunctionDescription.java
@@ -84,4 +84,13 @@ public @interface WindowFunctionDescription {
    * @return true if the function can be used as an ordered-set aggregate
    */
   boolean orderedAggregate() default false;
+
+  /**
+   * Some aggregate functions allow specifying null treatment.
+   * Example:
+   *   SELECT last_value(b) IGNORE NULLS OVER (ORDER BY b) FROM table1;
+   *
+   * @return true if this aggregate functions support null treatment.
+   */
+  boolean supportsNullTreatment() default false;
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/WindowFunctionInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/WindowFunctionInfo.java
@@ -28,6 +28,7 @@ public class WindowFunctionInfo extends FunctionInfo {
   private final boolean pivotResult;
   private final boolean impliesOrder;
   private final boolean orderedAggregate;
+  private final boolean supportsNullTreatment;
 
   public WindowFunctionInfo(FunctionType functionType, String functionName,
       GenericUDAFResolver resolver, FunctionResource[] resources) {
@@ -38,6 +39,7 @@ public class WindowFunctionInfo extends FunctionInfo {
     pivotResult = def == null ? false : def.pivotResult();
     impliesOrder = def == null ? false : def.impliesOrder();
     orderedAggregate = def == null ? false : def.orderedAggregate();
+    supportsNullTreatment = def == null ? false : def.supportsNullTreatment();
   }
 
   public boolean isSupportsWindow() {
@@ -67,5 +69,9 @@ public class WindowFunctionInfo extends FunctionInfo {
    */
   public boolean isOrderedAggregate() {
     return orderedAggregate;
+  }
+
+  public boolean isSupportsNullTreatment() {
+    return supportsNullTreatment;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ASTConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/translator/ASTConverter.java
@@ -740,10 +740,6 @@ public class ASTConverter {
 
       // 1. Translate the UDAF
       final ASTNode wUDAFAst = visitCall(over);
-      if (over.ignoreNulls()) {
-        ASTNode trueLiteral = ASTBuilder.createAST(HiveParser.KW_TRUE, "true");
-        wUDAFAst.addChild(trueLiteral);
-      }
 
       // 2. Add TOK_WINDOW as child of UDAF
       ASTNode wSpec = ASTBuilder.createAST(HiveParser.TOK_WINDOWSPEC, "TOK_WINDOWSPEC");
@@ -758,6 +754,10 @@ public class ASTConverter {
       }
       if (wRangeAst != null) {
         wSpec.addChild(wRangeAst);
+      }
+      if (over.ignoreNulls()) {
+        ASTNode ignoreNulls = ASTBuilder.createAST(HiveParser.TOK_IGNORE_NULLS, "TOK_IGNORE_NULLS");
+        wSpec.addChild(ignoreNulls);
       }
 
       return wUDAFAst;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -4519,7 +4519,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
         // 6. Translate Window spec
         RowResolver inputRR = relToHiveRR.get(srcRel);
-        WindowSpec wndSpec = ((WindowFunctionSpec) wExpSpec).getWindowSpec();
+        WindowFunctionSpec wndFuncSpec = (WindowFunctionSpec) wExpSpec;
+        WindowSpec wndSpec = wndFuncSpec.getWindowSpec();
         List<RexNode> partitionKeys = getPartitionKeys(wndSpec.getPartition(), inputRR);
         List<RexFieldCollation> orderKeys = getOrderKeys(wndSpec.getOrder(), inputRR);
         RexWindowBound lowerBound = getBound(wndSpec.getWindowFrame().getStart());
@@ -4528,7 +4529,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
         w = cluster.getRexBuilder().makeOver(calciteAggFnRetType, calciteAggFn, calciteAggFnArgs,
             partitionKeys, ImmutableList.<RexFieldCollation> copyOf(orderKeys), lowerBound,
-            upperBound, isRows, true, false, hiveAggInfo.isDistinct(), !wndSpec.respectNulls());
+            upperBound, isRows, true, false, hiveAggInfo.isDistinct(), !wndFuncSpec.isRespectNulls());
       } else {
         // TODO: Convert to Semantic Exception
         throw new RuntimeException("Unsupported window Spec");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -108,7 +108,6 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexShuttle;
-import org.apache.calcite.rex.RexSubQuery;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexWindowBound;
 import org.apache.calcite.schema.SchemaPlus;
@@ -123,8 +122,6 @@ import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.SqlWindow;
 import org.apache.calcite.sql.dialect.HiveSqlDialect;
-import org.apache.calcite.sql.fun.SqlQuantifyOperator;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
@@ -304,7 +301,6 @@ import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
 import org.apache.hadoop.hive.ql.plan.SelectDesc;
-import org.apache.hadoop.hive.ql.plan.SubqueryType;
 import org.apache.hadoop.hive.ql.plan.mapper.EmptyStatsSource;
 import org.apache.hadoop.hive.ql.plan.mapper.StatsSource;
 import org.apache.hadoop.hive.ql.session.SessionState;
@@ -352,7 +348,6 @@ import javax.sql.DataSource;
 import static java.util.Collections.singletonList;
 import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils.copyMaterializationToNewCluster;
 import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedViewUtils.extractTable;
-import static org.apache.hadoop.hive.ql.parse.type.RexNodeExprFactory.convertSubquerySomeAll;
 
 
 public class CalcitePlanner extends SemanticAnalyzer {
@@ -4533,7 +4528,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
         w = cluster.getRexBuilder().makeOver(calciteAggFnRetType, calciteAggFn, calciteAggFnArgs,
             partitionKeys, ImmutableList.<RexFieldCollation> copyOf(orderKeys), lowerBound,
-            upperBound, isRows, true, false, hiveAggInfo.isDistinct(), wndSpec.ignoreNulls());
+            upperBound, isRows, true, false, hiveAggInfo.isDistinct(), !wndSpec.respectNulls());
       } else {
         // TODO: Convert to Semantic Exception
         throw new RuntimeException("Unsupported window Spec");

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
@@ -353,7 +353,7 @@ public class PTFTranslator {
     def.setExpressionTreeString(spec.getExpression().toStringTree());
     def.setStar(spec.isStar());
     def.setPivotResult(wFnInfo.isPivotResult());
-    def.setRespectNulls(spec.windowSpec.respectNulls());
+    def.setRespectNulls(spec.isRespectNulls());
     ShapeDetails inpShape = wdwTFnDef.getRawInputShape();
 
     /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/PTFTranslator.java
@@ -79,7 +79,6 @@ import org.apache.hadoop.hive.ql.udf.ptf.TableFunctionResolver;
 import org.apache.hadoop.hive.ql.udf.ptf.WindowingTableFunction.WindowingTableFunctionResolver;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.SerDeException;
-import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.hadoop.hive.serde2.lazybinary.LazyBinarySerDe;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
@@ -90,8 +89,6 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.PrimitiveCategory;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
-import org.apache.hadoop.hive.serde2.typeinfo.StructTypeInfo;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -356,6 +353,7 @@ public class PTFTranslator {
     def.setExpressionTreeString(spec.getExpression().toStringTree());
     def.setStar(spec.isStar());
     def.setPivotResult(wFnInfo.isPivotResult());
+    def.setRespectNulls(spec.windowSpec.respectNulls());
     ShapeDetails inpShape = wdwTFnDef.getRawInputShape();
 
     /*
@@ -585,7 +583,7 @@ public class PTFTranslator {
 
     GenericUDAFEvaluator wFnEval = FunctionRegistry.getGenericWindowingEvaluator(def.getName(),
         argOIs,
-        def.isDistinct(), def.isStar());
+        def.isDistinct(), def.isStar(), def.respectNulls());
     ObjectInspector OI = wFnEval.init(GenericUDAFEvaluator.Mode.COMPLETE, funcArgOIs);
     def.setWFnEval(wFnEval);
     def.setOI(OI);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/WindowingSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/WindowingSpec.java
@@ -446,7 +446,7 @@ public class WindowingSpec {
     private String sourceId;
     private PartitioningSpec partitioning;
     private WindowFrameSpec windowFrame;
-    private boolean ignoreNulls;
+    private boolean respectNulls;
 
     public String getSourceId() {
       return sourceId;
@@ -505,12 +505,12 @@ public class WindowingSpec {
           windowFrame == null ? "" : windowFrame);
     }
 
-    public void setIgnoreNulls(boolean ignoreNulls) {
-      this.ignoreNulls = ignoreNulls;
+    public void setRespectNulls(boolean respectNulls) {
+      this.respectNulls = respectNulls;
     }
 
-    public boolean ignoreNulls() {
-      return ignoreNulls;
+    public boolean respectNulls() {
+      return respectNulls;
     }
   };
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/WindowingSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/WindowingSpec.java
@@ -346,6 +346,7 @@ public class WindowingSpec {
     String name;
     boolean isStar;
     boolean isDistinct;
+    boolean respectNulls;
     ArrayList<ASTNode> args;
     WindowSpec windowSpec;
 
@@ -384,6 +385,15 @@ public class WindowingSpec {
     public void setWindowSpec(WindowSpec windowSpec) {
       this.windowSpec = windowSpec;
     }
+
+    public boolean isRespectNulls() {
+      return respectNulls;
+    }
+
+    public void setRespectNulls(boolean respectNulls) {
+      this.respectNulls = respectNulls;
+    }
+
     @Override
     public String toString() {
       StringBuilder buf = new StringBuilder();
@@ -414,6 +424,10 @@ public class WindowingSpec {
       }
 
       buf.append(")");
+
+      if (!respectNulls) {
+        buf.append(" ignore nulls ");
+      }
 
       if ( windowSpec != null )
       {
@@ -446,7 +460,6 @@ public class WindowingSpec {
     private String sourceId;
     private PartitioningSpec partitioning;
     private WindowFrameSpec windowFrame;
-    private boolean respectNulls;
 
     public String getSourceId() {
       return sourceId;
@@ -503,14 +516,6 @@ public class WindowingSpec {
           sourceId == null ? "" : "Name='" + sourceId + "'",
           partitioning == null ? "" : partitioning,
           windowFrame == null ? "" : windowFrame);
-    }
-
-    public void setRespectNulls(boolean respectNulls) {
-      this.respectNulls = respectNulls;
-    }
-
-    public boolean respectNulls() {
-      return respectNulls;
     }
   };
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/HiveFunctionHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/HiveFunctionHelper.java
@@ -412,7 +412,7 @@ public class HiveFunctionHelper implements FunctionHelper {
         if (aggregateName.toLowerCase().equals(FunctionRegistry.LEAD_FUNC_NAME)
             || aggregateName.toLowerCase().equals(FunctionRegistry.LAG_FUNC_NAME)) {
           GenericUDAFEvaluator genericUDAFEvaluator = FunctionRegistry.getGenericWindowingEvaluator(aggregateName,
-              aggParameterOIs, isDistinct, isAllColumns);
+              aggParameterOIs, isDistinct, isAllColumns, true);
           GenericUDAFInfo udaf = SemanticAnalyzer.getGenericUDAFInfo2(
               genericUDAFEvaluator, udafMode, aggParameterOIs);
           returnType = ((ListTypeInfo) udaf.returnType).getListElementTypeInfo();

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/ptf/WindowFunctionDef.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/ptf/WindowFunctionDef.java
@@ -33,6 +33,7 @@ public class WindowFunctionDef extends WindowExpressionDef {
   WindowFrameDef windowFrame;
   GenericUDAFEvaluator wFnEval;
   boolean pivotResult;
+  boolean respectNulls = true;
 
   @Explain(displayName = "name")
   public String getName() {
@@ -124,4 +125,11 @@ public class WindowFunctionDef extends WindowExpressionDef {
     this.pivotResult = pivotResult;
   }
 
+  public boolean respectNulls() {
+    return respectNulls;
+  }
+
+  public void setRespectNulls(boolean respectNulls) {
+    this.respectNulls = respectNulls;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFParameterInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDAFParameterInfo.java
@@ -88,4 +88,5 @@ public interface GenericUDAFParameterInfo {
    */
   boolean isAllColumns();
 
+  boolean respectNulls();
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/SimpleGenericUDAFParameterInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/SimpleGenericUDAFParameterInfo.java
@@ -32,13 +32,20 @@ public class SimpleGenericUDAFParameterInfo implements GenericUDAFParameterInfo
   private final boolean isWindowing;
   private final boolean distinct;
   private final boolean allColumns;
+  private final boolean respectNulls;
 
   public SimpleGenericUDAFParameterInfo(ObjectInspector[] params, boolean isWindowing, boolean distinct,
       boolean allColumns) {
+    this(params, isWindowing, distinct, allColumns, true);
+  }
+
+  public SimpleGenericUDAFParameterInfo(ObjectInspector[] params, boolean isWindowing, boolean distinct,
+      boolean allColumns, boolean respectNulls) {
     this.parameters = params;
     this.isWindowing = isWindowing;
     this.distinct = distinct;
     this.allColumns = allColumns;
+    this.respectNulls = respectNulls;
   }
 
   @Override
@@ -69,5 +76,10 @@ public class SimpleGenericUDAFParameterInfo implements GenericUDAFParameterInfo
   @Override
   public boolean isWindowing() {
     return isWindowing;
+  }
+
+  @Override
+  public boolean respectNulls() {
+    return respectNulls;
   }
 }

--- a/ql/src/test/queries/clientnegative/nulltreatment.q
+++ b/ql/src/test/queries/clientnegative/nulltreatment.q
@@ -1,0 +1,3 @@
+CREATE TABLE t1(a int);
+
+SELECT sum(a) IGNORE NULLS OVER (ORDER BY a) FROM t1;

--- a/ql/src/test/results/clientnegative/nulltreatment.q.out
+++ b/ql/src/test/results/clientnegative/nulltreatment.q.out
@@ -1,0 +1,9 @@
+PREHOOK: query: CREATE TABLE t1(a int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1(a int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+FAILED: SemanticException [Error 10426]: Function sum does not support null treatment.

--- a/ql/src/test/results/clientnegative/windowing_invalid_udaf.q.out
+++ b/ql/src/test/results/clientnegative/windowing_invalid_udaf.q.out
@@ -1,2 +1,1 @@
-FAILED: SemanticException Failed to breakup Windowing invocations into Groups. At least 1 group must only depend on input columns. Also check for circular dependencies.
-Underlying error: Invalid function nonexistfunc
+FAILED: SemanticException [Error 10011]: Invalid function nonexistfunc


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add `respectNulls` boolean property to `GenericUDAFParameterInfo`.
2. Map this property to Windowing specification/definitions objects.
3. Introduce property to `WindowFunctionDescription` which show whether the function supports handling null treatment settings. 
* If the `supportNullTreatment` property is not set explicitly the UDAF does not support null treatment and the compiler throws `SemanticException` if specified.
* If the `supportNullTreatment` property is set to true but the function call does not specify null treatment the default null treatment is used: `RESPECT NULLS`
* The specified null treatment is used othervise.

### Why are the changes needed?
This patch is a follow-up of #2060. See jira for details.

### Does this PR introduce _any_ user-facing change?
Yes. When calling `lead` or `lag` functions by specifying `RESPECT/IGNORE NULLS`
* and no default value parameter is given `RESPECT/IGNORE NULLS` are not passed as default value parameter: `NULL` is returned if rows has no corresponding following/preceding rows 
* and default value parameter is given `RESPECT/IGNORE NULLS` are not passed as default value parameter: no Exception is thrown

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestNegativeLlapLocalCliDriver -Dqfile=nulltreatment.q -pl itests/qtest -Pitests
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=windowing_navfn.q -pl itests/qtest -Pitests
```