### PR TITLE
HIVE-24909: Skip the repl events from getting logged in notification log

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Compiler.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hive.ql.parse.ParseException;
 import org.apache.hadoop.hive.ql.parse.ParseUtils;
 import org.apache.hadoop.hive.ql.parse.SemanticAnalyzerFactory;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
+import org.apache.hadoop.hive.ql.plan.PlanUtils;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
 import org.apache.hadoop.hive.ql.security.authorization.command.CommandAuthorizer;
@@ -265,7 +266,10 @@ public class Compiler {
     if (DriverUtils.checkConcurrency(driverContext) && startImplicitTxn(driverContext.getTxnManager()) &&
         !driverContext.getTxnManager().isTxnOpen() && txnType != TxnType.COMPACTION) {
       String userFromUGI = DriverUtils.getUserFromUGI(driverContext);
-      driverContext.getTxnManager().openTxn(context, userFromUGI, txnType);
+      boolean isReplDumpOrLoadOp = driverContext.getQueryState().getHiveOperation().equals(HiveOperation.REPLDUMP)
+              || driverContext.getQueryState().getHiveOperation().equals(HiveOperation.REPLLOAD);
+      String dbNameUnderReplication = (isReplDumpOrLoadOp) ? PlanUtils.stripQuotes(tree.getChild(0).getText()) : null;
+      driverContext.getTxnManager().openTxn(context, userFromUGI, txnType, dbNameUnderReplication);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Driver.java
@@ -245,7 +245,7 @@ public class Driver implements IDriver {
             driverContext.getTxnManager().rollbackTxn();
 
             String userFromUGI = DriverUtils.getUserFromUGI(driverContext);
-            driverContext.getTxnManager().openTxn(context, userFromUGI, driverContext.getTxnType());
+            driverContext.getTxnManager().openTxn(context, userFromUGI, driverContext.getTxnType(), null);
             lockAndRespond();
           }
           driverContext.setRetrial(true);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.exec;
 import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
+import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -106,6 +107,7 @@ public class ReplTxnTask extends Task<ReplTxnWork> {
         CommitTxnRequest commitTxnRequest = new CommitTxnRequest(txnId);
         commitTxnRequest.setReplPolicy(work.getReplPolicy());
         commitTxnRequest.setWriteEventInfos(work.getWriteEventInfos());
+        commitTxnRequest.setTxn_type(TxnType.REPL_CREATED);
         txnManager.replCommitTxn(commitTxnRequest);
         LOG.info("Replayed CommitTxn Event for replPolicy: " + replPolicy + " with srcTxn: " + txnId +
             "WriteEventInfos: " + work.getWriteEventInfos());

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/DummyTxnManager.java
@@ -56,7 +56,7 @@ class DummyTxnManager extends HiveTxnManagerImpl {
   private HiveLockManagerCtx lockManagerCtx;
 
   @Override
-  public long openTxn(Context ctx, String user, TxnType txnType) throws LockException {
+  public long openTxn(Context ctx, String user, TxnType txnType, String dbNameUnderReplication) throws LockException {
     // No-op
     return 0L;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/lockmgr/HiveTxnManager.java
@@ -60,7 +60,7 @@ public interface HiveTxnManager {
   * @return The new transaction id
   * @throws LockException if a transaction is already open.
   */
-  long openTxn(Context ctx, String user, TxnType txnType) throws LockException;
+  long openTxn(Context ctx, String user, TxnType txnType, String dbNameUnderReplication) throws LockException;
 
   /**
    * Open a new transaction in target cluster.

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager2.java
@@ -3057,7 +3057,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
 
   @Test
   public void testValidTxnList() throws Exception {
-    long readTxnId = txnMgr.openTxn(ctx, "u0", TxnType.READ_ONLY);
+    long readTxnId = txnMgr.openTxn(ctx, "u0", TxnType.READ_ONLY, null);
     HiveTxnManager txnManager1 = TxnManagerFactory.getTxnManagerFactory().getTxnManager(conf);
     txnManager1.openTxn(ctx, "u0");
     //Excludes open read only txns by default
@@ -3071,7 +3071,7 @@ public class TestDbTxnManager2 extends DbTxnManagerEndToEndTestBase{
     txnManager1.commitTxn();
     txnMgr.commitTxn();
 
-    long replTxnId = txnMgr.openTxn(ctx, "u0", TxnType.REPL_CREATED);
+    long replTxnId = txnMgr.openTxn(ctx, "u0", TxnType.REPL_CREATED, null);
     txnManager1 = TxnManagerFactory.getTxnManagerFactory().getTxnManager(conf);
     txnManager1.openTxn(ctx, "u0");
     //Excludes open read only txns by default

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnRequest.java
@@ -13,17 +13,24 @@ package org.apache.hadoop.hive.metastore.api;
 
   private static final org.apache.thrift.protocol.TField TXNID_FIELD_DESC = new org.apache.thrift.protocol.TField("txnid", org.apache.thrift.protocol.TType.I64, (short)1);
   private static final org.apache.thrift.protocol.TField REPL_POLICY_FIELD_DESC = new org.apache.thrift.protocol.TField("replPolicy", org.apache.thrift.protocol.TType.STRING, (short)2);
+  private static final org.apache.thrift.protocol.TField TXN_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("txn_type", org.apache.thrift.protocol.TType.I32, (short)3);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new AbortTxnRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new AbortTxnRequestTupleSchemeFactory();
 
   private long txnid; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String replPolicy; // optional
+  private @org.apache.thrift.annotation.Nullable TxnType txn_type; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
     TXNID((short)1, "txnid"),
-    REPL_POLICY((short)2, "replPolicy");
+    REPL_POLICY((short)2, "replPolicy"),
+    /**
+     *
+     * @see TxnType
+     */
+    TXN_TYPE((short)3, "txn_type");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -43,6 +50,8 @@ package org.apache.hadoop.hive.metastore.api;
           return TXNID;
         case 2: // REPL_POLICY
           return REPL_POLICY;
+        case 3: // TXN_TYPE
+          return TXN_TYPE;
         default:
           return null;
       }
@@ -94,6 +103,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.REPL_POLICY, new org.apache.thrift.meta_data.FieldMetaData("replPolicy", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(AbortTxnRequest._Fields.TXN_TYPE, new org.apache.thrift.meta_data.FieldMetaData("txn_type", org.apache.thrift.TFieldRequirementType.OPTIONAL,
+            new org.apache.thrift.meta_data.EnumMetaData(org.apache.thrift.protocol.TType.ENUM, TxnType.class)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(AbortTxnRequest.class, metaDataMap);
   }
@@ -118,6 +129,9 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetReplPolicy()) {
       this.replPolicy = other.replPolicy;
     }
+    if (other.isSetTxn_type()) {
+      this.txn_type = other.txn_type;
+    }
   }
 
   public AbortTxnRequest deepCopy() {
@@ -129,6 +143,7 @@ package org.apache.hadoop.hive.metastore.api;
     setTxnidIsSet(false);
     this.txnid = 0;
     this.replPolicy = null;
+    this.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.DEFAULT;
   }
 
   public long getTxnid() {
@@ -177,6 +192,38 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  /**
+   *
+   * @see TxnType
+   */
+  @org.apache.thrift.annotation.Nullable
+  public TxnType getTxn_type() {
+    return this.txn_type;
+  }
+
+  /**
+   *
+   * @see TxnType
+   */
+  public void setTxn_type(@org.apache.thrift.annotation.Nullable TxnType txn_type) {
+    this.txn_type = txn_type;
+  }
+
+  public void unsetTxn_type() {
+    this.txn_type = null;
+  }
+
+  /** Returns true if field txn_type is set (has been assigned a value) and false otherwise */
+  public boolean isSetTxn_type() {
+    return this.txn_type != null;
+  }
+
+  public void setTxn_typeIsSet(boolean value) {
+    if (!value) {
+      this.txn_type = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case TXNID:
@@ -195,6 +242,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case TXN_TYPE:
+      if (value == null) {
+        unsetTxn_type();
+      } else {
+        setTxn_type((TxnType)value);
+      }
+      break;
+
     }
   }
 
@@ -207,6 +262,8 @@ package org.apache.hadoop.hive.metastore.api;
     case REPL_POLICY:
       return getReplPolicy();
 
+    case TXN_TYPE:
+      return getTxn_type();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -222,6 +279,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetTxnid();
     case REPL_POLICY:
       return isSetReplPolicy();
+    case TXN_TYPE:
+      return isSetTxn_type();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -259,6 +318,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_txn_type = true && this.isSetTxn_type();
+    boolean that_present_txn_type = true && that.isSetTxn_type();
+    if (this_present_txn_type || that_present_txn_type) {
+      if (!(this_present_txn_type && that_present_txn_type))
+        return false;
+      if (!this.txn_type.equals(that.txn_type))
+        return false;
+    }
+
     return true;
   }
 
@@ -271,6 +339,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetReplPolicy()) ? 131071 : 524287);
     if (isSetReplPolicy())
       hashCode = hashCode * 8191 + replPolicy.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetTxn_type()) ? 131071 : 524287);
+    if (isSetTxn_type())
+      hashCode = hashCode * 8191 + txn_type.getValue();
 
     return hashCode;
   }
@@ -299,6 +371,12 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetReplPolicy()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.replPolicy, other.replPolicy);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    if (isSetTxn_type()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.txn_type, other.txn_type);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -334,6 +412,16 @@ package org.apache.hadoop.hive.metastore.api;
         sb.append("null");
       } else {
         sb.append(this.replPolicy);
+      }
+      first = false;
+    }
+    if (isSetTxn_type()) {
+      if (!first) sb.append(", ");
+      sb.append("txn_type:");
+      if (this.txn_type == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.txn_type);
       }
       first = false;
     }
