### PR TITLE
HIVE-24912: Support to add repl.target.for property during incrementa…

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenarios.java
@@ -485,7 +485,7 @@ public class TestReplicationScenarios {
 
   private Task getReplLoadRootTask(String sourceDb, String replicadb, boolean isIncrementalDump,
                                    Tuple tuple) throws Throwable {
-    HiveConf confTemp = new HiveConf();
+    HiveConf confTemp = driverMirror.getConf();
     Path loadPath = new Path(tuple.dumpLocation, ReplUtils.REPL_HIVE_BASE_DIR);
     ReplicationMetricCollector metricCollector;
     if (isIncrementalDump) {

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -458,11 +458,6 @@ public class WarehouseInstance implements Closeable {
     assertTrue(props.containsKey(ReplConst.REPL_TARGET_TABLE_PROPERTY));
   }
 
-  public void verifyTargetOfReplProperty(String dbName) throws Exception {
-    Database db = getDatabase(dbName);
-    assertTrue(db.getParameters().containsKey(ReplUtils.TARGET_OF_REPLICATION));
-    assertTrue(Boolean.getBoolean(db.getParameters().get(ReplUtils.TARGET_OF_REPLICATION)));
-  }
 
   public WarehouseInstance verifyReplTargetProperty(String dbName, List<String> tblNames) throws Exception {
     for (String tblName : tblNames) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplLoadTask.java
@@ -604,6 +604,18 @@ public class ReplLoadTask extends Task<ReplLoadWork> implements Serializable {
     if (work.replScopeModified) {
       dropTablesExcludedInReplScope(work.currentReplScope);
     }
+    if (!ReplUtils.isTargetOfReplication(getHive().getDatabase(work.dbNameToLoadIn))) {
+      Map<String, String> props = new HashMap<>();
+      props.put(ReplUtils.TARGET_OF_REPLICATION, "true");
+      AlterDatabaseSetPropertiesDesc setTargetDesc = new AlterDatabaseSetPropertiesDesc(work.dbNameToLoadIn, props, null);
+      Task<?> addReplTargetPropTask =
+              TaskFactory.get(new DDLWork(new HashSet<>(), new HashSet<>(), setTargetDesc, true,
+                      work.dumpDirectory, work.getMetricCollector()), conf);
+      if (this.childTasks == null) {
+        this.childTasks = new ArrayList<>();
+      }
+      this.childTasks.add(addReplTargetPropTask);
+    }
     IncrementalLoadTasksBuilder builder = work.incrementalLoadTasksBuilder();
     // If incremental events are already applied, then check and perform if need to bootstrap any tables.
     if (!builder.hasMoreWork() && work.isLastReplIDUpdated()) {


### PR DESCRIPTION
What changes were proposed in this pull request?
Support to add repl.target.for property during incremental run.

Why are the changes needed?

Does this PR introduce any user-facing change?
No

How was this patch tested?
Added one test => TestReplicationScenarios#testReplTargetInIncremental 