### PR TITLE
HIVE-24918: Handle failover case during repl dump.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -506,8 +506,9 @@ public class HiveConf extends Configuration {
         "HDFS root scratch dir for Hive jobs which gets created with write all (733) permission. " +
         "For each connecting user, an HDFS scratch dir: ${hive.exec.scratchdir}/<username> is created, " +
         "with ${hive.scratch.dir.permission}."),
-    HIVE_REPL_FAILOVER("hive.repl.failover.start",false,
-            "Indicates if user wants to trigger failover for reverse replication."),
+    HIVE_REPL_FAILOVER_START("hive.repl.failover.start",false,
+            "A replication policy level config to indicate if user wants to initiate fail-over" +
+                      "to replicate the database in reverse direction."),
     REPLDIR("hive.repl.rootdir","/user/${system:user.name}/repl/",
         "HDFS root dir for all replication dumps."),
     REPLCMENABLED("hive.repl.cm.enabled", false,
@@ -574,11 +575,6 @@ public class HiveConf extends Configuration {
         "Indicates the timeout for all transactions which are opened before triggering bootstrap REPL DUMP. "
             + "If these open transactions are not closed within the timeout value, then REPL DUMP will "
             + "forcefully abort those transactions and continue with bootstrap dump."),
-    REPL_FAILOVER_DUMP_OPEN_TXN_TIMEOUT("hive.repl.failover.dump.open.txn.timeout", "1h",
-            new TimeValidator(TimeUnit.HOURS),
-            "Indicates the timeout for all transactions which are opened before triggering failover. "
-                    + "If these open transactions are not closed within the timeout value, then Repl Dump will not " +
-                    "mark this state as failover_ready."),
     REPL_BOOTSTRAP_DUMP_ABORT_WRITE_TXN_AFTER_TIMEOUT("hive.repl.bootstrap.dump.abort.write.txn.after.timeout",
       true,
       "Indicates whether to abort write transactions belonging to the db under replication while doing a" +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -506,6 +506,8 @@ public class HiveConf extends Configuration {
         "HDFS root scratch dir for Hive jobs which gets created with write all (733) permission. " +
         "For each connecting user, an HDFS scratch dir: ${hive.exec.scratchdir}/<username> is created, " +
         "with ${hive.scratch.dir.permission}."),
+    HIVE_REPL_FAILOVER("hive.repl.failover.start",false,
+            "Indicates if user wants to trigger failover for reverse replication."),
     REPLDIR("hive.repl.rootdir","/user/${system:user.name}/repl/",
         "HDFS root dir for all replication dumps."),
     REPLCMENABLED("hive.repl.cm.enabled", false,
@@ -572,6 +574,11 @@ public class HiveConf extends Configuration {
         "Indicates the timeout for all transactions which are opened before triggering bootstrap REPL DUMP. "
             + "If these open transactions are not closed within the timeout value, then REPL DUMP will "
             + "forcefully abort those transactions and continue with bootstrap dump."),
+    REPL_FAILOVER_DUMP_OPEN_TXN_TIMEOUT("hive.repl.failover.dump.open.txn.timeout", "1h",
+            new TimeValidator(TimeUnit.HOURS),
+            "Indicates the timeout for all transactions which are opened before triggering failover. "
+                    + "If these open transactions are not closed within the timeout value, then Repl Dump will not " +
+                    "mark this state as failover_ready."),
     REPL_BOOTSTRAP_DUMP_ABORT_WRITE_TXN_AFTER_TIMEOUT("hive.repl.bootstrap.dump.abort.write.txn.after.timeout",
       true,
       "Indicates whether to abort write transactions belonging to the db under replication while doing a" +

--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestReplicationScenariosAcidTables.java
@@ -355,10 +355,8 @@ public class TestReplicationScenariosAcidTables extends BaseReplicationScenarios
 
   @Test
   public void testFailoverWithNoOpenTxns() throws Throwable {
-    WarehouseInstance.Tuple dumpData = null;
-
     List<String> failoverConfigs = Arrays.asList("'" + HiveConf.ConfVars.HIVE_REPL_FAILOVER_START + "'='true'");
-    dumpData = primary.run("use " + primaryDbName)
+    WarehouseInstance.Tuple dumpData = primary.run("use " + primaryDbName)
             .run("create table t1 (id int) clustered by(id) into 3 buckets stored as orc " +
                     "tblproperties (\"transactional\"=\"true\")")
             .run("create table t2 (rank int) partitioned by (name string) tblproperties(\"transactional\"=\"true\", " +

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplAck.java
@@ -25,7 +25,8 @@ public enum ReplAck {
     EVENTS_DUMP("_events_dump"),
     LOAD_ACKNOWLEDGEMENT("_finished_load"),
     NON_RECOVERABLE_MARKER("_non_recoverable"),
-    LOAD_METADATA("_load_metadata");
+    LOAD_METADATA("_load_metadata"),
+    FAILOVER_READY_MARKER("_failover_ready");
   private String ack;
   ReplAck(String ack) {
     this.ack = ack;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -186,6 +186,10 @@ public class ReplDumpWork implements Serializable {
     return resultValues;
   }
 
+  public boolean isBootstrap() {
+    return this.isBootstrap;
+  }
+
   public void setResultValues(List<String> resultValues) {
     this.resultValues = resultValues;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpWork.java
@@ -57,6 +57,7 @@ public class ReplDumpWork implements Serializable {
   Long eventTo;
   Long eventFrom;
   private boolean isBootstrap;
+  private boolean isIncremental = false;
   private static String testInjectDumpDir = null;
   private static boolean testInjectDumpDirAutoIncrement = false;
   static boolean testDeletePreviousDumpMetaPath = false;
@@ -104,6 +105,14 @@ public class ReplDumpWork implements Serializable {
 
   void setOldReplScope(ReplScope replScope) {
     oldReplScope = replScope;
+  }
+
+  void setIncremental(boolean isIncremental) {
+    this.isIncremental = isIncremental;
+  }
+
+  boolean isIncremental() {
+    return this.isIncremental;
   }
 
   int maxEventLimit() throws Exception {
@@ -184,10 +193,6 @@ public class ReplDumpWork implements Serializable {
 
   public List<String> getResultValues() {
     return resultValues;
-  }
-
-  public boolean isBootstrap() {
-    return this.isBootstrap;
   }
 
   public void setResultValues(List<String> resultValues) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/metric/ReplicationMetricCollector.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/metric/ReplicationMetricCollector.java
@@ -69,6 +69,27 @@ public abstract class ReplicationMetricCollector {
     }
   }
 
+  public void reportStageEnd(String stageName, Status status, boolean isFailoverReady) throws SemanticException {
+    if (isEnabled) {
+      LOG.debug("Stage ended {}, {}, {}", stageName, status, isFailoverReady);
+      Progress progress = replicationMetric.getProgress();
+      Stage stage = progress.getStageByName(stageName);
+      if(stage == null){
+        stage = new Stage(stageName, status, -1L);
+      }
+      stage.setStatus(status);
+      stage.setEndTime(System.currentTimeMillis());
+      progress.addStage(stage);
+      replicationMetric.setProgress(progress);
+      Metadata metadata = replicationMetric.getMetadata();
+      metadata.setFailoverReady(isFailoverReady);
+      replicationMetric.setMetadata(metadata);
+      metricCollector.addMetric(replicationMetric);
+      if (Status.FAILED == status || Status.FAILED_ADMIN == status) {
+        reportEnd(status);
+      }
+    }
+  }
 
   public void reportStageEnd(String stageName, Status status, long lastReplId) throws SemanticException {
     if (isEnabled) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/metric/event/Metadata.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/repl/metric/event/Metadata.java
@@ -32,6 +32,7 @@ public class Metadata {
   private ReplicationType replicationType;
   private String stagingDir;
   private long lastReplId;
+  private boolean isFailoverReady;
 
   public Metadata() {
 
@@ -42,12 +43,14 @@ public class Metadata {
     this.replicationType = metadata.replicationType;
     this.stagingDir = metadata.stagingDir;
     this.lastReplId = metadata.lastReplId;
+    this.isFailoverReady = metadata.isFailoverReady;
   }
 
   public Metadata(String dbName, ReplicationType replicationType, String stagingDir) {
     this.dbName = dbName;
     this.replicationType = replicationType;
     this.stagingDir = stagingDir;
+    this.isFailoverReady = false;
   }
 
   public long getLastReplId() {
@@ -68,5 +71,9 @@ public class Metadata {
 
   public void setLastReplId(long lastReplId) {
     this.lastReplId = lastReplId;
+  }
+
+  public void setFailoverReady(boolean isFailoverReady) {
+    this.isFailoverReady = isFailoverReady;
   }
 }


### PR DESCRIPTION
What changes were proposed in this pull request?
Handle failover case during repl dump

Why are the changes needed?

Does this PR introduce any user-facing change?
No

How was this patch tested?
Added three tests in TestReplicationScenariosAcidTables.