@@ -402,6 +490,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 3: // TXN_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+              struct.setTxn_typeIsSet(true);
+            } else {
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -422,6 +518,13 @@ package org.apache.hadoop.hive.metastore.api;
         if (struct.isSetReplPolicy()) {
           oprot.writeFieldBegin(REPL_POLICY_FIELD_DESC);
           oprot.writeString(struct.replPolicy);
+          oprot.writeFieldEnd();
+        }
+      }
+      if (struct.txn_type != null) {
+        if (struct.isSetTxn_type()) {
+          oprot.writeFieldBegin(TXN_TYPE_FIELD_DESC);
+          oprot.writeI32(struct.txn_type.getValue());
           oprot.writeFieldEnd();
         }
       }
@@ -447,9 +550,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetReplPolicy()) {
         optionals.set(0);
       }
-      oprot.writeBitSet(optionals, 1);
+      if (struct.isSetTxn_type()) {
+        optionals.set(1);
+      }
+      oprot.writeBitSet(optionals, 2);
       if (struct.isSetReplPolicy()) {
         oprot.writeString(struct.replPolicy);
+      }
+      if (struct.isSetTxn_type()) {
+        oprot.writeI32(struct.txn_type.getValue());
       }
     }
 
@@ -462,6 +571,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(0)) {
         struct.replPolicy = iprot.readString();
         struct.setReplPolicyIsSet(true);
+      }
+      if (incoming.get(1)) {
+        struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+        struct.setTxn_typeIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField REPL_LAST_ID_INFO_FIELD_DESC = new org.apache.thrift.protocol.TField("replLastIdInfo", org.apache.thrift.protocol.TType.STRUCT, (short)4);
   private static final org.apache.thrift.protocol.TField KEY_VALUE_FIELD_DESC = new org.apache.thrift.protocol.TField("keyValue", org.apache.thrift.protocol.TType.STRUCT, (short)5);
   private static final org.apache.thrift.protocol.TField EXCL_WRITE_ENABLED_FIELD_DESC = new org.apache.thrift.protocol.TField("exclWriteEnabled", org.apache.thrift.protocol.TType.BOOL, (short)6);
+  private static final org.apache.thrift.protocol.TField TXN_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("txn_type", org.apache.thrift.protocol.TType.I32, (short)7);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new CommitTxnRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new CommitTxnRequestTupleSchemeFactory();
@@ -27,6 +28,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable ReplLastIdInfo replLastIdInfo; // optional
   private @org.apache.thrift.annotation.Nullable CommitTxnKeyValue keyValue; // optional
   private boolean exclWriteEnabled; // optional
+  private @org.apache.thrift.annotation.Nullable TxnType txn_type; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35,7 +37,12 @@ package org.apache.hadoop.hive.metastore.api;
     WRITE_EVENT_INFOS((short)3, "writeEventInfos"),
     REPL_LAST_ID_INFO((short)4, "replLastIdInfo"),
     KEY_VALUE((short)5, "keyValue"),
-    EXCL_WRITE_ENABLED((short)6, "exclWriteEnabled");
+    EXCL_WRITE_ENABLED((short)6, "exclWriteEnabled"),
+    /**
+     *
+     * @see TxnType
+     */
+    TXN_TYPE((short)7, "txn_type");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -63,6 +70,8 @@ package org.apache.hadoop.hive.metastore.api;
           return KEY_VALUE;
         case 6: // EXCL_WRITE_ENABLED
           return EXCL_WRITE_ENABLED;
+        case 7: // TXN_TYPE
+          return TXN_TYPE;
         default:
           return null;
       }
