### PR TITLE
HIVE-24175: getDatabase() should only return managedlocation if set (…

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDefaultTransformer.java
@@ -695,7 +695,8 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
     if (!isTenantBasedStorage) {
       Path locationPath = Path.getPathWithoutSchemeAndAuthority(new Path(db.getLocationUri()));
       Path whRootPath = Path.getPathWithoutSchemeAndAuthority(hmsHandler.getWh().getWhRoot());
-      if (FileUtils.isSubdirectory(whRootPath.toString(), locationPath.toString())) { // legacy path
+      LOG.debug("Comparing DB and warehouse paths warehouse={} db.getLocationUri={}", whRootPath.toString(), locationPath.toString());
+      if (FileUtils.isSubdirectory(whRootPath.toString(), locationPath.toString()) || locationPath.equals(whRootPath)) { // legacy path
         if (processorCapabilities != null && (processorCapabilities.contains(HIVEMANAGEDINSERTWRITE) ||
             processorCapabilities.contains(HIVEFULLACIDWRITE))) {
           LOG.debug("Processor has atleast one of ACID write capabilities, setting current locationUri " + db.getLocationUri() + " as managedLocationUri");
@@ -704,13 +705,6 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
         Path extWhLocation = hmsHandler.getWh().getDefaultExternalDatabasePath(db.getName());
         LOG.info("Database's location is a managed location, setting to a new default path based on external warehouse path:" + extWhLocation.toString());
         db.setLocationUri(extWhLocation.toString());
-      } else {
-        if (processorCapabilities != null && (processorCapabilities.contains(HIVEMANAGEDINSERTWRITE) ||
-            processorCapabilities.contains(HIVEFULLACIDWRITE))) {
-          Path mgdWhLocation = hmsHandler.getWh().getDefaultDatabasePath(db.getName(), false);
-          LOG.debug("Processor has atleast one of ACID write capabilities, setting default managed path to " + mgdWhLocation.toString());
-          db.setManagedLocationUri(mgdWhLocation.toString());
-        }
       }
     }
     LOG.info("Transformer returning database:" + db.toString());
@@ -783,8 +777,10 @@ public class MetastoreDefaultTransformer implements IMetaStoreMetadataTransforme
     if (TableType.MANAGED_TABLE.name().equals(table.getTableType())) {
       if (db.getManagedLocationUri() != null) {
         if (tableLocation != null) {
-          throw new MetaException("Location for managed table is derived from the database's managedLocationUri, "
-              + "it cannot be specified by the user");
+          if (!FileUtils.isSubdirectory(db.getManagedLocationUri(), tableLocation)) {
+            throw new MetaException(
+                "Illegal location for managed table, it has to be within database's managed location");
+          }
         } else {
           Path path = hmsHandler.getWh().getDefaultTablePath(db, table.getTableName(), false);
           table.getSd().setLocation(path.toString());


### PR DESCRIPTION
…Naveen Gangam)

### What changes were proposed in this pull request?
With the introduction of a managedLocation and HMS translation layer, getDatabase() call always returns a managedlocation as well even if not set (defaults to managed warehouse dir). This might have been a bit ambitious as the preevent and postevents sent out as part of this create database DDL does not include this managed location. This path is added by the translation layer on a getDatabase() call. HMS DB store does not have a value either. So we are a bit inconsistent on this matter.

### Why are the changes needed?
Address a bug fix.

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
Manually