@@ -124,6 +133,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, CommitTxnKeyValue.class)));
     tmpMap.put(_Fields.EXCL_WRITE_ENABLED, new org.apache.thrift.meta_data.FieldMetaData("exclWriteEnabled", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(CommitTxnRequest._Fields.TXN_TYPE, new org.apache.thrift.meta_data.FieldMetaData("txn_type", org.apache.thrift.TFieldRequirementType.OPTIONAL,
+            new org.apache.thrift.meta_data.EnumMetaData(org.apache.thrift.protocol.TType.ENUM, TxnType.class)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(CommitTxnRequest.class, metaDataMap);
   }
@@ -164,6 +175,9 @@ package org.apache.hadoop.hive.metastore.api;
       this.keyValue = new CommitTxnKeyValue(other.keyValue);
     }
     this.exclWriteEnabled = other.exclWriteEnabled;
+    if (other.isSetTxn_type()) {
+      this.txn_type = other.txn_type;
+    }
   }
 
   public CommitTxnRequest deepCopy() {
@@ -179,6 +193,7 @@ package org.apache.hadoop.hive.metastore.api;
     this.replLastIdInfo = null;
     this.keyValue = null;
     this.exclWriteEnabled = true;
+    this.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.DEFAULT;
 
   }
 
@@ -225,6 +240,38 @@ package org.apache.hadoop.hive.metastore.api;
   public void setReplPolicyIsSet(boolean value) {
     if (!value) {
       this.replPolicy = null;
+    }
+  }
+
+  /**
+   *
+   * @see TxnType
+   */
+  @org.apache.thrift.annotation.Nullable
+  public TxnType getTxn_type() {
+    return this.txn_type;
+  }
+
+  /**
+   *
+   * @see TxnType
+   */
+  public void setTxn_type(@org.apache.thrift.annotation.Nullable TxnType txn_type) {
+    this.txn_type = txn_type;
+  }
+
+  public void unsetTxn_type() {
+    this.txn_type = null;
+  }
+
+  /** Returns true if field txn_type is set (has been assigned a value) and false otherwise */
+  public boolean isSetTxn_type() {
+    return this.txn_type != null;
+  }
+
+  public void setTxn_typeIsSet(boolean value) {
+    if (!value) {
+      this.txn_type = null;
     }
   }
 
@@ -388,6 +435,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case TXN_TYPE:
+      if (value == null) {
+        unsetTxn_type();
+      } else {
+        setTxn_type((TxnType)value);
+      }
+      break;
+
     }
   }
 
@@ -412,6 +467,9 @@ package org.apache.hadoop.hive.metastore.api;
     case EXCL_WRITE_ENABLED:
       return isExclWriteEnabled();
 
+    case TXN_TYPE:
+      return getTxn_type();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -435,6 +493,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetKeyValue();
     case EXCL_WRITE_ENABLED:
       return isSetExclWriteEnabled();
+    case TXN_TYPE:
+      return isSetTxn_type();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -508,6 +568,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_txn_type = true && this.isSetTxn_type();
+    boolean that_present_txn_type = true && that.isSetTxn_type();
+    if (this_present_txn_type || that_present_txn_type) {
+      if (!(this_present_txn_type && that_present_txn_type))
+        return false;
+      if (!this.txn_type.equals(that.txn_type))
+        return false;
+    }
+
     return true;
   }
 
@@ -536,6 +605,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetExclWriteEnabled()) ? 131071 : 524287);
     if (isSetExclWriteEnabled())
       hashCode = hashCode * 8191 + ((exclWriteEnabled) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetTxn_type()) ? 131071 : 524287);
+    if (isSetTxn_type())
+      hashCode = hashCode * 8191 + txn_type.getValue();
 
     return hashCode;
   }
@@ -608,6 +681,12 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    if (isSetTxn_type()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.txn_type, other.txn_type);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -676,6 +755,16 @@ package org.apache.hadoop.hive.metastore.api;
       if (!first) sb.append(", ");
       sb.append("exclWriteEnabled:");
       sb.append(this.exclWriteEnabled);
+      first = false;
+    }
+    if (isSetTxn_type()) {
+      if (!first) sb.append(", ");
+      sb.append("txn_type:");
+      if (this.txn_type == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.txn_type);
+      }
       first = false;
     }
     sb.append(")");
@@ -794,6 +883,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 7: // TXN_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+              struct.setTxn_typeIsSet(true);
+            } else {
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -850,6 +947,13 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeBool(struct.exclWriteEnabled);
         oprot.writeFieldEnd();
       }
+      if (struct.txn_type != null) {
+        if (struct.isSetTxn_type()) {
+          oprot.writeFieldBegin(TXN_TYPE_FIELD_DESC);
+          oprot.writeI32(struct.txn_type.getValue());
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -884,7 +988,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetExclWriteEnabled()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetTxn_type()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetReplPolicy()) {
         oprot.writeString(struct.replPolicy);
       }
@@ -905,6 +1012,9 @@ package org.apache.hadoop.hive.metastore.api;
       }
       if (struct.isSetExclWriteEnabled()) {
         oprot.writeBool(struct.exclWriteEnabled);
+      }
+      if (struct.isSetTxn_type()) {
+        oprot.writeI32(struct.txn_type.getValue());
       }
     }
 
@@ -945,6 +1055,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(4)) {
         struct.exclWriteEnabled = iprot.readBool();
         struct.setExclWriteEnabledIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+        struct.setTxn_typeIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -3103,6 +3103,8 @@ public interface IMetaStoreClient {
    */
   long openTxn(String user, TxnType txnType) throws TException;
 
+  long openTxn(String user, TxnType txnType, String dbNameUnderReplication) throws TException;
+
   /**
    * Initiate a transaction at the target cluster.
    * @param replPolicy The replication policy to uniquely identify the source cluster.
@@ -3150,6 +3152,8 @@ public interface IMetaStoreClient {
    * @throws TException
    */
   void rollbackTxn(long txnid) throws NoSuchTxnException, TException;
+
+  void rollbackTxn(long txnid, String dbNameUnderReplication) throws NoSuchTxnException, TException;
 
   /**
    * Rollback a transaction.  This will also unlock any locks associated with

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClientPreCatalog.java
@@ -2375,6 +2375,12 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   }
 
   @Override
+  public long openTxn(String user, TxnType txnType, String dbNameUnderReplication) throws TException {
+    OpenTxnsResponse txns = openTxnsIntr(user, 1, dbNameUnderReplication, null, txnType);
+    return txns.getTxn_ids().get(0);
+  }
+
+  @Override
   public OpenTxnsResponse openTxns(String user, int numTxns) throws TException {
     return openTxnsIntr(user, numTxns, null, null, null);
   }
@@ -2383,7 +2389,8 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   public List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user) throws TException {
     // As this is called from replication task, the user is the user who has fired the repl command.
     // This is required for standalone metastore authentication.
-    OpenTxnsResponse txns = openTxnsIntr(user, srcTxnIds.size(), replPolicy, srcTxnIds, null);
+    OpenTxnsResponse txns = openTxnsIntr(user, srcTxnIds != null ? srcTxnIds.size() : 1,
+                                          replPolicy, srcTxnIds, TxnType.REPL_CREATED);
     return txns.getTxn_ids();
   }
 
@@ -2398,11 +2405,12 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
     }
     OpenTxnRequest rqst = new OpenTxnRequest(numTxns, user, hostname);
     if (replPolicy != null) {
-      assert  srcTxnIds != null;
-      assert numTxns == srcTxnIds.size();
-      // need to set this only for replication tasks
       rqst.setReplPolicy(replPolicy);
-      rqst.setReplSrcTxnIds(srcTxnIds);
+      if (txnType == TxnType.REPL_CREATED) {
+        assert srcTxnIds != null;
+        assert numTxns == srcTxnIds.size();
+        rqst.setReplSrcTxnIds(srcTxnIds);
+      }
     } else {
       assert srcTxnIds == null;
     }
@@ -2418,9 +2426,19 @@ public class HiveMetaStoreClientPreCatalog implements IMetaStoreClient, AutoClos
   }
 
   @Override
+  public void rollbackTxn(long txnid, String dbNameUnderReplication) throws NoSuchTxnException, TException {
+    AbortTxnRequest rqst = new AbortTxnRequest(txnid);
+    if (dbNameUnderReplication != null) {
+      rqst.setReplPolicy(dbNameUnderReplication);
+    }
+    client.abort_txn(rqst);
+  }
+
+  @Override
   public void replRollbackTxn(long srcTxnId, String replPolicy) throws NoSuchTxnException, TException {
     AbortTxnRequest rqst = new AbortTxnRequest(srcTxnId);
     rqst.setReplPolicy(replPolicy);
+    rqst.setTxn_type(TxnType.REPL_CREATED);
     client.abort_txn(rqst);
   }
 


### PR DESCRIPTION
What changes were proposed in this pull request?
Skip the repl events from getting logged in notification log

Why are the changes needed?
Currently REPL dump events are logged and replicated as a part of replication policy. Whenever one replication cycle completed, we always have one transaction left open on the target corresponding to repl dump operation. This will never be caught up without manually dealing with the transaction on target cluster.

Does this PR introduce any user-facing change?
No

How was this patch tested?
Added one test => TestDbNotificationListener#testReplEvents