### PR TITLE
HIVE-24909: Skip the repl events from getting logged in notification log

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/WarehouseInstance.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.ql.DriverFactory;
 import org.apache.hadoop.hive.ql.IDriver;
 import org.apache.hadoop.hive.ql.exec.repl.ReplDumpWork;
+import org.apache.hadoop.hive.ql.exec.repl.incremental.IncrementalLoadEventsIterator;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.parse.repl.PathBuilder;
 import org.apache.hadoop.hive.ql.processors.CommandProcessorException;
@@ -63,6 +64,7 @@ import org.codehaus.plexus.util.ExceptionUtils;
 import org.slf4j.Logger;
 
 import java.io.Closeable;
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -476,6 +478,12 @@ public class WarehouseInstance implements Closeable {
     } catch (NoSuchObjectException e) {
       return null;
     }
+  }
+
+  public int getNoOfEventsDumped(String dumpLocation, HiveConf conf) throws Throwable {
+    IncrementalLoadEventsIterator itr = new IncrementalLoadEventsIterator(
+            dumpLocation + File.separator + ReplUtils.REPL_HIVE_BASE_DIR, conf);
+    return itr.getNumEvents();
   }
 
   public List<String> getAllTables(String dbName) throws Exception {

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -123,7 +123,7 @@ public class Context {
   // up when we are done.
   private final Set<Context> subContexts;
 
-  private String replPolicy = null;
+  private String replPolicy;
 
   // List of Locks for this query
   protected List<HiveLock> hiveLocks;

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -123,6 +123,8 @@ public class Context {
   // up when we are done.
   private final Set<Context> subContexts;
 
+  private String replPolicy = null;
+
   // List of Locks for this query
   protected List<HiveLock> hiveLocks;
 
@@ -199,6 +201,14 @@ public class Context {
 
   public void setWmContext(final WmContext wmContext) {
     this.wmContext = wmContext;
+  }
+
+  public void setReplPolicy(String replPolicy) {
+    this.replPolicy = replPolicy;
+  }
+
+  public String getReplPolicy() {
+    return this.replPolicy;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
@@ -33,7 +33,6 @@ import org.apache.hadoop.hive.ql.plan.api.StageType;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.util.StringUtils;
 import java.util.List;
-import org.apache.hadoop.hive.common.ValidTxnList;
 
 /**
  * ReplTxnTask.

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ReplTxnTask.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.exec;
 import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
+import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
 import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.metadata.Hive;
@@ -105,6 +106,7 @@ public class ReplTxnTask extends Task<ReplTxnWork> {
         CommitTxnRequest commitTxnRequest = new CommitTxnRequest(txnId);
         commitTxnRequest.setReplPolicy(work.getReplPolicy());
         commitTxnRequest.setWriteEventInfos(work.getWriteEventInfos());
+        commitTxnRequest.setTxn_type(TxnType.REPL_CREATED);
         txnManager.replCommitTxn(commitTxnRequest);
         LOG.info("Replayed CommitTxn Event for replPolicy: " + replPolicy + " with srcTxn: " + txnId +
             "WriteEventInfos: " + work.getWriteEventInfos());

--- a/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestTxnHandler.java
+++ b/ql/src/test/org/apache/hadoop/hive/metastore/txn/TestTxnHandler.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hive.metastore.api.TxnOpenException;
 import org.apache.hadoop.hive.metastore.api.TxnState;
 import org.apache.hadoop.hive.metastore.api.UnlockRequest;
 import org.apache.hadoop.hive.metastore.api.TxnToWriteId;
+import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.util.StringUtils;
@@ -1244,6 +1245,7 @@ public class TestTxnHandler {
       OpenTxnsResponse response = txnHandler.openTxns(request);
       request.setReplPolicy("default.*");
       request.setReplSrcTxnIds(response.getTxn_ids());
+      request.setTxn_type(TxnType.REPL_CREATED);
       OpenTxnsResponse responseRepl = txnHandler.openTxns(request);
       Thread.sleep(1000);
       txnHandler.performTimeOuts();
@@ -1653,7 +1655,7 @@ public class TestTxnHandler {
     rqst.setReplPolicy(replPolicy);
     rqst.setReplSrcTxnIds(LongStream.rangeClosed(startId, lastId)
             .boxed().collect(Collectors.toList()));
-
+    rqst.setTxn_type(TxnType.REPL_CREATED);
     OpenTxnsResponse openedTxns = txnHandler.openTxns(rqst);
     List<Long> txnList = openedTxns.getTxn_ids();
     assertEquals(txnList.size(), numTxn);
@@ -1670,6 +1672,7 @@ public class TestTxnHandler {
     for (Long txnId : txnList) {
       AbortTxnRequest rqst = new AbortTxnRequest(txnId);
       rqst.setReplPolicy(replPolicy);
+      rqst.setTxn_type(TxnType.REPL_CREATED);
       txnHandler.abortTxn(rqst);
     }
     checkReplTxnForTest(txnList.get(0), txnList.get(txnList.size() - 1), replPolicy, new ArrayList<>());

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.metastore.api.ShowLocksResponseElement;
 import org.apache.hadoop.hive.metastore.api.TxnState;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.metastore.api.TxnType;
+import org.apache.hadoop.hive.metastore.api.CommitTxnRequest;
 import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.metrics.Metrics;
 import org.apache.hadoop.hive.metastore.metrics.MetricsConstants;
@@ -55,6 +56,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
 import static junit.framework.Assert.assertEquals;
@@ -426,23 +428,7 @@ public class TestDbTxnManager {
 
   @Test
   public void testHeartbeater() throws Exception {
-    testHeartbeater(TxnType.DEFAULT, MetastoreConf.ConfVars.TXN_TIMEOUT);
-  }
-
-  /**
-   * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
-   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 30s for testing purposes.
-   */
-  @Test
-  public void testHeartbeaterReplicationTxn() throws Exception {
-    testHeartbeater(TxnType.REPL_CREATED, MetastoreConf.ConfVars.REPL_TXN_TIMEOUT);
-  };
-
-  /**
-   * @param txnType e.g. TxnType.DEFAULT or TxnType.REPL_CREATED. There's a different timeout for
-   *                cleaning replication txns vs. non-replication txns
-   */
-  private void testHeartbeater(TxnType txnType, MetastoreConf.ConfVars timeThresholdConfVar) throws Exception {
+    MetastoreConf.ConfVars timeThresholdConfVar = MetastoreConf.ConfVars.TXN_TIMEOUT;
     Assert.assertTrue(txnMgr instanceof DbTxnManager);
 
     addTableInput();
@@ -450,7 +436,7 @@ public class TestDbTxnManager {
     QueryPlan qp = new MockQueryPlan(this, HiveOperation.QUERY);
 
     // Case 1: If there's no delay for the heartbeat, txn should be able to commit
-    txnMgr.openTxn(ctx, "fred", txnType);
+    txnMgr.openTxn(ctx, "fred", TxnType.DEFAULT);
     txnMgr.acquireLocks(qp, ctx, "fred"); // heartbeat started..
     runReaper();
     try {
@@ -464,7 +450,7 @@ public class TestDbTxnManager {
     // Case 2: If there's delay for the heartbeat, but the delay is within the reaper's tolerance,
     //         then txt should be able to commit
     // Start the heartbeat after a delay, which is shorter than the timeout threshold (e.g. TXN_TIMEOUT)
-    ((DbTxnManager) txnMgr).openTxn(ctx, "tom", txnType,
+    ((DbTxnManager) txnMgr).openTxn(ctx, "tom", TxnType.DEFAULT,
             MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS) / 2);
     txnMgr.acquireLocks(qp, ctx, "tom");
     runReaper();
@@ -480,8 +466,8 @@ public class TestDbTxnManager {
     //         then the txn will time out and be aborted.
     //         Here we just don't send the heartbeat at all - an infinite delay.
     // Start the heartbeat after a delay, which exceeds the timeout threshold (e.g. TXN_TIMEOUT)
-    ((DbTxnManager) txnMgr).openTxn(ctx, "jerry", txnType,
-        MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS) * 2);
+    ((DbTxnManager) txnMgr).openTxn(ctx, "jerry", TxnType.DEFAULT,
+            MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS) * 2);
     txnMgr.acquireLocks(qp, ctx, "jerry");
     Thread.sleep(MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS));
     runReaper();
@@ -494,6 +480,56 @@ public class TestDbTxnManager {
     Assert.assertEquals(ErrorMsg.TXN_ABORTED, exception.getCanonicalErrorMsg());
     Assert.assertEquals(1, Metrics.getOrCreateCounter(MetricsConstants.TOTAL_NUM_TIMED_OUT_TXNS).getCount());
   }
+
+  /**
+   * Same as testHeartbeater, but testing cleanup of replication txns (TxnType.REPL_CREATED)
+   * Note: in TestDbTxnManager metastore.repl.txn.timeout is set to 30s for testing purposes.
+   */
+  @Test
+  public void testHeartbeaterReplicationTxn() throws Exception {
+    MetastoreConf.ConfVars timeThresholdConfVar = MetastoreConf.ConfVars.REPL_TXN_TIMEOUT;
+    Assert.assertTrue(txnMgr instanceof DbTxnManager);
+
+    addTableInput();
+    LockException exception = null;
+    String replPolicy = "default.*";
+    // Case 1: If there's no delay for the heartbeat, txn should be able to commit
+    txnMgr.replOpenTxn(replPolicy, Arrays.asList(1L), "fred");
+    runReaper();
+    try {
+      CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
+      commitTxnRequest.setReplPolicy(replPolicy);
+      txnMgr.replCommitTxn(commitTxnRequest);
+    } catch (LockException e) {
+      exception = e;
+    }
+    Assert.assertNull("Txn commit should be successful", exception);
+    exception = null;
+    txnMgr.replOpenTxn(replPolicy, Arrays.asList(1L), "tom");
+    runReaper();
+    try {
+      CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
+      commitTxnRequest.setReplPolicy(replPolicy);
+      txnMgr.replCommitTxn(commitTxnRequest);
+    } catch (LockException e) {
+      exception = e;
+    }
+    Assert.assertNull("Txn commit should also be successful", exception);
+    exception = null;
+    txnMgr.replOpenTxn(replPolicy, Arrays.asList(1L), "jerry");
+    Thread.sleep(MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS));
+    runReaper();
+    try {
+      CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
+      commitTxnRequest.setReplPolicy(replPolicy);
+      txnMgr.replCommitTxn(commitTxnRequest);
+    } catch (LockException e) {
+      exception = e;
+    }
+    Assert.assertNotNull("Txn should have been aborted", exception);
+    Assert.assertEquals(ErrorMsg.TXN_ABORTED, exception.getCanonicalErrorMsg());
+    Assert.assertEquals(1, Metrics.getOrCreateCounter(MetricsConstants.TOTAL_NUM_TIMED_OUT_TXNS).getCount());
+  };
 
   @Before
   public void setUp() throws Exception {

--- a/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/lockmgr/TestDbTxnManager.java
@@ -499,29 +499,19 @@ public class TestDbTxnManager {
     try {
       CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
       commitTxnRequest.setReplPolicy(replPolicy);
+      commitTxnRequest.setTxn_type(TxnType.REPL_CREATED);
       txnMgr.replCommitTxn(commitTxnRequest);
     } catch (LockException e) {
       exception = e;
     }
     Assert.assertNull("Txn commit should be successful", exception);
-    exception = null;
-    txnMgr.replOpenTxn(replPolicy, Arrays.asList(1L), "tom");
-    runReaper();
-    try {
-      CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
-      commitTxnRequest.setReplPolicy(replPolicy);
-      txnMgr.replCommitTxn(commitTxnRequest);
-    } catch (LockException e) {
-      exception = e;
-    }
-    Assert.assertNull("Txn commit should also be successful", exception);
-    exception = null;
     txnMgr.replOpenTxn(replPolicy, Arrays.asList(1L), "jerry");
     Thread.sleep(MetastoreConf.getTimeVar(conf, timeThresholdConfVar, TimeUnit.MILLISECONDS));
     runReaper();
     try {
       CommitTxnRequest commitTxnRequest = new CommitTxnRequest(1);
       commitTxnRequest.setReplPolicy(replPolicy);
+      commitTxnRequest.setTxn_type(TxnType.REPL_CREATED);
       txnMgr.replCommitTxn(commitTxnRequest);
     } catch (LockException e) {
       exception = e;

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/CompactorTest.java
@@ -92,6 +92,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Stack;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -214,6 +215,10 @@ public abstract class CompactorTest {
   protected long openTxn(TxnType txnType) throws MetaException {
     OpenTxnRequest rqst = new OpenTxnRequest(1, System.getProperty("user.name"), ServerUtils.hostname());
     rqst.setTxn_type(txnType);
+    if (txnType == TxnType.REPL_CREATED) {
+      rqst.setReplPolicy("default.*");
+      rqst.setReplSrcTxnIds(Arrays.asList(1L));
+    }
     List<Long> txns = txnHandler.openTxns(rqst).getTxn_ids();
     return txns.get(0);
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
@@ -2561,14 +2561,14 @@ uint32_t ThriftHiveMetastore_get_databases_result::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1694;
-            ::apache::thrift::protocol::TType _etype1697;
-            xfer += iprot->readListBegin(_etype1697, _size1694);
-            this->success.resize(_size1694);
-            uint32_t _i1698;
-            for (_i1698 = 0; _i1698 < _size1694; ++_i1698)
+            uint32_t _size1696;
+            ::apache::thrift::protocol::TType _etype1699;
+            xfer += iprot->readListBegin(_etype1699, _size1696);
+            this->success.resize(_size1696);
+            uint32_t _i1700;
+            for (_i1700 = 0; _i1700 < _size1696; ++_i1700)
             {
-              xfer += iprot->readString(this->success[_i1698]);
+              xfer += iprot->readString(this->success[_i1700]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2607,10 +2607,10 @@ uint32_t ThriftHiveMetastore_get_databases_result::write(::apache::thrift::proto
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1699;
-      for (_iter1699 = this->success.begin(); _iter1699 != this->success.end(); ++_iter1699)
+      std::vector<std::string> ::const_iterator _iter1701;
+      for (_iter1701 = this->success.begin(); _iter1701 != this->success.end(); ++_iter1701)
       {
-        xfer += oprot->writeString((*_iter1699));
+        xfer += oprot->writeString((*_iter1701));
       }
       xfer += oprot->writeListEnd();
     }
@@ -2655,14 +2655,14 @@ uint32_t ThriftHiveMetastore_get_databases_presult::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1700;
-            ::apache::thrift::protocol::TType _etype1703;
-            xfer += iprot->readListBegin(_etype1703, _size1700);
-            (*(this->success)).resize(_size1700);
-            uint32_t _i1704;
-            for (_i1704 = 0; _i1704 < _size1700; ++_i1704)
+            uint32_t _size1702;
+            ::apache::thrift::protocol::TType _etype1705;
+            xfer += iprot->readListBegin(_etype1705, _size1702);
+            (*(this->success)).resize(_size1702);
+            uint32_t _i1706;
+            for (_i1706 = 0; _i1706 < _size1702; ++_i1706)
             {
-              xfer += iprot->readString((*(this->success))[_i1704]);
+              xfer += iprot->readString((*(this->success))[_i1706]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2779,14 +2779,14 @@ uint32_t ThriftHiveMetastore_get_all_databases_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1705;
-            ::apache::thrift::protocol::TType _etype1708;
-            xfer += iprot->readListBegin(_etype1708, _size1705);
-            this->success.resize(_size1705);
-            uint32_t _i1709;
-            for (_i1709 = 0; _i1709 < _size1705; ++_i1709)
+            uint32_t _size1707;
+            ::apache::thrift::protocol::TType _etype1710;
+            xfer += iprot->readListBegin(_etype1710, _size1707);
+            this->success.resize(_size1707);
+            uint32_t _i1711;
+            for (_i1711 = 0; _i1711 < _size1707; ++_i1711)
             {
-              xfer += iprot->readString(this->success[_i1709]);
+              xfer += iprot->readString(this->success[_i1711]);
             }
             xfer += iprot->readListEnd();
           }
@@ -2825,10 +2825,10 @@ uint32_t ThriftHiveMetastore_get_all_databases_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1710;
-      for (_iter1710 = this->success.begin(); _iter1710 != this->success.end(); ++_iter1710)
+      std::vector<std::string> ::const_iterator _iter1712;
+      for (_iter1712 = this->success.begin(); _iter1712 != this->success.end(); ++_iter1712)
       {
-        xfer += oprot->writeString((*_iter1710));
+        xfer += oprot->writeString((*_iter1712));
       }
       xfer += oprot->writeListEnd();
     }
@@ -2873,14 +2873,14 @@ uint32_t ThriftHiveMetastore_get_all_databases_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1711;
-            ::apache::thrift::protocol::TType _etype1714;
-            xfer += iprot->readListBegin(_etype1714, _size1711);
-            (*(this->success)).resize(_size1711);
-            uint32_t _i1715;
-            for (_i1715 = 0; _i1715 < _size1711; ++_i1715)
+            uint32_t _size1713;
+            ::apache::thrift::protocol::TType _etype1716;
+            xfer += iprot->readListBegin(_etype1716, _size1713);
+            (*(this->success)).resize(_size1713);
+            uint32_t _i1717;
+            for (_i1717 = 0; _i1717 < _size1713; ++_i1717)
             {
-              xfer += iprot->readString((*(this->success))[_i1715]);
+              xfer += iprot->readString((*(this->success))[_i1717]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3933,14 +3933,14 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_result::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1716;
-            ::apache::thrift::protocol::TType _etype1719;
-            xfer += iprot->readListBegin(_etype1719, _size1716);
-            this->success.resize(_size1716);
-            uint32_t _i1720;
-            for (_i1720 = 0; _i1720 < _size1716; ++_i1720)
+            uint32_t _size1718;
+            ::apache::thrift::protocol::TType _etype1721;
+            xfer += iprot->readListBegin(_etype1721, _size1718);
+            this->success.resize(_size1718);
+            uint32_t _i1722;
+            for (_i1722 = 0; _i1722 < _size1718; ++_i1722)
             {
-              xfer += iprot->readString(this->success[_i1720]);
+              xfer += iprot->readString(this->success[_i1722]);
             }
             xfer += iprot->readListEnd();
           }
@@ -3979,10 +3979,10 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_result::write(::apache::thrift::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1721;
-      for (_iter1721 = this->success.begin(); _iter1721 != this->success.end(); ++_iter1721)
+      std::vector<std::string> ::const_iterator _iter1723;
+      for (_iter1723 = this->success.begin(); _iter1723 != this->success.end(); ++_iter1723)
       {
-        xfer += oprot->writeString((*_iter1721));
+        xfer += oprot->writeString((*_iter1723));
       }
       xfer += oprot->writeListEnd();
     }
@@ -4027,14 +4027,14 @@ uint32_t ThriftHiveMetastore_get_dataconnectors_presult::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1722;
-            ::apache::thrift::protocol::TType _etype1725;
-            xfer += iprot->readListBegin(_etype1725, _size1722);
-            (*(this->success)).resize(_size1722);
-            uint32_t _i1726;
-            for (_i1726 = 0; _i1726 < _size1722; ++_i1726)
+            uint32_t _size1724;
+            ::apache::thrift::protocol::TType _etype1727;
+            xfer += iprot->readListBegin(_etype1727, _size1724);
+            (*(this->success)).resize(_size1724);
+            uint32_t _i1728;
+            for (_i1728 = 0; _i1728 < _size1724; ++_i1728)
             {
-              xfer += iprot->readString((*(this->success))[_i1726]);
+              xfer += iprot->readString((*(this->success))[_i1728]);
             }
             xfer += iprot->readListEnd();
           }
@@ -5096,17 +5096,17 @@ uint32_t ThriftHiveMetastore_get_type_all_result::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size1727;
-            ::apache::thrift::protocol::TType _ktype1728;
-            ::apache::thrift::protocol::TType _vtype1729;
-            xfer += iprot->readMapBegin(_ktype1728, _vtype1729, _size1727);
-            uint32_t _i1731;
-            for (_i1731 = 0; _i1731 < _size1727; ++_i1731)
+            uint32_t _size1729;
+            ::apache::thrift::protocol::TType _ktype1730;
+            ::apache::thrift::protocol::TType _vtype1731;
+            xfer += iprot->readMapBegin(_ktype1730, _vtype1731, _size1729);
+            uint32_t _i1733;
+            for (_i1733 = 0; _i1733 < _size1729; ++_i1733)
             {
-              std::string _key1732;
-              xfer += iprot->readString(_key1732);
-              Type& _val1733 = this->success[_key1732];
-              xfer += _val1733.read(iprot);
+              std::string _key1734;
+              xfer += iprot->readString(_key1734);
+              Type& _val1735 = this->success[_key1734];
+              xfer += _val1735.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -5145,11 +5145,11 @@ uint32_t ThriftHiveMetastore_get_type_all_result::write(::apache::thrift::protoc
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::map<std::string, Type> ::const_iterator _iter1734;
-      for (_iter1734 = this->success.begin(); _iter1734 != this->success.end(); ++_iter1734)
+      std::map<std::string, Type> ::const_iterator _iter1736;
+      for (_iter1736 = this->success.begin(); _iter1736 != this->success.end(); ++_iter1736)
       {
-        xfer += oprot->writeString(_iter1734->first);
-        xfer += _iter1734->second.write(oprot);
+        xfer += oprot->writeString(_iter1736->first);
+        xfer += _iter1736->second.write(oprot);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -5194,17 +5194,17 @@ uint32_t ThriftHiveMetastore_get_type_all_presult::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size1735;
-            ::apache::thrift::protocol::TType _ktype1736;
-            ::apache::thrift::protocol::TType _vtype1737;
-            xfer += iprot->readMapBegin(_ktype1736, _vtype1737, _size1735);
-            uint32_t _i1739;
-            for (_i1739 = 0; _i1739 < _size1735; ++_i1739)
+            uint32_t _size1737;
+            ::apache::thrift::protocol::TType _ktype1738;
+            ::apache::thrift::protocol::TType _vtype1739;
+            xfer += iprot->readMapBegin(_ktype1738, _vtype1739, _size1737);
+            uint32_t _i1741;
+            for (_i1741 = 0; _i1741 < _size1737; ++_i1741)
             {
-              std::string _key1740;
-              xfer += iprot->readString(_key1740);
-              Type& _val1741 = (*(this->success))[_key1740];
-              xfer += _val1741.read(iprot);
+              std::string _key1742;
+              xfer += iprot->readString(_key1742);
+              Type& _val1743 = (*(this->success))[_key1742];
+              xfer += _val1743.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -5358,14 +5358,14 @@ uint32_t ThriftHiveMetastore_get_fields_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1742;
-            ::apache::thrift::protocol::TType _etype1745;
-            xfer += iprot->readListBegin(_etype1745, _size1742);
-            this->success.resize(_size1742);
-            uint32_t _i1746;
-            for (_i1746 = 0; _i1746 < _size1742; ++_i1746)
+            uint32_t _size1744;
+            ::apache::thrift::protocol::TType _etype1747;
+            xfer += iprot->readListBegin(_etype1747, _size1744);
+            this->success.resize(_size1744);
+            uint32_t _i1748;
+            for (_i1748 = 0; _i1748 < _size1744; ++_i1748)
             {
-              xfer += this->success[_i1746].read(iprot);
+              xfer += this->success[_i1748].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5420,10 +5420,10 @@ uint32_t ThriftHiveMetastore_get_fields_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1747;
-      for (_iter1747 = this->success.begin(); _iter1747 != this->success.end(); ++_iter1747)
+      std::vector<FieldSchema> ::const_iterator _iter1749;
+      for (_iter1749 = this->success.begin(); _iter1749 != this->success.end(); ++_iter1749)
       {
-        xfer += (*_iter1747).write(oprot);
+        xfer += (*_iter1749).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5476,14 +5476,14 @@ uint32_t ThriftHiveMetastore_get_fields_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1748;
-            ::apache::thrift::protocol::TType _etype1751;
-            xfer += iprot->readListBegin(_etype1751, _size1748);
-            (*(this->success)).resize(_size1748);
-            uint32_t _i1752;
-            for (_i1752 = 0; _i1752 < _size1748; ++_i1752)
+            uint32_t _size1750;
+            ::apache::thrift::protocol::TType _etype1753;
+            xfer += iprot->readListBegin(_etype1753, _size1750);
+            (*(this->success)).resize(_size1750);
+            uint32_t _i1754;
+            for (_i1754 = 0; _i1754 < _size1750; ++_i1754)
             {
-              xfer += (*(this->success))[_i1752].read(iprot);
+              xfer += (*(this->success))[_i1754].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5669,14 +5669,14 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_result::read(::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1753;
-            ::apache::thrift::protocol::TType _etype1756;
-            xfer += iprot->readListBegin(_etype1756, _size1753);
-            this->success.resize(_size1753);
-            uint32_t _i1757;
-            for (_i1757 = 0; _i1757 < _size1753; ++_i1757)
+            uint32_t _size1755;
+            ::apache::thrift::protocol::TType _etype1758;
+            xfer += iprot->readListBegin(_etype1758, _size1755);
+            this->success.resize(_size1755);
+            uint32_t _i1759;
+            for (_i1759 = 0; _i1759 < _size1755; ++_i1759)
             {
-              xfer += this->success[_i1757].read(iprot);
+              xfer += this->success[_i1759].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -5731,10 +5731,10 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_result::write(:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1758;
-      for (_iter1758 = this->success.begin(); _iter1758 != this->success.end(); ++_iter1758)
+      std::vector<FieldSchema> ::const_iterator _iter1760;
+      for (_iter1760 = this->success.begin(); _iter1760 != this->success.end(); ++_iter1760)
       {
-        xfer += (*_iter1758).write(oprot);
+        xfer += (*_iter1760).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -5787,14 +5787,14 @@ uint32_t ThriftHiveMetastore_get_fields_with_environment_context_presult::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1759;
-            ::apache::thrift::protocol::TType _etype1762;
-            xfer += iprot->readListBegin(_etype1762, _size1759);
-            (*(this->success)).resize(_size1759);
-            uint32_t _i1763;
-            for (_i1763 = 0; _i1763 < _size1759; ++_i1763)
+            uint32_t _size1761;
+            ::apache::thrift::protocol::TType _etype1764;
+            xfer += iprot->readListBegin(_etype1764, _size1761);
+            (*(this->success)).resize(_size1761);
+            uint32_t _i1765;
+            for (_i1765 = 0; _i1765 < _size1761; ++_i1765)
             {
-              xfer += (*(this->success))[_i1763].read(iprot);
+              xfer += (*(this->success))[_i1765].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6211,14 +6211,14 @@ uint32_t ThriftHiveMetastore_get_schema_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1764;
-            ::apache::thrift::protocol::TType _etype1767;
-            xfer += iprot->readListBegin(_etype1767, _size1764);
-            this->success.resize(_size1764);
-            uint32_t _i1768;
-            for (_i1768 = 0; _i1768 < _size1764; ++_i1768)
+            uint32_t _size1766;
+            ::apache::thrift::protocol::TType _etype1769;
+            xfer += iprot->readListBegin(_etype1769, _size1766);
+            this->success.resize(_size1766);
+            uint32_t _i1770;
+            for (_i1770 = 0; _i1770 < _size1766; ++_i1770)
             {
-              xfer += this->success[_i1768].read(iprot);
+              xfer += this->success[_i1770].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6273,10 +6273,10 @@ uint32_t ThriftHiveMetastore_get_schema_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1769;
-      for (_iter1769 = this->success.begin(); _iter1769 != this->success.end(); ++_iter1769)
+      std::vector<FieldSchema> ::const_iterator _iter1771;
+      for (_iter1771 = this->success.begin(); _iter1771 != this->success.end(); ++_iter1771)
       {
-        xfer += (*_iter1769).write(oprot);
+        xfer += (*_iter1771).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -6329,14 +6329,14 @@ uint32_t ThriftHiveMetastore_get_schema_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1770;
-            ::apache::thrift::protocol::TType _etype1773;
-            xfer += iprot->readListBegin(_etype1773, _size1770);
-            (*(this->success)).resize(_size1770);
-            uint32_t _i1774;
-            for (_i1774 = 0; _i1774 < _size1770; ++_i1774)
+            uint32_t _size1772;
+            ::apache::thrift::protocol::TType _etype1775;
+            xfer += iprot->readListBegin(_etype1775, _size1772);
+            (*(this->success)).resize(_size1772);
+            uint32_t _i1776;
+            for (_i1776 = 0; _i1776 < _size1772; ++_i1776)
             {
-              xfer += (*(this->success))[_i1774].read(iprot);
+              xfer += (*(this->success))[_i1776].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6522,14 +6522,14 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_result::read(::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1775;
-            ::apache::thrift::protocol::TType _etype1778;
-            xfer += iprot->readListBegin(_etype1778, _size1775);
-            this->success.resize(_size1775);
-            uint32_t _i1779;
-            for (_i1779 = 0; _i1779 < _size1775; ++_i1779)
+            uint32_t _size1777;
+            ::apache::thrift::protocol::TType _etype1780;
+            xfer += iprot->readListBegin(_etype1780, _size1777);
+            this->success.resize(_size1777);
+            uint32_t _i1781;
+            for (_i1781 = 0; _i1781 < _size1777; ++_i1781)
             {
-              xfer += this->success[_i1779].read(iprot);
+              xfer += this->success[_i1781].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -6584,10 +6584,10 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_result::write(:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<FieldSchema> ::const_iterator _iter1780;
-      for (_iter1780 = this->success.begin(); _iter1780 != this->success.end(); ++_iter1780)
+      std::vector<FieldSchema> ::const_iterator _iter1782;
+      for (_iter1782 = this->success.begin(); _iter1782 != this->success.end(); ++_iter1782)
       {
-        xfer += (*_iter1780).write(oprot);
+        xfer += (*_iter1782).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -6640,14 +6640,14 @@ uint32_t ThriftHiveMetastore_get_schema_with_environment_context_presult::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1781;
-            ::apache::thrift::protocol::TType _etype1784;
-            xfer += iprot->readListBegin(_etype1784, _size1781);
-            (*(this->success)).resize(_size1781);
-            uint32_t _i1785;
-            for (_i1785 = 0; _i1785 < _size1781; ++_i1785)
+            uint32_t _size1783;
+            ::apache::thrift::protocol::TType _etype1786;
+            xfer += iprot->readListBegin(_etype1786, _size1783);
+            (*(this->success)).resize(_size1783);
+            uint32_t _i1787;
+            for (_i1787 = 0; _i1787 < _size1783; ++_i1787)
             {
-              xfer += (*(this->success))[_i1785].read(iprot);
+              xfer += (*(this->success))[_i1787].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7487,14 +7487,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size1786;
-            ::apache::thrift::protocol::TType _etype1789;
-            xfer += iprot->readListBegin(_etype1789, _size1786);
-            this->primaryKeys.resize(_size1786);
-            uint32_t _i1790;
-            for (_i1790 = 0; _i1790 < _size1786; ++_i1790)
+            uint32_t _size1788;
+            ::apache::thrift::protocol::TType _etype1791;
+            xfer += iprot->readListBegin(_etype1791, _size1788);
+            this->primaryKeys.resize(_size1788);
+            uint32_t _i1792;
+            for (_i1792 = 0; _i1792 < _size1788; ++_i1792)
             {
-              xfer += this->primaryKeys[_i1790].read(iprot);
+              xfer += this->primaryKeys[_i1792].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7507,14 +7507,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size1791;
-            ::apache::thrift::protocol::TType _etype1794;
-            xfer += iprot->readListBegin(_etype1794, _size1791);
-            this->foreignKeys.resize(_size1791);
-            uint32_t _i1795;
-            for (_i1795 = 0; _i1795 < _size1791; ++_i1795)
+            uint32_t _size1793;
+            ::apache::thrift::protocol::TType _etype1796;
+            xfer += iprot->readListBegin(_etype1796, _size1793);
+            this->foreignKeys.resize(_size1793);
+            uint32_t _i1797;
+            for (_i1797 = 0; _i1797 < _size1793; ++_i1797)
             {
-              xfer += this->foreignKeys[_i1795].read(iprot);
+              xfer += this->foreignKeys[_i1797].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7527,14 +7527,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size1796;
-            ::apache::thrift::protocol::TType _etype1799;
-            xfer += iprot->readListBegin(_etype1799, _size1796);
-            this->uniqueConstraints.resize(_size1796);
-            uint32_t _i1800;
-            for (_i1800 = 0; _i1800 < _size1796; ++_i1800)
+            uint32_t _size1798;
+            ::apache::thrift::protocol::TType _etype1801;
+            xfer += iprot->readListBegin(_etype1801, _size1798);
+            this->uniqueConstraints.resize(_size1798);
+            uint32_t _i1802;
+            for (_i1802 = 0; _i1802 < _size1798; ++_i1802)
             {
-              xfer += this->uniqueConstraints[_i1800].read(iprot);
+              xfer += this->uniqueConstraints[_i1802].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7547,14 +7547,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size1801;
-            ::apache::thrift::protocol::TType _etype1804;
-            xfer += iprot->readListBegin(_etype1804, _size1801);
-            this->notNullConstraints.resize(_size1801);
-            uint32_t _i1805;
-            for (_i1805 = 0; _i1805 < _size1801; ++_i1805)
+            uint32_t _size1803;
+            ::apache::thrift::protocol::TType _etype1806;
+            xfer += iprot->readListBegin(_etype1806, _size1803);
+            this->notNullConstraints.resize(_size1803);
+            uint32_t _i1807;
+            for (_i1807 = 0; _i1807 < _size1803; ++_i1807)
             {
-              xfer += this->notNullConstraints[_i1805].read(iprot);
+              xfer += this->notNullConstraints[_i1807].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7567,14 +7567,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size1806;
-            ::apache::thrift::protocol::TType _etype1809;
-            xfer += iprot->readListBegin(_etype1809, _size1806);
-            this->defaultConstraints.resize(_size1806);
-            uint32_t _i1810;
-            for (_i1810 = 0; _i1810 < _size1806; ++_i1810)
+            uint32_t _size1808;
+            ::apache::thrift::protocol::TType _etype1811;
+            xfer += iprot->readListBegin(_etype1811, _size1808);
+            this->defaultConstraints.resize(_size1808);
+            uint32_t _i1812;
+            for (_i1812 = 0; _i1812 < _size1808; ++_i1812)
             {
-              xfer += this->defaultConstraints[_i1810].read(iprot);
+              xfer += this->defaultConstraints[_i1812].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7587,14 +7587,14 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size1811;
-            ::apache::thrift::protocol::TType _etype1814;
-            xfer += iprot->readListBegin(_etype1814, _size1811);
-            this->checkConstraints.resize(_size1811);
-            uint32_t _i1815;
-            for (_i1815 = 0; _i1815 < _size1811; ++_i1815)
+            uint32_t _size1813;
+            ::apache::thrift::protocol::TType _etype1816;
+            xfer += iprot->readListBegin(_etype1816, _size1813);
+            this->checkConstraints.resize(_size1813);
+            uint32_t _i1817;
+            for (_i1817 = 0; _i1817 < _size1813; ++_i1817)
             {
-              xfer += this->checkConstraints[_i1815].read(iprot);
+              xfer += this->checkConstraints[_i1817].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -7627,10 +7627,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter1816;
-    for (_iter1816 = this->primaryKeys.begin(); _iter1816 != this->primaryKeys.end(); ++_iter1816)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter1818;
+    for (_iter1818 = this->primaryKeys.begin(); _iter1818 != this->primaryKeys.end(); ++_iter1818)
     {
-      xfer += (*_iter1816).write(oprot);
+      xfer += (*_iter1818).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7639,10 +7639,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter1817;
-    for (_iter1817 = this->foreignKeys.begin(); _iter1817 != this->foreignKeys.end(); ++_iter1817)
+    std::vector<SQLForeignKey> ::const_iterator _iter1819;
+    for (_iter1819 = this->foreignKeys.begin(); _iter1819 != this->foreignKeys.end(); ++_iter1819)
     {
-      xfer += (*_iter1817).write(oprot);
+      xfer += (*_iter1819).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7651,10 +7651,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter1818;
-    for (_iter1818 = this->uniqueConstraints.begin(); _iter1818 != this->uniqueConstraints.end(); ++_iter1818)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter1820;
+    for (_iter1820 = this->uniqueConstraints.begin(); _iter1820 != this->uniqueConstraints.end(); ++_iter1820)
     {
-      xfer += (*_iter1818).write(oprot);
+      xfer += (*_iter1820).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7663,10 +7663,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter1819;
-    for (_iter1819 = this->notNullConstraints.begin(); _iter1819 != this->notNullConstraints.end(); ++_iter1819)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter1821;
+    for (_iter1821 = this->notNullConstraints.begin(); _iter1821 != this->notNullConstraints.end(); ++_iter1821)
     {
-      xfer += (*_iter1819).write(oprot);
+      xfer += (*_iter1821).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7675,10 +7675,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter1820;
-    for (_iter1820 = this->defaultConstraints.begin(); _iter1820 != this->defaultConstraints.end(); ++_iter1820)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter1822;
+    for (_iter1822 = this->defaultConstraints.begin(); _iter1822 != this->defaultConstraints.end(); ++_iter1822)
     {
-      xfer += (*_iter1820).write(oprot);
+      xfer += (*_iter1822).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7687,10 +7687,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_args::write(::apache:
   xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 7);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter1821;
-    for (_iter1821 = this->checkConstraints.begin(); _iter1821 != this->checkConstraints.end(); ++_iter1821)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter1823;
+    for (_iter1823 = this->checkConstraints.begin(); _iter1823 != this->checkConstraints.end(); ++_iter1823)
     {
-      xfer += (*_iter1821).write(oprot);
+      xfer += (*_iter1823).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7718,10 +7718,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->primaryKeys)).size()));
-    std::vector<SQLPrimaryKey> ::const_iterator _iter1822;
-    for (_iter1822 = (*(this->primaryKeys)).begin(); _iter1822 != (*(this->primaryKeys)).end(); ++_iter1822)
+    std::vector<SQLPrimaryKey> ::const_iterator _iter1824;
+    for (_iter1824 = (*(this->primaryKeys)).begin(); _iter1824 != (*(this->primaryKeys)).end(); ++_iter1824)
     {
-      xfer += (*_iter1822).write(oprot);
+      xfer += (*_iter1824).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7730,10 +7730,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->foreignKeys)).size()));
-    std::vector<SQLForeignKey> ::const_iterator _iter1823;
-    for (_iter1823 = (*(this->foreignKeys)).begin(); _iter1823 != (*(this->foreignKeys)).end(); ++_iter1823)
+    std::vector<SQLForeignKey> ::const_iterator _iter1825;
+    for (_iter1825 = (*(this->foreignKeys)).begin(); _iter1825 != (*(this->foreignKeys)).end(); ++_iter1825)
     {
-      xfer += (*_iter1823).write(oprot);
+      xfer += (*_iter1825).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7742,10 +7742,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->uniqueConstraints)).size()));
-    std::vector<SQLUniqueConstraint> ::const_iterator _iter1824;
-    for (_iter1824 = (*(this->uniqueConstraints)).begin(); _iter1824 != (*(this->uniqueConstraints)).end(); ++_iter1824)
+    std::vector<SQLUniqueConstraint> ::const_iterator _iter1826;
+    for (_iter1826 = (*(this->uniqueConstraints)).begin(); _iter1826 != (*(this->uniqueConstraints)).end(); ++_iter1826)
     {
-      xfer += (*_iter1824).write(oprot);
+      xfer += (*_iter1826).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7754,10 +7754,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->notNullConstraints)).size()));
-    std::vector<SQLNotNullConstraint> ::const_iterator _iter1825;
-    for (_iter1825 = (*(this->notNullConstraints)).begin(); _iter1825 != (*(this->notNullConstraints)).end(); ++_iter1825)
+    std::vector<SQLNotNullConstraint> ::const_iterator _iter1827;
+    for (_iter1827 = (*(this->notNullConstraints)).begin(); _iter1827 != (*(this->notNullConstraints)).end(); ++_iter1827)
     {
-      xfer += (*_iter1825).write(oprot);
+      xfer += (*_iter1827).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7766,10 +7766,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->defaultConstraints)).size()));
-    std::vector<SQLDefaultConstraint> ::const_iterator _iter1826;
-    for (_iter1826 = (*(this->defaultConstraints)).begin(); _iter1826 != (*(this->defaultConstraints)).end(); ++_iter1826)
+    std::vector<SQLDefaultConstraint> ::const_iterator _iter1828;
+    for (_iter1828 = (*(this->defaultConstraints)).begin(); _iter1828 != (*(this->defaultConstraints)).end(); ++_iter1828)
     {
-      xfer += (*_iter1826).write(oprot);
+      xfer += (*_iter1828).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -7778,10 +7778,10 @@ uint32_t ThriftHiveMetastore_create_table_with_constraints_pargs::write(::apache
   xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 7);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->checkConstraints)).size()));
-    std::vector<SQLCheckConstraint> ::const_iterator _iter1827;
-    for (_iter1827 = (*(this->checkConstraints)).begin(); _iter1827 != (*(this->checkConstraints)).end(); ++_iter1827)
+    std::vector<SQLCheckConstraint> ::const_iterator _iter1829;
+    for (_iter1829 = (*(this->checkConstraints)).begin(); _iter1829 != (*(this->checkConstraints)).end(); ++_iter1829)
     {
-      xfer += (*_iter1827).write(oprot);
+      xfer += (*_iter1829).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -10196,14 +10196,14 @@ uint32_t ThriftHiveMetastore_truncate_table_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size1828;
-            ::apache::thrift::protocol::TType _etype1831;
-            xfer += iprot->readListBegin(_etype1831, _size1828);
-            this->partNames.resize(_size1828);
-            uint32_t _i1832;
-            for (_i1832 = 0; _i1832 < _size1828; ++_i1832)
+            uint32_t _size1830;
+            ::apache::thrift::protocol::TType _etype1833;
+            xfer += iprot->readListBegin(_etype1833, _size1830);
+            this->partNames.resize(_size1830);
+            uint32_t _i1834;
+            for (_i1834 = 0; _i1834 < _size1830; ++_i1834)
             {
-              xfer += iprot->readString(this->partNames[_i1832]);
+              xfer += iprot->readString(this->partNames[_i1834]);
             }
             xfer += iprot->readListEnd();
           }
@@ -10240,10 +10240,10 @@ uint32_t ThriftHiveMetastore_truncate_table_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-    std::vector<std::string> ::const_iterator _iter1833;
-    for (_iter1833 = this->partNames.begin(); _iter1833 != this->partNames.end(); ++_iter1833)
+    std::vector<std::string> ::const_iterator _iter1835;
+    for (_iter1835 = this->partNames.begin(); _iter1835 != this->partNames.end(); ++_iter1835)
     {
-      xfer += oprot->writeString((*_iter1833));
+      xfer += oprot->writeString((*_iter1835));
     }
     xfer += oprot->writeListEnd();
   }
@@ -10275,10 +10275,10 @@ uint32_t ThriftHiveMetastore_truncate_table_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partNames)).size()));
-    std::vector<std::string> ::const_iterator _iter1834;
-    for (_iter1834 = (*(this->partNames)).begin(); _iter1834 != (*(this->partNames)).end(); ++_iter1834)
+    std::vector<std::string> ::const_iterator _iter1836;
+    for (_iter1836 = (*(this->partNames)).begin(); _iter1836 != (*(this->partNames)).end(); ++_iter1836)
     {
-      xfer += oprot->writeString((*_iter1834));
+      xfer += oprot->writeString((*_iter1836));
     }
     xfer += oprot->writeListEnd();
   }
@@ -10729,14 +10729,14 @@ uint32_t ThriftHiveMetastore_get_tables_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1835;
-            ::apache::thrift::protocol::TType _etype1838;
-            xfer += iprot->readListBegin(_etype1838, _size1835);
-            this->success.resize(_size1835);
-            uint32_t _i1839;
-            for (_i1839 = 0; _i1839 < _size1835; ++_i1839)
+            uint32_t _size1837;
+            ::apache::thrift::protocol::TType _etype1840;
+            xfer += iprot->readListBegin(_etype1840, _size1837);
+            this->success.resize(_size1837);
+            uint32_t _i1841;
+            for (_i1841 = 0; _i1841 < _size1837; ++_i1841)
             {
-              xfer += iprot->readString(this->success[_i1839]);
+              xfer += iprot->readString(this->success[_i1841]);
             }
             xfer += iprot->readListEnd();
           }
@@ -10775,10 +10775,10 @@ uint32_t ThriftHiveMetastore_get_tables_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1840;
-      for (_iter1840 = this->success.begin(); _iter1840 != this->success.end(); ++_iter1840)
+      std::vector<std::string> ::const_iterator _iter1842;
+      for (_iter1842 = this->success.begin(); _iter1842 != this->success.end(); ++_iter1842)
       {
-        xfer += oprot->writeString((*_iter1840));
+        xfer += oprot->writeString((*_iter1842));
       }
       xfer += oprot->writeListEnd();
     }
@@ -10823,14 +10823,14 @@ uint32_t ThriftHiveMetastore_get_tables_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1841;
-            ::apache::thrift::protocol::TType _etype1844;
-            xfer += iprot->readListBegin(_etype1844, _size1841);
-            (*(this->success)).resize(_size1841);
-            uint32_t _i1845;
-            for (_i1845 = 0; _i1845 < _size1841; ++_i1845)
+            uint32_t _size1843;
+            ::apache::thrift::protocol::TType _etype1846;
+            xfer += iprot->readListBegin(_etype1846, _size1843);
+            (*(this->success)).resize(_size1843);
+            uint32_t _i1847;
+            for (_i1847 = 0; _i1847 < _size1843; ++_i1847)
             {
-              xfer += iprot->readString((*(this->success))[_i1845]);
+              xfer += iprot->readString((*(this->success))[_i1847]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11000,14 +11000,14 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_result::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1846;
-            ::apache::thrift::protocol::TType _etype1849;
-            xfer += iprot->readListBegin(_etype1849, _size1846);
-            this->success.resize(_size1846);
-            uint32_t _i1850;
-            for (_i1850 = 0; _i1850 < _size1846; ++_i1850)
+            uint32_t _size1848;
+            ::apache::thrift::protocol::TType _etype1851;
+            xfer += iprot->readListBegin(_etype1851, _size1848);
+            this->success.resize(_size1848);
+            uint32_t _i1852;
+            for (_i1852 = 0; _i1852 < _size1848; ++_i1852)
             {
-              xfer += iprot->readString(this->success[_i1850]);
+              xfer += iprot->readString(this->success[_i1852]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11046,10 +11046,10 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_result::write(::apache::thrift::
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1851;
-      for (_iter1851 = this->success.begin(); _iter1851 != this->success.end(); ++_iter1851)
+      std::vector<std::string> ::const_iterator _iter1853;
+      for (_iter1853 = this->success.begin(); _iter1853 != this->success.end(); ++_iter1853)
       {
-        xfer += oprot->writeString((*_iter1851));
+        xfer += oprot->writeString((*_iter1853));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11094,14 +11094,14 @@ uint32_t ThriftHiveMetastore_get_tables_by_type_presult::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1852;
-            ::apache::thrift::protocol::TType _etype1855;
-            xfer += iprot->readListBegin(_etype1855, _size1852);
-            (*(this->success)).resize(_size1852);
-            uint32_t _i1856;
-            for (_i1856 = 0; _i1856 < _size1852; ++_i1856)
+            uint32_t _size1854;
+            ::apache::thrift::protocol::TType _etype1857;
+            xfer += iprot->readListBegin(_etype1857, _size1854);
+            (*(this->success)).resize(_size1854);
+            uint32_t _i1858;
+            for (_i1858 = 0; _i1858 < _size1854; ++_i1858)
             {
-              xfer += iprot->readString((*(this->success))[_i1856]);
+              xfer += iprot->readString((*(this->success))[_i1858]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11218,14 +11218,14 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_res
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1857;
-            ::apache::thrift::protocol::TType _etype1860;
-            xfer += iprot->readListBegin(_etype1860, _size1857);
-            this->success.resize(_size1857);
-            uint32_t _i1861;
-            for (_i1861 = 0; _i1861 < _size1857; ++_i1861)
+            uint32_t _size1859;
+            ::apache::thrift::protocol::TType _etype1862;
+            xfer += iprot->readListBegin(_etype1862, _size1859);
+            this->success.resize(_size1859);
+            uint32_t _i1863;
+            for (_i1863 = 0; _i1863 < _size1859; ++_i1863)
             {
-              xfer += this->success[_i1861].read(iprot);
+              xfer += this->success[_i1863].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11264,10 +11264,10 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_res
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Table> ::const_iterator _iter1862;
-      for (_iter1862 = this->success.begin(); _iter1862 != this->success.end(); ++_iter1862)
+      std::vector<Table> ::const_iterator _iter1864;
+      for (_iter1864 = this->success.begin(); _iter1864 != this->success.end(); ++_iter1864)
       {
-        xfer += (*_iter1862).write(oprot);
+        xfer += (*_iter1864).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -11312,14 +11312,14 @@ uint32_t ThriftHiveMetastore_get_all_materialized_view_objects_for_rewriting_pre
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1863;
-            ::apache::thrift::protocol::TType _etype1866;
-            xfer += iprot->readListBegin(_etype1866, _size1863);
-            (*(this->success)).resize(_size1863);
-            uint32_t _i1867;
-            for (_i1867 = 0; _i1867 < _size1863; ++_i1867)
+            uint32_t _size1865;
+            ::apache::thrift::protocol::TType _etype1868;
+            xfer += iprot->readListBegin(_etype1868, _size1865);
+            (*(this->success)).resize(_size1865);
+            uint32_t _i1869;
+            for (_i1869 = 0; _i1869 < _size1865; ++_i1869)
             {
-              xfer += (*(this->success))[_i1867].read(iprot);
+              xfer += (*(this->success))[_i1869].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11457,14 +11457,14 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_result::read(:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1868;
-            ::apache::thrift::protocol::TType _etype1871;
-            xfer += iprot->readListBegin(_etype1871, _size1868);
-            this->success.resize(_size1868);
-            uint32_t _i1872;
-            for (_i1872 = 0; _i1872 < _size1868; ++_i1872)
+            uint32_t _size1870;
+            ::apache::thrift::protocol::TType _etype1873;
+            xfer += iprot->readListBegin(_etype1873, _size1870);
+            this->success.resize(_size1870);
+            uint32_t _i1874;
+            for (_i1874 = 0; _i1874 < _size1870; ++_i1874)
             {
-              xfer += iprot->readString(this->success[_i1872]);
+              xfer += iprot->readString(this->success[_i1874]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11503,10 +11503,10 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_result::write(
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1873;
-      for (_iter1873 = this->success.begin(); _iter1873 != this->success.end(); ++_iter1873)
+      std::vector<std::string> ::const_iterator _iter1875;
+      for (_iter1875 = this->success.begin(); _iter1875 != this->success.end(); ++_iter1875)
       {
-        xfer += oprot->writeString((*_iter1873));
+        xfer += oprot->writeString((*_iter1875));
       }
       xfer += oprot->writeListEnd();
     }
@@ -11551,14 +11551,14 @@ uint32_t ThriftHiveMetastore_get_materialized_views_for_rewriting_presult::read(
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1874;
-            ::apache::thrift::protocol::TType _etype1877;
-            xfer += iprot->readListBegin(_etype1877, _size1874);
-            (*(this->success)).resize(_size1874);
-            uint32_t _i1878;
-            for (_i1878 = 0; _i1878 < _size1874; ++_i1878)
+            uint32_t _size1876;
+            ::apache::thrift::protocol::TType _etype1879;
+            xfer += iprot->readListBegin(_etype1879, _size1876);
+            (*(this->success)).resize(_size1876);
+            uint32_t _i1880;
+            for (_i1880 = 0; _i1880 < _size1876; ++_i1880)
             {
-              xfer += iprot->readString((*(this->success))[_i1878]);
+              xfer += iprot->readString((*(this->success))[_i1880]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11633,14 +11633,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tbl_types.clear();
-            uint32_t _size1879;
-            ::apache::thrift::protocol::TType _etype1882;
-            xfer += iprot->readListBegin(_etype1882, _size1879);
-            this->tbl_types.resize(_size1879);
-            uint32_t _i1883;
-            for (_i1883 = 0; _i1883 < _size1879; ++_i1883)
+            uint32_t _size1881;
+            ::apache::thrift::protocol::TType _etype1884;
+            xfer += iprot->readListBegin(_etype1884, _size1881);
+            this->tbl_types.resize(_size1881);
+            uint32_t _i1885;
+            for (_i1885 = 0; _i1885 < _size1881; ++_i1885)
             {
-              xfer += iprot->readString(this->tbl_types[_i1883]);
+              xfer += iprot->readString(this->tbl_types[_i1885]);
             }
             xfer += iprot->readListEnd();
           }
@@ -11677,10 +11677,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("tbl_types", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tbl_types.size()));
-    std::vector<std::string> ::const_iterator _iter1884;
-    for (_iter1884 = this->tbl_types.begin(); _iter1884 != this->tbl_types.end(); ++_iter1884)
+    std::vector<std::string> ::const_iterator _iter1886;
+    for (_iter1886 = this->tbl_types.begin(); _iter1886 != this->tbl_types.end(); ++_iter1886)
     {
-      xfer += oprot->writeString((*_iter1884));
+      xfer += oprot->writeString((*_iter1886));
     }
     xfer += oprot->writeListEnd();
   }
@@ -11712,10 +11712,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("tbl_types", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->tbl_types)).size()));
-    std::vector<std::string> ::const_iterator _iter1885;
-    for (_iter1885 = (*(this->tbl_types)).begin(); _iter1885 != (*(this->tbl_types)).end(); ++_iter1885)
+    std::vector<std::string> ::const_iterator _iter1887;
+    for (_iter1887 = (*(this->tbl_types)).begin(); _iter1887 != (*(this->tbl_types)).end(); ++_iter1887)
     {
-      xfer += oprot->writeString((*_iter1885));
+      xfer += oprot->writeString((*_iter1887));
     }
     xfer += oprot->writeListEnd();
   }
@@ -11756,14 +11756,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1886;
-            ::apache::thrift::protocol::TType _etype1889;
-            xfer += iprot->readListBegin(_etype1889, _size1886);
-            this->success.resize(_size1886);
-            uint32_t _i1890;
-            for (_i1890 = 0; _i1890 < _size1886; ++_i1890)
+            uint32_t _size1888;
+            ::apache::thrift::protocol::TType _etype1891;
+            xfer += iprot->readListBegin(_etype1891, _size1888);
+            this->success.resize(_size1888);
+            uint32_t _i1892;
+            for (_i1892 = 0; _i1892 < _size1888; ++_i1892)
             {
-              xfer += this->success[_i1890].read(iprot);
+              xfer += this->success[_i1892].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11802,10 +11802,10 @@ uint32_t ThriftHiveMetastore_get_table_meta_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<TableMeta> ::const_iterator _iter1891;
-      for (_iter1891 = this->success.begin(); _iter1891 != this->success.end(); ++_iter1891)
+      std::vector<TableMeta> ::const_iterator _iter1893;
+      for (_iter1893 = this->success.begin(); _iter1893 != this->success.end(); ++_iter1893)
       {
-        xfer += (*_iter1891).write(oprot);
+        xfer += (*_iter1893).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -11850,14 +11850,14 @@ uint32_t ThriftHiveMetastore_get_table_meta_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1892;
-            ::apache::thrift::protocol::TType _etype1895;
-            xfer += iprot->readListBegin(_etype1895, _size1892);
-            (*(this->success)).resize(_size1892);
-            uint32_t _i1896;
-            for (_i1896 = 0; _i1896 < _size1892; ++_i1896)
+            uint32_t _size1894;
+            ::apache::thrift::protocol::TType _etype1897;
+            xfer += iprot->readListBegin(_etype1897, _size1894);
+            (*(this->success)).resize(_size1894);
+            uint32_t _i1898;
+            for (_i1898 = 0; _i1898 < _size1894; ++_i1898)
             {
-              xfer += (*(this->success))[_i1896].read(iprot);
+              xfer += (*(this->success))[_i1898].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -11995,14 +11995,14 @@ uint32_t ThriftHiveMetastore_get_all_tables_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1897;
-            ::apache::thrift::protocol::TType _etype1900;
-            xfer += iprot->readListBegin(_etype1900, _size1897);
-            this->success.resize(_size1897);
-            uint32_t _i1901;
-            for (_i1901 = 0; _i1901 < _size1897; ++_i1901)
+            uint32_t _size1899;
+            ::apache::thrift::protocol::TType _etype1902;
+            xfer += iprot->readListBegin(_etype1902, _size1899);
+            this->success.resize(_size1899);
+            uint32_t _i1903;
+            for (_i1903 = 0; _i1903 < _size1899; ++_i1903)
             {
-              xfer += iprot->readString(this->success[_i1901]);
+              xfer += iprot->readString(this->success[_i1903]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12041,10 +12041,10 @@ uint32_t ThriftHiveMetastore_get_all_tables_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1902;
-      for (_iter1902 = this->success.begin(); _iter1902 != this->success.end(); ++_iter1902)
+      std::vector<std::string> ::const_iterator _iter1904;
+      for (_iter1904 = this->success.begin(); _iter1904 != this->success.end(); ++_iter1904)
       {
-        xfer += oprot->writeString((*_iter1902));
+        xfer += oprot->writeString((*_iter1904));
       }
       xfer += oprot->writeListEnd();
     }
@@ -12089,14 +12089,14 @@ uint32_t ThriftHiveMetastore_get_all_tables_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1903;
-            ::apache::thrift::protocol::TType _etype1906;
-            xfer += iprot->readListBegin(_etype1906, _size1903);
-            (*(this->success)).resize(_size1903);
-            uint32_t _i1907;
-            for (_i1907 = 0; _i1907 < _size1903; ++_i1907)
+            uint32_t _size1905;
+            ::apache::thrift::protocol::TType _etype1908;
+            xfer += iprot->readListBegin(_etype1908, _size1905);
+            (*(this->success)).resize(_size1905);
+            uint32_t _i1909;
+            for (_i1909 = 0; _i1909 < _size1905; ++_i1909)
             {
-              xfer += iprot->readString((*(this->success))[_i1907]);
+              xfer += iprot->readString((*(this->success))[_i1909]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12406,14 +12406,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_args::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tbl_names.clear();
-            uint32_t _size1908;
-            ::apache::thrift::protocol::TType _etype1911;
-            xfer += iprot->readListBegin(_etype1911, _size1908);
-            this->tbl_names.resize(_size1908);
-            uint32_t _i1912;
-            for (_i1912 = 0; _i1912 < _size1908; ++_i1912)
+            uint32_t _size1910;
+            ::apache::thrift::protocol::TType _etype1913;
+            xfer += iprot->readListBegin(_etype1913, _size1910);
+            this->tbl_names.resize(_size1910);
+            uint32_t _i1914;
+            for (_i1914 = 0; _i1914 < _size1910; ++_i1914)
             {
-              xfer += iprot->readString(this->tbl_names[_i1912]);
+              xfer += iprot->readString(this->tbl_names[_i1914]);
             }
             xfer += iprot->readListEnd();
           }
@@ -12446,10 +12446,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_args::write(::apache::thr
   xfer += oprot->writeFieldBegin("tbl_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tbl_names.size()));
-    std::vector<std::string> ::const_iterator _iter1913;
-    for (_iter1913 = this->tbl_names.begin(); _iter1913 != this->tbl_names.end(); ++_iter1913)
+    std::vector<std::string> ::const_iterator _iter1915;
+    for (_iter1915 = this->tbl_names.begin(); _iter1915 != this->tbl_names.end(); ++_iter1915)
     {
-      xfer += oprot->writeString((*_iter1913));
+      xfer += oprot->writeString((*_iter1915));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12477,10 +12477,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_pargs::write(::apache::th
   xfer += oprot->writeFieldBegin("tbl_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->tbl_names)).size()));
-    std::vector<std::string> ::const_iterator _iter1914;
-    for (_iter1914 = (*(this->tbl_names)).begin(); _iter1914 != (*(this->tbl_names)).end(); ++_iter1914)
+    std::vector<std::string> ::const_iterator _iter1916;
+    for (_iter1916 = (*(this->tbl_names)).begin(); _iter1916 != (*(this->tbl_names)).end(); ++_iter1916)
     {
-      xfer += oprot->writeString((*_iter1914));
+      xfer += oprot->writeString((*_iter1916));
     }
     xfer += oprot->writeListEnd();
   }
@@ -12521,14 +12521,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1915;
-            ::apache::thrift::protocol::TType _etype1918;
-            xfer += iprot->readListBegin(_etype1918, _size1915);
-            this->success.resize(_size1915);
-            uint32_t _i1919;
-            for (_i1919 = 0; _i1919 < _size1915; ++_i1919)
+            uint32_t _size1917;
+            ::apache::thrift::protocol::TType _etype1920;
+            xfer += iprot->readListBegin(_etype1920, _size1917);
+            this->success.resize(_size1917);
+            uint32_t _i1921;
+            for (_i1921 = 0; _i1921 < _size1917; ++_i1921)
             {
-              xfer += this->success[_i1919].read(iprot);
+              xfer += this->success[_i1921].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12559,10 +12559,10 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Table> ::const_iterator _iter1920;
-      for (_iter1920 = this->success.begin(); _iter1920 != this->success.end(); ++_iter1920)
+      std::vector<Table> ::const_iterator _iter1922;
+      for (_iter1922 = this->success.begin(); _iter1922 != this->success.end(); ++_iter1922)
       {
-        xfer += (*_iter1920).write(oprot);
+        xfer += (*_iter1922).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -12603,14 +12603,14 @@ uint32_t ThriftHiveMetastore_get_table_objects_by_name_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1921;
-            ::apache::thrift::protocol::TType _etype1924;
-            xfer += iprot->readListBegin(_etype1924, _size1921);
-            (*(this->success)).resize(_size1921);
-            uint32_t _i1925;
-            for (_i1925 = 0; _i1925 < _size1921; ++_i1925)
+            uint32_t _size1923;
+            ::apache::thrift::protocol::TType _etype1926;
+            xfer += iprot->readListBegin(_etype1926, _size1923);
+            (*(this->success)).resize(_size1923);
+            uint32_t _i1927;
+            for (_i1927 = 0; _i1927 < _size1923; ++_i1927)
             {
-              xfer += (*(this->success))[_i1925].read(iprot);
+              xfer += (*(this->success))[_i1927].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12740,14 +12740,14 @@ uint32_t ThriftHiveMetastore_get_tables_ext_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1926;
-            ::apache::thrift::protocol::TType _etype1929;
-            xfer += iprot->readListBegin(_etype1929, _size1926);
-            this->success.resize(_size1926);
-            uint32_t _i1930;
-            for (_i1930 = 0; _i1930 < _size1926; ++_i1930)
+            uint32_t _size1928;
+            ::apache::thrift::protocol::TType _etype1931;
+            xfer += iprot->readListBegin(_etype1931, _size1928);
+            this->success.resize(_size1928);
+            uint32_t _i1932;
+            for (_i1932 = 0; _i1932 < _size1928; ++_i1932)
             {
-              xfer += this->success[_i1930].read(iprot);
+              xfer += this->success[_i1932].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -12786,10 +12786,10 @@ uint32_t ThriftHiveMetastore_get_tables_ext_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<ExtendedTableInfo> ::const_iterator _iter1931;
-      for (_iter1931 = this->success.begin(); _iter1931 != this->success.end(); ++_iter1931)
+      std::vector<ExtendedTableInfo> ::const_iterator _iter1933;
+      for (_iter1933 = this->success.begin(); _iter1933 != this->success.end(); ++_iter1933)
       {
-        xfer += (*_iter1931).write(oprot);
+        xfer += (*_iter1933).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -12834,14 +12834,14 @@ uint32_t ThriftHiveMetastore_get_tables_ext_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1932;
-            ::apache::thrift::protocol::TType _etype1935;
-            xfer += iprot->readListBegin(_etype1935, _size1932);
-            (*(this->success)).resize(_size1932);
-            uint32_t _i1936;
-            for (_i1936 = 0; _i1936 < _size1932; ++_i1936)
+            uint32_t _size1934;
+            ::apache::thrift::protocol::TType _etype1937;
+            xfer += iprot->readListBegin(_etype1937, _size1934);
+            (*(this->success)).resize(_size1934);
+            uint32_t _i1938;
+            for (_i1938 = 0; _i1938 < _size1934; ++_i1938)
             {
-              xfer += (*(this->success))[_i1936].read(iprot);
+              xfer += (*(this->success))[_i1938].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -14023,14 +14023,14 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size1937;
-            ::apache::thrift::protocol::TType _etype1940;
-            xfer += iprot->readListBegin(_etype1940, _size1937);
-            this->success.resize(_size1937);
-            uint32_t _i1941;
-            for (_i1941 = 0; _i1941 < _size1937; ++_i1941)
+            uint32_t _size1939;
+            ::apache::thrift::protocol::TType _etype1942;
+            xfer += iprot->readListBegin(_etype1942, _size1939);
+            this->success.resize(_size1939);
+            uint32_t _i1943;
+            for (_i1943 = 0; _i1943 < _size1939; ++_i1943)
             {
-              xfer += iprot->readString(this->success[_i1941]);
+              xfer += iprot->readString(this->success[_i1943]);
             }
             xfer += iprot->readListEnd();
           }
@@ -14085,10 +14085,10 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter1942;
-      for (_iter1942 = this->success.begin(); _iter1942 != this->success.end(); ++_iter1942)
+      std::vector<std::string> ::const_iterator _iter1944;
+      for (_iter1944 = this->success.begin(); _iter1944 != this->success.end(); ++_iter1944)
       {
-        xfer += oprot->writeString((*_iter1942));
+        xfer += oprot->writeString((*_iter1944));
       }
       xfer += oprot->writeListEnd();
     }
@@ -14141,14 +14141,14 @@ uint32_t ThriftHiveMetastore_get_table_names_by_filter_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size1943;
-            ::apache::thrift::protocol::TType _etype1946;
-            xfer += iprot->readListBegin(_etype1946, _size1943);
-            (*(this->success)).resize(_size1943);
-            uint32_t _i1947;
-            for (_i1947 = 0; _i1947 < _size1943; ++_i1947)
+            uint32_t _size1945;
+            ::apache::thrift::protocol::TType _etype1948;
+            xfer += iprot->readListBegin(_etype1948, _size1945);
+            (*(this->success)).resize(_size1945);
+            uint32_t _i1949;
+            for (_i1949 = 0; _i1949 < _size1945; ++_i1949)
             {
-              xfer += iprot->readString((*(this->success))[_i1947]);
+              xfer += iprot->readString((*(this->success))[_i1949]);
             }
             xfer += iprot->readListEnd();
           }
@@ -15709,14 +15709,14 @@ uint32_t ThriftHiveMetastore_add_partitions_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size1948;
-            ::apache::thrift::protocol::TType _etype1951;
-            xfer += iprot->readListBegin(_etype1951, _size1948);
-            this->new_parts.resize(_size1948);
-            uint32_t _i1952;
-            for (_i1952 = 0; _i1952 < _size1948; ++_i1952)
+            uint32_t _size1950;
+            ::apache::thrift::protocol::TType _etype1953;
+            xfer += iprot->readListBegin(_etype1953, _size1950);
+            this->new_parts.resize(_size1950);
+            uint32_t _i1954;
+            for (_i1954 = 0; _i1954 < _size1950; ++_i1954)
             {
-              xfer += this->new_parts[_i1952].read(iprot);
+              xfer += this->new_parts[_i1954].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -15745,10 +15745,10 @@ uint32_t ThriftHiveMetastore_add_partitions_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter1953;
-    for (_iter1953 = this->new_parts.begin(); _iter1953 != this->new_parts.end(); ++_iter1953)
+    std::vector<Partition> ::const_iterator _iter1955;
+    for (_iter1955 = this->new_parts.begin(); _iter1955 != this->new_parts.end(); ++_iter1955)
     {
-      xfer += (*_iter1953).write(oprot);
+      xfer += (*_iter1955).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -15772,10 +15772,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter1954;
-    for (_iter1954 = (*(this->new_parts)).begin(); _iter1954 != (*(this->new_parts)).end(); ++_iter1954)
+    std::vector<Partition> ::const_iterator _iter1956;
+    for (_iter1956 = (*(this->new_parts)).begin(); _iter1956 != (*(this->new_parts)).end(); ++_iter1956)
     {
-      xfer += (*_iter1954).write(oprot);
+      xfer += (*_iter1956).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -15984,14 +15984,14 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_args::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size1955;
-            ::apache::thrift::protocol::TType _etype1958;
-            xfer += iprot->readListBegin(_etype1958, _size1955);
-            this->new_parts.resize(_size1955);
-            uint32_t _i1959;
-            for (_i1959 = 0; _i1959 < _size1955; ++_i1959)
+            uint32_t _size1957;
+            ::apache::thrift::protocol::TType _etype1960;
+            xfer += iprot->readListBegin(_etype1960, _size1957);
+            this->new_parts.resize(_size1957);
+            uint32_t _i1961;
+            for (_i1961 = 0; _i1961 < _size1957; ++_i1961)
             {
-              xfer += this->new_parts[_i1959].read(iprot);
+              xfer += this->new_parts[_i1961].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -16020,10 +16020,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_args::write(::apache::thrift::
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<PartitionSpec> ::const_iterator _iter1960;
-    for (_iter1960 = this->new_parts.begin(); _iter1960 != this->new_parts.end(); ++_iter1960)
+    std::vector<PartitionSpec> ::const_iterator _iter1962;
+    for (_iter1962 = this->new_parts.begin(); _iter1962 != this->new_parts.end(); ++_iter1962)
     {
-      xfer += (*_iter1960).write(oprot);
+      xfer += (*_iter1962).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16047,10 +16047,10 @@ uint32_t ThriftHiveMetastore_add_partitions_pspec_pargs::write(::apache::thrift:
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<PartitionSpec> ::const_iterator _iter1961;
-    for (_iter1961 = (*(this->new_parts)).begin(); _iter1961 != (*(this->new_parts)).end(); ++_iter1961)
+    std::vector<PartitionSpec> ::const_iterator _iter1963;
+    for (_iter1963 = (*(this->new_parts)).begin(); _iter1963 != (*(this->new_parts)).end(); ++_iter1963)
     {
-      xfer += (*_iter1961).write(oprot);
+      xfer += (*_iter1963).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -16275,14 +16275,14 @@ uint32_t ThriftHiveMetastore_append_partition_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size1962;
-            ::apache::thrift::protocol::TType _etype1965;
-            xfer += iprot->readListBegin(_etype1965, _size1962);
-            this->part_vals.resize(_size1962);
-            uint32_t _i1966;
-            for (_i1966 = 0; _i1966 < _size1962; ++_i1966)
+            uint32_t _size1964;
+            ::apache::thrift::protocol::TType _etype1967;
+            xfer += iprot->readListBegin(_etype1967, _size1964);
+            this->part_vals.resize(_size1964);
+            uint32_t _i1968;
+            for (_i1968 = 0; _i1968 < _size1964; ++_i1968)
             {
-              xfer += iprot->readString(this->part_vals[_i1966]);
+              xfer += iprot->readString(this->part_vals[_i1968]);
             }
             xfer += iprot->readListEnd();
           }
@@ -16319,10 +16319,10 @@ uint32_t ThriftHiveMetastore_append_partition_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter1967;
-    for (_iter1967 = this->part_vals.begin(); _iter1967 != this->part_vals.end(); ++_iter1967)
+    std::vector<std::string> ::const_iterator _iter1969;
+    for (_iter1969 = this->part_vals.begin(); _iter1969 != this->part_vals.end(); ++_iter1969)
     {
-      xfer += oprot->writeString((*_iter1967));
+      xfer += oprot->writeString((*_iter1969));
     }
     xfer += oprot->writeListEnd();
   }
@@ -16354,10 +16354,10 @@ uint32_t ThriftHiveMetastore_append_partition_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter1968;
-    for (_iter1968 = (*(this->part_vals)).begin(); _iter1968 != (*(this->part_vals)).end(); ++_iter1968)
+    std::vector<std::string> ::const_iterator _iter1970;
+    for (_iter1970 = (*(this->part_vals)).begin(); _iter1970 != (*(this->part_vals)).end(); ++_iter1970)
     {
-      xfer += oprot->writeString((*_iter1968));
+      xfer += oprot->writeString((*_iter1970));
     }
     xfer += oprot->writeListEnd();
   }
@@ -16829,14 +16829,14 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_args::rea
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size1969;
-            ::apache::thrift::protocol::TType _etype1972;
-            xfer += iprot->readListBegin(_etype1972, _size1969);
-            this->part_vals.resize(_size1969);
-            uint32_t _i1973;
-            for (_i1973 = 0; _i1973 < _size1969; ++_i1973)
+            uint32_t _size1971;
+            ::apache::thrift::protocol::TType _etype1974;
+            xfer += iprot->readListBegin(_etype1974, _size1971);
+            this->part_vals.resize(_size1971);
+            uint32_t _i1975;
+            for (_i1975 = 0; _i1975 < _size1971; ++_i1975)
             {
-              xfer += iprot->readString(this->part_vals[_i1973]);
+              xfer += iprot->readString(this->part_vals[_i1975]);
             }
             xfer += iprot->readListEnd();
           }
@@ -16881,10 +16881,10 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_args::wri
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter1974;
-    for (_iter1974 = this->part_vals.begin(); _iter1974 != this->part_vals.end(); ++_iter1974)
+    std::vector<std::string> ::const_iterator _iter1976;
+    for (_iter1976 = this->part_vals.begin(); _iter1976 != this->part_vals.end(); ++_iter1976)
     {
-      xfer += oprot->writeString((*_iter1974));
+      xfer += oprot->writeString((*_iter1976));
     }
     xfer += oprot->writeListEnd();
   }
@@ -16920,10 +16920,10 @@ uint32_t ThriftHiveMetastore_append_partition_with_environment_context_pargs::wr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter1975;
-    for (_iter1975 = (*(this->part_vals)).begin(); _iter1975 != (*(this->part_vals)).end(); ++_iter1975)
+    std::vector<std::string> ::const_iterator _iter1977;
+    for (_iter1977 = (*(this->part_vals)).begin(); _iter1977 != (*(this->part_vals)).end(); ++_iter1977)
     {
-      xfer += oprot->writeString((*_iter1975));
+      xfer += oprot->writeString((*_iter1977));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17726,14 +17726,14 @@ uint32_t ThriftHiveMetastore_drop_partition_args::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size1976;
-            ::apache::thrift::protocol::TType _etype1979;
-            xfer += iprot->readListBegin(_etype1979, _size1976);
-            this->part_vals.resize(_size1976);
-            uint32_t _i1980;
-            for (_i1980 = 0; _i1980 < _size1976; ++_i1980)
+            uint32_t _size1978;
+            ::apache::thrift::protocol::TType _etype1981;
+            xfer += iprot->readListBegin(_etype1981, _size1978);
+            this->part_vals.resize(_size1978);
+            uint32_t _i1982;
+            for (_i1982 = 0; _i1982 < _size1978; ++_i1982)
             {
-              xfer += iprot->readString(this->part_vals[_i1980]);
+              xfer += iprot->readString(this->part_vals[_i1982]);
             }
             xfer += iprot->readListEnd();
           }
@@ -17778,10 +17778,10 @@ uint32_t ThriftHiveMetastore_drop_partition_args::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter1981;
-    for (_iter1981 = this->part_vals.begin(); _iter1981 != this->part_vals.end(); ++_iter1981)
+    std::vector<std::string> ::const_iterator _iter1983;
+    for (_iter1983 = this->part_vals.begin(); _iter1983 != this->part_vals.end(); ++_iter1983)
     {
-      xfer += oprot->writeString((*_iter1981));
+      xfer += oprot->writeString((*_iter1983));
     }
     xfer += oprot->writeListEnd();
   }
@@ -17817,10 +17817,10 @@ uint32_t ThriftHiveMetastore_drop_partition_pargs::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter1982;
-    for (_iter1982 = (*(this->part_vals)).begin(); _iter1982 != (*(this->part_vals)).end(); ++_iter1982)
+    std::vector<std::string> ::const_iterator _iter1984;
+    for (_iter1984 = (*(this->part_vals)).begin(); _iter1984 != (*(this->part_vals)).end(); ++_iter1984)
     {
-      xfer += oprot->writeString((*_iter1982));
+      xfer += oprot->writeString((*_iter1984));
     }
     xfer += oprot->writeListEnd();
   }
@@ -18029,14 +18029,14 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_args::read(
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size1983;
-            ::apache::thrift::protocol::TType _etype1986;
-            xfer += iprot->readListBegin(_etype1986, _size1983);
-            this->part_vals.resize(_size1983);
-            uint32_t _i1987;
-            for (_i1987 = 0; _i1987 < _size1983; ++_i1987)
+            uint32_t _size1985;
+            ::apache::thrift::protocol::TType _etype1988;
+            xfer += iprot->readListBegin(_etype1988, _size1985);
+            this->part_vals.resize(_size1985);
+            uint32_t _i1989;
+            for (_i1989 = 0; _i1989 < _size1985; ++_i1989)
             {
-              xfer += iprot->readString(this->part_vals[_i1987]);
+              xfer += iprot->readString(this->part_vals[_i1989]);
             }
             xfer += iprot->readListEnd();
           }
@@ -18089,10 +18089,10 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_args::write
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter1988;
-    for (_iter1988 = this->part_vals.begin(); _iter1988 != this->part_vals.end(); ++_iter1988)
+    std::vector<std::string> ::const_iterator _iter1990;
+    for (_iter1990 = this->part_vals.begin(); _iter1990 != this->part_vals.end(); ++_iter1990)
     {
-      xfer += oprot->writeString((*_iter1988));
+      xfer += oprot->writeString((*_iter1990));
     }
     xfer += oprot->writeListEnd();
   }
@@ -18132,10 +18132,10 @@ uint32_t ThriftHiveMetastore_drop_partition_with_environment_context_pargs::writ
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter1989;
-    for (_iter1989 = (*(this->part_vals)).begin(); _iter1989 != (*(this->part_vals)).end(); ++_iter1989)
+    std::vector<std::string> ::const_iterator _iter1991;
+    for (_iter1991 = (*(this->part_vals)).begin(); _iter1991 != (*(this->part_vals)).end(); ++_iter1991)
     {
-      xfer += oprot->writeString((*_iter1989));
+      xfer += oprot->writeString((*_iter1991));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19141,14 +19141,14 @@ uint32_t ThriftHiveMetastore_get_partition_args::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size1990;
-            ::apache::thrift::protocol::TType _etype1993;
-            xfer += iprot->readListBegin(_etype1993, _size1990);
-            this->part_vals.resize(_size1990);
-            uint32_t _i1994;
-            for (_i1994 = 0; _i1994 < _size1990; ++_i1994)
+            uint32_t _size1992;
+            ::apache::thrift::protocol::TType _etype1995;
+            xfer += iprot->readListBegin(_etype1995, _size1992);
+            this->part_vals.resize(_size1992);
+            uint32_t _i1996;
+            for (_i1996 = 0; _i1996 < _size1992; ++_i1996)
             {
-              xfer += iprot->readString(this->part_vals[_i1994]);
+              xfer += iprot->readString(this->part_vals[_i1996]);
             }
             xfer += iprot->readListEnd();
           }
@@ -19185,10 +19185,10 @@ uint32_t ThriftHiveMetastore_get_partition_args::write(::apache::thrift::protoco
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter1995;
-    for (_iter1995 = this->part_vals.begin(); _iter1995 != this->part_vals.end(); ++_iter1995)
+    std::vector<std::string> ::const_iterator _iter1997;
+    for (_iter1997 = this->part_vals.begin(); _iter1997 != this->part_vals.end(); ++_iter1997)
     {
-      xfer += oprot->writeString((*_iter1995));
+      xfer += oprot->writeString((*_iter1997));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19220,10 +19220,10 @@ uint32_t ThriftHiveMetastore_get_partition_pargs::write(::apache::thrift::protoc
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter1996;
-    for (_iter1996 = (*(this->part_vals)).begin(); _iter1996 != (*(this->part_vals)).end(); ++_iter1996)
+    std::vector<std::string> ::const_iterator _iter1998;
+    for (_iter1998 = (*(this->part_vals)).begin(); _iter1998 != (*(this->part_vals)).end(); ++_iter1998)
     {
-      xfer += oprot->writeString((*_iter1996));
+      xfer += oprot->writeString((*_iter1998));
     }
     xfer += oprot->writeListEnd();
   }
@@ -19639,17 +19639,17 @@ uint32_t ThriftHiveMetastore_exchange_partition_args::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->partitionSpecs.clear();
-            uint32_t _size1997;
-            ::apache::thrift::protocol::TType _ktype1998;
-            ::apache::thrift::protocol::TType _vtype1999;
-            xfer += iprot->readMapBegin(_ktype1998, _vtype1999, _size1997);
-            uint32_t _i2001;
-            for (_i2001 = 0; _i2001 < _size1997; ++_i2001)
+            uint32_t _size1999;
+            ::apache::thrift::protocol::TType _ktype2000;
+            ::apache::thrift::protocol::TType _vtype2001;
+            xfer += iprot->readMapBegin(_ktype2000, _vtype2001, _size1999);
+            uint32_t _i2003;
+            for (_i2003 = 0; _i2003 < _size1999; ++_i2003)
             {
-              std::string _key2002;
-              xfer += iprot->readString(_key2002);
-              std::string& _val2003 = this->partitionSpecs[_key2002];
-              xfer += iprot->readString(_val2003);
+              std::string _key2004;
+              xfer += iprot->readString(_key2004);
+              std::string& _val2005 = this->partitionSpecs[_key2004];
+              xfer += iprot->readString(_val2005);
             }
             xfer += iprot->readMapEnd();
           }
@@ -19710,11 +19710,11 @@ uint32_t ThriftHiveMetastore_exchange_partition_args::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionSpecs.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2004;
-    for (_iter2004 = this->partitionSpecs.begin(); _iter2004 != this->partitionSpecs.end(); ++_iter2004)
+    std::map<std::string, std::string> ::const_iterator _iter2006;
+    for (_iter2006 = this->partitionSpecs.begin(); _iter2006 != this->partitionSpecs.end(); ++_iter2006)
     {
-      xfer += oprot->writeString(_iter2004->first);
-      xfer += oprot->writeString(_iter2004->second);
+      xfer += oprot->writeString(_iter2006->first);
+      xfer += oprot->writeString(_iter2006->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -19754,11 +19754,11 @@ uint32_t ThriftHiveMetastore_exchange_partition_pargs::write(::apache::thrift::p
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partitionSpecs)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2005;
-    for (_iter2005 = (*(this->partitionSpecs)).begin(); _iter2005 != (*(this->partitionSpecs)).end(); ++_iter2005)
+    std::map<std::string, std::string> ::const_iterator _iter2007;
+    for (_iter2007 = (*(this->partitionSpecs)).begin(); _iter2007 != (*(this->partitionSpecs)).end(); ++_iter2007)
     {
-      xfer += oprot->writeString(_iter2005->first);
-      xfer += oprot->writeString(_iter2005->second);
+      xfer += oprot->writeString(_iter2007->first);
+      xfer += oprot->writeString(_iter2007->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20003,17 +20003,17 @@ uint32_t ThriftHiveMetastore_exchange_partitions_args::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->partitionSpecs.clear();
-            uint32_t _size2006;
-            ::apache::thrift::protocol::TType _ktype2007;
-            ::apache::thrift::protocol::TType _vtype2008;
-            xfer += iprot->readMapBegin(_ktype2007, _vtype2008, _size2006);
-            uint32_t _i2010;
-            for (_i2010 = 0; _i2010 < _size2006; ++_i2010)
+            uint32_t _size2008;
+            ::apache::thrift::protocol::TType _ktype2009;
+            ::apache::thrift::protocol::TType _vtype2010;
+            xfer += iprot->readMapBegin(_ktype2009, _vtype2010, _size2008);
+            uint32_t _i2012;
+            for (_i2012 = 0; _i2012 < _size2008; ++_i2012)
             {
-              std::string _key2011;
-              xfer += iprot->readString(_key2011);
-              std::string& _val2012 = this->partitionSpecs[_key2011];
-              xfer += iprot->readString(_val2012);
+              std::string _key2013;
+              xfer += iprot->readString(_key2013);
+              std::string& _val2014 = this->partitionSpecs[_key2013];
+              xfer += iprot->readString(_val2014);
             }
             xfer += iprot->readMapEnd();
           }
@@ -20074,11 +20074,11 @@ uint32_t ThriftHiveMetastore_exchange_partitions_args::write(::apache::thrift::p
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionSpecs.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2013;
-    for (_iter2013 = this->partitionSpecs.begin(); _iter2013 != this->partitionSpecs.end(); ++_iter2013)
+    std::map<std::string, std::string> ::const_iterator _iter2015;
+    for (_iter2015 = this->partitionSpecs.begin(); _iter2015 != this->partitionSpecs.end(); ++_iter2015)
     {
-      xfer += oprot->writeString(_iter2013->first);
-      xfer += oprot->writeString(_iter2013->second);
+      xfer += oprot->writeString(_iter2015->first);
+      xfer += oprot->writeString(_iter2015->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20118,11 +20118,11 @@ uint32_t ThriftHiveMetastore_exchange_partitions_pargs::write(::apache::thrift::
   xfer += oprot->writeFieldBegin("partitionSpecs", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->partitionSpecs)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2014;
-    for (_iter2014 = (*(this->partitionSpecs)).begin(); _iter2014 != (*(this->partitionSpecs)).end(); ++_iter2014)
+    std::map<std::string, std::string> ::const_iterator _iter2016;
+    for (_iter2016 = (*(this->partitionSpecs)).begin(); _iter2016 != (*(this->partitionSpecs)).end(); ++_iter2016)
     {
-      xfer += oprot->writeString(_iter2014->first);
-      xfer += oprot->writeString(_iter2014->second);
+      xfer += oprot->writeString(_iter2016->first);
+      xfer += oprot->writeString(_iter2016->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -20179,14 +20179,14 @@ uint32_t ThriftHiveMetastore_exchange_partitions_result::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2015;
-            ::apache::thrift::protocol::TType _etype2018;
-            xfer += iprot->readListBegin(_etype2018, _size2015);
-            this->success.resize(_size2015);
-            uint32_t _i2019;
-            for (_i2019 = 0; _i2019 < _size2015; ++_i2019)
+            uint32_t _size2017;
+            ::apache::thrift::protocol::TType _etype2020;
+            xfer += iprot->readListBegin(_etype2020, _size2017);
+            this->success.resize(_size2017);
+            uint32_t _i2021;
+            for (_i2021 = 0; _i2021 < _size2017; ++_i2021)
             {
-              xfer += this->success[_i2019].read(iprot);
+              xfer += this->success[_i2021].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20249,10 +20249,10 @@ uint32_t ThriftHiveMetastore_exchange_partitions_result::write(::apache::thrift:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2020;
-      for (_iter2020 = this->success.begin(); _iter2020 != this->success.end(); ++_iter2020)
+      std::vector<Partition> ::const_iterator _iter2022;
+      for (_iter2022 = this->success.begin(); _iter2022 != this->success.end(); ++_iter2022)
       {
-        xfer += (*_iter2020).write(oprot);
+        xfer += (*_iter2022).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -20309,14 +20309,14 @@ uint32_t ThriftHiveMetastore_exchange_partitions_presult::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2021;
-            ::apache::thrift::protocol::TType _etype2024;
-            xfer += iprot->readListBegin(_etype2024, _size2021);
-            (*(this->success)).resize(_size2021);
-            uint32_t _i2025;
-            for (_i2025 = 0; _i2025 < _size2021; ++_i2025)
+            uint32_t _size2023;
+            ::apache::thrift::protocol::TType _etype2026;
+            xfer += iprot->readListBegin(_etype2026, _size2023);
+            (*(this->success)).resize(_size2023);
+            uint32_t _i2027;
+            for (_i2027 = 0; _i2027 < _size2023; ++_i2027)
             {
-              xfer += (*(this->success))[_i2025].read(iprot);
+              xfer += (*(this->success))[_i2027].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -20415,14 +20415,14 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2026;
-            ::apache::thrift::protocol::TType _etype2029;
-            xfer += iprot->readListBegin(_etype2029, _size2026);
-            this->part_vals.resize(_size2026);
-            uint32_t _i2030;
-            for (_i2030 = 0; _i2030 < _size2026; ++_i2030)
+            uint32_t _size2028;
+            ::apache::thrift::protocol::TType _etype2031;
+            xfer += iprot->readListBegin(_etype2031, _size2028);
+            this->part_vals.resize(_size2028);
+            uint32_t _i2032;
+            for (_i2032 = 0; _i2032 < _size2028; ++_i2032)
             {
-              xfer += iprot->readString(this->part_vals[_i2030]);
+              xfer += iprot->readString(this->part_vals[_i2032]);
             }
             xfer += iprot->readListEnd();
           }
@@ -20443,14 +20443,14 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2031;
-            ::apache::thrift::protocol::TType _etype2034;
-            xfer += iprot->readListBegin(_etype2034, _size2031);
-            this->group_names.resize(_size2031);
-            uint32_t _i2035;
-            for (_i2035 = 0; _i2035 < _size2031; ++_i2035)
+            uint32_t _size2033;
+            ::apache::thrift::protocol::TType _etype2036;
+            xfer += iprot->readListBegin(_etype2036, _size2033);
+            this->group_names.resize(_size2033);
+            uint32_t _i2037;
+            for (_i2037 = 0; _i2037 < _size2033; ++_i2037)
             {
-              xfer += iprot->readString(this->group_names[_i2035]);
+              xfer += iprot->readString(this->group_names[_i2037]);
             }
             xfer += iprot->readListEnd();
           }
@@ -20487,10 +20487,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2036;
-    for (_iter2036 = this->part_vals.begin(); _iter2036 != this->part_vals.end(); ++_iter2036)
+    std::vector<std::string> ::const_iterator _iter2038;
+    for (_iter2038 = this->part_vals.begin(); _iter2038 != this->part_vals.end(); ++_iter2038)
     {
-      xfer += oprot->writeString((*_iter2036));
+      xfer += oprot->writeString((*_iter2038));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20503,10 +20503,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2037;
-    for (_iter2037 = this->group_names.begin(); _iter2037 != this->group_names.end(); ++_iter2037)
+    std::vector<std::string> ::const_iterator _iter2039;
+    for (_iter2039 = this->group_names.begin(); _iter2039 != this->group_names.end(); ++_iter2039)
     {
-      xfer += oprot->writeString((*_iter2037));
+      xfer += oprot->writeString((*_iter2039));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20538,10 +20538,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2038;
-    for (_iter2038 = (*(this->part_vals)).begin(); _iter2038 != (*(this->part_vals)).end(); ++_iter2038)
+    std::vector<std::string> ::const_iterator _iter2040;
+    for (_iter2040 = (*(this->part_vals)).begin(); _iter2040 != (*(this->part_vals)).end(); ++_iter2040)
     {
-      xfer += oprot->writeString((*_iter2038));
+      xfer += oprot->writeString((*_iter2040));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20554,10 +20554,10 @@ uint32_t ThriftHiveMetastore_get_partition_with_auth_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2039;
-    for (_iter2039 = (*(this->group_names)).begin(); _iter2039 != (*(this->group_names)).end(); ++_iter2039)
+    std::vector<std::string> ::const_iterator _iter2041;
+    for (_iter2041 = (*(this->group_names)).begin(); _iter2041 != (*(this->group_names)).end(); ++_iter2041)
     {
-      xfer += oprot->writeString((*_iter2039));
+      xfer += oprot->writeString((*_iter2041));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21116,14 +21116,14 @@ uint32_t ThriftHiveMetastore_get_partitions_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2040;
-            ::apache::thrift::protocol::TType _etype2043;
-            xfer += iprot->readListBegin(_etype2043, _size2040);
-            this->success.resize(_size2040);
-            uint32_t _i2044;
-            for (_i2044 = 0; _i2044 < _size2040; ++_i2044)
+            uint32_t _size2042;
+            ::apache::thrift::protocol::TType _etype2045;
+            xfer += iprot->readListBegin(_etype2045, _size2042);
+            this->success.resize(_size2042);
+            uint32_t _i2046;
+            for (_i2046 = 0; _i2046 < _size2042; ++_i2046)
             {
-              xfer += this->success[_i2044].read(iprot);
+              xfer += this->success[_i2046].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21170,10 +21170,10 @@ uint32_t ThriftHiveMetastore_get_partitions_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2045;
-      for (_iter2045 = this->success.begin(); _iter2045 != this->success.end(); ++_iter2045)
+      std::vector<Partition> ::const_iterator _iter2047;
+      for (_iter2047 = this->success.begin(); _iter2047 != this->success.end(); ++_iter2047)
       {
-        xfer += (*_iter2045).write(oprot);
+        xfer += (*_iter2047).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -21222,14 +21222,14 @@ uint32_t ThriftHiveMetastore_get_partitions_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2046;
-            ::apache::thrift::protocol::TType _etype2049;
-            xfer += iprot->readListBegin(_etype2049, _size2046);
-            (*(this->success)).resize(_size2046);
-            uint32_t _i2050;
-            for (_i2050 = 0; _i2050 < _size2046; ++_i2050)
+            uint32_t _size2048;
+            ::apache::thrift::protocol::TType _etype2051;
+            xfer += iprot->readListBegin(_etype2051, _size2048);
+            (*(this->success)).resize(_size2048);
+            uint32_t _i2052;
+            for (_i2052 = 0; _i2052 < _size2048; ++_i2052)
             {
-              xfer += (*(this->success))[_i2050].read(iprot);
+              xfer += (*(this->success))[_i2052].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21555,14 +21555,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_args::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2051;
-            ::apache::thrift::protocol::TType _etype2054;
-            xfer += iprot->readListBegin(_etype2054, _size2051);
-            this->group_names.resize(_size2051);
-            uint32_t _i2055;
-            for (_i2055 = 0; _i2055 < _size2051; ++_i2055)
+            uint32_t _size2053;
+            ::apache::thrift::protocol::TType _etype2056;
+            xfer += iprot->readListBegin(_etype2056, _size2053);
+            this->group_names.resize(_size2053);
+            uint32_t _i2057;
+            for (_i2057 = 0; _i2057 < _size2053; ++_i2057)
             {
-              xfer += iprot->readString(this->group_names[_i2055]);
+              xfer += iprot->readString(this->group_names[_i2057]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21607,10 +21607,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_args::write(::apache::thri
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2056;
-    for (_iter2056 = this->group_names.begin(); _iter2056 != this->group_names.end(); ++_iter2056)
+    std::vector<std::string> ::const_iterator _iter2058;
+    for (_iter2058 = this->group_names.begin(); _iter2058 != this->group_names.end(); ++_iter2058)
     {
-      xfer += oprot->writeString((*_iter2056));
+      xfer += oprot->writeString((*_iter2058));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21650,10 +21650,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_pargs::write(::apache::thr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2057;
-    for (_iter2057 = (*(this->group_names)).begin(); _iter2057 != (*(this->group_names)).end(); ++_iter2057)
+    std::vector<std::string> ::const_iterator _iter2059;
+    for (_iter2059 = (*(this->group_names)).begin(); _iter2059 != (*(this->group_names)).end(); ++_iter2059)
     {
-      xfer += oprot->writeString((*_iter2057));
+      xfer += oprot->writeString((*_iter2059));
     }
     xfer += oprot->writeListEnd();
   }
@@ -21694,14 +21694,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2058;
-            ::apache::thrift::protocol::TType _etype2061;
-            xfer += iprot->readListBegin(_etype2061, _size2058);
-            this->success.resize(_size2058);
-            uint32_t _i2062;
-            for (_i2062 = 0; _i2062 < _size2058; ++_i2062)
+            uint32_t _size2060;
+            ::apache::thrift::protocol::TType _etype2063;
+            xfer += iprot->readListBegin(_etype2063, _size2060);
+            this->success.resize(_size2060);
+            uint32_t _i2064;
+            for (_i2064 = 0; _i2064 < _size2060; ++_i2064)
             {
-              xfer += this->success[_i2062].read(iprot);
+              xfer += this->success[_i2064].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21748,10 +21748,10 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2063;
-      for (_iter2063 = this->success.begin(); _iter2063 != this->success.end(); ++_iter2063)
+      std::vector<Partition> ::const_iterator _iter2065;
+      for (_iter2065 = this->success.begin(); _iter2065 != this->success.end(); ++_iter2065)
       {
-        xfer += (*_iter2063).write(oprot);
+        xfer += (*_iter2065).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -21800,14 +21800,14 @@ uint32_t ThriftHiveMetastore_get_partitions_with_auth_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2064;
-            ::apache::thrift::protocol::TType _etype2067;
-            xfer += iprot->readListBegin(_etype2067, _size2064);
-            (*(this->success)).resize(_size2064);
-            uint32_t _i2068;
-            for (_i2068 = 0; _i2068 < _size2064; ++_i2068)
+            uint32_t _size2066;
+            ::apache::thrift::protocol::TType _etype2069;
+            xfer += iprot->readListBegin(_etype2069, _size2066);
+            (*(this->success)).resize(_size2066);
+            uint32_t _i2070;
+            for (_i2070 = 0; _i2070 < _size2066; ++_i2070)
             {
-              xfer += (*(this->success))[_i2068].read(iprot);
+              xfer += (*(this->success))[_i2070].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21985,14 +21985,14 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_result::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2069;
-            ::apache::thrift::protocol::TType _etype2072;
-            xfer += iprot->readListBegin(_etype2072, _size2069);
-            this->success.resize(_size2069);
-            uint32_t _i2073;
-            for (_i2073 = 0; _i2073 < _size2069; ++_i2073)
+            uint32_t _size2071;
+            ::apache::thrift::protocol::TType _etype2074;
+            xfer += iprot->readListBegin(_etype2074, _size2071);
+            this->success.resize(_size2071);
+            uint32_t _i2075;
+            for (_i2075 = 0; _i2075 < _size2071; ++_i2075)
             {
-              xfer += this->success[_i2073].read(iprot);
+              xfer += this->success[_i2075].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22039,10 +22039,10 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_result::write(::apache::thrift
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<PartitionSpec> ::const_iterator _iter2074;
-      for (_iter2074 = this->success.begin(); _iter2074 != this->success.end(); ++_iter2074)
+      std::vector<PartitionSpec> ::const_iterator _iter2076;
+      for (_iter2076 = this->success.begin(); _iter2076 != this->success.end(); ++_iter2076)
       {
-        xfer += (*_iter2074).write(oprot);
+        xfer += (*_iter2076).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22091,14 +22091,14 @@ uint32_t ThriftHiveMetastore_get_partitions_pspec_presult::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2075;
-            ::apache::thrift::protocol::TType _etype2078;
-            xfer += iprot->readListBegin(_etype2078, _size2075);
-            (*(this->success)).resize(_size2075);
-            uint32_t _i2079;
-            for (_i2079 = 0; _i2079 < _size2075; ++_i2079)
+            uint32_t _size2077;
+            ::apache::thrift::protocol::TType _etype2080;
+            xfer += iprot->readListBegin(_etype2080, _size2077);
+            (*(this->success)).resize(_size2077);
+            uint32_t _i2081;
+            for (_i2081 = 0; _i2081 < _size2077; ++_i2081)
             {
-              xfer += (*(this->success))[_i2079].read(iprot);
+              xfer += (*(this->success))[_i2081].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22276,14 +22276,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_result::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2080;
-            ::apache::thrift::protocol::TType _etype2083;
-            xfer += iprot->readListBegin(_etype2083, _size2080);
-            this->success.resize(_size2080);
-            uint32_t _i2084;
-            for (_i2084 = 0; _i2084 < _size2080; ++_i2084)
+            uint32_t _size2082;
+            ::apache::thrift::protocol::TType _etype2085;
+            xfer += iprot->readListBegin(_etype2085, _size2082);
+            this->success.resize(_size2082);
+            uint32_t _i2086;
+            for (_i2086 = 0; _i2086 < _size2082; ++_i2086)
             {
-              xfer += iprot->readString(this->success[_i2084]);
+              xfer += iprot->readString(this->success[_i2086]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22330,10 +22330,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_result::write(::apache::thrift:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2085;
-      for (_iter2085 = this->success.begin(); _iter2085 != this->success.end(); ++_iter2085)
+      std::vector<std::string> ::const_iterator _iter2087;
+      for (_iter2087 = this->success.begin(); _iter2087 != this->success.end(); ++_iter2087)
       {
-        xfer += oprot->writeString((*_iter2085));
+        xfer += oprot->writeString((*_iter2087));
       }
       xfer += oprot->writeListEnd();
     }
@@ -22382,14 +22382,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_presult::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2086;
-            ::apache::thrift::protocol::TType _etype2089;
-            xfer += iprot->readListBegin(_etype2089, _size2086);
-            (*(this->success)).resize(_size2086);
-            uint32_t _i2090;
-            for (_i2090 = 0; _i2090 < _size2086; ++_i2090)
+            uint32_t _size2088;
+            ::apache::thrift::protocol::TType _etype2091;
+            xfer += iprot->readListBegin(_etype2091, _size2088);
+            (*(this->success)).resize(_size2088);
+            uint32_t _i2092;
+            for (_i2092 = 0; _i2092 < _size2088; ++_i2092)
             {
-              xfer += iprot->readString((*(this->success))[_i2090]);
+              xfer += iprot->readString((*(this->success))[_i2092]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22699,14 +22699,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_args::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2091;
-            ::apache::thrift::protocol::TType _etype2094;
-            xfer += iprot->readListBegin(_etype2094, _size2091);
-            this->part_vals.resize(_size2091);
-            uint32_t _i2095;
-            for (_i2095 = 0; _i2095 < _size2091; ++_i2095)
+            uint32_t _size2093;
+            ::apache::thrift::protocol::TType _etype2096;
+            xfer += iprot->readListBegin(_etype2096, _size2093);
+            this->part_vals.resize(_size2093);
+            uint32_t _i2097;
+            for (_i2097 = 0; _i2097 < _size2093; ++_i2097)
             {
-              xfer += iprot->readString(this->part_vals[_i2095]);
+              xfer += iprot->readString(this->part_vals[_i2097]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22751,10 +22751,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_args::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2096;
-    for (_iter2096 = this->part_vals.begin(); _iter2096 != this->part_vals.end(); ++_iter2096)
+    std::vector<std::string> ::const_iterator _iter2098;
+    for (_iter2098 = this->part_vals.begin(); _iter2098 != this->part_vals.end(); ++_iter2098)
     {
-      xfer += oprot->writeString((*_iter2096));
+      xfer += oprot->writeString((*_iter2098));
     }
     xfer += oprot->writeListEnd();
   }
@@ -22790,10 +22790,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_pargs::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2097;
-    for (_iter2097 = (*(this->part_vals)).begin(); _iter2097 != (*(this->part_vals)).end(); ++_iter2097)
+    std::vector<std::string> ::const_iterator _iter2099;
+    for (_iter2099 = (*(this->part_vals)).begin(); _iter2099 != (*(this->part_vals)).end(); ++_iter2099)
     {
-      xfer += oprot->writeString((*_iter2097));
+      xfer += oprot->writeString((*_iter2099));
     }
     xfer += oprot->writeListEnd();
   }
@@ -22838,14 +22838,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2098;
-            ::apache::thrift::protocol::TType _etype2101;
-            xfer += iprot->readListBegin(_etype2101, _size2098);
-            this->success.resize(_size2098);
-            uint32_t _i2102;
-            for (_i2102 = 0; _i2102 < _size2098; ++_i2102)
+            uint32_t _size2100;
+            ::apache::thrift::protocol::TType _etype2103;
+            xfer += iprot->readListBegin(_etype2103, _size2100);
+            this->success.resize(_size2100);
+            uint32_t _i2104;
+            for (_i2104 = 0; _i2104 < _size2100; ++_i2104)
             {
-              xfer += this->success[_i2102].read(iprot);
+              xfer += this->success[_i2104].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22892,10 +22892,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2103;
-      for (_iter2103 = this->success.begin(); _iter2103 != this->success.end(); ++_iter2103)
+      std::vector<Partition> ::const_iterator _iter2105;
+      for (_iter2105 = this->success.begin(); _iter2105 != this->success.end(); ++_iter2105)
       {
-        xfer += (*_iter2103).write(oprot);
+        xfer += (*_iter2105).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22944,14 +22944,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2104;
-            ::apache::thrift::protocol::TType _etype2107;
-            xfer += iprot->readListBegin(_etype2107, _size2104);
-            (*(this->success)).resize(_size2104);
-            uint32_t _i2108;
-            for (_i2108 = 0; _i2108 < _size2104; ++_i2108)
+            uint32_t _size2106;
+            ::apache::thrift::protocol::TType _etype2109;
+            xfer += iprot->readListBegin(_etype2109, _size2106);
+            (*(this->success)).resize(_size2106);
+            uint32_t _i2110;
+            for (_i2110 = 0; _i2110 < _size2106; ++_i2110)
             {
-              xfer += (*(this->success))[_i2108].read(iprot);
+              xfer += (*(this->success))[_i2110].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23034,14 +23034,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2109;
-            ::apache::thrift::protocol::TType _etype2112;
-            xfer += iprot->readListBegin(_etype2112, _size2109);
-            this->part_vals.resize(_size2109);
-            uint32_t _i2113;
-            for (_i2113 = 0; _i2113 < _size2109; ++_i2113)
+            uint32_t _size2111;
+            ::apache::thrift::protocol::TType _etype2114;
+            xfer += iprot->readListBegin(_etype2114, _size2111);
+            this->part_vals.resize(_size2111);
+            uint32_t _i2115;
+            for (_i2115 = 0; _i2115 < _size2111; ++_i2115)
             {
-              xfer += iprot->readString(this->part_vals[_i2113]);
+              xfer += iprot->readString(this->part_vals[_i2115]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23070,14 +23070,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2114;
-            ::apache::thrift::protocol::TType _etype2117;
-            xfer += iprot->readListBegin(_etype2117, _size2114);
-            this->group_names.resize(_size2114);
-            uint32_t _i2118;
-            for (_i2118 = 0; _i2118 < _size2114; ++_i2118)
+            uint32_t _size2116;
+            ::apache::thrift::protocol::TType _etype2119;
+            xfer += iprot->readListBegin(_etype2119, _size2116);
+            this->group_names.resize(_size2116);
+            uint32_t _i2120;
+            for (_i2120 = 0; _i2120 < _size2116; ++_i2120)
             {
-              xfer += iprot->readString(this->group_names[_i2118]);
+              xfer += iprot->readString(this->group_names[_i2120]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23114,10 +23114,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::write(::apache::t
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2119;
-    for (_iter2119 = this->part_vals.begin(); _iter2119 != this->part_vals.end(); ++_iter2119)
+    std::vector<std::string> ::const_iterator _iter2121;
+    for (_iter2121 = this->part_vals.begin(); _iter2121 != this->part_vals.end(); ++_iter2121)
     {
-      xfer += oprot->writeString((*_iter2119));
+      xfer += oprot->writeString((*_iter2121));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23134,10 +23134,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_args::write(::apache::t
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2120;
-    for (_iter2120 = this->group_names.begin(); _iter2120 != this->group_names.end(); ++_iter2120)
+    std::vector<std::string> ::const_iterator _iter2122;
+    for (_iter2122 = this->group_names.begin(); _iter2122 != this->group_names.end(); ++_iter2122)
     {
-      xfer += oprot->writeString((*_iter2120));
+      xfer += oprot->writeString((*_iter2122));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23169,10 +23169,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_pargs::write(::apache::
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2121;
-    for (_iter2121 = (*(this->part_vals)).begin(); _iter2121 != (*(this->part_vals)).end(); ++_iter2121)
+    std::vector<std::string> ::const_iterator _iter2123;
+    for (_iter2123 = (*(this->part_vals)).begin(); _iter2123 != (*(this->part_vals)).end(); ++_iter2123)
     {
-      xfer += oprot->writeString((*_iter2121));
+      xfer += oprot->writeString((*_iter2123));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23189,10 +23189,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_pargs::write(::apache::
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 6);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2122;
-    for (_iter2122 = (*(this->group_names)).begin(); _iter2122 != (*(this->group_names)).end(); ++_iter2122)
+    std::vector<std::string> ::const_iterator _iter2124;
+    for (_iter2124 = (*(this->group_names)).begin(); _iter2124 != (*(this->group_names)).end(); ++_iter2124)
     {
-      xfer += oprot->writeString((*_iter2122));
+      xfer += oprot->writeString((*_iter2124));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23233,14 +23233,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_result::read(::apache::
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2123;
-            ::apache::thrift::protocol::TType _etype2126;
-            xfer += iprot->readListBegin(_etype2126, _size2123);
-            this->success.resize(_size2123);
-            uint32_t _i2127;
-            for (_i2127 = 0; _i2127 < _size2123; ++_i2127)
+            uint32_t _size2125;
+            ::apache::thrift::protocol::TType _etype2128;
+            xfer += iprot->readListBegin(_etype2128, _size2125);
+            this->success.resize(_size2125);
+            uint32_t _i2129;
+            for (_i2129 = 0; _i2129 < _size2125; ++_i2129)
             {
-              xfer += this->success[_i2127].read(iprot);
+              xfer += this->success[_i2129].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23287,10 +23287,10 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_result::write(::apache:
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2128;
-      for (_iter2128 = this->success.begin(); _iter2128 != this->success.end(); ++_iter2128)
+      std::vector<Partition> ::const_iterator _iter2130;
+      for (_iter2130 = this->success.begin(); _iter2130 != this->success.end(); ++_iter2130)
       {
-        xfer += (*_iter2128).write(oprot);
+        xfer += (*_iter2130).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -23339,14 +23339,14 @@ uint32_t ThriftHiveMetastore_get_partitions_ps_with_auth_presult::read(::apache:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2129;
-            ::apache::thrift::protocol::TType _etype2132;
-            xfer += iprot->readListBegin(_etype2132, _size2129);
-            (*(this->success)).resize(_size2129);
-            uint32_t _i2133;
-            for (_i2133 = 0; _i2133 < _size2129; ++_i2133)
+            uint32_t _size2131;
+            ::apache::thrift::protocol::TType _etype2134;
+            xfer += iprot->readListBegin(_etype2134, _size2131);
+            (*(this->success)).resize(_size2131);
+            uint32_t _i2135;
+            for (_i2135 = 0; _i2135 < _size2131; ++_i2135)
             {
-              xfer += (*(this->success))[_i2133].read(iprot);
+              xfer += (*(this->success))[_i2135].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23656,14 +23656,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_args::read(::apache::thrift:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2134;
-            ::apache::thrift::protocol::TType _etype2137;
-            xfer += iprot->readListBegin(_etype2137, _size2134);
-            this->part_vals.resize(_size2134);
-            uint32_t _i2138;
-            for (_i2138 = 0; _i2138 < _size2134; ++_i2138)
+            uint32_t _size2136;
+            ::apache::thrift::protocol::TType _etype2139;
+            xfer += iprot->readListBegin(_etype2139, _size2136);
+            this->part_vals.resize(_size2136);
+            uint32_t _i2140;
+            for (_i2140 = 0; _i2140 < _size2136; ++_i2140)
             {
-              xfer += iprot->readString(this->part_vals[_i2138]);
+              xfer += iprot->readString(this->part_vals[_i2140]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23708,10 +23708,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_args::write(::apache::thrift
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2139;
-    for (_iter2139 = this->part_vals.begin(); _iter2139 != this->part_vals.end(); ++_iter2139)
+    std::vector<std::string> ::const_iterator _iter2141;
+    for (_iter2141 = this->part_vals.begin(); _iter2141 != this->part_vals.end(); ++_iter2141)
     {
-      xfer += oprot->writeString((*_iter2139));
+      xfer += oprot->writeString((*_iter2141));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23747,10 +23747,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_pargs::write(::apache::thrif
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2140;
-    for (_iter2140 = (*(this->part_vals)).begin(); _iter2140 != (*(this->part_vals)).end(); ++_iter2140)
+    std::vector<std::string> ::const_iterator _iter2142;
+    for (_iter2142 = (*(this->part_vals)).begin(); _iter2142 != (*(this->part_vals)).end(); ++_iter2142)
     {
-      xfer += oprot->writeString((*_iter2140));
+      xfer += oprot->writeString((*_iter2142));
     }
     xfer += oprot->writeListEnd();
   }
@@ -23795,14 +23795,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2141;
-            ::apache::thrift::protocol::TType _etype2144;
-            xfer += iprot->readListBegin(_etype2144, _size2141);
-            this->success.resize(_size2141);
-            uint32_t _i2145;
-            for (_i2145 = 0; _i2145 < _size2141; ++_i2145)
+            uint32_t _size2143;
+            ::apache::thrift::protocol::TType _etype2146;
+            xfer += iprot->readListBegin(_etype2146, _size2143);
+            this->success.resize(_size2143);
+            uint32_t _i2147;
+            for (_i2147 = 0; _i2147 < _size2143; ++_i2147)
             {
-              xfer += iprot->readString(this->success[_i2145]);
+              xfer += iprot->readString(this->success[_i2147]);
             }
             xfer += iprot->readListEnd();
           }
@@ -23849,10 +23849,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2146;
-      for (_iter2146 = this->success.begin(); _iter2146 != this->success.end(); ++_iter2146)
+      std::vector<std::string> ::const_iterator _iter2148;
+      for (_iter2148 = this->success.begin(); _iter2148 != this->success.end(); ++_iter2148)
       {
-        xfer += oprot->writeString((*_iter2146));
+        xfer += oprot->writeString((*_iter2148));
       }
       xfer += oprot->writeListEnd();
     }
@@ -23901,14 +23901,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_ps_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2147;
-            ::apache::thrift::protocol::TType _etype2150;
-            xfer += iprot->readListBegin(_etype2150, _size2147);
-            (*(this->success)).resize(_size2147);
-            uint32_t _i2151;
-            for (_i2151 = 0; _i2151 < _size2147; ++_i2151)
+            uint32_t _size2149;
+            ::apache::thrift::protocol::TType _etype2152;
+            xfer += iprot->readListBegin(_etype2152, _size2149);
+            (*(this->success)).resize(_size2149);
+            uint32_t _i2153;
+            for (_i2153 = 0; _i2153 < _size2149; ++_i2153)
             {
-              xfer += iprot->readString((*(this->success))[_i2151]);
+              xfer += iprot->readString((*(this->success))[_i2153]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24281,14 +24281,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2152;
-            ::apache::thrift::protocol::TType _etype2155;
-            xfer += iprot->readListBegin(_etype2155, _size2152);
-            this->success.resize(_size2152);
-            uint32_t _i2156;
-            for (_i2156 = 0; _i2156 < _size2152; ++_i2156)
+            uint32_t _size2154;
+            ::apache::thrift::protocol::TType _etype2157;
+            xfer += iprot->readListBegin(_etype2157, _size2154);
+            this->success.resize(_size2154);
+            uint32_t _i2158;
+            for (_i2158 = 0; _i2158 < _size2154; ++_i2158)
             {
-              xfer += iprot->readString(this->success[_i2156]);
+              xfer += iprot->readString(this->success[_i2158]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24335,10 +24335,10 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2157;
-      for (_iter2157 = this->success.begin(); _iter2157 != this->success.end(); ++_iter2157)
+      std::vector<std::string> ::const_iterator _iter2159;
+      for (_iter2159 = this->success.begin(); _iter2159 != this->success.end(); ++_iter2159)
       {
-        xfer += oprot->writeString((*_iter2157));
+        xfer += oprot->writeString((*_iter2159));
       }
       xfer += oprot->writeListEnd();
     }
@@ -24387,14 +24387,14 @@ uint32_t ThriftHiveMetastore_get_partition_names_req_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2158;
-            ::apache::thrift::protocol::TType _etype2161;
-            xfer += iprot->readListBegin(_etype2161, _size2158);
-            (*(this->success)).resize(_size2158);
-            uint32_t _i2162;
-            for (_i2162 = 0; _i2162 < _size2158; ++_i2162)
+            uint32_t _size2160;
+            ::apache::thrift::protocol::TType _etype2163;
+            xfer += iprot->readListBegin(_etype2163, _size2160);
+            (*(this->success)).resize(_size2160);
+            uint32_t _i2164;
+            for (_i2164 = 0; _i2164 < _size2160; ++_i2164)
             {
-              xfer += iprot->readString((*(this->success))[_i2162]);
+              xfer += iprot->readString((*(this->success))[_i2164]);
             }
             xfer += iprot->readListEnd();
           }
@@ -24588,14 +24588,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2163;
-            ::apache::thrift::protocol::TType _etype2166;
-            xfer += iprot->readListBegin(_etype2166, _size2163);
-            this->success.resize(_size2163);
-            uint32_t _i2167;
-            for (_i2167 = 0; _i2167 < _size2163; ++_i2167)
+            uint32_t _size2165;
+            ::apache::thrift::protocol::TType _etype2168;
+            xfer += iprot->readListBegin(_etype2168, _size2165);
+            this->success.resize(_size2165);
+            uint32_t _i2169;
+            for (_i2169 = 0; _i2169 < _size2165; ++_i2169)
             {
-              xfer += this->success[_i2167].read(iprot);
+              xfer += this->success[_i2169].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24642,10 +24642,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2168;
-      for (_iter2168 = this->success.begin(); _iter2168 != this->success.end(); ++_iter2168)
+      std::vector<Partition> ::const_iterator _iter2170;
+      for (_iter2170 = this->success.begin(); _iter2170 != this->success.end(); ++_iter2170)
       {
-        xfer += (*_iter2168).write(oprot);
+        xfer += (*_iter2170).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -24694,14 +24694,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_filter_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2169;
-            ::apache::thrift::protocol::TType _etype2172;
-            xfer += iprot->readListBegin(_etype2172, _size2169);
-            (*(this->success)).resize(_size2169);
-            uint32_t _i2173;
-            for (_i2173 = 0; _i2173 < _size2169; ++_i2173)
+            uint32_t _size2171;
+            ::apache::thrift::protocol::TType _etype2174;
+            xfer += iprot->readListBegin(_etype2174, _size2171);
+            (*(this->success)).resize(_size2171);
+            uint32_t _i2175;
+            for (_i2175 = 0; _i2175 < _size2171; ++_i2175)
             {
-              xfer += (*(this->success))[_i2173].read(iprot);
+              xfer += (*(this->success))[_i2175].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24895,14 +24895,14 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_result::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2174;
-            ::apache::thrift::protocol::TType _etype2177;
-            xfer += iprot->readListBegin(_etype2177, _size2174);
-            this->success.resize(_size2174);
-            uint32_t _i2178;
-            for (_i2178 = 0; _i2178 < _size2174; ++_i2178)
+            uint32_t _size2176;
+            ::apache::thrift::protocol::TType _etype2179;
+            xfer += iprot->readListBegin(_etype2179, _size2176);
+            this->success.resize(_size2176);
+            uint32_t _i2180;
+            for (_i2180 = 0; _i2180 < _size2176; ++_i2180)
             {
-              xfer += this->success[_i2178].read(iprot);
+              xfer += this->success[_i2180].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24949,10 +24949,10 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_result::write(::apache::th
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<PartitionSpec> ::const_iterator _iter2179;
-      for (_iter2179 = this->success.begin(); _iter2179 != this->success.end(); ++_iter2179)
+      std::vector<PartitionSpec> ::const_iterator _iter2181;
+      for (_iter2181 = this->success.begin(); _iter2181 != this->success.end(); ++_iter2181)
       {
-        xfer += (*_iter2179).write(oprot);
+        xfer += (*_iter2181).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -25001,14 +25001,14 @@ uint32_t ThriftHiveMetastore_get_part_specs_by_filter_presult::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2180;
-            ::apache::thrift::protocol::TType _etype2183;
-            xfer += iprot->readListBegin(_etype2183, _size2180);
-            (*(this->success)).resize(_size2180);
-            uint32_t _i2184;
-            for (_i2184 = 0; _i2184 < _size2180; ++_i2184)
+            uint32_t _size2182;
+            ::apache::thrift::protocol::TType _etype2185;
+            xfer += iprot->readListBegin(_etype2185, _size2182);
+            (*(this->success)).resize(_size2182);
+            uint32_t _i2186;
+            for (_i2186 = 0; _i2186 < _size2182; ++_i2186)
             {
-              xfer += (*(this->success))[_i2184].read(iprot);
+              xfer += (*(this->success))[_i2186].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -25804,14 +25804,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_args::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size2185;
-            ::apache::thrift::protocol::TType _etype2188;
-            xfer += iprot->readListBegin(_etype2188, _size2185);
-            this->names.resize(_size2185);
-            uint32_t _i2189;
-            for (_i2189 = 0; _i2189 < _size2185; ++_i2189)
+            uint32_t _size2187;
+            ::apache::thrift::protocol::TType _etype2190;
+            xfer += iprot->readListBegin(_etype2190, _size2187);
+            this->names.resize(_size2187);
+            uint32_t _i2191;
+            for (_i2191 = 0; _i2191 < _size2187; ++_i2191)
             {
-              xfer += iprot->readString(this->names[_i2189]);
+              xfer += iprot->readString(this->names[_i2191]);
             }
             xfer += iprot->readListEnd();
           }
@@ -25848,10 +25848,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_args::write(::apache::thrif
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-    std::vector<std::string> ::const_iterator _iter2190;
-    for (_iter2190 = this->names.begin(); _iter2190 != this->names.end(); ++_iter2190)
+    std::vector<std::string> ::const_iterator _iter2192;
+    for (_iter2192 = this->names.begin(); _iter2192 != this->names.end(); ++_iter2192)
     {
-      xfer += oprot->writeString((*_iter2190));
+      xfer += oprot->writeString((*_iter2192));
     }
     xfer += oprot->writeListEnd();
   }
@@ -25883,10 +25883,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_pargs::write(::apache::thri
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->names)).size()));
-    std::vector<std::string> ::const_iterator _iter2191;
-    for (_iter2191 = (*(this->names)).begin(); _iter2191 != (*(this->names)).end(); ++_iter2191)
+    std::vector<std::string> ::const_iterator _iter2193;
+    for (_iter2193 = (*(this->names)).begin(); _iter2193 != (*(this->names)).end(); ++_iter2193)
     {
-      xfer += oprot->writeString((*_iter2191));
+      xfer += oprot->writeString((*_iter2193));
     }
     xfer += oprot->writeListEnd();
   }
@@ -25927,14 +25927,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2192;
-            ::apache::thrift::protocol::TType _etype2195;
-            xfer += iprot->readListBegin(_etype2195, _size2192);
-            this->success.resize(_size2192);
-            uint32_t _i2196;
-            for (_i2196 = 0; _i2196 < _size2192; ++_i2196)
+            uint32_t _size2194;
+            ::apache::thrift::protocol::TType _etype2197;
+            xfer += iprot->readListBegin(_etype2197, _size2194);
+            this->success.resize(_size2194);
+            uint32_t _i2198;
+            for (_i2198 = 0; _i2198 < _size2194; ++_i2198)
             {
-              xfer += this->success[_i2196].read(iprot);
+              xfer += this->success[_i2198].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -25981,10 +25981,10 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Partition> ::const_iterator _iter2197;
-      for (_iter2197 = this->success.begin(); _iter2197 != this->success.end(); ++_iter2197)
+      std::vector<Partition> ::const_iterator _iter2199;
+      for (_iter2199 = this->success.begin(); _iter2199 != this->success.end(); ++_iter2199)
       {
-        xfer += (*_iter2197).write(oprot);
+        xfer += (*_iter2199).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -26033,14 +26033,14 @@ uint32_t ThriftHiveMetastore_get_partitions_by_names_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2198;
-            ::apache::thrift::protocol::TType _etype2201;
-            xfer += iprot->readListBegin(_etype2201, _size2198);
-            (*(this->success)).resize(_size2198);
-            uint32_t _i2202;
-            for (_i2202 = 0; _i2202 < _size2198; ++_i2202)
+            uint32_t _size2200;
+            ::apache::thrift::protocol::TType _etype2203;
+            xfer += iprot->readListBegin(_etype2203, _size2200);
+            (*(this->success)).resize(_size2200);
+            uint32_t _i2204;
+            for (_i2204 = 0; _i2204 < _size2200; ++_i2204)
             {
-              xfer += (*(this->success))[_i2202].read(iprot);
+              xfer += (*(this->success))[_i2204].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26589,14 +26589,14 @@ uint32_t ThriftHiveMetastore_alter_partitions_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size2203;
-            ::apache::thrift::protocol::TType _etype2206;
-            xfer += iprot->readListBegin(_etype2206, _size2203);
-            this->new_parts.resize(_size2203);
-            uint32_t _i2207;
-            for (_i2207 = 0; _i2207 < _size2203; ++_i2207)
+            uint32_t _size2205;
+            ::apache::thrift::protocol::TType _etype2208;
+            xfer += iprot->readListBegin(_etype2208, _size2205);
+            this->new_parts.resize(_size2205);
+            uint32_t _i2209;
+            for (_i2209 = 0; _i2209 < _size2205; ++_i2209)
             {
-              xfer += this->new_parts[_i2207].read(iprot);
+              xfer += this->new_parts[_i2209].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26633,10 +26633,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter2208;
-    for (_iter2208 = this->new_parts.begin(); _iter2208 != this->new_parts.end(); ++_iter2208)
+    std::vector<Partition> ::const_iterator _iter2210;
+    for (_iter2210 = this->new_parts.begin(); _iter2210 != this->new_parts.end(); ++_iter2210)
     {
-      xfer += (*_iter2208).write(oprot);
+      xfer += (*_iter2210).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26668,10 +26668,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter2209;
-    for (_iter2209 = (*(this->new_parts)).begin(); _iter2209 != (*(this->new_parts)).end(); ++_iter2209)
+    std::vector<Partition> ::const_iterator _iter2211;
+    for (_iter2211 = (*(this->new_parts)).begin(); _iter2211 != (*(this->new_parts)).end(); ++_iter2211)
     {
-      xfer += (*_iter2209).write(oprot);
+      xfer += (*_iter2211).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26856,14 +26856,14 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_args::rea
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->new_parts.clear();
-            uint32_t _size2210;
-            ::apache::thrift::protocol::TType _etype2213;
-            xfer += iprot->readListBegin(_etype2213, _size2210);
-            this->new_parts.resize(_size2210);
-            uint32_t _i2214;
-            for (_i2214 = 0; _i2214 < _size2210; ++_i2214)
+            uint32_t _size2212;
+            ::apache::thrift::protocol::TType _etype2215;
+            xfer += iprot->readListBegin(_etype2215, _size2212);
+            this->new_parts.resize(_size2212);
+            uint32_t _i2216;
+            for (_i2216 = 0; _i2216 < _size2212; ++_i2216)
             {
-              xfer += this->new_parts[_i2214].read(iprot);
+              xfer += this->new_parts[_i2216].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26908,10 +26908,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_args::wri
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->new_parts.size()));
-    std::vector<Partition> ::const_iterator _iter2215;
-    for (_iter2215 = this->new_parts.begin(); _iter2215 != this->new_parts.end(); ++_iter2215)
+    std::vector<Partition> ::const_iterator _iter2217;
+    for (_iter2217 = this->new_parts.begin(); _iter2217 != this->new_parts.end(); ++_iter2217)
     {
-      xfer += (*_iter2215).write(oprot);
+      xfer += (*_iter2217).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26947,10 +26947,10 @@ uint32_t ThriftHiveMetastore_alter_partitions_with_environment_context_pargs::wr
   xfer += oprot->writeFieldBegin("new_parts", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>((*(this->new_parts)).size()));
-    std::vector<Partition> ::const_iterator _iter2216;
-    for (_iter2216 = (*(this->new_parts)).begin(); _iter2216 != (*(this->new_parts)).end(); ++_iter2216)
+    std::vector<Partition> ::const_iterator _iter2218;
+    for (_iter2218 = (*(this->new_parts)).begin(); _iter2218 != (*(this->new_parts)).end(); ++_iter2218)
     {
-      xfer += (*_iter2216).write(oprot);
+      xfer += (*_iter2218).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -27621,14 +27621,14 @@ uint32_t ThriftHiveMetastore_rename_partition_args::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2217;
-            ::apache::thrift::protocol::TType _etype2220;
-            xfer += iprot->readListBegin(_etype2220, _size2217);
-            this->part_vals.resize(_size2217);
-            uint32_t _i2221;
-            for (_i2221 = 0; _i2221 < _size2217; ++_i2221)
+            uint32_t _size2219;
+            ::apache::thrift::protocol::TType _etype2222;
+            xfer += iprot->readListBegin(_etype2222, _size2219);
+            this->part_vals.resize(_size2219);
+            uint32_t _i2223;
+            for (_i2223 = 0; _i2223 < _size2219; ++_i2223)
             {
-              xfer += iprot->readString(this->part_vals[_i2221]);
+              xfer += iprot->readString(this->part_vals[_i2223]);
             }
             xfer += iprot->readListEnd();
           }
@@ -27673,10 +27673,10 @@ uint32_t ThriftHiveMetastore_rename_partition_args::write(::apache::thrift::prot
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2222;
-    for (_iter2222 = this->part_vals.begin(); _iter2222 != this->part_vals.end(); ++_iter2222)
+    std::vector<std::string> ::const_iterator _iter2224;
+    for (_iter2224 = this->part_vals.begin(); _iter2224 != this->part_vals.end(); ++_iter2224)
     {
-      xfer += oprot->writeString((*_iter2222));
+      xfer += oprot->writeString((*_iter2224));
     }
     xfer += oprot->writeListEnd();
   }
@@ -27712,10 +27712,10 @@ uint32_t ThriftHiveMetastore_rename_partition_pargs::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2223;
-    for (_iter2223 = (*(this->part_vals)).begin(); _iter2223 != (*(this->part_vals)).end(); ++_iter2223)
+    std::vector<std::string> ::const_iterator _iter2225;
+    for (_iter2225 = (*(this->part_vals)).begin(); _iter2225 != (*(this->part_vals)).end(); ++_iter2225)
     {
-      xfer += oprot->writeString((*_iter2223));
+      xfer += oprot->writeString((*_iter2225));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28115,14 +28115,14 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_args::read(::ap
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->part_vals.clear();
-            uint32_t _size2224;
-            ::apache::thrift::protocol::TType _etype2227;
-            xfer += iprot->readListBegin(_etype2227, _size2224);
-            this->part_vals.resize(_size2224);
-            uint32_t _i2228;
-            for (_i2228 = 0; _i2228 < _size2224; ++_i2228)
+            uint32_t _size2226;
+            ::apache::thrift::protocol::TType _etype2229;
+            xfer += iprot->readListBegin(_etype2229, _size2226);
+            this->part_vals.resize(_size2226);
+            uint32_t _i2230;
+            for (_i2230 = 0; _i2230 < _size2226; ++_i2230)
             {
-              xfer += iprot->readString(this->part_vals[_i2228]);
+              xfer += iprot->readString(this->part_vals[_i2230]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28159,10 +28159,10 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_args::write(::a
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::vector<std::string> ::const_iterator _iter2229;
-    for (_iter2229 = this->part_vals.begin(); _iter2229 != this->part_vals.end(); ++_iter2229)
+    std::vector<std::string> ::const_iterator _iter2231;
+    for (_iter2231 = this->part_vals.begin(); _iter2231 != this->part_vals.end(); ++_iter2231)
     {
-      xfer += oprot->writeString((*_iter2229));
+      xfer += oprot->writeString((*_iter2231));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28190,10 +28190,10 @@ uint32_t ThriftHiveMetastore_partition_name_has_valid_characters_pargs::write(::
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::vector<std::string> ::const_iterator _iter2230;
-    for (_iter2230 = (*(this->part_vals)).begin(); _iter2230 != (*(this->part_vals)).end(); ++_iter2230)
+    std::vector<std::string> ::const_iterator _iter2232;
+    for (_iter2232 = (*(this->part_vals)).begin(); _iter2232 != (*(this->part_vals)).end(); ++_iter2232)
     {
-      xfer += oprot->writeString((*_iter2230));
+      xfer += oprot->writeString((*_iter2232));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28668,14 +28668,14 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2231;
-            ::apache::thrift::protocol::TType _etype2234;
-            xfer += iprot->readListBegin(_etype2234, _size2231);
-            this->success.resize(_size2231);
-            uint32_t _i2235;
-            for (_i2235 = 0; _i2235 < _size2231; ++_i2235)
+            uint32_t _size2233;
+            ::apache::thrift::protocol::TType _etype2236;
+            xfer += iprot->readListBegin(_etype2236, _size2233);
+            this->success.resize(_size2233);
+            uint32_t _i2237;
+            for (_i2237 = 0; _i2237 < _size2233; ++_i2237)
             {
-              xfer += iprot->readString(this->success[_i2235]);
+              xfer += iprot->readString(this->success[_i2237]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28714,10 +28714,10 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2236;
-      for (_iter2236 = this->success.begin(); _iter2236 != this->success.end(); ++_iter2236)
+      std::vector<std::string> ::const_iterator _iter2238;
+      for (_iter2238 = this->success.begin(); _iter2238 != this->success.end(); ++_iter2238)
       {
-        xfer += oprot->writeString((*_iter2236));
+        xfer += oprot->writeString((*_iter2238));
       }
       xfer += oprot->writeListEnd();
     }
@@ -28762,14 +28762,14 @@ uint32_t ThriftHiveMetastore_partition_name_to_vals_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2237;
-            ::apache::thrift::protocol::TType _etype2240;
-            xfer += iprot->readListBegin(_etype2240, _size2237);
-            (*(this->success)).resize(_size2237);
-            uint32_t _i2241;
-            for (_i2241 = 0; _i2241 < _size2237; ++_i2241)
+            uint32_t _size2239;
+            ::apache::thrift::protocol::TType _etype2242;
+            xfer += iprot->readListBegin(_etype2242, _size2239);
+            (*(this->success)).resize(_size2239);
+            uint32_t _i2243;
+            for (_i2243 = 0; _i2243 < _size2239; ++_i2243)
             {
-              xfer += iprot->readString((*(this->success))[_i2241]);
+              xfer += iprot->readString((*(this->success))[_i2243]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28907,17 +28907,17 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_result::read(::apache::thrif
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->success.clear();
-            uint32_t _size2242;
-            ::apache::thrift::protocol::TType _ktype2243;
-            ::apache::thrift::protocol::TType _vtype2244;
-            xfer += iprot->readMapBegin(_ktype2243, _vtype2244, _size2242);
-            uint32_t _i2246;
-            for (_i2246 = 0; _i2246 < _size2242; ++_i2246)
+            uint32_t _size2244;
+            ::apache::thrift::protocol::TType _ktype2245;
+            ::apache::thrift::protocol::TType _vtype2246;
+            xfer += iprot->readMapBegin(_ktype2245, _vtype2246, _size2244);
+            uint32_t _i2248;
+            for (_i2248 = 0; _i2248 < _size2244; ++_i2248)
             {
-              std::string _key2247;
-              xfer += iprot->readString(_key2247);
-              std::string& _val2248 = this->success[_key2247];
-              xfer += iprot->readString(_val2248);
+              std::string _key2249;
+              xfer += iprot->readString(_key2249);
+              std::string& _val2250 = this->success[_key2249];
+              xfer += iprot->readString(_val2250);
             }
             xfer += iprot->readMapEnd();
           }
@@ -28956,11 +28956,11 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_result::write(::apache::thri
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_MAP, 0);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::map<std::string, std::string> ::const_iterator _iter2249;
-      for (_iter2249 = this->success.begin(); _iter2249 != this->success.end(); ++_iter2249)
+      std::map<std::string, std::string> ::const_iterator _iter2251;
+      for (_iter2251 = this->success.begin(); _iter2251 != this->success.end(); ++_iter2251)
       {
-        xfer += oprot->writeString(_iter2249->first);
-        xfer += oprot->writeString(_iter2249->second);
+        xfer += oprot->writeString(_iter2251->first);
+        xfer += oprot->writeString(_iter2251->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -29005,17 +29005,17 @@ uint32_t ThriftHiveMetastore_partition_name_to_spec_presult::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             (*(this->success)).clear();
-            uint32_t _size2250;
-            ::apache::thrift::protocol::TType _ktype2251;
-            ::apache::thrift::protocol::TType _vtype2252;
-            xfer += iprot->readMapBegin(_ktype2251, _vtype2252, _size2250);
-            uint32_t _i2254;
-            for (_i2254 = 0; _i2254 < _size2250; ++_i2254)
+            uint32_t _size2252;
+            ::apache::thrift::protocol::TType _ktype2253;
+            ::apache::thrift::protocol::TType _vtype2254;
+            xfer += iprot->readMapBegin(_ktype2253, _vtype2254, _size2252);
+            uint32_t _i2256;
+            for (_i2256 = 0; _i2256 < _size2252; ++_i2256)
             {
-              std::string _key2255;
-              xfer += iprot->readString(_key2255);
-              std::string& _val2256 = (*(this->success))[_key2255];
-              xfer += iprot->readString(_val2256);
+              std::string _key2257;
+              xfer += iprot->readString(_key2257);
+              std::string& _val2258 = (*(this->success))[_key2257];
+              xfer += iprot->readString(_val2258);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29090,17 +29090,17 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::read(::apache::thrift::
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->part_vals.clear();
-            uint32_t _size2257;
-            ::apache::thrift::protocol::TType _ktype2258;
-            ::apache::thrift::protocol::TType _vtype2259;
-            xfer += iprot->readMapBegin(_ktype2258, _vtype2259, _size2257);
-            uint32_t _i2261;
-            for (_i2261 = 0; _i2261 < _size2257; ++_i2261)
+            uint32_t _size2259;
+            ::apache::thrift::protocol::TType _ktype2260;
+            ::apache::thrift::protocol::TType _vtype2261;
+            xfer += iprot->readMapBegin(_ktype2260, _vtype2261, _size2259);
+            uint32_t _i2263;
+            for (_i2263 = 0; _i2263 < _size2259; ++_i2263)
             {
-              std::string _key2262;
-              xfer += iprot->readString(_key2262);
-              std::string& _val2263 = this->part_vals[_key2262];
-              xfer += iprot->readString(_val2263);
+              std::string _key2264;
+              xfer += iprot->readString(_key2264);
+              std::string& _val2265 = this->part_vals[_key2264];
+              xfer += iprot->readString(_val2265);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29111,9 +29111,9 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::read(::apache::thrift::
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2264;
-          xfer += iprot->readI32(ecast2264);
-          this->eventType = (PartitionEventType::type)ecast2264;
+          int32_t ecast2266;
+          xfer += iprot->readI32(ecast2266);
+          this->eventType = (PartitionEventType::type)ecast2266;
           this->__isset.eventType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -29147,11 +29147,11 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_args::write(::apache::thrift:
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2265;
-    for (_iter2265 = this->part_vals.begin(); _iter2265 != this->part_vals.end(); ++_iter2265)
+    std::map<std::string, std::string> ::const_iterator _iter2267;
+    for (_iter2267 = this->part_vals.begin(); _iter2267 != this->part_vals.end(); ++_iter2267)
     {
-      xfer += oprot->writeString(_iter2265->first);
-      xfer += oprot->writeString(_iter2265->second);
+      xfer += oprot->writeString(_iter2267->first);
+      xfer += oprot->writeString(_iter2267->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29187,11 +29187,11 @@ uint32_t ThriftHiveMetastore_markPartitionForEvent_pargs::write(::apache::thrift
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2266;
-    for (_iter2266 = (*(this->part_vals)).begin(); _iter2266 != (*(this->part_vals)).end(); ++_iter2266)
+    std::map<std::string, std::string> ::const_iterator _iter2268;
+    for (_iter2268 = (*(this->part_vals)).begin(); _iter2268 != (*(this->part_vals)).end(); ++_iter2268)
     {
-      xfer += oprot->writeString(_iter2266->first);
-      xfer += oprot->writeString(_iter2266->second);
+      xfer += oprot->writeString(_iter2268->first);
+      xfer += oprot->writeString(_iter2268->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29460,17 +29460,17 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->part_vals.clear();
-            uint32_t _size2267;
-            ::apache::thrift::protocol::TType _ktype2268;
-            ::apache::thrift::protocol::TType _vtype2269;
-            xfer += iprot->readMapBegin(_ktype2268, _vtype2269, _size2267);
-            uint32_t _i2271;
-            for (_i2271 = 0; _i2271 < _size2267; ++_i2271)
+            uint32_t _size2269;
+            ::apache::thrift::protocol::TType _ktype2270;
+            ::apache::thrift::protocol::TType _vtype2271;
+            xfer += iprot->readMapBegin(_ktype2270, _vtype2271, _size2269);
+            uint32_t _i2273;
+            for (_i2273 = 0; _i2273 < _size2269; ++_i2273)
             {
-              std::string _key2272;
-              xfer += iprot->readString(_key2272);
-              std::string& _val2273 = this->part_vals[_key2272];
-              xfer += iprot->readString(_val2273);
+              std::string _key2274;
+              xfer += iprot->readString(_key2274);
+              std::string& _val2275 = this->part_vals[_key2274];
+              xfer += iprot->readString(_val2275);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29481,9 +29481,9 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::read(::apache::thri
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2274;
-          xfer += iprot->readI32(ecast2274);
-          this->eventType = (PartitionEventType::type)ecast2274;
+          int32_t ecast2276;
+          xfer += iprot->readI32(ecast2276);
+          this->eventType = (PartitionEventType::type)ecast2276;
           this->__isset.eventType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -29517,11 +29517,11 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_args::write(::apache::thr
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->part_vals.size()));
-    std::map<std::string, std::string> ::const_iterator _iter2275;
-    for (_iter2275 = this->part_vals.begin(); _iter2275 != this->part_vals.end(); ++_iter2275)
+    std::map<std::string, std::string> ::const_iterator _iter2277;
+    for (_iter2277 = this->part_vals.begin(); _iter2277 != this->part_vals.end(); ++_iter2277)
     {
-      xfer += oprot->writeString(_iter2275->first);
-      xfer += oprot->writeString(_iter2275->second);
+      xfer += oprot->writeString(_iter2277->first);
+      xfer += oprot->writeString(_iter2277->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29557,11 +29557,11 @@ uint32_t ThriftHiveMetastore_isPartitionMarkedForEvent_pargs::write(::apache::th
   xfer += oprot->writeFieldBegin("part_vals", ::apache::thrift::protocol::T_MAP, 3);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->part_vals)).size()));
-    std::map<std::string, std::string> ::const_iterator _iter2276;
-    for (_iter2276 = (*(this->part_vals)).begin(); _iter2276 != (*(this->part_vals)).end(); ++_iter2276)
+    std::map<std::string, std::string> ::const_iterator _iter2278;
+    for (_iter2278 = (*(this->part_vals)).begin(); _iter2278 != (*(this->part_vals)).end(); ++_iter2278)
     {
-      xfer += oprot->writeString(_iter2276->first);
-      xfer += oprot->writeString(_iter2276->second);
+      xfer += oprot->writeString(_iter2278->first);
+      xfer += oprot->writeString(_iter2278->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -35503,14 +35503,14 @@ uint32_t ThriftHiveMetastore_get_functions_result::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2277;
-            ::apache::thrift::protocol::TType _etype2280;
-            xfer += iprot->readListBegin(_etype2280, _size2277);
-            this->success.resize(_size2277);
-            uint32_t _i2281;
-            for (_i2281 = 0; _i2281 < _size2277; ++_i2281)
+            uint32_t _size2279;
+            ::apache::thrift::protocol::TType _etype2282;
+            xfer += iprot->readListBegin(_etype2282, _size2279);
+            this->success.resize(_size2279);
+            uint32_t _i2283;
+            for (_i2283 = 0; _i2283 < _size2279; ++_i2283)
             {
-              xfer += iprot->readString(this->success[_i2281]);
+              xfer += iprot->readString(this->success[_i2283]);
             }
             xfer += iprot->readListEnd();
           }
@@ -35549,10 +35549,10 @@ uint32_t ThriftHiveMetastore_get_functions_result::write(::apache::thrift::proto
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2282;
-      for (_iter2282 = this->success.begin(); _iter2282 != this->success.end(); ++_iter2282)
+      std::vector<std::string> ::const_iterator _iter2284;
+      for (_iter2284 = this->success.begin(); _iter2284 != this->success.end(); ++_iter2284)
       {
-        xfer += oprot->writeString((*_iter2282));
+        xfer += oprot->writeString((*_iter2284));
       }
       xfer += oprot->writeListEnd();
     }
@@ -35597,14 +35597,14 @@ uint32_t ThriftHiveMetastore_get_functions_presult::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2283;
-            ::apache::thrift::protocol::TType _etype2286;
-            xfer += iprot->readListBegin(_etype2286, _size2283);
-            (*(this->success)).resize(_size2283);
-            uint32_t _i2287;
-            for (_i2287 = 0; _i2287 < _size2283; ++_i2287)
+            uint32_t _size2285;
+            ::apache::thrift::protocol::TType _etype2288;
+            xfer += iprot->readListBegin(_etype2288, _size2285);
+            (*(this->success)).resize(_size2285);
+            uint32_t _i2289;
+            for (_i2289 = 0; _i2289 < _size2285; ++_i2289)
             {
-              xfer += iprot->readString((*(this->success))[_i2287]);
+              xfer += iprot->readString((*(this->success))[_i2289]);
             }
             xfer += iprot->readListEnd();
           }
@@ -36564,14 +36564,14 @@ uint32_t ThriftHiveMetastore_get_role_names_result::read(::apache::thrift::proto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2288;
-            ::apache::thrift::protocol::TType _etype2291;
-            xfer += iprot->readListBegin(_etype2291, _size2288);
-            this->success.resize(_size2288);
-            uint32_t _i2292;
-            for (_i2292 = 0; _i2292 < _size2288; ++_i2292)
+            uint32_t _size2290;
+            ::apache::thrift::protocol::TType _etype2293;
+            xfer += iprot->readListBegin(_etype2293, _size2290);
+            this->success.resize(_size2290);
+            uint32_t _i2294;
+            for (_i2294 = 0; _i2294 < _size2290; ++_i2294)
             {
-              xfer += iprot->readString(this->success[_i2292]);
+              xfer += iprot->readString(this->success[_i2294]);
             }
             xfer += iprot->readListEnd();
           }
@@ -36610,10 +36610,10 @@ uint32_t ThriftHiveMetastore_get_role_names_result::write(::apache::thrift::prot
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2293;
-      for (_iter2293 = this->success.begin(); _iter2293 != this->success.end(); ++_iter2293)
+      std::vector<std::string> ::const_iterator _iter2295;
+      for (_iter2295 = this->success.begin(); _iter2295 != this->success.end(); ++_iter2295)
       {
-        xfer += oprot->writeString((*_iter2293));
+        xfer += oprot->writeString((*_iter2295));
       }
       xfer += oprot->writeListEnd();
     }
@@ -36658,14 +36658,14 @@ uint32_t ThriftHiveMetastore_get_role_names_presult::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2294;
-            ::apache::thrift::protocol::TType _etype2297;
-            xfer += iprot->readListBegin(_etype2297, _size2294);
-            (*(this->success)).resize(_size2294);
-            uint32_t _i2298;
-            for (_i2298 = 0; _i2298 < _size2294; ++_i2298)
+            uint32_t _size2296;
+            ::apache::thrift::protocol::TType _etype2299;
+            xfer += iprot->readListBegin(_etype2299, _size2296);
+            (*(this->success)).resize(_size2296);
+            uint32_t _i2300;
+            for (_i2300 = 0; _i2300 < _size2296; ++_i2300)
             {
-              xfer += iprot->readString((*(this->success))[_i2298]);
+              xfer += iprot->readString((*(this->success))[_i2300]);
             }
             xfer += iprot->readListEnd();
           }
@@ -36738,9 +36738,9 @@ uint32_t ThriftHiveMetastore_grant_role_args::read(::apache::thrift::protocol::T
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2299;
-          xfer += iprot->readI32(ecast2299);
-          this->principal_type = (PrincipalType::type)ecast2299;
+          int32_t ecast2301;
+          xfer += iprot->readI32(ecast2301);
+          this->principal_type = (PrincipalType::type)ecast2301;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -36756,9 +36756,9 @@ uint32_t ThriftHiveMetastore_grant_role_args::read(::apache::thrift::protocol::T
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2300;
-          xfer += iprot->readI32(ecast2300);
-          this->grantorType = (PrincipalType::type)ecast2300;
+          int32_t ecast2302;
+          xfer += iprot->readI32(ecast2302);
+          this->grantorType = (PrincipalType::type)ecast2302;
           this->__isset.grantorType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37029,9 +37029,9 @@ uint32_t ThriftHiveMetastore_revoke_role_args::read(::apache::thrift::protocol::
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2301;
-          xfer += iprot->readI32(ecast2301);
-          this->principal_type = (PrincipalType::type)ecast2301;
+          int32_t ecast2303;
+          xfer += iprot->readI32(ecast2303);
+          this->principal_type = (PrincipalType::type)ecast2303;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37262,9 +37262,9 @@ uint32_t ThriftHiveMetastore_list_roles_args::read(::apache::thrift::protocol::T
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2302;
-          xfer += iprot->readI32(ecast2302);
-          this->principal_type = (PrincipalType::type)ecast2302;
+          int32_t ecast2304;
+          xfer += iprot->readI32(ecast2304);
+          this->principal_type = (PrincipalType::type)ecast2304;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -37353,14 +37353,14 @@ uint32_t ThriftHiveMetastore_list_roles_result::read(::apache::thrift::protocol:
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2303;
-            ::apache::thrift::protocol::TType _etype2306;
-            xfer += iprot->readListBegin(_etype2306, _size2303);
-            this->success.resize(_size2303);
-            uint32_t _i2307;
-            for (_i2307 = 0; _i2307 < _size2303; ++_i2307)
+            uint32_t _size2305;
+            ::apache::thrift::protocol::TType _etype2308;
+            xfer += iprot->readListBegin(_etype2308, _size2305);
+            this->success.resize(_size2305);
+            uint32_t _i2309;
+            for (_i2309 = 0; _i2309 < _size2305; ++_i2309)
             {
-              xfer += this->success[_i2307].read(iprot);
+              xfer += this->success[_i2309].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -37399,10 +37399,10 @@ uint32_t ThriftHiveMetastore_list_roles_result::write(::apache::thrift::protocol
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<Role> ::const_iterator _iter2308;
-      for (_iter2308 = this->success.begin(); _iter2308 != this->success.end(); ++_iter2308)
+      std::vector<Role> ::const_iterator _iter2310;
+      for (_iter2310 = this->success.begin(); _iter2310 != this->success.end(); ++_iter2310)
       {
-        xfer += (*_iter2308).write(oprot);
+        xfer += (*_iter2310).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -37447,14 +37447,14 @@ uint32_t ThriftHiveMetastore_list_roles_presult::read(::apache::thrift::protocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2309;
-            ::apache::thrift::protocol::TType _etype2312;
-            xfer += iprot->readListBegin(_etype2312, _size2309);
-            (*(this->success)).resize(_size2309);
-            uint32_t _i2313;
-            for (_i2313 = 0; _i2313 < _size2309; ++_i2313)
+            uint32_t _size2311;
+            ::apache::thrift::protocol::TType _etype2314;
+            xfer += iprot->readListBegin(_etype2314, _size2311);
+            (*(this->success)).resize(_size2311);
+            uint32_t _i2315;
+            for (_i2315 = 0; _i2315 < _size2311; ++_i2315)
             {
-              xfer += (*(this->success))[_i2313].read(iprot);
+              xfer += (*(this->success))[_i2315].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -38150,14 +38150,14 @@ uint32_t ThriftHiveMetastore_get_privilege_set_args::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2314;
-            ::apache::thrift::protocol::TType _etype2317;
-            xfer += iprot->readListBegin(_etype2317, _size2314);
-            this->group_names.resize(_size2314);
-            uint32_t _i2318;
-            for (_i2318 = 0; _i2318 < _size2314; ++_i2318)
+            uint32_t _size2316;
+            ::apache::thrift::protocol::TType _etype2319;
+            xfer += iprot->readListBegin(_etype2319, _size2316);
+            this->group_names.resize(_size2316);
+            uint32_t _i2320;
+            for (_i2320 = 0; _i2320 < _size2316; ++_i2320)
             {
-              xfer += iprot->readString(this->group_names[_i2318]);
+              xfer += iprot->readString(this->group_names[_i2320]);
             }
             xfer += iprot->readListEnd();
           }
@@ -38194,10 +38194,10 @@ uint32_t ThriftHiveMetastore_get_privilege_set_args::write(::apache::thrift::pro
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2319;
-    for (_iter2319 = this->group_names.begin(); _iter2319 != this->group_names.end(); ++_iter2319)
+    std::vector<std::string> ::const_iterator _iter2321;
+    for (_iter2321 = this->group_names.begin(); _iter2321 != this->group_names.end(); ++_iter2321)
     {
-      xfer += oprot->writeString((*_iter2319));
+      xfer += oprot->writeString((*_iter2321));
     }
     xfer += oprot->writeListEnd();
   }
@@ -38229,10 +38229,10 @@ uint32_t ThriftHiveMetastore_get_privilege_set_pargs::write(::apache::thrift::pr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2320;
-    for (_iter2320 = (*(this->group_names)).begin(); _iter2320 != (*(this->group_names)).end(); ++_iter2320)
+    std::vector<std::string> ::const_iterator _iter2322;
+    for (_iter2322 = (*(this->group_names)).begin(); _iter2322 != (*(this->group_names)).end(); ++_iter2322)
     {
-      xfer += oprot->writeString((*_iter2320));
+      xfer += oprot->writeString((*_iter2322));
     }
     xfer += oprot->writeListEnd();
   }
@@ -38407,9 +38407,9 @@ uint32_t ThriftHiveMetastore_list_privileges_args::read(::apache::thrift::protoc
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast2321;
-          xfer += iprot->readI32(ecast2321);
-          this->principal_type = (PrincipalType::type)ecast2321;
+          int32_t ecast2323;
+          xfer += iprot->readI32(ecast2323);
+          this->principal_type = (PrincipalType::type)ecast2323;
           this->__isset.principal_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -38514,14 +38514,14 @@ uint32_t ThriftHiveMetastore_list_privileges_result::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2322;
-            ::apache::thrift::protocol::TType _etype2325;
-            xfer += iprot->readListBegin(_etype2325, _size2322);
-            this->success.resize(_size2322);
-            uint32_t _i2326;
-            for (_i2326 = 0; _i2326 < _size2322; ++_i2326)
+            uint32_t _size2324;
+            ::apache::thrift::protocol::TType _etype2327;
+            xfer += iprot->readListBegin(_etype2327, _size2324);
+            this->success.resize(_size2324);
+            uint32_t _i2328;
+            for (_i2328 = 0; _i2328 < _size2324; ++_i2328)
             {
-              xfer += this->success[_i2326].read(iprot);
+              xfer += this->success[_i2328].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -38560,10 +38560,10 @@ uint32_t ThriftHiveMetastore_list_privileges_result::write(::apache::thrift::pro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<HiveObjectPrivilege> ::const_iterator _iter2327;
-      for (_iter2327 = this->success.begin(); _iter2327 != this->success.end(); ++_iter2327)
+      std::vector<HiveObjectPrivilege> ::const_iterator _iter2329;
+      for (_iter2329 = this->success.begin(); _iter2329 != this->success.end(); ++_iter2329)
       {
-        xfer += (*_iter2327).write(oprot);
+        xfer += (*_iter2329).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -38608,14 +38608,14 @@ uint32_t ThriftHiveMetastore_list_privileges_presult::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2328;
-            ::apache::thrift::protocol::TType _etype2331;
-            xfer += iprot->readListBegin(_etype2331, _size2328);
-            (*(this->success)).resize(_size2328);
-            uint32_t _i2332;
-            for (_i2332 = 0; _i2332 < _size2328; ++_i2332)
+            uint32_t _size2330;
+            ::apache::thrift::protocol::TType _etype2333;
+            xfer += iprot->readListBegin(_etype2333, _size2330);
+            (*(this->success)).resize(_size2330);
+            uint32_t _i2334;
+            for (_i2334 = 0; _i2334 < _size2330; ++_i2334)
             {
-              xfer += (*(this->success))[_i2332].read(iprot);
+              xfer += (*(this->success))[_i2334].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -39542,14 +39542,14 @@ uint32_t ThriftHiveMetastore_set_ugi_args::read(::apache::thrift::protocol::TPro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->group_names.clear();
-            uint32_t _size2333;
-            ::apache::thrift::protocol::TType _etype2336;
-            xfer += iprot->readListBegin(_etype2336, _size2333);
-            this->group_names.resize(_size2333);
-            uint32_t _i2337;
-            for (_i2337 = 0; _i2337 < _size2333; ++_i2337)
+            uint32_t _size2335;
+            ::apache::thrift::protocol::TType _etype2338;
+            xfer += iprot->readListBegin(_etype2338, _size2335);
+            this->group_names.resize(_size2335);
+            uint32_t _i2339;
+            for (_i2339 = 0; _i2339 < _size2335; ++_i2339)
             {
-              xfer += iprot->readString(this->group_names[_i2337]);
+              xfer += iprot->readString(this->group_names[_i2339]);
             }
             xfer += iprot->readListEnd();
           }
@@ -39582,10 +39582,10 @@ uint32_t ThriftHiveMetastore_set_ugi_args::write(::apache::thrift::protocol::TPr
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->group_names.size()));
-    std::vector<std::string> ::const_iterator _iter2338;
-    for (_iter2338 = this->group_names.begin(); _iter2338 != this->group_names.end(); ++_iter2338)
+    std::vector<std::string> ::const_iterator _iter2340;
+    for (_iter2340 = this->group_names.begin(); _iter2340 != this->group_names.end(); ++_iter2340)
     {
-      xfer += oprot->writeString((*_iter2338));
+      xfer += oprot->writeString((*_iter2340));
     }
     xfer += oprot->writeListEnd();
   }
@@ -39613,10 +39613,10 @@ uint32_t ThriftHiveMetastore_set_ugi_pargs::write(::apache::thrift::protocol::TP
   xfer += oprot->writeFieldBegin("group_names", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>((*(this->group_names)).size()));
-    std::vector<std::string> ::const_iterator _iter2339;
-    for (_iter2339 = (*(this->group_names)).begin(); _iter2339 != (*(this->group_names)).end(); ++_iter2339)
+    std::vector<std::string> ::const_iterator _iter2341;
+    for (_iter2341 = (*(this->group_names)).begin(); _iter2341 != (*(this->group_names)).end(); ++_iter2341)
     {
-      xfer += oprot->writeString((*_iter2339));
+      xfer += oprot->writeString((*_iter2341));
     }
     xfer += oprot->writeListEnd();
   }
@@ -39657,14 +39657,14 @@ uint32_t ThriftHiveMetastore_set_ugi_result::read(::apache::thrift::protocol::TP
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2340;
-            ::apache::thrift::protocol::TType _etype2343;
-            xfer += iprot->readListBegin(_etype2343, _size2340);
-            this->success.resize(_size2340);
-            uint32_t _i2344;
-            for (_i2344 = 0; _i2344 < _size2340; ++_i2344)
+            uint32_t _size2342;
+            ::apache::thrift::protocol::TType _etype2345;
+            xfer += iprot->readListBegin(_etype2345, _size2342);
+            this->success.resize(_size2342);
+            uint32_t _i2346;
+            for (_i2346 = 0; _i2346 < _size2342; ++_i2346)
             {
-              xfer += iprot->readString(this->success[_i2344]);
+              xfer += iprot->readString(this->success[_i2346]);
             }
             xfer += iprot->readListEnd();
           }
@@ -39703,10 +39703,10 @@ uint32_t ThriftHiveMetastore_set_ugi_result::write(::apache::thrift::protocol::T
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2345;
-      for (_iter2345 = this->success.begin(); _iter2345 != this->success.end(); ++_iter2345)
+      std::vector<std::string> ::const_iterator _iter2347;
+      for (_iter2347 = this->success.begin(); _iter2347 != this->success.end(); ++_iter2347)
       {
-        xfer += oprot->writeString((*_iter2345));
+        xfer += oprot->writeString((*_iter2347));
       }
       xfer += oprot->writeListEnd();
     }
@@ -39751,14 +39751,14 @@ uint32_t ThriftHiveMetastore_set_ugi_presult::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2346;
-            ::apache::thrift::protocol::TType _etype2349;
-            xfer += iprot->readListBegin(_etype2349, _size2346);
-            (*(this->success)).resize(_size2346);
-            uint32_t _i2350;
-            for (_i2350 = 0; _i2350 < _size2346; ++_i2350)
+            uint32_t _size2348;
+            ::apache::thrift::protocol::TType _etype2351;
+            xfer += iprot->readListBegin(_etype2351, _size2348);
+            (*(this->success)).resize(_size2348);
+            uint32_t _i2352;
+            for (_i2352 = 0; _i2352 < _size2348; ++_i2352)
             {
-              xfer += iprot->readString((*(this->success))[_i2350]);
+              xfer += iprot->readString((*(this->success))[_i2352]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41069,14 +41069,14 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2351;
-            ::apache::thrift::protocol::TType _etype2354;
-            xfer += iprot->readListBegin(_etype2354, _size2351);
-            this->success.resize(_size2351);
-            uint32_t _i2355;
-            for (_i2355 = 0; _i2355 < _size2351; ++_i2355)
+            uint32_t _size2353;
+            ::apache::thrift::protocol::TType _etype2356;
+            xfer += iprot->readListBegin(_etype2356, _size2353);
+            this->success.resize(_size2353);
+            uint32_t _i2357;
+            for (_i2357 = 0; _i2357 < _size2353; ++_i2357)
             {
-              xfer += iprot->readString(this->success[_i2355]);
+              xfer += iprot->readString(this->success[_i2357]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41107,10 +41107,10 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2356;
-      for (_iter2356 = this->success.begin(); _iter2356 != this->success.end(); ++_iter2356)
+      std::vector<std::string> ::const_iterator _iter2358;
+      for (_iter2358 = this->success.begin(); _iter2358 != this->success.end(); ++_iter2358)
       {
-        xfer += oprot->writeString((*_iter2356));
+        xfer += oprot->writeString((*_iter2358));
       }
       xfer += oprot->writeListEnd();
     }
@@ -41151,14 +41151,14 @@ uint32_t ThriftHiveMetastore_get_all_token_identifiers_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2357;
-            ::apache::thrift::protocol::TType _etype2360;
-            xfer += iprot->readListBegin(_etype2360, _size2357);
-            (*(this->success)).resize(_size2357);
-            uint32_t _i2361;
-            for (_i2361 = 0; _i2361 < _size2357; ++_i2361)
+            uint32_t _size2359;
+            ::apache::thrift::protocol::TType _etype2362;
+            xfer += iprot->readListBegin(_etype2362, _size2359);
+            (*(this->success)).resize(_size2359);
+            uint32_t _i2363;
+            for (_i2363 = 0; _i2363 < _size2359; ++_i2363)
             {
-              xfer += iprot->readString((*(this->success))[_i2361]);
+              xfer += iprot->readString((*(this->success))[_i2363]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41884,14 +41884,14 @@ uint32_t ThriftHiveMetastore_get_master_keys_result::read(::apache::thrift::prot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2362;
-            ::apache::thrift::protocol::TType _etype2365;
-            xfer += iprot->readListBegin(_etype2365, _size2362);
-            this->success.resize(_size2362);
-            uint32_t _i2366;
-            for (_i2366 = 0; _i2366 < _size2362; ++_i2366)
+            uint32_t _size2364;
+            ::apache::thrift::protocol::TType _etype2367;
+            xfer += iprot->readListBegin(_etype2367, _size2364);
+            this->success.resize(_size2364);
+            uint32_t _i2368;
+            for (_i2368 = 0; _i2368 < _size2364; ++_i2368)
             {
-              xfer += iprot->readString(this->success[_i2366]);
+              xfer += iprot->readString(this->success[_i2368]);
             }
             xfer += iprot->readListEnd();
           }
@@ -41922,10 +41922,10 @@ uint32_t ThriftHiveMetastore_get_master_keys_result::write(::apache::thrift::pro
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2367;
-      for (_iter2367 = this->success.begin(); _iter2367 != this->success.end(); ++_iter2367)
+      std::vector<std::string> ::const_iterator _iter2369;
+      for (_iter2369 = this->success.begin(); _iter2369 != this->success.end(); ++_iter2369)
       {
-        xfer += oprot->writeString((*_iter2367));
+        xfer += oprot->writeString((*_iter2369));
       }
       xfer += oprot->writeListEnd();
     }
@@ -41966,14 +41966,14 @@ uint32_t ThriftHiveMetastore_get_master_keys_presult::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2368;
-            ::apache::thrift::protocol::TType _etype2371;
-            xfer += iprot->readListBegin(_etype2371, _size2368);
-            (*(this->success)).resize(_size2368);
-            uint32_t _i2372;
-            for (_i2372 = 0; _i2372 < _size2368; ++_i2372)
+            uint32_t _size2370;
+            ::apache::thrift::protocol::TType _etype2373;
+            xfer += iprot->readListBegin(_etype2373, _size2370);
+            (*(this->success)).resize(_size2370);
+            uint32_t _i2374;
+            for (_i2374 = 0; _i2374 < _size2370; ++_i2374)
             {
-              xfer += iprot->readString((*(this->success))[_i2372]);
+              xfer += iprot->readString((*(this->success))[_i2374]);
             }
             xfer += iprot->readListEnd();
           }
@@ -47035,14 +47035,14 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2373;
-            ::apache::thrift::protocol::TType _etype2376;
-            xfer += iprot->readListBegin(_etype2376, _size2373);
-            this->success.resize(_size2373);
-            uint32_t _i2377;
-            for (_i2377 = 0; _i2377 < _size2373; ++_i2377)
+            uint32_t _size2375;
+            ::apache::thrift::protocol::TType _etype2378;
+            xfer += iprot->readListBegin(_etype2378, _size2375);
+            this->success.resize(_size2375);
+            uint32_t _i2379;
+            for (_i2379 = 0; _i2379 < _size2375; ++_i2379)
             {
-              xfer += iprot->readString(this->success[_i2377]);
+              xfer += iprot->readString(this->success[_i2379]);
             }
             xfer += iprot->readListEnd();
           }
@@ -47073,10 +47073,10 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2378;
-      for (_iter2378 = this->success.begin(); _iter2378 != this->success.end(); ++_iter2378)
+      std::vector<std::string> ::const_iterator _iter2380;
+      for (_iter2380 = this->success.begin(); _iter2380 != this->success.end(); ++_iter2380)
       {
-        xfer += oprot->writeString((*_iter2378));
+        xfer += oprot->writeString((*_iter2380));
       }
       xfer += oprot->writeListEnd();
     }
@@ -47117,14 +47117,14 @@ uint32_t ThriftHiveMetastore_find_columns_with_stats_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2379;
-            ::apache::thrift::protocol::TType _etype2382;
-            xfer += iprot->readListBegin(_etype2382, _size2379);
-            (*(this->success)).resize(_size2379);
-            uint32_t _i2383;
-            for (_i2383 = 0; _i2383 < _size2379; ++_i2383)
+            uint32_t _size2381;
+            ::apache::thrift::protocol::TType _etype2384;
+            xfer += iprot->readListBegin(_etype2384, _size2381);
+            (*(this->success)).resize(_size2381);
+            uint32_t _i2385;
+            for (_i2385 = 0; _i2385 < _size2381; ++_i2385)
             {
-              xfer += iprot->readString((*(this->success))[_i2383]);
+              xfer += iprot->readString((*(this->success))[_i2385]);
             }
             xfer += iprot->readListEnd();
           }
@@ -56279,14 +56279,14 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_result::read(::apache::thri
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2384;
-            ::apache::thrift::protocol::TType _etype2387;
-            xfer += iprot->readListBegin(_etype2387, _size2384);
-            this->success.resize(_size2384);
-            uint32_t _i2388;
-            for (_i2388 = 0; _i2388 < _size2384; ++_i2388)
+            uint32_t _size2386;
+            ::apache::thrift::protocol::TType _etype2389;
+            xfer += iprot->readListBegin(_etype2389, _size2386);
+            this->success.resize(_size2386);
+            uint32_t _i2390;
+            for (_i2390 = 0; _i2390 < _size2386; ++_i2390)
             {
-              xfer += this->success[_i2388].read(iprot);
+              xfer += this->success[_i2390].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -56333,10 +56333,10 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_result::write(::apache::thr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<SchemaVersion> ::const_iterator _iter2389;
-      for (_iter2389 = this->success.begin(); _iter2389 != this->success.end(); ++_iter2389)
+      std::vector<SchemaVersion> ::const_iterator _iter2391;
+      for (_iter2391 = this->success.begin(); _iter2391 != this->success.end(); ++_iter2391)
       {
-        xfer += (*_iter2389).write(oprot);
+        xfer += (*_iter2391).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -56385,14 +56385,14 @@ uint32_t ThriftHiveMetastore_get_schema_all_versions_presult::read(::apache::thr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2390;
-            ::apache::thrift::protocol::TType _etype2393;
-            xfer += iprot->readListBegin(_etype2393, _size2390);
-            (*(this->success)).resize(_size2390);
-            uint32_t _i2394;
-            for (_i2394 = 0; _i2394 < _size2390; ++_i2394)
+            uint32_t _size2392;
+            ::apache::thrift::protocol::TType _etype2395;
+            xfer += iprot->readListBegin(_etype2395, _size2392);
+            (*(this->success)).resize(_size2392);
+            uint32_t _i2396;
+            for (_i2396 = 0; _i2396 < _size2392; ++_i2396)
             {
-              xfer += (*(this->success))[_i2394].read(iprot);
+              xfer += (*(this->success))[_i2396].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -58445,14 +58445,14 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_result::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2395;
-            ::apache::thrift::protocol::TType _etype2398;
-            xfer += iprot->readListBegin(_etype2398, _size2395);
-            this->success.resize(_size2395);
-            uint32_t _i2399;
-            for (_i2399 = 0; _i2399 < _size2395; ++_i2399)
+            uint32_t _size2397;
+            ::apache::thrift::protocol::TType _etype2400;
+            xfer += iprot->readListBegin(_etype2400, _size2397);
+            this->success.resize(_size2397);
+            uint32_t _i2401;
+            for (_i2401 = 0; _i2401 < _size2397; ++_i2401)
             {
-              xfer += this->success[_i2399].read(iprot);
+              xfer += this->success[_i2401].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -58491,10 +58491,10 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_result::write(::apache::thrift::p
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->success.size()));
-      std::vector<RuntimeStat> ::const_iterator _iter2400;
-      for (_iter2400 = this->success.begin(); _iter2400 != this->success.end(); ++_iter2400)
+      std::vector<RuntimeStat> ::const_iterator _iter2402;
+      for (_iter2402 = this->success.begin(); _iter2402 != this->success.end(); ++_iter2402)
       {
-        xfer += (*_iter2400).write(oprot);
+        xfer += (*_iter2402).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -58539,14 +58539,14 @@ uint32_t ThriftHiveMetastore_get_runtime_stats_presult::read(::apache::thrift::p
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2401;
-            ::apache::thrift::protocol::TType _etype2404;
-            xfer += iprot->readListBegin(_etype2404, _size2401);
-            (*(this->success)).resize(_size2401);
-            uint32_t _i2405;
-            for (_i2405 = 0; _i2405 < _size2401; ++_i2405)
+            uint32_t _size2403;
+            ::apache::thrift::protocol::TType _etype2406;
+            xfer += iprot->readListBegin(_etype2406, _size2403);
+            (*(this->success)).resize(_size2403);
+            uint32_t _i2407;
+            for (_i2407 = 0; _i2407 < _size2403; ++_i2407)
             {
-              xfer += (*(this->success))[_i2405].read(iprot);
+              xfer += (*(this->success))[_i2407].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -60981,14 +60981,14 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_result::read(::apache::th
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2406;
-            ::apache::thrift::protocol::TType _etype2409;
-            xfer += iprot->readListBegin(_etype2409, _size2406);
-            this->success.resize(_size2406);
-            uint32_t _i2410;
-            for (_i2410 = 0; _i2410 < _size2406; ++_i2410)
+            uint32_t _size2408;
+            ::apache::thrift::protocol::TType _etype2411;
+            xfer += iprot->readListBegin(_etype2411, _size2408);
+            this->success.resize(_size2408);
+            uint32_t _i2412;
+            for (_i2412 = 0; _i2412 < _size2408; ++_i2412)
             {
-              xfer += iprot->readString(this->success[_i2410]);
+              xfer += iprot->readString(this->success[_i2412]);
             }
             xfer += iprot->readListEnd();
           }
@@ -61027,10 +61027,10 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_result::write(::apache::t
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2411;
-      for (_iter2411 = this->success.begin(); _iter2411 != this->success.end(); ++_iter2411)
+      std::vector<std::string> ::const_iterator _iter2413;
+      for (_iter2413 = this->success.begin(); _iter2413 != this->success.end(); ++_iter2413)
       {
-        xfer += oprot->writeString((*_iter2411));
+        xfer += oprot->writeString((*_iter2413));
       }
       xfer += oprot->writeListEnd();
     }
@@ -61075,14 +61075,14 @@ uint32_t ThriftHiveMetastore_get_all_stored_procedures_presult::read(::apache::t
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2412;
-            ::apache::thrift::protocol::TType _etype2415;
-            xfer += iprot->readListBegin(_etype2415, _size2412);
-            (*(this->success)).resize(_size2412);
-            uint32_t _i2416;
-            for (_i2416 = 0; _i2416 < _size2412; ++_i2416)
+            uint32_t _size2414;
+            ::apache::thrift::protocol::TType _etype2417;
+            xfer += iprot->readListBegin(_etype2417, _size2414);
+            (*(this->success)).resize(_size2414);
+            uint32_t _i2418;
+            for (_i2418 = 0; _i2418 < _size2414; ++_i2418)
             {
-              xfer += iprot->readString((*(this->success))[_i2416]);
+              xfer += iprot->readString((*(this->success))[_i2418]);
             }
             xfer += iprot->readListEnd();
           }
@@ -61634,14 +61634,14 @@ uint32_t ThriftHiveMetastore_get_all_packages_result::read(::apache::thrift::pro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->success.clear();
-            uint32_t _size2417;
-            ::apache::thrift::protocol::TType _etype2420;
-            xfer += iprot->readListBegin(_etype2420, _size2417);
-            this->success.resize(_size2417);
-            uint32_t _i2421;
-            for (_i2421 = 0; _i2421 < _size2417; ++_i2421)
+            uint32_t _size2419;
+            ::apache::thrift::protocol::TType _etype2422;
+            xfer += iprot->readListBegin(_etype2422, _size2419);
+            this->success.resize(_size2419);
+            uint32_t _i2423;
+            for (_i2423 = 0; _i2423 < _size2419; ++_i2423)
             {
-              xfer += iprot->readString(this->success[_i2421]);
+              xfer += iprot->readString(this->success[_i2423]);
             }
             xfer += iprot->readListEnd();
           }
@@ -61680,10 +61680,10 @@ uint32_t ThriftHiveMetastore_get_all_packages_result::write(::apache::thrift::pr
     xfer += oprot->writeFieldBegin("success", ::apache::thrift::protocol::T_LIST, 0);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->success.size()));
-      std::vector<std::string> ::const_iterator _iter2422;
-      for (_iter2422 = this->success.begin(); _iter2422 != this->success.end(); ++_iter2422)
+      std::vector<std::string> ::const_iterator _iter2424;
+      for (_iter2424 = this->success.begin(); _iter2424 != this->success.end(); ++_iter2424)
       {
-        xfer += oprot->writeString((*_iter2422));
+        xfer += oprot->writeString((*_iter2424));
       }
       xfer += oprot->writeListEnd();
     }
@@ -61728,14 +61728,14 @@ uint32_t ThriftHiveMetastore_get_all_packages_presult::read(::apache::thrift::pr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             (*(this->success)).clear();
-            uint32_t _size2423;
-            ::apache::thrift::protocol::TType _etype2426;
-            xfer += iprot->readListBegin(_etype2426, _size2423);
-            (*(this->success)).resize(_size2423);
-            uint32_t _i2427;
-            for (_i2427 = 0; _i2427 < _size2423; ++_i2427)
+            uint32_t _size2425;
+            ::apache::thrift::protocol::TType _etype2428;
+            xfer += iprot->readListBegin(_etype2428, _size2425);
+            (*(this->success)).resize(_size2425);
+            uint32_t _i2429;
+            for (_i2429 = 0; _i2429 < _size2425; ++_i2429)
             {
-              xfer += iprot->readString((*(this->success))[_i2427]);
+              xfer += iprot->readString((*(this->success))[_i2429]);
             }
             xfer += iprot->readListEnd();
           }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -20793,6 +20793,11 @@ void AbortTxnRequest::__set_replPolicy(const std::string& val) {
   this->replPolicy = val;
 __isset.replPolicy = true;
 }
+
+void AbortTxnRequest::__set_txn_type(const TxnType::type val) {
+  this->txn_type = val;
+__isset.txn_type = true;
+}
 std::ostream& operator<<(std::ostream& out, const AbortTxnRequest& obj)
 {
   obj.printTo(out);
@@ -20838,6 +20843,16 @@ uint32_t AbortTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
           xfer += iprot->skip(ftype);
         }
         break;
+      case 3:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast785;
+          xfer += iprot->readI32(ecast785);
+          this->txn_type = (TxnType::type)ecast785;
+          this->__isset.txn_type = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -20866,6 +20881,11 @@ uint32_t AbortTxnRequest::write(::apache::thrift::protocol::TProtocol* oprot) co
     xfer += oprot->writeString(this->replPolicy);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.txn_type) {
+    xfer += oprot->writeFieldBegin("txn_type", ::apache::thrift::protocol::T_I32, 3);
+    xfer += oprot->writeI32((int32_t)this->txn_type);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -20875,18 +20895,21 @@ void swap(AbortTxnRequest &a, AbortTxnRequest &b) {
   using ::std::swap;
   swap(a.txnid, b.txnid);
   swap(a.replPolicy, b.replPolicy);
+  swap(a.txn_type, b.txn_type);
   swap(a.__isset, b.__isset);
 }
 
-AbortTxnRequest::AbortTxnRequest(const AbortTxnRequest& other785) {
-  txnid = other785.txnid;
-  replPolicy = other785.replPolicy;
-  __isset = other785.__isset;
-}
-AbortTxnRequest& AbortTxnRequest::operator=(const AbortTxnRequest& other786) {
+AbortTxnRequest::AbortTxnRequest(const AbortTxnRequest& other786) {
   txnid = other786.txnid;
   replPolicy = other786.replPolicy;
+  txn_type = other786.txn_type;
   __isset = other786.__isset;
+}
+AbortTxnRequest& AbortTxnRequest::operator=(const AbortTxnRequest& other787) {
+  txnid = other787.txnid;
+  replPolicy = other787.replPolicy;
+  txn_type = other787.txn_type;
+  __isset = other787.__isset;
   return *this;
 }
 void AbortTxnRequest::printTo(std::ostream& out) const {
@@ -20894,6 +20917,7 @@ void AbortTxnRequest::printTo(std::ostream& out) const {
   out << "AbortTxnRequest(";
   out << "txnid=" << to_string(txnid);
   out << ", " << "replPolicy="; (__isset.replPolicy ? (out << to_string(replPolicy)) : (out << "<null>"));
+  out << ", " << "txn_type="; (__isset.txn_type ? (out << to_string(txn_type)) : (out << "<null>"));
   out << ")";
 }
 
@@ -20938,14 +20962,14 @@ uint32_t AbortTxnsRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txn_ids.clear();
-            uint32_t _size787;
-            ::apache::thrift::protocol::TType _etype790;
-            xfer += iprot->readListBegin(_etype790, _size787);
-            this->txn_ids.resize(_size787);
-            uint32_t _i791;
-            for (_i791 = 0; _i791 < _size787; ++_i791)
+            uint32_t _size788;
+            ::apache::thrift::protocol::TType _etype791;
+            xfer += iprot->readListBegin(_etype791, _size788);
+            this->txn_ids.resize(_size788);
+            uint32_t _i792;
+            for (_i792 = 0; _i792 < _size788; ++_i792)
             {
-              xfer += iprot->readI64(this->txn_ids[_i791]);
+              xfer += iprot->readI64(this->txn_ids[_i792]);
             }
             xfer += iprot->readListEnd();
           }
@@ -20976,10 +21000,10 @@ uint32_t AbortTxnsRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
   xfer += oprot->writeFieldBegin("txn_ids", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->txn_ids.size()));
-    std::vector<int64_t> ::const_iterator _iter792;
-    for (_iter792 = this->txn_ids.begin(); _iter792 != this->txn_ids.end(); ++_iter792)
+    std::vector<int64_t> ::const_iterator _iter793;
+    for (_iter793 = this->txn_ids.begin(); _iter793 != this->txn_ids.end(); ++_iter793)
     {
-      xfer += oprot->writeI64((*_iter792));
+      xfer += oprot->writeI64((*_iter793));
     }
     xfer += oprot->writeListEnd();
   }
@@ -20995,11 +21019,11 @@ void swap(AbortTxnsRequest &a, AbortTxnsRequest &b) {
   swap(a.txn_ids, b.txn_ids);
 }
 
-AbortTxnsRequest::AbortTxnsRequest(const AbortTxnsRequest& other793) {
-  txn_ids = other793.txn_ids;
-}
-AbortTxnsRequest& AbortTxnsRequest::operator=(const AbortTxnsRequest& other794) {
+AbortTxnsRequest::AbortTxnsRequest(const AbortTxnsRequest& other794) {
   txn_ids = other794.txn_ids;
+}
+AbortTxnsRequest& AbortTxnsRequest::operator=(const AbortTxnsRequest& other795) {
+  txn_ids = other795.txn_ids;
   return *this;
 }
 void AbortTxnsRequest::printTo(std::ostream& out) const {
@@ -21127,15 +21151,15 @@ void swap(CommitTxnKeyValue &a, CommitTxnKeyValue &b) {
   swap(a.value, b.value);
 }
 
-CommitTxnKeyValue::CommitTxnKeyValue(const CommitTxnKeyValue& other795) {
-  tableId = other795.tableId;
-  key = other795.key;
-  value = other795.value;
-}
-CommitTxnKeyValue& CommitTxnKeyValue::operator=(const CommitTxnKeyValue& other796) {
+CommitTxnKeyValue::CommitTxnKeyValue(const CommitTxnKeyValue& other796) {
   tableId = other796.tableId;
   key = other796.key;
   value = other796.value;
+}
+CommitTxnKeyValue& CommitTxnKeyValue::operator=(const CommitTxnKeyValue& other797) {
+  tableId = other797.tableId;
+  key = other797.key;
+  value = other797.value;
   return *this;
 }
 void CommitTxnKeyValue::printTo(std::ostream& out) const {
@@ -21343,17 +21367,7 @@ void swap(WriteEventInfo &a, WriteEventInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-WriteEventInfo::WriteEventInfo(const WriteEventInfo& other797) {
-  writeId = other797.writeId;
-  database = other797.database;
-  table = other797.table;
-  files = other797.files;
-  partition = other797.partition;
-  tableObj = other797.tableObj;
-  partitionObj = other797.partitionObj;
-  __isset = other797.__isset;
-}
-WriteEventInfo& WriteEventInfo::operator=(const WriteEventInfo& other798) {
+WriteEventInfo::WriteEventInfo(const WriteEventInfo& other798) {
   writeId = other798.writeId;
   database = other798.database;
   table = other798.table;
@@ -21362,6 +21376,16 @@ WriteEventInfo& WriteEventInfo::operator=(const WriteEventInfo& other798) {
   tableObj = other798.tableObj;
   partitionObj = other798.partitionObj;
   __isset = other798.__isset;
+}
+WriteEventInfo& WriteEventInfo::operator=(const WriteEventInfo& other799) {
+  writeId = other799.writeId;
+  database = other799.database;
+  table = other799.table;
+  files = other799.files;
+  partition = other799.partition;
+  tableObj = other799.tableObj;
+  partitionObj = other799.partitionObj;
+  __isset = other799.__isset;
   return *this;
 }
 void WriteEventInfo::printTo(std::ostream& out) const {
@@ -21470,14 +21494,14 @@ uint32_t ReplLastIdInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionList.clear();
-            uint32_t _size799;
-            ::apache::thrift::protocol::TType _etype802;
-            xfer += iprot->readListBegin(_etype802, _size799);
-            this->partitionList.resize(_size799);
-            uint32_t _i803;
-            for (_i803 = 0; _i803 < _size799; ++_i803)
+            uint32_t _size800;
+            ::apache::thrift::protocol::TType _etype803;
+            xfer += iprot->readListBegin(_etype803, _size800);
+            this->partitionList.resize(_size800);
+            uint32_t _i804;
+            for (_i804 = 0; _i804 < _size800; ++_i804)
             {
-              xfer += iprot->readString(this->partitionList[_i803]);
+              xfer += iprot->readString(this->partitionList[_i804]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21529,10 +21553,10 @@ uint32_t ReplLastIdInfo::write(::apache::thrift::protocol::TProtocol* oprot) con
     xfer += oprot->writeFieldBegin("partitionList", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionList.size()));
-      std::vector<std::string> ::const_iterator _iter804;
-      for (_iter804 = this->partitionList.begin(); _iter804 != this->partitionList.end(); ++_iter804)
+      std::vector<std::string> ::const_iterator _iter805;
+      for (_iter805 = this->partitionList.begin(); _iter805 != this->partitionList.end(); ++_iter805)
       {
-        xfer += oprot->writeString((*_iter804));
+        xfer += oprot->writeString((*_iter805));
       }
       xfer += oprot->writeListEnd();
     }
@@ -21553,21 +21577,21 @@ void swap(ReplLastIdInfo &a, ReplLastIdInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplLastIdInfo::ReplLastIdInfo(const ReplLastIdInfo& other805) {
-  database = other805.database;
-  lastReplId = other805.lastReplId;
-  table = other805.table;
-  catalog = other805.catalog;
-  partitionList = other805.partitionList;
-  __isset = other805.__isset;
-}
-ReplLastIdInfo& ReplLastIdInfo::operator=(const ReplLastIdInfo& other806) {
+ReplLastIdInfo::ReplLastIdInfo(const ReplLastIdInfo& other806) {
   database = other806.database;
   lastReplId = other806.lastReplId;
   table = other806.table;
   catalog = other806.catalog;
   partitionList = other806.partitionList;
   __isset = other806.__isset;
+}
+ReplLastIdInfo& ReplLastIdInfo::operator=(const ReplLastIdInfo& other807) {
+  database = other807.database;
+  lastReplId = other807.lastReplId;
+  table = other807.table;
+  catalog = other807.catalog;
+  partitionList = other807.partitionList;
+  __isset = other807.__isset;
   return *this;
 }
 void ReplLastIdInfo::printTo(std::ostream& out) const {
@@ -21613,6 +21637,11 @@ __isset.keyValue = true;
 void CommitTxnRequest::__set_exclWriteEnabled(const bool val) {
   this->exclWriteEnabled = val;
 __isset.exclWriteEnabled = true;
+}
+
+void CommitTxnRequest::__set_txn_type(const TxnType::type val) {
+  this->txn_type = val;
+__isset.txn_type = true;
 }
 std::ostream& operator<<(std::ostream& out, const CommitTxnRequest& obj)
 {
@@ -21663,14 +21692,14 @@ uint32_t CommitTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->writeEventInfos.clear();
-            uint32_t _size807;
-            ::apache::thrift::protocol::TType _etype810;
-            xfer += iprot->readListBegin(_etype810, _size807);
-            this->writeEventInfos.resize(_size807);
-            uint32_t _i811;
-            for (_i811 = 0; _i811 < _size807; ++_i811)
+            uint32_t _size808;
+            ::apache::thrift::protocol::TType _etype811;
+            xfer += iprot->readListBegin(_etype811, _size808);
+            this->writeEventInfos.resize(_size808);
+            uint32_t _i812;
+            for (_i812 = 0; _i812 < _size808; ++_i812)
             {
-              xfer += this->writeEventInfos[_i811].read(iprot);
+              xfer += this->writeEventInfos[_i812].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -21699,6 +21728,16 @@ uint32_t CommitTxnRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_BOOL) {
           xfer += iprot->readBool(this->exclWriteEnabled);
           this->__isset.exclWriteEnabled = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 7:
+        if (ftype == ::apache::thrift::protocol::T_I32) {
+          int32_t ecast813;
+          xfer += iprot->readI32(ecast813);
+          this->txn_type = (TxnType::type)ecast813;
+          this->__isset.txn_type = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -21735,10 +21774,10 @@ uint32_t CommitTxnRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("writeEventInfos", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->writeEventInfos.size()));
-      std::vector<WriteEventInfo> ::const_iterator _iter812;
-      for (_iter812 = this->writeEventInfos.begin(); _iter812 != this->writeEventInfos.end(); ++_iter812)
+      std::vector<WriteEventInfo> ::const_iterator _iter814;
+      for (_iter814 = this->writeEventInfos.begin(); _iter814 != this->writeEventInfos.end(); ++_iter814)
       {
-        xfer += (*_iter812).write(oprot);
+        xfer += (*_iter814).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -21759,6 +21798,11 @@ uint32_t CommitTxnRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeBool(this->exclWriteEnabled);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.txn_type) {
+    xfer += oprot->writeFieldBegin("txn_type", ::apache::thrift::protocol::T_I32, 7);
+    xfer += oprot->writeI32((int32_t)this->txn_type);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -21772,26 +21816,29 @@ void swap(CommitTxnRequest &a, CommitTxnRequest &b) {
   swap(a.replLastIdInfo, b.replLastIdInfo);
   swap(a.keyValue, b.keyValue);
   swap(a.exclWriteEnabled, b.exclWriteEnabled);
+  swap(a.txn_type, b.txn_type);
   swap(a.__isset, b.__isset);
 }
 
-CommitTxnRequest::CommitTxnRequest(const CommitTxnRequest& other813) {
-  txnid = other813.txnid;
-  replPolicy = other813.replPolicy;
-  writeEventInfos = other813.writeEventInfos;
-  replLastIdInfo = other813.replLastIdInfo;
-  keyValue = other813.keyValue;
-  exclWriteEnabled = other813.exclWriteEnabled;
-  __isset = other813.__isset;
+CommitTxnRequest::CommitTxnRequest(const CommitTxnRequest& other815) {
+  txnid = other815.txnid;
+  replPolicy = other815.replPolicy;
+  writeEventInfos = other815.writeEventInfos;
+  replLastIdInfo = other815.replLastIdInfo;
+  keyValue = other815.keyValue;
+  exclWriteEnabled = other815.exclWriteEnabled;
+  txn_type = other815.txn_type;
+  __isset = other815.__isset;
 }
-CommitTxnRequest& CommitTxnRequest::operator=(const CommitTxnRequest& other814) {
-  txnid = other814.txnid;
-  replPolicy = other814.replPolicy;
-  writeEventInfos = other814.writeEventInfos;
-  replLastIdInfo = other814.replLastIdInfo;
-  keyValue = other814.keyValue;
-  exclWriteEnabled = other814.exclWriteEnabled;
-  __isset = other814.__isset;
+CommitTxnRequest& CommitTxnRequest::operator=(const CommitTxnRequest& other816) {
+  txnid = other816.txnid;
+  replPolicy = other816.replPolicy;
+  writeEventInfos = other816.writeEventInfos;
+  replLastIdInfo = other816.replLastIdInfo;
+  keyValue = other816.keyValue;
+  exclWriteEnabled = other816.exclWriteEnabled;
+  txn_type = other816.txn_type;
+  __isset = other816.__isset;
   return *this;
 }
 void CommitTxnRequest::printTo(std::ostream& out) const {
@@ -21803,6 +21850,7 @@ void CommitTxnRequest::printTo(std::ostream& out) const {
   out << ", " << "replLastIdInfo="; (__isset.replLastIdInfo ? (out << to_string(replLastIdInfo)) : (out << "<null>"));
   out << ", " << "keyValue="; (__isset.keyValue ? (out << to_string(keyValue)) : (out << "<null>"));
   out << ", " << "exclWriteEnabled="; (__isset.exclWriteEnabled ? (out << to_string(exclWriteEnabled)) : (out << "<null>"));
+  out << ", " << "txn_type="; (__isset.txn_type ? (out << to_string(txn_type)) : (out << "<null>"));
   out << ")";
 }
 
@@ -21912,14 +21960,14 @@ uint32_t ReplTblWriteIdStateRequest::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partNames.clear();
-            uint32_t _size815;
-            ::apache::thrift::protocol::TType _etype818;
-            xfer += iprot->readListBegin(_etype818, _size815);
-            this->partNames.resize(_size815);
-            uint32_t _i819;
-            for (_i819 = 0; _i819 < _size815; ++_i819)
+            uint32_t _size817;
+            ::apache::thrift::protocol::TType _etype820;
+            xfer += iprot->readListBegin(_etype820, _size817);
+            this->partNames.resize(_size817);
+            uint32_t _i821;
+            for (_i821 = 0; _i821 < _size817; ++_i821)
             {
-              xfer += iprot->readString(this->partNames[_i819]);
+              xfer += iprot->readString(this->partNames[_i821]);
             }
             xfer += iprot->readListEnd();
           }
@@ -21979,10 +22027,10 @@ uint32_t ReplTblWriteIdStateRequest::write(::apache::thrift::protocol::TProtocol
     xfer += oprot->writeFieldBegin("partNames", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partNames.size()));
-      std::vector<std::string> ::const_iterator _iter820;
-      for (_iter820 = this->partNames.begin(); _iter820 != this->partNames.end(); ++_iter820)
+      std::vector<std::string> ::const_iterator _iter822;
+      for (_iter822 = this->partNames.begin(); _iter822 != this->partNames.end(); ++_iter822)
       {
-        xfer += oprot->writeString((*_iter820));
+        xfer += oprot->writeString((*_iter822));
       }
       xfer += oprot->writeListEnd();
     }
@@ -22004,23 +22052,23 @@ void swap(ReplTblWriteIdStateRequest &a, ReplTblWriteIdStateRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplTblWriteIdStateRequest::ReplTblWriteIdStateRequest(const ReplTblWriteIdStateRequest& other821) {
-  validWriteIdlist = other821.validWriteIdlist;
-  user = other821.user;
-  hostName = other821.hostName;
-  dbName = other821.dbName;
-  tableName = other821.tableName;
-  partNames = other821.partNames;
-  __isset = other821.__isset;
+ReplTblWriteIdStateRequest::ReplTblWriteIdStateRequest(const ReplTblWriteIdStateRequest& other823) {
+  validWriteIdlist = other823.validWriteIdlist;
+  user = other823.user;
+  hostName = other823.hostName;
+  dbName = other823.dbName;
+  tableName = other823.tableName;
+  partNames = other823.partNames;
+  __isset = other823.__isset;
 }
-ReplTblWriteIdStateRequest& ReplTblWriteIdStateRequest::operator=(const ReplTblWriteIdStateRequest& other822) {
-  validWriteIdlist = other822.validWriteIdlist;
-  user = other822.user;
-  hostName = other822.hostName;
-  dbName = other822.dbName;
-  tableName = other822.tableName;
-  partNames = other822.partNames;
-  __isset = other822.__isset;
+ReplTblWriteIdStateRequest& ReplTblWriteIdStateRequest::operator=(const ReplTblWriteIdStateRequest& other824) {
+  validWriteIdlist = other824.validWriteIdlist;
+  user = other824.user;
+  hostName = other824.hostName;
+  dbName = other824.dbName;
+  tableName = other824.tableName;
+  partNames = other824.partNames;
+  __isset = other824.__isset;
   return *this;
 }
 void ReplTblWriteIdStateRequest::printTo(std::ostream& out) const {
@@ -22086,14 +22134,14 @@ uint32_t GetValidWriteIdsRequest::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fullTableNames.clear();
-            uint32_t _size823;
-            ::apache::thrift::protocol::TType _etype826;
-            xfer += iprot->readListBegin(_etype826, _size823);
-            this->fullTableNames.resize(_size823);
-            uint32_t _i827;
-            for (_i827 = 0; _i827 < _size823; ++_i827)
+            uint32_t _size825;
+            ::apache::thrift::protocol::TType _etype828;
+            xfer += iprot->readListBegin(_etype828, _size825);
+            this->fullTableNames.resize(_size825);
+            uint32_t _i829;
+            for (_i829 = 0; _i829 < _size825; ++_i829)
             {
-              xfer += iprot->readString(this->fullTableNames[_i827]);
+              xfer += iprot->readString(this->fullTableNames[_i829]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22140,10 +22188,10 @@ uint32_t GetValidWriteIdsRequest::write(::apache::thrift::protocol::TProtocol* o
   xfer += oprot->writeFieldBegin("fullTableNames", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->fullTableNames.size()));
-    std::vector<std::string> ::const_iterator _iter828;
-    for (_iter828 = this->fullTableNames.begin(); _iter828 != this->fullTableNames.end(); ++_iter828)
+    std::vector<std::string> ::const_iterator _iter830;
+    for (_iter830 = this->fullTableNames.begin(); _iter830 != this->fullTableNames.end(); ++_iter830)
     {
-      xfer += oprot->writeString((*_iter828));
+      xfer += oprot->writeString((*_iter830));
     }
     xfer += oprot->writeListEnd();
   }
@@ -22172,17 +22220,17 @@ void swap(GetValidWriteIdsRequest &a, GetValidWriteIdsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetValidWriteIdsRequest::GetValidWriteIdsRequest(const GetValidWriteIdsRequest& other829) {
-  fullTableNames = other829.fullTableNames;
-  validTxnList = other829.validTxnList;
-  writeId = other829.writeId;
-  __isset = other829.__isset;
+GetValidWriteIdsRequest::GetValidWriteIdsRequest(const GetValidWriteIdsRequest& other831) {
+  fullTableNames = other831.fullTableNames;
+  validTxnList = other831.validTxnList;
+  writeId = other831.writeId;
+  __isset = other831.__isset;
 }
-GetValidWriteIdsRequest& GetValidWriteIdsRequest::operator=(const GetValidWriteIdsRequest& other830) {
-  fullTableNames = other830.fullTableNames;
-  validTxnList = other830.validTxnList;
-  writeId = other830.writeId;
-  __isset = other830.__isset;
+GetValidWriteIdsRequest& GetValidWriteIdsRequest::operator=(const GetValidWriteIdsRequest& other832) {
+  fullTableNames = other832.fullTableNames;
+  validTxnList = other832.validTxnList;
+  writeId = other832.writeId;
+  __isset = other832.__isset;
   return *this;
 }
 void GetValidWriteIdsRequest::printTo(std::ostream& out) const {
@@ -22271,14 +22319,14 @@ uint32_t TableValidWriteIds::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->invalidWriteIds.clear();
-            uint32_t _size831;
-            ::apache::thrift::protocol::TType _etype834;
-            xfer += iprot->readListBegin(_etype834, _size831);
-            this->invalidWriteIds.resize(_size831);
-            uint32_t _i835;
-            for (_i835 = 0; _i835 < _size831; ++_i835)
+            uint32_t _size833;
+            ::apache::thrift::protocol::TType _etype836;
+            xfer += iprot->readListBegin(_etype836, _size833);
+            this->invalidWriteIds.resize(_size833);
+            uint32_t _i837;
+            for (_i837 = 0; _i837 < _size833; ++_i837)
             {
-              xfer += iprot->readI64(this->invalidWriteIds[_i835]);
+              xfer += iprot->readI64(this->invalidWriteIds[_i837]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22339,10 +22387,10 @@ uint32_t TableValidWriteIds::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("invalidWriteIds", ::apache::thrift::protocol::T_LIST, 3);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->invalidWriteIds.size()));
-    std::vector<int64_t> ::const_iterator _iter836;
-    for (_iter836 = this->invalidWriteIds.begin(); _iter836 != this->invalidWriteIds.end(); ++_iter836)
+    std::vector<int64_t> ::const_iterator _iter838;
+    for (_iter838 = this->invalidWriteIds.begin(); _iter838 != this->invalidWriteIds.end(); ++_iter838)
     {
-      xfer += oprot->writeI64((*_iter836));
+      xfer += oprot->writeI64((*_iter838));
     }
     xfer += oprot->writeListEnd();
   }
@@ -22372,21 +22420,21 @@ void swap(TableValidWriteIds &a, TableValidWriteIds &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableValidWriteIds::TableValidWriteIds(const TableValidWriteIds& other837) {
-  fullTableName = other837.fullTableName;
-  writeIdHighWaterMark = other837.writeIdHighWaterMark;
-  invalidWriteIds = other837.invalidWriteIds;
-  minOpenWriteId = other837.minOpenWriteId;
-  abortedBits = other837.abortedBits;
-  __isset = other837.__isset;
+TableValidWriteIds::TableValidWriteIds(const TableValidWriteIds& other839) {
+  fullTableName = other839.fullTableName;
+  writeIdHighWaterMark = other839.writeIdHighWaterMark;
+  invalidWriteIds = other839.invalidWriteIds;
+  minOpenWriteId = other839.minOpenWriteId;
+  abortedBits = other839.abortedBits;
+  __isset = other839.__isset;
 }
-TableValidWriteIds& TableValidWriteIds::operator=(const TableValidWriteIds& other838) {
-  fullTableName = other838.fullTableName;
-  writeIdHighWaterMark = other838.writeIdHighWaterMark;
-  invalidWriteIds = other838.invalidWriteIds;
-  minOpenWriteId = other838.minOpenWriteId;
-  abortedBits = other838.abortedBits;
-  __isset = other838.__isset;
+TableValidWriteIds& TableValidWriteIds::operator=(const TableValidWriteIds& other840) {
+  fullTableName = other840.fullTableName;
+  writeIdHighWaterMark = other840.writeIdHighWaterMark;
+  invalidWriteIds = other840.invalidWriteIds;
+  minOpenWriteId = other840.minOpenWriteId;
+  abortedBits = other840.abortedBits;
+  __isset = other840.__isset;
   return *this;
 }
 void TableValidWriteIds::printTo(std::ostream& out) const {
@@ -22441,14 +22489,14 @@ uint32_t GetValidWriteIdsResponse::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tblValidWriteIds.clear();
-            uint32_t _size839;
-            ::apache::thrift::protocol::TType _etype842;
-            xfer += iprot->readListBegin(_etype842, _size839);
-            this->tblValidWriteIds.resize(_size839);
-            uint32_t _i843;
-            for (_i843 = 0; _i843 < _size839; ++_i843)
+            uint32_t _size841;
+            ::apache::thrift::protocol::TType _etype844;
+            xfer += iprot->readListBegin(_etype844, _size841);
+            this->tblValidWriteIds.resize(_size841);
+            uint32_t _i845;
+            for (_i845 = 0; _i845 < _size841; ++_i845)
             {
-              xfer += this->tblValidWriteIds[_i843].read(iprot);
+              xfer += this->tblValidWriteIds[_i845].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22479,10 +22527,10 @@ uint32_t GetValidWriteIdsResponse::write(::apache::thrift::protocol::TProtocol* 
   xfer += oprot->writeFieldBegin("tblValidWriteIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tblValidWriteIds.size()));
-    std::vector<TableValidWriteIds> ::const_iterator _iter844;
-    for (_iter844 = this->tblValidWriteIds.begin(); _iter844 != this->tblValidWriteIds.end(); ++_iter844)
+    std::vector<TableValidWriteIds> ::const_iterator _iter846;
+    for (_iter846 = this->tblValidWriteIds.begin(); _iter846 != this->tblValidWriteIds.end(); ++_iter846)
     {
-      xfer += (*_iter844).write(oprot);
+      xfer += (*_iter846).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -22498,11 +22546,11 @@ void swap(GetValidWriteIdsResponse &a, GetValidWriteIdsResponse &b) {
   swap(a.tblValidWriteIds, b.tblValidWriteIds);
 }
 
-GetValidWriteIdsResponse::GetValidWriteIdsResponse(const GetValidWriteIdsResponse& other845) {
-  tblValidWriteIds = other845.tblValidWriteIds;
+GetValidWriteIdsResponse::GetValidWriteIdsResponse(const GetValidWriteIdsResponse& other847) {
+  tblValidWriteIds = other847.tblValidWriteIds;
 }
-GetValidWriteIdsResponse& GetValidWriteIdsResponse::operator=(const GetValidWriteIdsResponse& other846) {
-  tblValidWriteIds = other846.tblValidWriteIds;
+GetValidWriteIdsResponse& GetValidWriteIdsResponse::operator=(const GetValidWriteIdsResponse& other848) {
+  tblValidWriteIds = other848.tblValidWriteIds;
   return *this;
 }
 void GetValidWriteIdsResponse::printTo(std::ostream& out) const {
@@ -22610,13 +22658,13 @@ void swap(TxnToWriteId &a, TxnToWriteId &b) {
   swap(a.writeId, b.writeId);
 }
 
-TxnToWriteId::TxnToWriteId(const TxnToWriteId& other847) {
-  txnId = other847.txnId;
-  writeId = other847.writeId;
+TxnToWriteId::TxnToWriteId(const TxnToWriteId& other849) {
+  txnId = other849.txnId;
+  writeId = other849.writeId;
 }
-TxnToWriteId& TxnToWriteId::operator=(const TxnToWriteId& other848) {
-  txnId = other848.txnId;
-  writeId = other848.writeId;
+TxnToWriteId& TxnToWriteId::operator=(const TxnToWriteId& other850) {
+  txnId = other850.txnId;
+  writeId = other850.writeId;
   return *this;
 }
 void TxnToWriteId::printTo(std::ostream& out) const {
@@ -22704,14 +22752,14 @@ uint32_t AllocateTableWriteIdsRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txnIds.clear();
-            uint32_t _size849;
-            ::apache::thrift::protocol::TType _etype852;
-            xfer += iprot->readListBegin(_etype852, _size849);
-            this->txnIds.resize(_size849);
-            uint32_t _i853;
-            for (_i853 = 0; _i853 < _size849; ++_i853)
+            uint32_t _size851;
+            ::apache::thrift::protocol::TType _etype854;
+            xfer += iprot->readListBegin(_etype854, _size851);
+            this->txnIds.resize(_size851);
+            uint32_t _i855;
+            for (_i855 = 0; _i855 < _size851; ++_i855)
             {
-              xfer += iprot->readI64(this->txnIds[_i853]);
+              xfer += iprot->readI64(this->txnIds[_i855]);
             }
             xfer += iprot->readListEnd();
           }
@@ -22732,14 +22780,14 @@ uint32_t AllocateTableWriteIdsRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->srcTxnToWriteIdList.clear();
-            uint32_t _size854;
-            ::apache::thrift::protocol::TType _etype857;
-            xfer += iprot->readListBegin(_etype857, _size854);
-            this->srcTxnToWriteIdList.resize(_size854);
-            uint32_t _i858;
-            for (_i858 = 0; _i858 < _size854; ++_i858)
+            uint32_t _size856;
+            ::apache::thrift::protocol::TType _etype859;
+            xfer += iprot->readListBegin(_etype859, _size856);
+            this->srcTxnToWriteIdList.resize(_size856);
+            uint32_t _i860;
+            for (_i860 = 0; _i860 < _size856; ++_i860)
             {
-              xfer += this->srcTxnToWriteIdList[_i858].read(iprot);
+              xfer += this->srcTxnToWriteIdList[_i860].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22781,10 +22829,10 @@ uint32_t AllocateTableWriteIdsRequest::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("txnIds", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->txnIds.size()));
-      std::vector<int64_t> ::const_iterator _iter859;
-      for (_iter859 = this->txnIds.begin(); _iter859 != this->txnIds.end(); ++_iter859)
+      std::vector<int64_t> ::const_iterator _iter861;
+      for (_iter861 = this->txnIds.begin(); _iter861 != this->txnIds.end(); ++_iter861)
       {
-        xfer += oprot->writeI64((*_iter859));
+        xfer += oprot->writeI64((*_iter861));
       }
       xfer += oprot->writeListEnd();
     }
@@ -22799,10 +22847,10 @@ uint32_t AllocateTableWriteIdsRequest::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("srcTxnToWriteIdList", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->srcTxnToWriteIdList.size()));
-      std::vector<TxnToWriteId> ::const_iterator _iter860;
-      for (_iter860 = this->srcTxnToWriteIdList.begin(); _iter860 != this->srcTxnToWriteIdList.end(); ++_iter860)
+      std::vector<TxnToWriteId> ::const_iterator _iter862;
+      for (_iter862 = this->srcTxnToWriteIdList.begin(); _iter862 != this->srcTxnToWriteIdList.end(); ++_iter862)
       {
-        xfer += (*_iter860).write(oprot);
+        xfer += (*_iter862).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -22823,21 +22871,21 @@ void swap(AllocateTableWriteIdsRequest &a, AllocateTableWriteIdsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AllocateTableWriteIdsRequest::AllocateTableWriteIdsRequest(const AllocateTableWriteIdsRequest& other861) {
-  dbName = other861.dbName;
-  tableName = other861.tableName;
-  txnIds = other861.txnIds;
-  replPolicy = other861.replPolicy;
-  srcTxnToWriteIdList = other861.srcTxnToWriteIdList;
-  __isset = other861.__isset;
+AllocateTableWriteIdsRequest::AllocateTableWriteIdsRequest(const AllocateTableWriteIdsRequest& other863) {
+  dbName = other863.dbName;
+  tableName = other863.tableName;
+  txnIds = other863.txnIds;
+  replPolicy = other863.replPolicy;
+  srcTxnToWriteIdList = other863.srcTxnToWriteIdList;
+  __isset = other863.__isset;
 }
-AllocateTableWriteIdsRequest& AllocateTableWriteIdsRequest::operator=(const AllocateTableWriteIdsRequest& other862) {
-  dbName = other862.dbName;
-  tableName = other862.tableName;
-  txnIds = other862.txnIds;
-  replPolicy = other862.replPolicy;
-  srcTxnToWriteIdList = other862.srcTxnToWriteIdList;
-  __isset = other862.__isset;
+AllocateTableWriteIdsRequest& AllocateTableWriteIdsRequest::operator=(const AllocateTableWriteIdsRequest& other864) {
+  dbName = other864.dbName;
+  tableName = other864.tableName;
+  txnIds = other864.txnIds;
+  replPolicy = other864.replPolicy;
+  srcTxnToWriteIdList = other864.srcTxnToWriteIdList;
+  __isset = other864.__isset;
   return *this;
 }
 void AllocateTableWriteIdsRequest::printTo(std::ostream& out) const {
@@ -22892,14 +22940,14 @@ uint32_t AllocateTableWriteIdsResponse::read(::apache::thrift::protocol::TProtoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->txnToWriteIds.clear();
-            uint32_t _size863;
-            ::apache::thrift::protocol::TType _etype866;
-            xfer += iprot->readListBegin(_etype866, _size863);
-            this->txnToWriteIds.resize(_size863);
-            uint32_t _i867;
-            for (_i867 = 0; _i867 < _size863; ++_i867)
+            uint32_t _size865;
+            ::apache::thrift::protocol::TType _etype868;
+            xfer += iprot->readListBegin(_etype868, _size865);
+            this->txnToWriteIds.resize(_size865);
+            uint32_t _i869;
+            for (_i869 = 0; _i869 < _size865; ++_i869)
             {
-              xfer += this->txnToWriteIds[_i867].read(iprot);
+              xfer += this->txnToWriteIds[_i869].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -22930,10 +22978,10 @@ uint32_t AllocateTableWriteIdsResponse::write(::apache::thrift::protocol::TProto
   xfer += oprot->writeFieldBegin("txnToWriteIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->txnToWriteIds.size()));
-    std::vector<TxnToWriteId> ::const_iterator _iter868;
-    for (_iter868 = this->txnToWriteIds.begin(); _iter868 != this->txnToWriteIds.end(); ++_iter868)
+    std::vector<TxnToWriteId> ::const_iterator _iter870;
+    for (_iter870 = this->txnToWriteIds.begin(); _iter870 != this->txnToWriteIds.end(); ++_iter870)
     {
-      xfer += (*_iter868).write(oprot);
+      xfer += (*_iter870).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -22949,11 +22997,11 @@ void swap(AllocateTableWriteIdsResponse &a, AllocateTableWriteIdsResponse &b) {
   swap(a.txnToWriteIds, b.txnToWriteIds);
 }
 
-AllocateTableWriteIdsResponse::AllocateTableWriteIdsResponse(const AllocateTableWriteIdsResponse& other869) {
-  txnToWriteIds = other869.txnToWriteIds;
+AllocateTableWriteIdsResponse::AllocateTableWriteIdsResponse(const AllocateTableWriteIdsResponse& other871) {
+  txnToWriteIds = other871.txnToWriteIds;
 }
-AllocateTableWriteIdsResponse& AllocateTableWriteIdsResponse::operator=(const AllocateTableWriteIdsResponse& other870) {
-  txnToWriteIds = other870.txnToWriteIds;
+AllocateTableWriteIdsResponse& AllocateTableWriteIdsResponse::operator=(const AllocateTableWriteIdsResponse& other872) {
+  txnToWriteIds = other872.txnToWriteIds;
   return *this;
 }
 void AllocateTableWriteIdsResponse::printTo(std::ostream& out) const {
@@ -23061,13 +23109,13 @@ void swap(MaxAllocatedTableWriteIdRequest &a, MaxAllocatedTableWriteIdRequest &b
   swap(a.tableName, b.tableName);
 }
 
-MaxAllocatedTableWriteIdRequest::MaxAllocatedTableWriteIdRequest(const MaxAllocatedTableWriteIdRequest& other871) {
-  dbName = other871.dbName;
-  tableName = other871.tableName;
+MaxAllocatedTableWriteIdRequest::MaxAllocatedTableWriteIdRequest(const MaxAllocatedTableWriteIdRequest& other873) {
+  dbName = other873.dbName;
+  tableName = other873.tableName;
 }
-MaxAllocatedTableWriteIdRequest& MaxAllocatedTableWriteIdRequest::operator=(const MaxAllocatedTableWriteIdRequest& other872) {
-  dbName = other872.dbName;
-  tableName = other872.tableName;
+MaxAllocatedTableWriteIdRequest& MaxAllocatedTableWriteIdRequest::operator=(const MaxAllocatedTableWriteIdRequest& other874) {
+  dbName = other874.dbName;
+  tableName = other874.tableName;
   return *this;
 }
 void MaxAllocatedTableWriteIdRequest::printTo(std::ostream& out) const {
@@ -23156,11 +23204,11 @@ void swap(MaxAllocatedTableWriteIdResponse &a, MaxAllocatedTableWriteIdResponse 
   swap(a.maxWriteId, b.maxWriteId);
 }
 
-MaxAllocatedTableWriteIdResponse::MaxAllocatedTableWriteIdResponse(const MaxAllocatedTableWriteIdResponse& other873) {
-  maxWriteId = other873.maxWriteId;
+MaxAllocatedTableWriteIdResponse::MaxAllocatedTableWriteIdResponse(const MaxAllocatedTableWriteIdResponse& other875) {
+  maxWriteId = other875.maxWriteId;
 }
-MaxAllocatedTableWriteIdResponse& MaxAllocatedTableWriteIdResponse::operator=(const MaxAllocatedTableWriteIdResponse& other874) {
-  maxWriteId = other874.maxWriteId;
+MaxAllocatedTableWriteIdResponse& MaxAllocatedTableWriteIdResponse::operator=(const MaxAllocatedTableWriteIdResponse& other876) {
+  maxWriteId = other876.maxWriteId;
   return *this;
 }
 void MaxAllocatedTableWriteIdResponse::printTo(std::ostream& out) const {
@@ -23288,15 +23336,15 @@ void swap(SeedTableWriteIdsRequest &a, SeedTableWriteIdsRequest &b) {
   swap(a.seedWriteId, b.seedWriteId);
 }
 
-SeedTableWriteIdsRequest::SeedTableWriteIdsRequest(const SeedTableWriteIdsRequest& other875) {
-  dbName = other875.dbName;
-  tableName = other875.tableName;
-  seedWriteId = other875.seedWriteId;
+SeedTableWriteIdsRequest::SeedTableWriteIdsRequest(const SeedTableWriteIdsRequest& other877) {
+  dbName = other877.dbName;
+  tableName = other877.tableName;
+  seedWriteId = other877.seedWriteId;
 }
-SeedTableWriteIdsRequest& SeedTableWriteIdsRequest::operator=(const SeedTableWriteIdsRequest& other876) {
-  dbName = other876.dbName;
-  tableName = other876.tableName;
-  seedWriteId = other876.seedWriteId;
+SeedTableWriteIdsRequest& SeedTableWriteIdsRequest::operator=(const SeedTableWriteIdsRequest& other878) {
+  dbName = other878.dbName;
+  tableName = other878.tableName;
+  seedWriteId = other878.seedWriteId;
   return *this;
 }
 void SeedTableWriteIdsRequest::printTo(std::ostream& out) const {
@@ -23386,11 +23434,11 @@ void swap(SeedTxnIdRequest &a, SeedTxnIdRequest &b) {
   swap(a.seedTxnId, b.seedTxnId);
 }
 
-SeedTxnIdRequest::SeedTxnIdRequest(const SeedTxnIdRequest& other877) {
-  seedTxnId = other877.seedTxnId;
+SeedTxnIdRequest::SeedTxnIdRequest(const SeedTxnIdRequest& other879) {
+  seedTxnId = other879.seedTxnId;
 }
-SeedTxnIdRequest& SeedTxnIdRequest::operator=(const SeedTxnIdRequest& other878) {
-  seedTxnId = other878.seedTxnId;
+SeedTxnIdRequest& SeedTxnIdRequest::operator=(const SeedTxnIdRequest& other880) {
+  seedTxnId = other880.seedTxnId;
   return *this;
 }
 void SeedTxnIdRequest::printTo(std::ostream& out) const {
@@ -23474,9 +23522,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast879;
-          xfer += iprot->readI32(ecast879);
-          this->type = (LockType::type)ecast879;
+          int32_t ecast881;
+          xfer += iprot->readI32(ecast881);
+          this->type = (LockType::type)ecast881;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -23484,9 +23532,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast880;
-          xfer += iprot->readI32(ecast880);
-          this->level = (LockLevel::type)ecast880;
+          int32_t ecast882;
+          xfer += iprot->readI32(ecast882);
+          this->level = (LockLevel::type)ecast882;
           isset_level = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -23518,9 +23566,9 @@ uint32_t LockComponent::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast881;
-          xfer += iprot->readI32(ecast881);
-          this->operationType = (DataOperationType::type)ecast881;
+          int32_t ecast883;
+          xfer += iprot->readI32(ecast883);
+          this->operationType = (DataOperationType::type)ecast883;
           this->__isset.operationType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -23620,27 +23668,27 @@ void swap(LockComponent &a, LockComponent &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockComponent::LockComponent(const LockComponent& other882) {
-  type = other882.type;
-  level = other882.level;
-  dbname = other882.dbname;
-  tablename = other882.tablename;
-  partitionname = other882.partitionname;
-  operationType = other882.operationType;
-  isTransactional = other882.isTransactional;
-  isDynamicPartitionWrite = other882.isDynamicPartitionWrite;
-  __isset = other882.__isset;
+LockComponent::LockComponent(const LockComponent& other884) {
+  type = other884.type;
+  level = other884.level;
+  dbname = other884.dbname;
+  tablename = other884.tablename;
+  partitionname = other884.partitionname;
+  operationType = other884.operationType;
+  isTransactional = other884.isTransactional;
+  isDynamicPartitionWrite = other884.isDynamicPartitionWrite;
+  __isset = other884.__isset;
 }
-LockComponent& LockComponent::operator=(const LockComponent& other883) {
-  type = other883.type;
-  level = other883.level;
-  dbname = other883.dbname;
-  tablename = other883.tablename;
-  partitionname = other883.partitionname;
-  operationType = other883.operationType;
-  isTransactional = other883.isTransactional;
-  isDynamicPartitionWrite = other883.isDynamicPartitionWrite;
-  __isset = other883.__isset;
+LockComponent& LockComponent::operator=(const LockComponent& other885) {
+  type = other885.type;
+  level = other885.level;
+  dbname = other885.dbname;
+  tablename = other885.tablename;
+  partitionname = other885.partitionname;
+  operationType = other885.operationType;
+  isTransactional = other885.isTransactional;
+  isDynamicPartitionWrite = other885.isDynamicPartitionWrite;
+  __isset = other885.__isset;
   return *this;
 }
 void LockComponent::printTo(std::ostream& out) const {
@@ -23723,14 +23771,14 @@ uint32_t LockRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->component.clear();
-            uint32_t _size884;
-            ::apache::thrift::protocol::TType _etype887;
-            xfer += iprot->readListBegin(_etype887, _size884);
-            this->component.resize(_size884);
-            uint32_t _i888;
-            for (_i888 = 0; _i888 < _size884; ++_i888)
+            uint32_t _size886;
+            ::apache::thrift::protocol::TType _etype889;
+            xfer += iprot->readListBegin(_etype889, _size886);
+            this->component.resize(_size886);
+            uint32_t _i890;
+            for (_i890 = 0; _i890 < _size886; ++_i890)
             {
-              xfer += this->component[_i888].read(iprot);
+              xfer += this->component[_i890].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -23805,10 +23853,10 @@ uint32_t LockRequest::write(::apache::thrift::protocol::TProtocol* oprot) const 
   xfer += oprot->writeFieldBegin("component", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->component.size()));
-    std::vector<LockComponent> ::const_iterator _iter889;
-    for (_iter889 = this->component.begin(); _iter889 != this->component.end(); ++_iter889)
+    std::vector<LockComponent> ::const_iterator _iter891;
+    for (_iter891 = this->component.begin(); _iter891 != this->component.end(); ++_iter891)
     {
-      xfer += (*_iter889).write(oprot);
+      xfer += (*_iter891).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -23853,23 +23901,23 @@ void swap(LockRequest &a, LockRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockRequest::LockRequest(const LockRequest& other890) {
-  component = other890.component;
-  txnid = other890.txnid;
-  user = other890.user;
-  hostname = other890.hostname;
-  agentInfo = other890.agentInfo;
-  zeroWaitReadEnabled = other890.zeroWaitReadEnabled;
-  __isset = other890.__isset;
+LockRequest::LockRequest(const LockRequest& other892) {
+  component = other892.component;
+  txnid = other892.txnid;
+  user = other892.user;
+  hostname = other892.hostname;
+  agentInfo = other892.agentInfo;
+  zeroWaitReadEnabled = other892.zeroWaitReadEnabled;
+  __isset = other892.__isset;
 }
-LockRequest& LockRequest::operator=(const LockRequest& other891) {
-  component = other891.component;
-  txnid = other891.txnid;
-  user = other891.user;
-  hostname = other891.hostname;
-  agentInfo = other891.agentInfo;
-  zeroWaitReadEnabled = other891.zeroWaitReadEnabled;
-  __isset = other891.__isset;
+LockRequest& LockRequest::operator=(const LockRequest& other893) {
+  component = other893.component;
+  txnid = other893.txnid;
+  user = other893.user;
+  hostname = other893.hostname;
+  agentInfo = other893.agentInfo;
+  zeroWaitReadEnabled = other893.zeroWaitReadEnabled;
+  __isset = other893.__isset;
   return *this;
 }
 void LockRequest::printTo(std::ostream& out) const {
@@ -23941,9 +23989,9 @@ uint32_t LockResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast892;
-          xfer += iprot->readI32(ecast892);
-          this->state = (LockState::type)ecast892;
+          int32_t ecast894;
+          xfer += iprot->readI32(ecast894);
+          this->state = (LockState::type)ecast894;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24004,17 +24052,17 @@ void swap(LockResponse &a, LockResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-LockResponse::LockResponse(const LockResponse& other893) {
-  lockid = other893.lockid;
-  state = other893.state;
-  errorMessage = other893.errorMessage;
-  __isset = other893.__isset;
+LockResponse::LockResponse(const LockResponse& other895) {
+  lockid = other895.lockid;
+  state = other895.state;
+  errorMessage = other895.errorMessage;
+  __isset = other895.__isset;
 }
-LockResponse& LockResponse::operator=(const LockResponse& other894) {
-  lockid = other894.lockid;
-  state = other894.state;
-  errorMessage = other894.errorMessage;
-  __isset = other894.__isset;
+LockResponse& LockResponse::operator=(const LockResponse& other896) {
+  lockid = other896.lockid;
+  state = other896.state;
+  errorMessage = other896.errorMessage;
+  __isset = other896.__isset;
   return *this;
 }
 void LockResponse::printTo(std::ostream& out) const {
@@ -24143,17 +24191,17 @@ void swap(CheckLockRequest &a, CheckLockRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CheckLockRequest::CheckLockRequest(const CheckLockRequest& other895) {
-  lockid = other895.lockid;
-  txnid = other895.txnid;
-  elapsed_ms = other895.elapsed_ms;
-  __isset = other895.__isset;
+CheckLockRequest::CheckLockRequest(const CheckLockRequest& other897) {
+  lockid = other897.lockid;
+  txnid = other897.txnid;
+  elapsed_ms = other897.elapsed_ms;
+  __isset = other897.__isset;
 }
-CheckLockRequest& CheckLockRequest::operator=(const CheckLockRequest& other896) {
-  lockid = other896.lockid;
-  txnid = other896.txnid;
-  elapsed_ms = other896.elapsed_ms;
-  __isset = other896.__isset;
+CheckLockRequest& CheckLockRequest::operator=(const CheckLockRequest& other898) {
+  lockid = other898.lockid;
+  txnid = other898.txnid;
+  elapsed_ms = other898.elapsed_ms;
+  __isset = other898.__isset;
   return *this;
 }
 void CheckLockRequest::printTo(std::ostream& out) const {
@@ -24243,11 +24291,11 @@ void swap(UnlockRequest &a, UnlockRequest &b) {
   swap(a.lockid, b.lockid);
 }
 
-UnlockRequest::UnlockRequest(const UnlockRequest& other897) {
-  lockid = other897.lockid;
+UnlockRequest::UnlockRequest(const UnlockRequest& other899) {
+  lockid = other899.lockid;
 }
-UnlockRequest& UnlockRequest::operator=(const UnlockRequest& other898) {
-  lockid = other898.lockid;
+UnlockRequest& UnlockRequest::operator=(const UnlockRequest& other900) {
+  lockid = other900.lockid;
   return *this;
 }
 void UnlockRequest::printTo(std::ostream& out) const {
@@ -24411,21 +24459,21 @@ void swap(ShowLocksRequest &a, ShowLocksRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksRequest::ShowLocksRequest(const ShowLocksRequest& other899) {
-  dbname = other899.dbname;
-  tablename = other899.tablename;
-  partname = other899.partname;
-  isExtended = other899.isExtended;
-  txnid = other899.txnid;
-  __isset = other899.__isset;
+ShowLocksRequest::ShowLocksRequest(const ShowLocksRequest& other901) {
+  dbname = other901.dbname;
+  tablename = other901.tablename;
+  partname = other901.partname;
+  isExtended = other901.isExtended;
+  txnid = other901.txnid;
+  __isset = other901.__isset;
 }
-ShowLocksRequest& ShowLocksRequest::operator=(const ShowLocksRequest& other900) {
-  dbname = other900.dbname;
-  tablename = other900.tablename;
-  partname = other900.partname;
-  isExtended = other900.isExtended;
-  txnid = other900.txnid;
-  __isset = other900.__isset;
+ShowLocksRequest& ShowLocksRequest::operator=(const ShowLocksRequest& other902) {
+  dbname = other902.dbname;
+  tablename = other902.tablename;
+  partname = other902.partname;
+  isExtended = other902.isExtended;
+  txnid = other902.txnid;
+  __isset = other902.__isset;
   return *this;
 }
 void ShowLocksRequest::printTo(std::ostream& out) const {
@@ -24585,9 +24633,9 @@ uint32_t ShowLocksResponseElement::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast901;
-          xfer += iprot->readI32(ecast901);
-          this->state = (LockState::type)ecast901;
+          int32_t ecast903;
+          xfer += iprot->readI32(ecast903);
+          this->state = (LockState::type)ecast903;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24595,9 +24643,9 @@ uint32_t ShowLocksResponseElement::read(::apache::thrift::protocol::TProtocol* i
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast902;
-          xfer += iprot->readI32(ecast902);
-          this->type = (LockType::type)ecast902;
+          int32_t ecast904;
+          xfer += iprot->readI32(ecast904);
+          this->type = (LockType::type)ecast904;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -24813,43 +24861,43 @@ void swap(ShowLocksResponseElement &a, ShowLocksResponseElement &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksResponseElement::ShowLocksResponseElement(const ShowLocksResponseElement& other903) {
-  lockid = other903.lockid;
-  dbname = other903.dbname;
-  tablename = other903.tablename;
-  partname = other903.partname;
-  state = other903.state;
-  type = other903.type;
-  txnid = other903.txnid;
-  lastheartbeat = other903.lastheartbeat;
-  acquiredat = other903.acquiredat;
-  user = other903.user;
-  hostname = other903.hostname;
-  heartbeatCount = other903.heartbeatCount;
-  agentInfo = other903.agentInfo;
-  blockedByExtId = other903.blockedByExtId;
-  blockedByIntId = other903.blockedByIntId;
-  lockIdInternal = other903.lockIdInternal;
-  __isset = other903.__isset;
+ShowLocksResponseElement::ShowLocksResponseElement(const ShowLocksResponseElement& other905) {
+  lockid = other905.lockid;
+  dbname = other905.dbname;
+  tablename = other905.tablename;
+  partname = other905.partname;
+  state = other905.state;
+  type = other905.type;
+  txnid = other905.txnid;
+  lastheartbeat = other905.lastheartbeat;
+  acquiredat = other905.acquiredat;
+  user = other905.user;
+  hostname = other905.hostname;
+  heartbeatCount = other905.heartbeatCount;
+  agentInfo = other905.agentInfo;
+  blockedByExtId = other905.blockedByExtId;
+  blockedByIntId = other905.blockedByIntId;
+  lockIdInternal = other905.lockIdInternal;
+  __isset = other905.__isset;
 }
-ShowLocksResponseElement& ShowLocksResponseElement::operator=(const ShowLocksResponseElement& other904) {
-  lockid = other904.lockid;
-  dbname = other904.dbname;
-  tablename = other904.tablename;
-  partname = other904.partname;
-  state = other904.state;
-  type = other904.type;
-  txnid = other904.txnid;
-  lastheartbeat = other904.lastheartbeat;
-  acquiredat = other904.acquiredat;
-  user = other904.user;
-  hostname = other904.hostname;
-  heartbeatCount = other904.heartbeatCount;
-  agentInfo = other904.agentInfo;
-  blockedByExtId = other904.blockedByExtId;
-  blockedByIntId = other904.blockedByIntId;
-  lockIdInternal = other904.lockIdInternal;
-  __isset = other904.__isset;
+ShowLocksResponseElement& ShowLocksResponseElement::operator=(const ShowLocksResponseElement& other906) {
+  lockid = other906.lockid;
+  dbname = other906.dbname;
+  tablename = other906.tablename;
+  partname = other906.partname;
+  state = other906.state;
+  type = other906.type;
+  txnid = other906.txnid;
+  lastheartbeat = other906.lastheartbeat;
+  acquiredat = other906.acquiredat;
+  user = other906.user;
+  hostname = other906.hostname;
+  heartbeatCount = other906.heartbeatCount;
+  agentInfo = other906.agentInfo;
+  blockedByExtId = other906.blockedByExtId;
+  blockedByIntId = other906.blockedByIntId;
+  lockIdInternal = other906.lockIdInternal;
+  __isset = other906.__isset;
   return *this;
 }
 void ShowLocksResponseElement::printTo(std::ostream& out) const {
@@ -24914,14 +24962,14 @@ uint32_t ShowLocksResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->locks.clear();
-            uint32_t _size905;
-            ::apache::thrift::protocol::TType _etype908;
-            xfer += iprot->readListBegin(_etype908, _size905);
-            this->locks.resize(_size905);
-            uint32_t _i909;
-            for (_i909 = 0; _i909 < _size905; ++_i909)
+            uint32_t _size907;
+            ::apache::thrift::protocol::TType _etype910;
+            xfer += iprot->readListBegin(_etype910, _size907);
+            this->locks.resize(_size907);
+            uint32_t _i911;
+            for (_i911 = 0; _i911 < _size907; ++_i911)
             {
-              xfer += this->locks[_i909].read(iprot);
+              xfer += this->locks[_i911].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -24950,10 +24998,10 @@ uint32_t ShowLocksResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("locks", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->locks.size()));
-    std::vector<ShowLocksResponseElement> ::const_iterator _iter910;
-    for (_iter910 = this->locks.begin(); _iter910 != this->locks.end(); ++_iter910)
+    std::vector<ShowLocksResponseElement> ::const_iterator _iter912;
+    for (_iter912 = this->locks.begin(); _iter912 != this->locks.end(); ++_iter912)
     {
-      xfer += (*_iter910).write(oprot);
+      xfer += (*_iter912).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -24970,13 +25018,13 @@ void swap(ShowLocksResponse &a, ShowLocksResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowLocksResponse::ShowLocksResponse(const ShowLocksResponse& other911) {
-  locks = other911.locks;
-  __isset = other911.__isset;
+ShowLocksResponse::ShowLocksResponse(const ShowLocksResponse& other913) {
+  locks = other913.locks;
+  __isset = other913.__isset;
 }
-ShowLocksResponse& ShowLocksResponse::operator=(const ShowLocksResponse& other912) {
-  locks = other912.locks;
-  __isset = other912.__isset;
+ShowLocksResponse& ShowLocksResponse::operator=(const ShowLocksResponse& other914) {
+  locks = other914.locks;
+  __isset = other914.__isset;
   return *this;
 }
 void ShowLocksResponse::printTo(std::ostream& out) const {
@@ -25083,15 +25131,15 @@ void swap(HeartbeatRequest &a, HeartbeatRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-HeartbeatRequest::HeartbeatRequest(const HeartbeatRequest& other913) {
-  lockid = other913.lockid;
-  txnid = other913.txnid;
-  __isset = other913.__isset;
+HeartbeatRequest::HeartbeatRequest(const HeartbeatRequest& other915) {
+  lockid = other915.lockid;
+  txnid = other915.txnid;
+  __isset = other915.__isset;
 }
-HeartbeatRequest& HeartbeatRequest::operator=(const HeartbeatRequest& other914) {
-  lockid = other914.lockid;
-  txnid = other914.txnid;
-  __isset = other914.__isset;
+HeartbeatRequest& HeartbeatRequest::operator=(const HeartbeatRequest& other916) {
+  lockid = other916.lockid;
+  txnid = other916.txnid;
+  __isset = other916.__isset;
   return *this;
 }
 void HeartbeatRequest::printTo(std::ostream& out) const {
@@ -25200,13 +25248,13 @@ void swap(HeartbeatTxnRangeRequest &a, HeartbeatTxnRangeRequest &b) {
   swap(a.max, b.max);
 }
 
-HeartbeatTxnRangeRequest::HeartbeatTxnRangeRequest(const HeartbeatTxnRangeRequest& other915) {
-  min = other915.min;
-  max = other915.max;
+HeartbeatTxnRangeRequest::HeartbeatTxnRangeRequest(const HeartbeatTxnRangeRequest& other917) {
+  min = other917.min;
+  max = other917.max;
 }
-HeartbeatTxnRangeRequest& HeartbeatTxnRangeRequest::operator=(const HeartbeatTxnRangeRequest& other916) {
-  min = other916.min;
-  max = other916.max;
+HeartbeatTxnRangeRequest& HeartbeatTxnRangeRequest::operator=(const HeartbeatTxnRangeRequest& other918) {
+  min = other918.min;
+  max = other918.max;
   return *this;
 }
 void HeartbeatTxnRangeRequest::printTo(std::ostream& out) const {
@@ -25263,15 +25311,15 @@ uint32_t HeartbeatTxnRangeResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_SET) {
           {
             this->aborted.clear();
-            uint32_t _size917;
-            ::apache::thrift::protocol::TType _etype920;
-            xfer += iprot->readSetBegin(_etype920, _size917);
-            uint32_t _i921;
-            for (_i921 = 0; _i921 < _size917; ++_i921)
+            uint32_t _size919;
+            ::apache::thrift::protocol::TType _etype922;
+            xfer += iprot->readSetBegin(_etype922, _size919);
+            uint32_t _i923;
+            for (_i923 = 0; _i923 < _size919; ++_i923)
             {
-              int64_t _elem922;
-              xfer += iprot->readI64(_elem922);
-              this->aborted.insert(_elem922);
+              int64_t _elem924;
+              xfer += iprot->readI64(_elem924);
+              this->aborted.insert(_elem924);
             }
             xfer += iprot->readSetEnd();
           }
@@ -25284,15 +25332,15 @@ uint32_t HeartbeatTxnRangeResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_SET) {
           {
             this->nosuch.clear();
-            uint32_t _size923;
-            ::apache::thrift::protocol::TType _etype926;
-            xfer += iprot->readSetBegin(_etype926, _size923);
-            uint32_t _i927;
-            for (_i927 = 0; _i927 < _size923; ++_i927)
+            uint32_t _size925;
+            ::apache::thrift::protocol::TType _etype928;
+            xfer += iprot->readSetBegin(_etype928, _size925);
+            uint32_t _i929;
+            for (_i929 = 0; _i929 < _size925; ++_i929)
             {
-              int64_t _elem928;
-              xfer += iprot->readI64(_elem928);
-              this->nosuch.insert(_elem928);
+              int64_t _elem930;
+              xfer += iprot->readI64(_elem930);
+              this->nosuch.insert(_elem930);
             }
             xfer += iprot->readSetEnd();
           }
@@ -25325,10 +25373,10 @@ uint32_t HeartbeatTxnRangeResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("aborted", ::apache::thrift::protocol::T_SET, 1);
   {
     xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->aborted.size()));
-    std::set<int64_t> ::const_iterator _iter929;
-    for (_iter929 = this->aborted.begin(); _iter929 != this->aborted.end(); ++_iter929)
+    std::set<int64_t> ::const_iterator _iter931;
+    for (_iter931 = this->aborted.begin(); _iter931 != this->aborted.end(); ++_iter931)
     {
-      xfer += oprot->writeI64((*_iter929));
+      xfer += oprot->writeI64((*_iter931));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -25337,10 +25385,10 @@ uint32_t HeartbeatTxnRangeResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("nosuch", ::apache::thrift::protocol::T_SET, 2);
   {
     xfer += oprot->writeSetBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->nosuch.size()));
-    std::set<int64_t> ::const_iterator _iter930;
-    for (_iter930 = this->nosuch.begin(); _iter930 != this->nosuch.end(); ++_iter930)
+    std::set<int64_t> ::const_iterator _iter932;
+    for (_iter932 = this->nosuch.begin(); _iter932 != this->nosuch.end(); ++_iter932)
     {
-      xfer += oprot->writeI64((*_iter930));
+      xfer += oprot->writeI64((*_iter932));
     }
     xfer += oprot->writeSetEnd();
   }
@@ -25357,13 +25405,13 @@ void swap(HeartbeatTxnRangeResponse &a, HeartbeatTxnRangeResponse &b) {
   swap(a.nosuch, b.nosuch);
 }
 
-HeartbeatTxnRangeResponse::HeartbeatTxnRangeResponse(const HeartbeatTxnRangeResponse& other931) {
-  aborted = other931.aborted;
-  nosuch = other931.nosuch;
+HeartbeatTxnRangeResponse::HeartbeatTxnRangeResponse(const HeartbeatTxnRangeResponse& other933) {
+  aborted = other933.aborted;
+  nosuch = other933.nosuch;
 }
-HeartbeatTxnRangeResponse& HeartbeatTxnRangeResponse::operator=(const HeartbeatTxnRangeResponse& other932) {
-  aborted = other932.aborted;
-  nosuch = other932.nosuch;
+HeartbeatTxnRangeResponse& HeartbeatTxnRangeResponse::operator=(const HeartbeatTxnRangeResponse& other934) {
+  aborted = other934.aborted;
+  nosuch = other934.nosuch;
   return *this;
 }
 void HeartbeatTxnRangeResponse::printTo(std::ostream& out) const {
@@ -25472,9 +25520,9 @@ uint32_t CompactionRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast933;
-          xfer += iprot->readI32(ecast933);
-          this->type = (CompactionType::type)ecast933;
+          int32_t ecast935;
+          xfer += iprot->readI32(ecast935);
+          this->type = (CompactionType::type)ecast935;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -25492,17 +25540,17 @@ uint32_t CompactionRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->properties.clear();
-            uint32_t _size934;
-            ::apache::thrift::protocol::TType _ktype935;
-            ::apache::thrift::protocol::TType _vtype936;
-            xfer += iprot->readMapBegin(_ktype935, _vtype936, _size934);
-            uint32_t _i938;
-            for (_i938 = 0; _i938 < _size934; ++_i938)
+            uint32_t _size936;
+            ::apache::thrift::protocol::TType _ktype937;
+            ::apache::thrift::protocol::TType _vtype938;
+            xfer += iprot->readMapBegin(_ktype937, _vtype938, _size936);
+            uint32_t _i940;
+            for (_i940 = 0; _i940 < _size936; ++_i940)
             {
-              std::string _key939;
-              xfer += iprot->readString(_key939);
-              std::string& _val940 = this->properties[_key939];
-              xfer += iprot->readString(_val940);
+              std::string _key941;
+              xfer += iprot->readString(_key941);
+              std::string& _val942 = this->properties[_key941];
+              xfer += iprot->readString(_val942);
             }
             xfer += iprot->readMapEnd();
           }
@@ -25576,11 +25624,11 @@ uint32_t CompactionRequest::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("properties", ::apache::thrift::protocol::T_MAP, 6);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->properties.size()));
-      std::map<std::string, std::string> ::const_iterator _iter941;
-      for (_iter941 = this->properties.begin(); _iter941 != this->properties.end(); ++_iter941)
+      std::map<std::string, std::string> ::const_iterator _iter943;
+      for (_iter943 = this->properties.begin(); _iter943 != this->properties.end(); ++_iter943)
       {
-        xfer += oprot->writeString(_iter941->first);
-        xfer += oprot->writeString(_iter941->second);
+        xfer += oprot->writeString(_iter943->first);
+        xfer += oprot->writeString(_iter943->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -25614,27 +25662,27 @@ void swap(CompactionRequest &a, CompactionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CompactionRequest::CompactionRequest(const CompactionRequest& other942) {
-  dbname = other942.dbname;
-  tablename = other942.tablename;
-  partitionname = other942.partitionname;
-  type = other942.type;
-  runas = other942.runas;
-  properties = other942.properties;
-  initiatorId = other942.initiatorId;
-  initiatorVersion = other942.initiatorVersion;
-  __isset = other942.__isset;
+CompactionRequest::CompactionRequest(const CompactionRequest& other944) {
+  dbname = other944.dbname;
+  tablename = other944.tablename;
+  partitionname = other944.partitionname;
+  type = other944.type;
+  runas = other944.runas;
+  properties = other944.properties;
+  initiatorId = other944.initiatorId;
+  initiatorVersion = other944.initiatorVersion;
+  __isset = other944.__isset;
 }
-CompactionRequest& CompactionRequest::operator=(const CompactionRequest& other943) {
-  dbname = other943.dbname;
-  tablename = other943.tablename;
-  partitionname = other943.partitionname;
-  type = other943.type;
-  runas = other943.runas;
-  properties = other943.properties;
-  initiatorId = other943.initiatorId;
-  initiatorVersion = other943.initiatorVersion;
-  __isset = other943.__isset;
+CompactionRequest& CompactionRequest::operator=(const CompactionRequest& other945) {
+  dbname = other945.dbname;
+  tablename = other945.tablename;
+  partitionname = other945.partitionname;
+  type = other945.type;
+  runas = other945.runas;
+  properties = other945.properties;
+  initiatorId = other945.initiatorId;
+  initiatorVersion = other945.initiatorVersion;
+  __isset = other945.__isset;
   return *this;
 }
 void CompactionRequest::printTo(std::ostream& out) const {
@@ -25792,9 +25840,9 @@ uint32_t CompactionInfoStruct::read(::apache::thrift::protocol::TProtocol* iprot
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast944;
-          xfer += iprot->readI32(ecast944);
-          this->type = (CompactionType::type)ecast944;
+          int32_t ecast946;
+          xfer += iprot->readI32(ecast946);
+          this->type = (CompactionType::type)ecast946;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -26001,41 +26049,41 @@ void swap(CompactionInfoStruct &a, CompactionInfoStruct &b) {
   swap(a.__isset, b.__isset);
 }
 
-CompactionInfoStruct::CompactionInfoStruct(const CompactionInfoStruct& other945) {
-  id = other945.id;
-  dbname = other945.dbname;
-  tablename = other945.tablename;
-  partitionname = other945.partitionname;
-  type = other945.type;
-  runas = other945.runas;
-  properties = other945.properties;
-  toomanyaborts = other945.toomanyaborts;
-  state = other945.state;
-  workerId = other945.workerId;
-  start = other945.start;
-  highestWriteId = other945.highestWriteId;
-  errorMessage = other945.errorMessage;
-  hasoldabort = other945.hasoldabort;
-  enqueueTime = other945.enqueueTime;
-  __isset = other945.__isset;
+CompactionInfoStruct::CompactionInfoStruct(const CompactionInfoStruct& other947) {
+  id = other947.id;
+  dbname = other947.dbname;
+  tablename = other947.tablename;
+  partitionname = other947.partitionname;
+  type = other947.type;
+  runas = other947.runas;
+  properties = other947.properties;
+  toomanyaborts = other947.toomanyaborts;
+  state = other947.state;
+  workerId = other947.workerId;
+  start = other947.start;
+  highestWriteId = other947.highestWriteId;
+  errorMessage = other947.errorMessage;
+  hasoldabort = other947.hasoldabort;
+  enqueueTime = other947.enqueueTime;
+  __isset = other947.__isset;
 }
-CompactionInfoStruct& CompactionInfoStruct::operator=(const CompactionInfoStruct& other946) {
-  id = other946.id;
-  dbname = other946.dbname;
-  tablename = other946.tablename;
-  partitionname = other946.partitionname;
-  type = other946.type;
-  runas = other946.runas;
-  properties = other946.properties;
-  toomanyaborts = other946.toomanyaborts;
-  state = other946.state;
-  workerId = other946.workerId;
-  start = other946.start;
-  highestWriteId = other946.highestWriteId;
-  errorMessage = other946.errorMessage;
-  hasoldabort = other946.hasoldabort;
-  enqueueTime = other946.enqueueTime;
-  __isset = other946.__isset;
+CompactionInfoStruct& CompactionInfoStruct::operator=(const CompactionInfoStruct& other948) {
+  id = other948.id;
+  dbname = other948.dbname;
+  tablename = other948.tablename;
+  partitionname = other948.partitionname;
+  type = other948.type;
+  runas = other948.runas;
+  properties = other948.properties;
+  toomanyaborts = other948.toomanyaborts;
+  state = other948.state;
+  workerId = other948.workerId;
+  start = other948.start;
+  highestWriteId = other948.highestWriteId;
+  errorMessage = other948.errorMessage;
+  hasoldabort = other948.hasoldabort;
+  enqueueTime = other948.enqueueTime;
+  __isset = other948.__isset;
   return *this;
 }
 void CompactionInfoStruct::printTo(std::ostream& out) const {
@@ -26137,13 +26185,13 @@ void swap(OptionalCompactionInfoStruct &a, OptionalCompactionInfoStruct &b) {
   swap(a.__isset, b.__isset);
 }
 
-OptionalCompactionInfoStruct::OptionalCompactionInfoStruct(const OptionalCompactionInfoStruct& other947) {
-  ci = other947.ci;
-  __isset = other947.__isset;
+OptionalCompactionInfoStruct::OptionalCompactionInfoStruct(const OptionalCompactionInfoStruct& other949) {
+  ci = other949.ci;
+  __isset = other949.__isset;
 }
-OptionalCompactionInfoStruct& OptionalCompactionInfoStruct::operator=(const OptionalCompactionInfoStruct& other948) {
-  ci = other948.ci;
-  __isset = other948.__isset;
+OptionalCompactionInfoStruct& OptionalCompactionInfoStruct::operator=(const OptionalCompactionInfoStruct& other950) {
+  ci = other950.ci;
+  __isset = other950.__isset;
   return *this;
 }
 void OptionalCompactionInfoStruct::printTo(std::ostream& out) const {
@@ -26271,15 +26319,15 @@ void swap(CompactionResponse &a, CompactionResponse &b) {
   swap(a.accepted, b.accepted);
 }
 
-CompactionResponse::CompactionResponse(const CompactionResponse& other949) {
-  id = other949.id;
-  state = other949.state;
-  accepted = other949.accepted;
+CompactionResponse::CompactionResponse(const CompactionResponse& other951) {
+  id = other951.id;
+  state = other951.state;
+  accepted = other951.accepted;
 }
-CompactionResponse& CompactionResponse::operator=(const CompactionResponse& other950) {
-  id = other950.id;
-  state = other950.state;
-  accepted = other950.accepted;
+CompactionResponse& CompactionResponse::operator=(const CompactionResponse& other952) {
+  id = other952.id;
+  state = other952.state;
+  accepted = other952.accepted;
   return *this;
 }
 void CompactionResponse::printTo(std::ostream& out) const {
@@ -26346,11 +26394,11 @@ void swap(ShowCompactRequest &a, ShowCompactRequest &b) {
   (void) b;
 }
 
-ShowCompactRequest::ShowCompactRequest(const ShowCompactRequest& other951) {
-  (void) other951;
+ShowCompactRequest::ShowCompactRequest(const ShowCompactRequest& other953) {
+  (void) other953;
 }
-ShowCompactRequest& ShowCompactRequest::operator=(const ShowCompactRequest& other952) {
-  (void) other952;
+ShowCompactRequest& ShowCompactRequest::operator=(const ShowCompactRequest& other954) {
+  (void) other954;
   return *this;
 }
 void ShowCompactRequest::printTo(std::ostream& out) const {
@@ -26507,9 +26555,9 @@ uint32_t ShowCompactResponseElement::read(::apache::thrift::protocol::TProtocol*
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast953;
-          xfer += iprot->readI32(ecast953);
-          this->type = (CompactionType::type)ecast953;
+          int32_t ecast955;
+          xfer += iprot->readI32(ecast955);
+          this->type = (CompactionType::type)ecast955;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -26766,47 +26814,47 @@ void swap(ShowCompactResponseElement &a, ShowCompactResponseElement &b) {
   swap(a.__isset, b.__isset);
 }
 
-ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other954) {
-  dbname = other954.dbname;
-  tablename = other954.tablename;
-  partitionname = other954.partitionname;
-  type = other954.type;
-  state = other954.state;
-  workerid = other954.workerid;
-  start = other954.start;
-  runAs = other954.runAs;
-  hightestTxnId = other954.hightestTxnId;
-  metaInfo = other954.metaInfo;
-  endTime = other954.endTime;
-  hadoopJobId = other954.hadoopJobId;
-  id = other954.id;
-  errorMessage = other954.errorMessage;
-  enqueueTime = other954.enqueueTime;
-  workerVersion = other954.workerVersion;
-  initiatorId = other954.initiatorId;
-  initiatorVersion = other954.initiatorVersion;
-  __isset = other954.__isset;
+ShowCompactResponseElement::ShowCompactResponseElement(const ShowCompactResponseElement& other956) {
+  dbname = other956.dbname;
+  tablename = other956.tablename;
+  partitionname = other956.partitionname;
+  type = other956.type;
+  state = other956.state;
+  workerid = other956.workerid;
+  start = other956.start;
+  runAs = other956.runAs;
+  hightestTxnId = other956.hightestTxnId;
+  metaInfo = other956.metaInfo;
+  endTime = other956.endTime;
+  hadoopJobId = other956.hadoopJobId;
+  id = other956.id;
+  errorMessage = other956.errorMessage;
+  enqueueTime = other956.enqueueTime;
+  workerVersion = other956.workerVersion;
+  initiatorId = other956.initiatorId;
+  initiatorVersion = other956.initiatorVersion;
+  __isset = other956.__isset;
 }
-ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowCompactResponseElement& other955) {
-  dbname = other955.dbname;
-  tablename = other955.tablename;
-  partitionname = other955.partitionname;
-  type = other955.type;
-  state = other955.state;
-  workerid = other955.workerid;
-  start = other955.start;
-  runAs = other955.runAs;
-  hightestTxnId = other955.hightestTxnId;
-  metaInfo = other955.metaInfo;
-  endTime = other955.endTime;
-  hadoopJobId = other955.hadoopJobId;
-  id = other955.id;
-  errorMessage = other955.errorMessage;
-  enqueueTime = other955.enqueueTime;
-  workerVersion = other955.workerVersion;
-  initiatorId = other955.initiatorId;
-  initiatorVersion = other955.initiatorVersion;
-  __isset = other955.__isset;
+ShowCompactResponseElement& ShowCompactResponseElement::operator=(const ShowCompactResponseElement& other957) {
+  dbname = other957.dbname;
+  tablename = other957.tablename;
+  partitionname = other957.partitionname;
+  type = other957.type;
+  state = other957.state;
+  workerid = other957.workerid;
+  start = other957.start;
+  runAs = other957.runAs;
+  hightestTxnId = other957.hightestTxnId;
+  metaInfo = other957.metaInfo;
+  endTime = other957.endTime;
+  hadoopJobId = other957.hadoopJobId;
+  id = other957.id;
+  errorMessage = other957.errorMessage;
+  enqueueTime = other957.enqueueTime;
+  workerVersion = other957.workerVersion;
+  initiatorId = other957.initiatorId;
+  initiatorVersion = other957.initiatorVersion;
+  __isset = other957.__isset;
   return *this;
 }
 void ShowCompactResponseElement::printTo(std::ostream& out) const {
@@ -26874,14 +26922,14 @@ uint32_t ShowCompactResponse::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->compacts.clear();
-            uint32_t _size956;
-            ::apache::thrift::protocol::TType _etype959;
-            xfer += iprot->readListBegin(_etype959, _size956);
-            this->compacts.resize(_size956);
-            uint32_t _i960;
-            for (_i960 = 0; _i960 < _size956; ++_i960)
+            uint32_t _size958;
+            ::apache::thrift::protocol::TType _etype961;
+            xfer += iprot->readListBegin(_etype961, _size958);
+            this->compacts.resize(_size958);
+            uint32_t _i962;
+            for (_i962 = 0; _i962 < _size958; ++_i962)
             {
-              xfer += this->compacts[_i960].read(iprot);
+              xfer += this->compacts[_i962].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -26912,10 +26960,10 @@ uint32_t ShowCompactResponse::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("compacts", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->compacts.size()));
-    std::vector<ShowCompactResponseElement> ::const_iterator _iter961;
-    for (_iter961 = this->compacts.begin(); _iter961 != this->compacts.end(); ++_iter961)
+    std::vector<ShowCompactResponseElement> ::const_iterator _iter963;
+    for (_iter963 = this->compacts.begin(); _iter963 != this->compacts.end(); ++_iter963)
     {
-      xfer += (*_iter961).write(oprot);
+      xfer += (*_iter963).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -26931,11 +26979,11 @@ void swap(ShowCompactResponse &a, ShowCompactResponse &b) {
   swap(a.compacts, b.compacts);
 }
 
-ShowCompactResponse::ShowCompactResponse(const ShowCompactResponse& other962) {
-  compacts = other962.compacts;
+ShowCompactResponse::ShowCompactResponse(const ShowCompactResponse& other964) {
+  compacts = other964.compacts;
 }
-ShowCompactResponse& ShowCompactResponse::operator=(const ShowCompactResponse& other963) {
-  compacts = other963.compacts;
+ShowCompactResponse& ShowCompactResponse::operator=(const ShowCompactResponse& other965) {
+  compacts = other965.compacts;
   return *this;
 }
 void ShowCompactResponse::printTo(std::ostream& out) const {
@@ -27012,14 +27060,14 @@ uint32_t GetLatestCommittedCompactionInfoRequest::read(::apache::thrift::protoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionnames.clear();
-            uint32_t _size964;
-            ::apache::thrift::protocol::TType _etype967;
-            xfer += iprot->readListBegin(_etype967, _size964);
-            this->partitionnames.resize(_size964);
-            uint32_t _i968;
-            for (_i968 = 0; _i968 < _size964; ++_i968)
+            uint32_t _size966;
+            ::apache::thrift::protocol::TType _etype969;
+            xfer += iprot->readListBegin(_etype969, _size966);
+            this->partitionnames.resize(_size966);
+            uint32_t _i970;
+            for (_i970 = 0; _i970 < _size966; ++_i970)
             {
-              xfer += iprot->readString(this->partitionnames[_i968]);
+              xfer += iprot->readString(this->partitionnames[_i970]);
             }
             xfer += iprot->readListEnd();
           }
@@ -27061,10 +27109,10 @@ uint32_t GetLatestCommittedCompactionInfoRequest::write(::apache::thrift::protoc
     xfer += oprot->writeFieldBegin("partitionnames", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionnames.size()));
-      std::vector<std::string> ::const_iterator _iter969;
-      for (_iter969 = this->partitionnames.begin(); _iter969 != this->partitionnames.end(); ++_iter969)
+      std::vector<std::string> ::const_iterator _iter971;
+      for (_iter971 = this->partitionnames.begin(); _iter971 != this->partitionnames.end(); ++_iter971)
       {
-        xfer += oprot->writeString((*_iter969));
+        xfer += oprot->writeString((*_iter971));
       }
       xfer += oprot->writeListEnd();
     }
@@ -27083,17 +27131,17 @@ void swap(GetLatestCommittedCompactionInfoRequest &a, GetLatestCommittedCompacti
   swap(a.__isset, b.__isset);
 }
 
-GetLatestCommittedCompactionInfoRequest::GetLatestCommittedCompactionInfoRequest(const GetLatestCommittedCompactionInfoRequest& other970) {
-  dbname = other970.dbname;
-  tablename = other970.tablename;
-  partitionnames = other970.partitionnames;
-  __isset = other970.__isset;
+GetLatestCommittedCompactionInfoRequest::GetLatestCommittedCompactionInfoRequest(const GetLatestCommittedCompactionInfoRequest& other972) {
+  dbname = other972.dbname;
+  tablename = other972.tablename;
+  partitionnames = other972.partitionnames;
+  __isset = other972.__isset;
 }
-GetLatestCommittedCompactionInfoRequest& GetLatestCommittedCompactionInfoRequest::operator=(const GetLatestCommittedCompactionInfoRequest& other971) {
-  dbname = other971.dbname;
-  tablename = other971.tablename;
-  partitionnames = other971.partitionnames;
-  __isset = other971.__isset;
+GetLatestCommittedCompactionInfoRequest& GetLatestCommittedCompactionInfoRequest::operator=(const GetLatestCommittedCompactionInfoRequest& other973) {
+  dbname = other973.dbname;
+  tablename = other973.tablename;
+  partitionnames = other973.partitionnames;
+  __isset = other973.__isset;
   return *this;
 }
 void GetLatestCommittedCompactionInfoRequest::printTo(std::ostream& out) const {
@@ -27146,14 +27194,14 @@ uint32_t GetLatestCommittedCompactionInfoResponse::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->compactions.clear();
-            uint32_t _size972;
-            ::apache::thrift::protocol::TType _etype975;
-            xfer += iprot->readListBegin(_etype975, _size972);
-            this->compactions.resize(_size972);
-            uint32_t _i976;
-            for (_i976 = 0; _i976 < _size972; ++_i976)
+            uint32_t _size974;
+            ::apache::thrift::protocol::TType _etype977;
+            xfer += iprot->readListBegin(_etype977, _size974);
+            this->compactions.resize(_size974);
+            uint32_t _i978;
+            for (_i978 = 0; _i978 < _size974; ++_i978)
             {
-              xfer += this->compactions[_i976].read(iprot);
+              xfer += this->compactions[_i978].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -27184,10 +27232,10 @@ uint32_t GetLatestCommittedCompactionInfoResponse::write(::apache::thrift::proto
   xfer += oprot->writeFieldBegin("compactions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->compactions.size()));
-    std::vector<CompactionInfoStruct> ::const_iterator _iter977;
-    for (_iter977 = this->compactions.begin(); _iter977 != this->compactions.end(); ++_iter977)
+    std::vector<CompactionInfoStruct> ::const_iterator _iter979;
+    for (_iter979 = this->compactions.begin(); _iter979 != this->compactions.end(); ++_iter979)
     {
-      xfer += (*_iter977).write(oprot);
+      xfer += (*_iter979).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -27203,11 +27251,11 @@ void swap(GetLatestCommittedCompactionInfoResponse &a, GetLatestCommittedCompact
   swap(a.compactions, b.compactions);
 }
 
-GetLatestCommittedCompactionInfoResponse::GetLatestCommittedCompactionInfoResponse(const GetLatestCommittedCompactionInfoResponse& other978) {
-  compactions = other978.compactions;
+GetLatestCommittedCompactionInfoResponse::GetLatestCommittedCompactionInfoResponse(const GetLatestCommittedCompactionInfoResponse& other980) {
+  compactions = other980.compactions;
 }
-GetLatestCommittedCompactionInfoResponse& GetLatestCommittedCompactionInfoResponse::operator=(const GetLatestCommittedCompactionInfoResponse& other979) {
-  compactions = other979.compactions;
+GetLatestCommittedCompactionInfoResponse& GetLatestCommittedCompactionInfoResponse::operator=(const GetLatestCommittedCompactionInfoResponse& other981) {
+  compactions = other981.compactions;
   return *this;
 }
 void GetLatestCommittedCompactionInfoResponse::printTo(std::ostream& out) const {
@@ -27315,14 +27363,14 @@ uint32_t AddDynamicPartitions::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionnames.clear();
-            uint32_t _size980;
-            ::apache::thrift::protocol::TType _etype983;
-            xfer += iprot->readListBegin(_etype983, _size980);
-            this->partitionnames.resize(_size980);
-            uint32_t _i984;
-            for (_i984 = 0; _i984 < _size980; ++_i984)
+            uint32_t _size982;
+            ::apache::thrift::protocol::TType _etype985;
+            xfer += iprot->readListBegin(_etype985, _size982);
+            this->partitionnames.resize(_size982);
+            uint32_t _i986;
+            for (_i986 = 0; _i986 < _size982; ++_i986)
             {
-              xfer += iprot->readString(this->partitionnames[_i984]);
+              xfer += iprot->readString(this->partitionnames[_i986]);
             }
             xfer += iprot->readListEnd();
           }
@@ -27333,9 +27381,9 @@ uint32_t AddDynamicPartitions::read(::apache::thrift::protocol::TProtocol* iprot
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast985;
-          xfer += iprot->readI32(ecast985);
-          this->operationType = (DataOperationType::type)ecast985;
+          int32_t ecast987;
+          xfer += iprot->readI32(ecast987);
+          this->operationType = (DataOperationType::type)ecast987;
           this->__isset.operationType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -27387,10 +27435,10 @@ uint32_t AddDynamicPartitions::write(::apache::thrift::protocol::TProtocol* opro
   xfer += oprot->writeFieldBegin("partitionnames", ::apache::thrift::protocol::T_LIST, 5);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionnames.size()));
-    std::vector<std::string> ::const_iterator _iter986;
-    for (_iter986 = this->partitionnames.begin(); _iter986 != this->partitionnames.end(); ++_iter986)
+    std::vector<std::string> ::const_iterator _iter988;
+    for (_iter988 = this->partitionnames.begin(); _iter988 != this->partitionnames.end(); ++_iter988)
     {
-      xfer += oprot->writeString((*_iter986));
+      xfer += oprot->writeString((*_iter988));
     }
     xfer += oprot->writeListEnd();
   }
@@ -27417,23 +27465,23 @@ void swap(AddDynamicPartitions &a, AddDynamicPartitions &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddDynamicPartitions::AddDynamicPartitions(const AddDynamicPartitions& other987) {
-  txnid = other987.txnid;
-  writeid = other987.writeid;
-  dbname = other987.dbname;
-  tablename = other987.tablename;
-  partitionnames = other987.partitionnames;
-  operationType = other987.operationType;
-  __isset = other987.__isset;
+AddDynamicPartitions::AddDynamicPartitions(const AddDynamicPartitions& other989) {
+  txnid = other989.txnid;
+  writeid = other989.writeid;
+  dbname = other989.dbname;
+  tablename = other989.tablename;
+  partitionnames = other989.partitionnames;
+  operationType = other989.operationType;
+  __isset = other989.__isset;
 }
-AddDynamicPartitions& AddDynamicPartitions::operator=(const AddDynamicPartitions& other988) {
-  txnid = other988.txnid;
-  writeid = other988.writeid;
-  dbname = other988.dbname;
-  tablename = other988.tablename;
-  partitionnames = other988.partitionnames;
-  operationType = other988.operationType;
-  __isset = other988.__isset;
+AddDynamicPartitions& AddDynamicPartitions::operator=(const AddDynamicPartitions& other990) {
+  txnid = other990.txnid;
+  writeid = other990.writeid;
+  dbname = other990.dbname;
+  tablename = other990.tablename;
+  partitionnames = other990.partitionnames;
+  operationType = other990.operationType;
+  __isset = other990.__isset;
   return *this;
 }
 void AddDynamicPartitions::printTo(std::ostream& out) const {
@@ -27622,23 +27670,23 @@ void swap(BasicTxnInfo &a, BasicTxnInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-BasicTxnInfo::BasicTxnInfo(const BasicTxnInfo& other989) {
-  isnull = other989.isnull;
-  time = other989.time;
-  txnid = other989.txnid;
-  dbname = other989.dbname;
-  tablename = other989.tablename;
-  partitionname = other989.partitionname;
-  __isset = other989.__isset;
+BasicTxnInfo::BasicTxnInfo(const BasicTxnInfo& other991) {
+  isnull = other991.isnull;
+  time = other991.time;
+  txnid = other991.txnid;
+  dbname = other991.dbname;
+  tablename = other991.tablename;
+  partitionname = other991.partitionname;
+  __isset = other991.__isset;
 }
-BasicTxnInfo& BasicTxnInfo::operator=(const BasicTxnInfo& other990) {
-  isnull = other990.isnull;
-  time = other990.time;
-  txnid = other990.txnid;
-  dbname = other990.dbname;
-  tablename = other990.tablename;
-  partitionname = other990.partitionname;
-  __isset = other990.__isset;
+BasicTxnInfo& BasicTxnInfo::operator=(const BasicTxnInfo& other992) {
+  isnull = other992.isnull;
+  time = other992.time;
+  txnid = other992.txnid;
+  dbname = other992.dbname;
+  tablename = other992.tablename;
+  partitionname = other992.partitionname;
+  __isset = other992.__isset;
   return *this;
 }
 void BasicTxnInfo::printTo(std::ostream& out) const {
@@ -27720,14 +27768,14 @@ uint32_t NotificationEventRequest::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->eventTypeSkipList.clear();
-            uint32_t _size991;
-            ::apache::thrift::protocol::TType _etype994;
-            xfer += iprot->readListBegin(_etype994, _size991);
-            this->eventTypeSkipList.resize(_size991);
-            uint32_t _i995;
-            for (_i995 = 0; _i995 < _size991; ++_i995)
+            uint32_t _size993;
+            ::apache::thrift::protocol::TType _etype996;
+            xfer += iprot->readListBegin(_etype996, _size993);
+            this->eventTypeSkipList.resize(_size993);
+            uint32_t _i997;
+            for (_i997 = 0; _i997 < _size993; ++_i997)
             {
-              xfer += iprot->readString(this->eventTypeSkipList[_i995]);
+              xfer += iprot->readString(this->eventTypeSkipList[_i997]);
             }
             xfer += iprot->readListEnd();
           }
@@ -27768,10 +27816,10 @@ uint32_t NotificationEventRequest::write(::apache::thrift::protocol::TProtocol* 
     xfer += oprot->writeFieldBegin("eventTypeSkipList", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->eventTypeSkipList.size()));
-      std::vector<std::string> ::const_iterator _iter996;
-      for (_iter996 = this->eventTypeSkipList.begin(); _iter996 != this->eventTypeSkipList.end(); ++_iter996)
+      std::vector<std::string> ::const_iterator _iter998;
+      for (_iter998 = this->eventTypeSkipList.begin(); _iter998 != this->eventTypeSkipList.end(); ++_iter998)
       {
-        xfer += oprot->writeString((*_iter996));
+        xfer += oprot->writeString((*_iter998));
       }
       xfer += oprot->writeListEnd();
     }
@@ -27790,17 +27838,17 @@ void swap(NotificationEventRequest &a, NotificationEventRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-NotificationEventRequest::NotificationEventRequest(const NotificationEventRequest& other997) {
-  lastEvent = other997.lastEvent;
-  maxEvents = other997.maxEvents;
-  eventTypeSkipList = other997.eventTypeSkipList;
-  __isset = other997.__isset;
+NotificationEventRequest::NotificationEventRequest(const NotificationEventRequest& other999) {
+  lastEvent = other999.lastEvent;
+  maxEvents = other999.maxEvents;
+  eventTypeSkipList = other999.eventTypeSkipList;
+  __isset = other999.__isset;
 }
-NotificationEventRequest& NotificationEventRequest::operator=(const NotificationEventRequest& other998) {
-  lastEvent = other998.lastEvent;
-  maxEvents = other998.maxEvents;
-  eventTypeSkipList = other998.eventTypeSkipList;
-  __isset = other998.__isset;
+NotificationEventRequest& NotificationEventRequest::operator=(const NotificationEventRequest& other1000) {
+  lastEvent = other1000.lastEvent;
+  maxEvents = other1000.maxEvents;
+  eventTypeSkipList = other1000.eventTypeSkipList;
+  __isset = other1000.__isset;
   return *this;
 }
 void NotificationEventRequest::printTo(std::ostream& out) const {
@@ -28027,27 +28075,27 @@ void swap(NotificationEvent &a, NotificationEvent &b) {
   swap(a.__isset, b.__isset);
 }
 
-NotificationEvent::NotificationEvent(const NotificationEvent& other999) {
-  eventId = other999.eventId;
-  eventTime = other999.eventTime;
-  eventType = other999.eventType;
-  dbName = other999.dbName;
-  tableName = other999.tableName;
-  message = other999.message;
-  messageFormat = other999.messageFormat;
-  catName = other999.catName;
-  __isset = other999.__isset;
+NotificationEvent::NotificationEvent(const NotificationEvent& other1001) {
+  eventId = other1001.eventId;
+  eventTime = other1001.eventTime;
+  eventType = other1001.eventType;
+  dbName = other1001.dbName;
+  tableName = other1001.tableName;
+  message = other1001.message;
+  messageFormat = other1001.messageFormat;
+  catName = other1001.catName;
+  __isset = other1001.__isset;
 }
-NotificationEvent& NotificationEvent::operator=(const NotificationEvent& other1000) {
-  eventId = other1000.eventId;
-  eventTime = other1000.eventTime;
-  eventType = other1000.eventType;
-  dbName = other1000.dbName;
-  tableName = other1000.tableName;
-  message = other1000.message;
-  messageFormat = other1000.messageFormat;
-  catName = other1000.catName;
-  __isset = other1000.__isset;
+NotificationEvent& NotificationEvent::operator=(const NotificationEvent& other1002) {
+  eventId = other1002.eventId;
+  eventTime = other1002.eventTime;
+  eventType = other1002.eventType;
+  dbName = other1002.dbName;
+  tableName = other1002.tableName;
+  message = other1002.message;
+  messageFormat = other1002.messageFormat;
+  catName = other1002.catName;
+  __isset = other1002.__isset;
   return *this;
 }
 void NotificationEvent::printTo(std::ostream& out) const {
@@ -28105,14 +28153,14 @@ uint32_t NotificationEventResponse::read(::apache::thrift::protocol::TProtocol* 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->events.clear();
-            uint32_t _size1001;
-            ::apache::thrift::protocol::TType _etype1004;
-            xfer += iprot->readListBegin(_etype1004, _size1001);
-            this->events.resize(_size1001);
-            uint32_t _i1005;
-            for (_i1005 = 0; _i1005 < _size1001; ++_i1005)
+            uint32_t _size1003;
+            ::apache::thrift::protocol::TType _etype1006;
+            xfer += iprot->readListBegin(_etype1006, _size1003);
+            this->events.resize(_size1003);
+            uint32_t _i1007;
+            for (_i1007 = 0; _i1007 < _size1003; ++_i1007)
             {
-              xfer += this->events[_i1005].read(iprot);
+              xfer += this->events[_i1007].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -28143,10 +28191,10 @@ uint32_t NotificationEventResponse::write(::apache::thrift::protocol::TProtocol*
   xfer += oprot->writeFieldBegin("events", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->events.size()));
-    std::vector<NotificationEvent> ::const_iterator _iter1006;
-    for (_iter1006 = this->events.begin(); _iter1006 != this->events.end(); ++_iter1006)
+    std::vector<NotificationEvent> ::const_iterator _iter1008;
+    for (_iter1008 = this->events.begin(); _iter1008 != this->events.end(); ++_iter1008)
     {
-      xfer += (*_iter1006).write(oprot);
+      xfer += (*_iter1008).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -28162,11 +28210,11 @@ void swap(NotificationEventResponse &a, NotificationEventResponse &b) {
   swap(a.events, b.events);
 }
 
-NotificationEventResponse::NotificationEventResponse(const NotificationEventResponse& other1007) {
-  events = other1007.events;
+NotificationEventResponse::NotificationEventResponse(const NotificationEventResponse& other1009) {
+  events = other1009.events;
 }
-NotificationEventResponse& NotificationEventResponse::operator=(const NotificationEventResponse& other1008) {
-  events = other1008.events;
+NotificationEventResponse& NotificationEventResponse::operator=(const NotificationEventResponse& other1010) {
+  events = other1010.events;
   return *this;
 }
 void NotificationEventResponse::printTo(std::ostream& out) const {
@@ -28254,11 +28302,11 @@ void swap(CurrentNotificationEventId &a, CurrentNotificationEventId &b) {
   swap(a.eventId, b.eventId);
 }
 
-CurrentNotificationEventId::CurrentNotificationEventId(const CurrentNotificationEventId& other1009) {
-  eventId = other1009.eventId;
+CurrentNotificationEventId::CurrentNotificationEventId(const CurrentNotificationEventId& other1011) {
+  eventId = other1011.eventId;
 }
-CurrentNotificationEventId& CurrentNotificationEventId::operator=(const CurrentNotificationEventId& other1010) {
-  eventId = other1010.eventId;
+CurrentNotificationEventId& CurrentNotificationEventId::operator=(const CurrentNotificationEventId& other1012) {
+  eventId = other1012.eventId;
   return *this;
 }
 void CurrentNotificationEventId::printTo(std::ostream& out) const {
@@ -28424,21 +28472,21 @@ void swap(NotificationEventsCountRequest &a, NotificationEventsCountRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-NotificationEventsCountRequest::NotificationEventsCountRequest(const NotificationEventsCountRequest& other1011) {
-  fromEventId = other1011.fromEventId;
-  dbName = other1011.dbName;
-  catName = other1011.catName;
-  toEventId = other1011.toEventId;
-  limit = other1011.limit;
-  __isset = other1011.__isset;
+NotificationEventsCountRequest::NotificationEventsCountRequest(const NotificationEventsCountRequest& other1013) {
+  fromEventId = other1013.fromEventId;
+  dbName = other1013.dbName;
+  catName = other1013.catName;
+  toEventId = other1013.toEventId;
+  limit = other1013.limit;
+  __isset = other1013.__isset;
 }
-NotificationEventsCountRequest& NotificationEventsCountRequest::operator=(const NotificationEventsCountRequest& other1012) {
-  fromEventId = other1012.fromEventId;
-  dbName = other1012.dbName;
-  catName = other1012.catName;
-  toEventId = other1012.toEventId;
-  limit = other1012.limit;
-  __isset = other1012.__isset;
+NotificationEventsCountRequest& NotificationEventsCountRequest::operator=(const NotificationEventsCountRequest& other1014) {
+  fromEventId = other1014.fromEventId;
+  dbName = other1014.dbName;
+  catName = other1014.catName;
+  toEventId = other1014.toEventId;
+  limit = other1014.limit;
+  __isset = other1014.__isset;
   return *this;
 }
 void NotificationEventsCountRequest::printTo(std::ostream& out) const {
@@ -28530,11 +28578,11 @@ void swap(NotificationEventsCountResponse &a, NotificationEventsCountResponse &b
   swap(a.eventsCount, b.eventsCount);
 }
 
-NotificationEventsCountResponse::NotificationEventsCountResponse(const NotificationEventsCountResponse& other1013) {
-  eventsCount = other1013.eventsCount;
+NotificationEventsCountResponse::NotificationEventsCountResponse(const NotificationEventsCountResponse& other1015) {
+  eventsCount = other1015.eventsCount;
 }
-NotificationEventsCountResponse& NotificationEventsCountResponse::operator=(const NotificationEventsCountResponse& other1014) {
-  eventsCount = other1014.eventsCount;
+NotificationEventsCountResponse& NotificationEventsCountResponse::operator=(const NotificationEventsCountResponse& other1016) {
+  eventsCount = other1016.eventsCount;
   return *this;
 }
 void NotificationEventsCountResponse::printTo(std::ostream& out) const {
@@ -28613,14 +28661,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filesAdded.clear();
-            uint32_t _size1015;
-            ::apache::thrift::protocol::TType _etype1018;
-            xfer += iprot->readListBegin(_etype1018, _size1015);
-            this->filesAdded.resize(_size1015);
-            uint32_t _i1019;
-            for (_i1019 = 0; _i1019 < _size1015; ++_i1019)
+            uint32_t _size1017;
+            ::apache::thrift::protocol::TType _etype1020;
+            xfer += iprot->readListBegin(_etype1020, _size1017);
+            this->filesAdded.resize(_size1017);
+            uint32_t _i1021;
+            for (_i1021 = 0; _i1021 < _size1017; ++_i1021)
             {
-              xfer += iprot->readString(this->filesAdded[_i1019]);
+              xfer += iprot->readString(this->filesAdded[_i1021]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28633,14 +28681,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filesAddedChecksum.clear();
-            uint32_t _size1020;
-            ::apache::thrift::protocol::TType _etype1023;
-            xfer += iprot->readListBegin(_etype1023, _size1020);
-            this->filesAddedChecksum.resize(_size1020);
-            uint32_t _i1024;
-            for (_i1024 = 0; _i1024 < _size1020; ++_i1024)
+            uint32_t _size1022;
+            ::apache::thrift::protocol::TType _etype1025;
+            xfer += iprot->readListBegin(_etype1025, _size1022);
+            this->filesAddedChecksum.resize(_size1022);
+            uint32_t _i1026;
+            for (_i1026 = 0; _i1026 < _size1022; ++_i1026)
             {
-              xfer += iprot->readString(this->filesAddedChecksum[_i1024]);
+              xfer += iprot->readString(this->filesAddedChecksum[_i1026]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28653,14 +28701,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->subDirectoryList.clear();
-            uint32_t _size1025;
-            ::apache::thrift::protocol::TType _etype1028;
-            xfer += iprot->readListBegin(_etype1028, _size1025);
-            this->subDirectoryList.resize(_size1025);
-            uint32_t _i1029;
-            for (_i1029 = 0; _i1029 < _size1025; ++_i1029)
+            uint32_t _size1027;
+            ::apache::thrift::protocol::TType _etype1030;
+            xfer += iprot->readListBegin(_etype1030, _size1027);
+            this->subDirectoryList.resize(_size1027);
+            uint32_t _i1031;
+            for (_i1031 = 0; _i1031 < _size1027; ++_i1031)
             {
-              xfer += iprot->readString(this->subDirectoryList[_i1029]);
+              xfer += iprot->readString(this->subDirectoryList[_i1031]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28673,14 +28721,14 @@ uint32_t InsertEventRequestData::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVal.clear();
-            uint32_t _size1030;
-            ::apache::thrift::protocol::TType _etype1033;
-            xfer += iprot->readListBegin(_etype1033, _size1030);
-            this->partitionVal.resize(_size1030);
-            uint32_t _i1034;
-            for (_i1034 = 0; _i1034 < _size1030; ++_i1034)
+            uint32_t _size1032;
+            ::apache::thrift::protocol::TType _etype1035;
+            xfer += iprot->readListBegin(_etype1035, _size1032);
+            this->partitionVal.resize(_size1032);
+            uint32_t _i1036;
+            for (_i1036 = 0; _i1036 < _size1032; ++_i1036)
             {
-              xfer += iprot->readString(this->partitionVal[_i1034]);
+              xfer += iprot->readString(this->partitionVal[_i1036]);
             }
             xfer += iprot->readListEnd();
           }
@@ -28716,10 +28764,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("filesAdded", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filesAdded.size()));
-    std::vector<std::string> ::const_iterator _iter1035;
-    for (_iter1035 = this->filesAdded.begin(); _iter1035 != this->filesAdded.end(); ++_iter1035)
+    std::vector<std::string> ::const_iterator _iter1037;
+    for (_iter1037 = this->filesAdded.begin(); _iter1037 != this->filesAdded.end(); ++_iter1037)
     {
-      xfer += oprot->writeString((*_iter1035));
+      xfer += oprot->writeString((*_iter1037));
     }
     xfer += oprot->writeListEnd();
   }
@@ -28729,10 +28777,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("filesAddedChecksum", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filesAddedChecksum.size()));
-      std::vector<std::string> ::const_iterator _iter1036;
-      for (_iter1036 = this->filesAddedChecksum.begin(); _iter1036 != this->filesAddedChecksum.end(); ++_iter1036)
+      std::vector<std::string> ::const_iterator _iter1038;
+      for (_iter1038 = this->filesAddedChecksum.begin(); _iter1038 != this->filesAddedChecksum.end(); ++_iter1038)
       {
-        xfer += oprot->writeString((*_iter1036));
+        xfer += oprot->writeString((*_iter1038));
       }
       xfer += oprot->writeListEnd();
     }
@@ -28742,10 +28790,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("subDirectoryList", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->subDirectoryList.size()));
-      std::vector<std::string> ::const_iterator _iter1037;
-      for (_iter1037 = this->subDirectoryList.begin(); _iter1037 != this->subDirectoryList.end(); ++_iter1037)
+      std::vector<std::string> ::const_iterator _iter1039;
+      for (_iter1039 = this->subDirectoryList.begin(); _iter1039 != this->subDirectoryList.end(); ++_iter1039)
       {
-        xfer += oprot->writeString((*_iter1037));
+        xfer += oprot->writeString((*_iter1039));
       }
       xfer += oprot->writeListEnd();
     }
@@ -28755,10 +28803,10 @@ uint32_t InsertEventRequestData::write(::apache::thrift::protocol::TProtocol* op
     xfer += oprot->writeFieldBegin("partitionVal", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVal.size()));
-      std::vector<std::string> ::const_iterator _iter1038;
-      for (_iter1038 = this->partitionVal.begin(); _iter1038 != this->partitionVal.end(); ++_iter1038)
+      std::vector<std::string> ::const_iterator _iter1040;
+      for (_iter1040 = this->partitionVal.begin(); _iter1040 != this->partitionVal.end(); ++_iter1040)
       {
-        xfer += oprot->writeString((*_iter1038));
+        xfer += oprot->writeString((*_iter1040));
       }
       xfer += oprot->writeListEnd();
     }
@@ -28779,21 +28827,21 @@ void swap(InsertEventRequestData &a, InsertEventRequestData &b) {
   swap(a.__isset, b.__isset);
 }
 
-InsertEventRequestData::InsertEventRequestData(const InsertEventRequestData& other1039) {
-  replace = other1039.replace;
-  filesAdded = other1039.filesAdded;
-  filesAddedChecksum = other1039.filesAddedChecksum;
-  subDirectoryList = other1039.subDirectoryList;
-  partitionVal = other1039.partitionVal;
-  __isset = other1039.__isset;
+InsertEventRequestData::InsertEventRequestData(const InsertEventRequestData& other1041) {
+  replace = other1041.replace;
+  filesAdded = other1041.filesAdded;
+  filesAddedChecksum = other1041.filesAddedChecksum;
+  subDirectoryList = other1041.subDirectoryList;
+  partitionVal = other1041.partitionVal;
+  __isset = other1041.__isset;
 }
-InsertEventRequestData& InsertEventRequestData::operator=(const InsertEventRequestData& other1040) {
-  replace = other1040.replace;
-  filesAdded = other1040.filesAdded;
-  filesAddedChecksum = other1040.filesAddedChecksum;
-  subDirectoryList = other1040.subDirectoryList;
-  partitionVal = other1040.partitionVal;
-  __isset = other1040.__isset;
+InsertEventRequestData& InsertEventRequestData::operator=(const InsertEventRequestData& other1042) {
+  replace = other1042.replace;
+  filesAdded = other1042.filesAdded;
+  filesAddedChecksum = other1042.filesAddedChecksum;
+  subDirectoryList = other1042.subDirectoryList;
+  partitionVal = other1042.partitionVal;
+  __isset = other1042.__isset;
   return *this;
 }
 void InsertEventRequestData::printTo(std::ostream& out) const {
@@ -28861,14 +28909,14 @@ uint32_t FireEventRequestData::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->insertDatas.clear();
-            uint32_t _size1041;
-            ::apache::thrift::protocol::TType _etype1044;
-            xfer += iprot->readListBegin(_etype1044, _size1041);
-            this->insertDatas.resize(_size1041);
-            uint32_t _i1045;
-            for (_i1045 = 0; _i1045 < _size1041; ++_i1045)
+            uint32_t _size1043;
+            ::apache::thrift::protocol::TType _etype1046;
+            xfer += iprot->readListBegin(_etype1046, _size1043);
+            this->insertDatas.resize(_size1043);
+            uint32_t _i1047;
+            for (_i1047 = 0; _i1047 < _size1043; ++_i1047)
             {
-              xfer += this->insertDatas[_i1045].read(iprot);
+              xfer += this->insertDatas[_i1047].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -28903,10 +28951,10 @@ uint32_t FireEventRequestData::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("insertDatas", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->insertDatas.size()));
-      std::vector<InsertEventRequestData> ::const_iterator _iter1046;
-      for (_iter1046 = this->insertDatas.begin(); _iter1046 != this->insertDatas.end(); ++_iter1046)
+      std::vector<InsertEventRequestData> ::const_iterator _iter1048;
+      for (_iter1048 = this->insertDatas.begin(); _iter1048 != this->insertDatas.end(); ++_iter1048)
       {
-        xfer += (*_iter1046).write(oprot);
+        xfer += (*_iter1048).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -28924,15 +28972,15 @@ void swap(FireEventRequestData &a, FireEventRequestData &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventRequestData::FireEventRequestData(const FireEventRequestData& other1047) {
-  insertData = other1047.insertData;
-  insertDatas = other1047.insertDatas;
-  __isset = other1047.__isset;
+FireEventRequestData::FireEventRequestData(const FireEventRequestData& other1049) {
+  insertData = other1049.insertData;
+  insertDatas = other1049.insertDatas;
+  __isset = other1049.__isset;
 }
-FireEventRequestData& FireEventRequestData::operator=(const FireEventRequestData& other1048) {
-  insertData = other1048.insertData;
-  insertDatas = other1048.insertDatas;
-  __isset = other1048.__isset;
+FireEventRequestData& FireEventRequestData::operator=(const FireEventRequestData& other1050) {
+  insertData = other1050.insertData;
+  insertDatas = other1050.insertDatas;
+  __isset = other1050.__isset;
   return *this;
 }
 void FireEventRequestData::printTo(std::ostream& out) const {
@@ -29041,14 +29089,14 @@ uint32_t FireEventRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVals.clear();
-            uint32_t _size1049;
-            ::apache::thrift::protocol::TType _etype1052;
-            xfer += iprot->readListBegin(_etype1052, _size1049);
-            this->partitionVals.resize(_size1049);
-            uint32_t _i1053;
-            for (_i1053 = 0; _i1053 < _size1049; ++_i1053)
+            uint32_t _size1051;
+            ::apache::thrift::protocol::TType _etype1054;
+            xfer += iprot->readListBegin(_etype1054, _size1051);
+            this->partitionVals.resize(_size1051);
+            uint32_t _i1055;
+            for (_i1055 = 0; _i1055 < _size1051; ++_i1055)
             {
-              xfer += iprot->readString(this->partitionVals[_i1053]);
+              xfer += iprot->readString(this->partitionVals[_i1055]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29108,10 +29156,10 @@ uint32_t FireEventRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("partitionVals", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVals.size()));
-      std::vector<std::string> ::const_iterator _iter1054;
-      for (_iter1054 = this->partitionVals.begin(); _iter1054 != this->partitionVals.end(); ++_iter1054)
+      std::vector<std::string> ::const_iterator _iter1056;
+      for (_iter1056 = this->partitionVals.begin(); _iter1056 != this->partitionVals.end(); ++_iter1056)
       {
-        xfer += oprot->writeString((*_iter1054));
+        xfer += oprot->writeString((*_iter1056));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29138,23 +29186,23 @@ void swap(FireEventRequest &a, FireEventRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventRequest::FireEventRequest(const FireEventRequest& other1055) {
-  successful = other1055.successful;
-  data = other1055.data;
-  dbName = other1055.dbName;
-  tableName = other1055.tableName;
-  partitionVals = other1055.partitionVals;
-  catName = other1055.catName;
-  __isset = other1055.__isset;
+FireEventRequest::FireEventRequest(const FireEventRequest& other1057) {
+  successful = other1057.successful;
+  data = other1057.data;
+  dbName = other1057.dbName;
+  tableName = other1057.tableName;
+  partitionVals = other1057.partitionVals;
+  catName = other1057.catName;
+  __isset = other1057.__isset;
 }
-FireEventRequest& FireEventRequest::operator=(const FireEventRequest& other1056) {
-  successful = other1056.successful;
-  data = other1056.data;
-  dbName = other1056.dbName;
-  tableName = other1056.tableName;
-  partitionVals = other1056.partitionVals;
-  catName = other1056.catName;
-  __isset = other1056.__isset;
+FireEventRequest& FireEventRequest::operator=(const FireEventRequest& other1058) {
+  successful = other1058.successful;
+  data = other1058.data;
+  dbName = other1058.dbName;
+  tableName = other1058.tableName;
+  partitionVals = other1058.partitionVals;
+  catName = other1058.catName;
+  __isset = other1058.__isset;
   return *this;
 }
 void FireEventRequest::printTo(std::ostream& out) const {
@@ -29209,14 +29257,14 @@ uint32_t FireEventResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->eventIds.clear();
-            uint32_t _size1057;
-            ::apache::thrift::protocol::TType _etype1060;
-            xfer += iprot->readListBegin(_etype1060, _size1057);
-            this->eventIds.resize(_size1057);
-            uint32_t _i1061;
-            for (_i1061 = 0; _i1061 < _size1057; ++_i1061)
+            uint32_t _size1059;
+            ::apache::thrift::protocol::TType _etype1062;
+            xfer += iprot->readListBegin(_etype1062, _size1059);
+            this->eventIds.resize(_size1059);
+            uint32_t _i1063;
+            for (_i1063 = 0; _i1063 < _size1059; ++_i1063)
             {
-              xfer += iprot->readI64(this->eventIds[_i1061]);
+              xfer += iprot->readI64(this->eventIds[_i1063]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29245,10 +29293,10 @@ uint32_t FireEventResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("eventIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->eventIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1062;
-    for (_iter1062 = this->eventIds.begin(); _iter1062 != this->eventIds.end(); ++_iter1062)
+    std::vector<int64_t> ::const_iterator _iter1064;
+    for (_iter1064 = this->eventIds.begin(); _iter1064 != this->eventIds.end(); ++_iter1064)
     {
-      xfer += oprot->writeI64((*_iter1062));
+      xfer += oprot->writeI64((*_iter1064));
     }
     xfer += oprot->writeListEnd();
   }
@@ -29265,13 +29313,13 @@ void swap(FireEventResponse &a, FireEventResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-FireEventResponse::FireEventResponse(const FireEventResponse& other1063) {
-  eventIds = other1063.eventIds;
-  __isset = other1063.__isset;
+FireEventResponse::FireEventResponse(const FireEventResponse& other1065) {
+  eventIds = other1065.eventIds;
+  __isset = other1065.__isset;
 }
-FireEventResponse& FireEventResponse::operator=(const FireEventResponse& other1064) {
-  eventIds = other1064.eventIds;
-  __isset = other1064.__isset;
+FireEventResponse& FireEventResponse::operator=(const FireEventResponse& other1066) {
+  eventIds = other1066.eventIds;
+  __isset = other1066.__isset;
   return *this;
 }
 void FireEventResponse::printTo(std::ostream& out) const {
@@ -29387,14 +29435,14 @@ uint32_t WriteNotificationLogRequest::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionVals.clear();
-            uint32_t _size1065;
-            ::apache::thrift::protocol::TType _etype1068;
-            xfer += iprot->readListBegin(_etype1068, _size1065);
-            this->partitionVals.resize(_size1065);
-            uint32_t _i1069;
-            for (_i1069 = 0; _i1069 < _size1065; ++_i1069)
+            uint32_t _size1067;
+            ::apache::thrift::protocol::TType _etype1070;
+            xfer += iprot->readListBegin(_etype1070, _size1067);
+            this->partitionVals.resize(_size1067);
+            uint32_t _i1071;
+            for (_i1071 = 0; _i1071 < _size1067; ++_i1071)
             {
-              xfer += iprot->readString(this->partitionVals[_i1069]);
+              xfer += iprot->readString(this->partitionVals[_i1071]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29454,10 +29502,10 @@ uint32_t WriteNotificationLogRequest::write(::apache::thrift::protocol::TProtoco
     xfer += oprot->writeFieldBegin("partitionVals", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partitionVals.size()));
-      std::vector<std::string> ::const_iterator _iter1070;
-      for (_iter1070 = this->partitionVals.begin(); _iter1070 != this->partitionVals.end(); ++_iter1070)
+      std::vector<std::string> ::const_iterator _iter1072;
+      for (_iter1072 = this->partitionVals.begin(); _iter1072 != this->partitionVals.end(); ++_iter1072)
       {
-        xfer += oprot->writeString((*_iter1070));
+        xfer += oprot->writeString((*_iter1072));
       }
       xfer += oprot->writeListEnd();
     }
@@ -29479,23 +29527,23 @@ void swap(WriteNotificationLogRequest &a, WriteNotificationLogRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WriteNotificationLogRequest::WriteNotificationLogRequest(const WriteNotificationLogRequest& other1071) {
-  txnId = other1071.txnId;
-  writeId = other1071.writeId;
-  db = other1071.db;
-  table = other1071.table;
-  fileInfo = other1071.fileInfo;
-  partitionVals = other1071.partitionVals;
-  __isset = other1071.__isset;
+WriteNotificationLogRequest::WriteNotificationLogRequest(const WriteNotificationLogRequest& other1073) {
+  txnId = other1073.txnId;
+  writeId = other1073.writeId;
+  db = other1073.db;
+  table = other1073.table;
+  fileInfo = other1073.fileInfo;
+  partitionVals = other1073.partitionVals;
+  __isset = other1073.__isset;
 }
-WriteNotificationLogRequest& WriteNotificationLogRequest::operator=(const WriteNotificationLogRequest& other1072) {
-  txnId = other1072.txnId;
-  writeId = other1072.writeId;
-  db = other1072.db;
-  table = other1072.table;
-  fileInfo = other1072.fileInfo;
-  partitionVals = other1072.partitionVals;
-  __isset = other1072.__isset;
+WriteNotificationLogRequest& WriteNotificationLogRequest::operator=(const WriteNotificationLogRequest& other1074) {
+  txnId = other1074.txnId;
+  writeId = other1074.writeId;
+  db = other1074.db;
+  table = other1074.table;
+  fileInfo = other1074.fileInfo;
+  partitionVals = other1074.partitionVals;
+  __isset = other1074.__isset;
   return *this;
 }
 void WriteNotificationLogRequest::printTo(std::ostream& out) const {
@@ -29565,11 +29613,11 @@ void swap(WriteNotificationLogResponse &a, WriteNotificationLogResponse &b) {
   (void) b;
 }
 
-WriteNotificationLogResponse::WriteNotificationLogResponse(const WriteNotificationLogResponse& other1073) {
-  (void) other1073;
+WriteNotificationLogResponse::WriteNotificationLogResponse(const WriteNotificationLogResponse& other1075) {
+  (void) other1075;
 }
-WriteNotificationLogResponse& WriteNotificationLogResponse::operator=(const WriteNotificationLogResponse& other1074) {
-  (void) other1074;
+WriteNotificationLogResponse& WriteNotificationLogResponse::operator=(const WriteNotificationLogResponse& other1076) {
+  (void) other1076;
   return *this;
 }
 void WriteNotificationLogResponse::printTo(std::ostream& out) const {
@@ -29675,15 +29723,15 @@ void swap(MetadataPpdResult &a, MetadataPpdResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-MetadataPpdResult::MetadataPpdResult(const MetadataPpdResult& other1075) {
-  metadata = other1075.metadata;
-  includeBitset = other1075.includeBitset;
-  __isset = other1075.__isset;
+MetadataPpdResult::MetadataPpdResult(const MetadataPpdResult& other1077) {
+  metadata = other1077.metadata;
+  includeBitset = other1077.includeBitset;
+  __isset = other1077.__isset;
 }
-MetadataPpdResult& MetadataPpdResult::operator=(const MetadataPpdResult& other1076) {
-  metadata = other1076.metadata;
-  includeBitset = other1076.includeBitset;
-  __isset = other1076.__isset;
+MetadataPpdResult& MetadataPpdResult::operator=(const MetadataPpdResult& other1078) {
+  metadata = other1078.metadata;
+  includeBitset = other1078.includeBitset;
+  __isset = other1078.__isset;
   return *this;
 }
 void MetadataPpdResult::printTo(std::ostream& out) const {
@@ -29740,17 +29788,17 @@ uint32_t GetFileMetadataByExprResult::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->metadata.clear();
-            uint32_t _size1077;
-            ::apache::thrift::protocol::TType _ktype1078;
-            ::apache::thrift::protocol::TType _vtype1079;
-            xfer += iprot->readMapBegin(_ktype1078, _vtype1079, _size1077);
-            uint32_t _i1081;
-            for (_i1081 = 0; _i1081 < _size1077; ++_i1081)
+            uint32_t _size1079;
+            ::apache::thrift::protocol::TType _ktype1080;
+            ::apache::thrift::protocol::TType _vtype1081;
+            xfer += iprot->readMapBegin(_ktype1080, _vtype1081, _size1079);
+            uint32_t _i1083;
+            for (_i1083 = 0; _i1083 < _size1079; ++_i1083)
             {
-              int64_t _key1082;
-              xfer += iprot->readI64(_key1082);
-              MetadataPpdResult& _val1083 = this->metadata[_key1082];
-              xfer += _val1083.read(iprot);
+              int64_t _key1084;
+              xfer += iprot->readI64(_key1084);
+              MetadataPpdResult& _val1085 = this->metadata[_key1084];
+              xfer += _val1085.read(iprot);
             }
             xfer += iprot->readMapEnd();
           }
@@ -29791,11 +29839,11 @@ uint32_t GetFileMetadataByExprResult::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_I64, ::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->metadata.size()));
-    std::map<int64_t, MetadataPpdResult> ::const_iterator _iter1084;
-    for (_iter1084 = this->metadata.begin(); _iter1084 != this->metadata.end(); ++_iter1084)
+    std::map<int64_t, MetadataPpdResult> ::const_iterator _iter1086;
+    for (_iter1086 = this->metadata.begin(); _iter1086 != this->metadata.end(); ++_iter1086)
     {
-      xfer += oprot->writeI64(_iter1084->first);
-      xfer += _iter1084->second.write(oprot);
+      xfer += oprot->writeI64(_iter1086->first);
+      xfer += _iter1086->second.write(oprot);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -29816,13 +29864,13 @@ void swap(GetFileMetadataByExprResult &a, GetFileMetadataByExprResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-GetFileMetadataByExprResult::GetFileMetadataByExprResult(const GetFileMetadataByExprResult& other1085) {
-  metadata = other1085.metadata;
-  isSupported = other1085.isSupported;
+GetFileMetadataByExprResult::GetFileMetadataByExprResult(const GetFileMetadataByExprResult& other1087) {
+  metadata = other1087.metadata;
+  isSupported = other1087.isSupported;
 }
-GetFileMetadataByExprResult& GetFileMetadataByExprResult::operator=(const GetFileMetadataByExprResult& other1086) {
-  metadata = other1086.metadata;
-  isSupported = other1086.isSupported;
+GetFileMetadataByExprResult& GetFileMetadataByExprResult::operator=(const GetFileMetadataByExprResult& other1088) {
+  metadata = other1088.metadata;
+  isSupported = other1088.isSupported;
   return *this;
 }
 void GetFileMetadataByExprResult::printTo(std::ostream& out) const {
@@ -29889,14 +29937,14 @@ uint32_t GetFileMetadataByExprRequest::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1087;
-            ::apache::thrift::protocol::TType _etype1090;
-            xfer += iprot->readListBegin(_etype1090, _size1087);
-            this->fileIds.resize(_size1087);
-            uint32_t _i1091;
-            for (_i1091 = 0; _i1091 < _size1087; ++_i1091)
+            uint32_t _size1089;
+            ::apache::thrift::protocol::TType _etype1092;
+            xfer += iprot->readListBegin(_etype1092, _size1089);
+            this->fileIds.resize(_size1089);
+            uint32_t _i1093;
+            for (_i1093 = 0; _i1093 < _size1089; ++_i1093)
             {
-              xfer += iprot->readI64(this->fileIds[_i1091]);
+              xfer += iprot->readI64(this->fileIds[_i1093]);
             }
             xfer += iprot->readListEnd();
           }
@@ -29923,9 +29971,9 @@ uint32_t GetFileMetadataByExprRequest::read(::apache::thrift::protocol::TProtoco
         break;
       case 4:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1092;
-          xfer += iprot->readI32(ecast1092);
-          this->type = (FileMetadataExprType::type)ecast1092;
+          int32_t ecast1094;
+          xfer += iprot->readI32(ecast1094);
+          this->type = (FileMetadataExprType::type)ecast1094;
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -29955,10 +30003,10 @@ uint32_t GetFileMetadataByExprRequest::write(::apache::thrift::protocol::TProtoc
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1093;
-    for (_iter1093 = this->fileIds.begin(); _iter1093 != this->fileIds.end(); ++_iter1093)
+    std::vector<int64_t> ::const_iterator _iter1095;
+    for (_iter1095 = this->fileIds.begin(); _iter1095 != this->fileIds.end(); ++_iter1095)
     {
-      xfer += oprot->writeI64((*_iter1093));
+      xfer += oprot->writeI64((*_iter1095));
     }
     xfer += oprot->writeListEnd();
   }
@@ -29992,19 +30040,19 @@ void swap(GetFileMetadataByExprRequest &a, GetFileMetadataByExprRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetFileMetadataByExprRequest::GetFileMetadataByExprRequest(const GetFileMetadataByExprRequest& other1094) {
-  fileIds = other1094.fileIds;
-  expr = other1094.expr;
-  doGetFooters = other1094.doGetFooters;
-  type = other1094.type;
-  __isset = other1094.__isset;
+GetFileMetadataByExprRequest::GetFileMetadataByExprRequest(const GetFileMetadataByExprRequest& other1096) {
+  fileIds = other1096.fileIds;
+  expr = other1096.expr;
+  doGetFooters = other1096.doGetFooters;
+  type = other1096.type;
+  __isset = other1096.__isset;
 }
-GetFileMetadataByExprRequest& GetFileMetadataByExprRequest::operator=(const GetFileMetadataByExprRequest& other1095) {
-  fileIds = other1095.fileIds;
-  expr = other1095.expr;
-  doGetFooters = other1095.doGetFooters;
-  type = other1095.type;
-  __isset = other1095.__isset;
+GetFileMetadataByExprRequest& GetFileMetadataByExprRequest::operator=(const GetFileMetadataByExprRequest& other1097) {
+  fileIds = other1097.fileIds;
+  expr = other1097.expr;
+  doGetFooters = other1097.doGetFooters;
+  type = other1097.type;
+  __isset = other1097.__isset;
   return *this;
 }
 void GetFileMetadataByExprRequest::printTo(std::ostream& out) const {
@@ -30063,17 +30111,17 @@ uint32_t GetFileMetadataResult::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->metadata.clear();
-            uint32_t _size1096;
-            ::apache::thrift::protocol::TType _ktype1097;
-            ::apache::thrift::protocol::TType _vtype1098;
-            xfer += iprot->readMapBegin(_ktype1097, _vtype1098, _size1096);
-            uint32_t _i1100;
-            for (_i1100 = 0; _i1100 < _size1096; ++_i1100)
+            uint32_t _size1098;
+            ::apache::thrift::protocol::TType _ktype1099;
+            ::apache::thrift::protocol::TType _vtype1100;
+            xfer += iprot->readMapBegin(_ktype1099, _vtype1100, _size1098);
+            uint32_t _i1102;
+            for (_i1102 = 0; _i1102 < _size1098; ++_i1102)
             {
-              int64_t _key1101;
-              xfer += iprot->readI64(_key1101);
-              std::string& _val1102 = this->metadata[_key1101];
-              xfer += iprot->readBinary(_val1102);
+              int64_t _key1103;
+              xfer += iprot->readI64(_key1103);
+              std::string& _val1104 = this->metadata[_key1103];
+              xfer += iprot->readBinary(_val1104);
             }
             xfer += iprot->readMapEnd();
           }
@@ -30114,11 +30162,11 @@ uint32_t GetFileMetadataResult::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_MAP, 1);
   {
     xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_I64, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->metadata.size()));
-    std::map<int64_t, std::string> ::const_iterator _iter1103;
-    for (_iter1103 = this->metadata.begin(); _iter1103 != this->metadata.end(); ++_iter1103)
+    std::map<int64_t, std::string> ::const_iterator _iter1105;
+    for (_iter1105 = this->metadata.begin(); _iter1105 != this->metadata.end(); ++_iter1105)
     {
-      xfer += oprot->writeI64(_iter1103->first);
-      xfer += oprot->writeBinary(_iter1103->second);
+      xfer += oprot->writeI64(_iter1105->first);
+      xfer += oprot->writeBinary(_iter1105->second);
     }
     xfer += oprot->writeMapEnd();
   }
@@ -30139,13 +30187,13 @@ void swap(GetFileMetadataResult &a, GetFileMetadataResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-GetFileMetadataResult::GetFileMetadataResult(const GetFileMetadataResult& other1104) {
-  metadata = other1104.metadata;
-  isSupported = other1104.isSupported;
+GetFileMetadataResult::GetFileMetadataResult(const GetFileMetadataResult& other1106) {
+  metadata = other1106.metadata;
+  isSupported = other1106.isSupported;
 }
-GetFileMetadataResult& GetFileMetadataResult::operator=(const GetFileMetadataResult& other1105) {
-  metadata = other1105.metadata;
-  isSupported = other1105.isSupported;
+GetFileMetadataResult& GetFileMetadataResult::operator=(const GetFileMetadataResult& other1107) {
+  metadata = other1107.metadata;
+  isSupported = other1107.isSupported;
   return *this;
 }
 void GetFileMetadataResult::printTo(std::ostream& out) const {
@@ -30197,14 +30245,14 @@ uint32_t GetFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1106;
-            ::apache::thrift::protocol::TType _etype1109;
-            xfer += iprot->readListBegin(_etype1109, _size1106);
-            this->fileIds.resize(_size1106);
-            uint32_t _i1110;
-            for (_i1110 = 0; _i1110 < _size1106; ++_i1110)
+            uint32_t _size1108;
+            ::apache::thrift::protocol::TType _etype1111;
+            xfer += iprot->readListBegin(_etype1111, _size1108);
+            this->fileIds.resize(_size1108);
+            uint32_t _i1112;
+            for (_i1112 = 0; _i1112 < _size1108; ++_i1112)
             {
-              xfer += iprot->readI64(this->fileIds[_i1110]);
+              xfer += iprot->readI64(this->fileIds[_i1112]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30235,10 +30283,10 @@ uint32_t GetFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1111;
-    for (_iter1111 = this->fileIds.begin(); _iter1111 != this->fileIds.end(); ++_iter1111)
+    std::vector<int64_t> ::const_iterator _iter1113;
+    for (_iter1113 = this->fileIds.begin(); _iter1113 != this->fileIds.end(); ++_iter1113)
     {
-      xfer += oprot->writeI64((*_iter1111));
+      xfer += oprot->writeI64((*_iter1113));
     }
     xfer += oprot->writeListEnd();
   }
@@ -30254,11 +30302,11 @@ void swap(GetFileMetadataRequest &a, GetFileMetadataRequest &b) {
   swap(a.fileIds, b.fileIds);
 }
 
-GetFileMetadataRequest::GetFileMetadataRequest(const GetFileMetadataRequest& other1112) {
-  fileIds = other1112.fileIds;
+GetFileMetadataRequest::GetFileMetadataRequest(const GetFileMetadataRequest& other1114) {
+  fileIds = other1114.fileIds;
 }
-GetFileMetadataRequest& GetFileMetadataRequest::operator=(const GetFileMetadataRequest& other1113) {
-  fileIds = other1113.fileIds;
+GetFileMetadataRequest& GetFileMetadataRequest::operator=(const GetFileMetadataRequest& other1115) {
+  fileIds = other1115.fileIds;
   return *this;
 }
 void GetFileMetadataRequest::printTo(std::ostream& out) const {
@@ -30323,11 +30371,11 @@ void swap(PutFileMetadataResult &a, PutFileMetadataResult &b) {
   (void) b;
 }
 
-PutFileMetadataResult::PutFileMetadataResult(const PutFileMetadataResult& other1114) {
-  (void) other1114;
+PutFileMetadataResult::PutFileMetadataResult(const PutFileMetadataResult& other1116) {
+  (void) other1116;
 }
-PutFileMetadataResult& PutFileMetadataResult::operator=(const PutFileMetadataResult& other1115) {
-  (void) other1115;
+PutFileMetadataResult& PutFileMetadataResult::operator=(const PutFileMetadataResult& other1117) {
+  (void) other1117;
   return *this;
 }
 void PutFileMetadataResult::printTo(std::ostream& out) const {
@@ -30387,14 +30435,14 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1116;
-            ::apache::thrift::protocol::TType _etype1119;
-            xfer += iprot->readListBegin(_etype1119, _size1116);
-            this->fileIds.resize(_size1116);
-            uint32_t _i1120;
-            for (_i1120 = 0; _i1120 < _size1116; ++_i1120)
+            uint32_t _size1118;
+            ::apache::thrift::protocol::TType _etype1121;
+            xfer += iprot->readListBegin(_etype1121, _size1118);
+            this->fileIds.resize(_size1118);
+            uint32_t _i1122;
+            for (_i1122 = 0; _i1122 < _size1118; ++_i1122)
             {
-              xfer += iprot->readI64(this->fileIds[_i1120]);
+              xfer += iprot->readI64(this->fileIds[_i1122]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30407,14 +30455,14 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->metadata.clear();
-            uint32_t _size1121;
-            ::apache::thrift::protocol::TType _etype1124;
-            xfer += iprot->readListBegin(_etype1124, _size1121);
-            this->metadata.resize(_size1121);
-            uint32_t _i1125;
-            for (_i1125 = 0; _i1125 < _size1121; ++_i1125)
+            uint32_t _size1123;
+            ::apache::thrift::protocol::TType _etype1126;
+            xfer += iprot->readListBegin(_etype1126, _size1123);
+            this->metadata.resize(_size1123);
+            uint32_t _i1127;
+            for (_i1127 = 0; _i1127 < _size1123; ++_i1127)
             {
-              xfer += iprot->readBinary(this->metadata[_i1125]);
+              xfer += iprot->readBinary(this->metadata[_i1127]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30425,9 +30473,9 @@ uint32_t PutFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 3:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1126;
-          xfer += iprot->readI32(ecast1126);
-          this->type = (FileMetadataExprType::type)ecast1126;
+          int32_t ecast1128;
+          xfer += iprot->readI32(ecast1128);
+          this->type = (FileMetadataExprType::type)ecast1128;
           this->__isset.type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -30457,10 +30505,10 @@ uint32_t PutFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1127;
-    for (_iter1127 = this->fileIds.begin(); _iter1127 != this->fileIds.end(); ++_iter1127)
+    std::vector<int64_t> ::const_iterator _iter1129;
+    for (_iter1129 = this->fileIds.begin(); _iter1129 != this->fileIds.end(); ++_iter1129)
     {
-      xfer += oprot->writeI64((*_iter1127));
+      xfer += oprot->writeI64((*_iter1129));
     }
     xfer += oprot->writeListEnd();
   }
@@ -30469,10 +30517,10 @@ uint32_t PutFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("metadata", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->metadata.size()));
-    std::vector<std::string> ::const_iterator _iter1128;
-    for (_iter1128 = this->metadata.begin(); _iter1128 != this->metadata.end(); ++_iter1128)
+    std::vector<std::string> ::const_iterator _iter1130;
+    for (_iter1130 = this->metadata.begin(); _iter1130 != this->metadata.end(); ++_iter1130)
     {
-      xfer += oprot->writeBinary((*_iter1128));
+      xfer += oprot->writeBinary((*_iter1130));
     }
     xfer += oprot->writeListEnd();
   }
@@ -30496,17 +30544,17 @@ void swap(PutFileMetadataRequest &a, PutFileMetadataRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PutFileMetadataRequest::PutFileMetadataRequest(const PutFileMetadataRequest& other1129) {
-  fileIds = other1129.fileIds;
-  metadata = other1129.metadata;
-  type = other1129.type;
-  __isset = other1129.__isset;
+PutFileMetadataRequest::PutFileMetadataRequest(const PutFileMetadataRequest& other1131) {
+  fileIds = other1131.fileIds;
+  metadata = other1131.metadata;
+  type = other1131.type;
+  __isset = other1131.__isset;
 }
-PutFileMetadataRequest& PutFileMetadataRequest::operator=(const PutFileMetadataRequest& other1130) {
-  fileIds = other1130.fileIds;
-  metadata = other1130.metadata;
-  type = other1130.type;
-  __isset = other1130.__isset;
+PutFileMetadataRequest& PutFileMetadataRequest::operator=(const PutFileMetadataRequest& other1132) {
+  fileIds = other1132.fileIds;
+  metadata = other1132.metadata;
+  type = other1132.type;
+  __isset = other1132.__isset;
   return *this;
 }
 void PutFileMetadataRequest::printTo(std::ostream& out) const {
@@ -30573,11 +30621,11 @@ void swap(ClearFileMetadataResult &a, ClearFileMetadataResult &b) {
   (void) b;
 }
 
-ClearFileMetadataResult::ClearFileMetadataResult(const ClearFileMetadataResult& other1131) {
-  (void) other1131;
+ClearFileMetadataResult::ClearFileMetadataResult(const ClearFileMetadataResult& other1133) {
+  (void) other1133;
 }
-ClearFileMetadataResult& ClearFileMetadataResult::operator=(const ClearFileMetadataResult& other1132) {
-  (void) other1132;
+ClearFileMetadataResult& ClearFileMetadataResult::operator=(const ClearFileMetadataResult& other1134) {
+  (void) other1134;
   return *this;
 }
 void ClearFileMetadataResult::printTo(std::ostream& out) const {
@@ -30627,14 +30675,14 @@ uint32_t ClearFileMetadataRequest::read(::apache::thrift::protocol::TProtocol* i
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fileIds.clear();
-            uint32_t _size1133;
-            ::apache::thrift::protocol::TType _etype1136;
-            xfer += iprot->readListBegin(_etype1136, _size1133);
-            this->fileIds.resize(_size1133);
-            uint32_t _i1137;
-            for (_i1137 = 0; _i1137 < _size1133; ++_i1137)
+            uint32_t _size1135;
+            ::apache::thrift::protocol::TType _etype1138;
+            xfer += iprot->readListBegin(_etype1138, _size1135);
+            this->fileIds.resize(_size1135);
+            uint32_t _i1139;
+            for (_i1139 = 0; _i1139 < _size1135; ++_i1139)
             {
-              xfer += iprot->readI64(this->fileIds[_i1137]);
+              xfer += iprot->readI64(this->fileIds[_i1139]);
             }
             xfer += iprot->readListEnd();
           }
@@ -30665,10 +30713,10 @@ uint32_t ClearFileMetadataRequest::write(::apache::thrift::protocol::TProtocol* 
   xfer += oprot->writeFieldBegin("fileIds", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I64, static_cast<uint32_t>(this->fileIds.size()));
-    std::vector<int64_t> ::const_iterator _iter1138;
-    for (_iter1138 = this->fileIds.begin(); _iter1138 != this->fileIds.end(); ++_iter1138)
+    std::vector<int64_t> ::const_iterator _iter1140;
+    for (_iter1140 = this->fileIds.begin(); _iter1140 != this->fileIds.end(); ++_iter1140)
     {
-      xfer += oprot->writeI64((*_iter1138));
+      xfer += oprot->writeI64((*_iter1140));
     }
     xfer += oprot->writeListEnd();
   }
@@ -30684,11 +30732,11 @@ void swap(ClearFileMetadataRequest &a, ClearFileMetadataRequest &b) {
   swap(a.fileIds, b.fileIds);
 }
 
-ClearFileMetadataRequest::ClearFileMetadataRequest(const ClearFileMetadataRequest& other1139) {
-  fileIds = other1139.fileIds;
+ClearFileMetadataRequest::ClearFileMetadataRequest(const ClearFileMetadataRequest& other1141) {
+  fileIds = other1141.fileIds;
 }
-ClearFileMetadataRequest& ClearFileMetadataRequest::operator=(const ClearFileMetadataRequest& other1140) {
-  fileIds = other1140.fileIds;
+ClearFileMetadataRequest& ClearFileMetadataRequest::operator=(const ClearFileMetadataRequest& other1142) {
+  fileIds = other1142.fileIds;
   return *this;
 }
 void ClearFileMetadataRequest::printTo(std::ostream& out) const {
@@ -30776,11 +30824,11 @@ void swap(CacheFileMetadataResult &a, CacheFileMetadataResult &b) {
   swap(a.isSupported, b.isSupported);
 }
 
-CacheFileMetadataResult::CacheFileMetadataResult(const CacheFileMetadataResult& other1141) {
-  isSupported = other1141.isSupported;
+CacheFileMetadataResult::CacheFileMetadataResult(const CacheFileMetadataResult& other1143) {
+  isSupported = other1143.isSupported;
 }
-CacheFileMetadataResult& CacheFileMetadataResult::operator=(const CacheFileMetadataResult& other1142) {
-  isSupported = other1142.isSupported;
+CacheFileMetadataResult& CacheFileMetadataResult::operator=(const CacheFileMetadataResult& other1144) {
+  isSupported = other1144.isSupported;
   return *this;
 }
 void CacheFileMetadataResult::printTo(std::ostream& out) const {
@@ -30927,19 +30975,19 @@ void swap(CacheFileMetadataRequest &a, CacheFileMetadataRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CacheFileMetadataRequest::CacheFileMetadataRequest(const CacheFileMetadataRequest& other1143) {
-  dbName = other1143.dbName;
-  tblName = other1143.tblName;
-  partName = other1143.partName;
-  isAllParts = other1143.isAllParts;
-  __isset = other1143.__isset;
+CacheFileMetadataRequest::CacheFileMetadataRequest(const CacheFileMetadataRequest& other1145) {
+  dbName = other1145.dbName;
+  tblName = other1145.tblName;
+  partName = other1145.partName;
+  isAllParts = other1145.isAllParts;
+  __isset = other1145.__isset;
 }
-CacheFileMetadataRequest& CacheFileMetadataRequest::operator=(const CacheFileMetadataRequest& other1144) {
-  dbName = other1144.dbName;
-  tblName = other1144.tblName;
-  partName = other1144.partName;
-  isAllParts = other1144.isAllParts;
-  __isset = other1144.__isset;
+CacheFileMetadataRequest& CacheFileMetadataRequest::operator=(const CacheFileMetadataRequest& other1146) {
+  dbName = other1146.dbName;
+  tblName = other1146.tblName;
+  partName = other1146.partName;
+  isAllParts = other1146.isAllParts;
+  __isset = other1146.__isset;
   return *this;
 }
 void CacheFileMetadataRequest::printTo(std::ostream& out) const {
@@ -30993,14 +31041,14 @@ uint32_t GetAllFunctionsResponse::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->functions.clear();
-            uint32_t _size1145;
-            ::apache::thrift::protocol::TType _etype1148;
-            xfer += iprot->readListBegin(_etype1148, _size1145);
-            this->functions.resize(_size1145);
-            uint32_t _i1149;
-            for (_i1149 = 0; _i1149 < _size1145; ++_i1149)
+            uint32_t _size1147;
+            ::apache::thrift::protocol::TType _etype1150;
+            xfer += iprot->readListBegin(_etype1150, _size1147);
+            this->functions.resize(_size1147);
+            uint32_t _i1151;
+            for (_i1151 = 0; _i1151 < _size1147; ++_i1151)
             {
-              xfer += this->functions[_i1149].read(iprot);
+              xfer += this->functions[_i1151].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -31030,10 +31078,10 @@ uint32_t GetAllFunctionsResponse::write(::apache::thrift::protocol::TProtocol* o
     xfer += oprot->writeFieldBegin("functions", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->functions.size()));
-      std::vector<Function> ::const_iterator _iter1150;
-      for (_iter1150 = this->functions.begin(); _iter1150 != this->functions.end(); ++_iter1150)
+      std::vector<Function> ::const_iterator _iter1152;
+      for (_iter1152 = this->functions.begin(); _iter1152 != this->functions.end(); ++_iter1152)
       {
-        xfer += (*_iter1150).write(oprot);
+        xfer += (*_iter1152).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -31050,13 +31098,13 @@ void swap(GetAllFunctionsResponse &a, GetAllFunctionsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetAllFunctionsResponse::GetAllFunctionsResponse(const GetAllFunctionsResponse& other1151) {
-  functions = other1151.functions;
-  __isset = other1151.__isset;
+GetAllFunctionsResponse::GetAllFunctionsResponse(const GetAllFunctionsResponse& other1153) {
+  functions = other1153.functions;
+  __isset = other1153.__isset;
 }
-GetAllFunctionsResponse& GetAllFunctionsResponse::operator=(const GetAllFunctionsResponse& other1152) {
-  functions = other1152.functions;
-  __isset = other1152.__isset;
+GetAllFunctionsResponse& GetAllFunctionsResponse::operator=(const GetAllFunctionsResponse& other1154) {
+  functions = other1154.functions;
+  __isset = other1154.__isset;
   return *this;
 }
 void GetAllFunctionsResponse::printTo(std::ostream& out) const {
@@ -31107,16 +31155,16 @@ uint32_t ClientCapabilities::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->values.clear();
-            uint32_t _size1153;
-            ::apache::thrift::protocol::TType _etype1156;
-            xfer += iprot->readListBegin(_etype1156, _size1153);
-            this->values.resize(_size1153);
-            uint32_t _i1157;
-            for (_i1157 = 0; _i1157 < _size1153; ++_i1157)
+            uint32_t _size1155;
+            ::apache::thrift::protocol::TType _etype1158;
+            xfer += iprot->readListBegin(_etype1158, _size1155);
+            this->values.resize(_size1155);
+            uint32_t _i1159;
+            for (_i1159 = 0; _i1159 < _size1155; ++_i1159)
             {
-              int32_t ecast1158;
-              xfer += iprot->readI32(ecast1158);
-              this->values[_i1157] = (ClientCapability::type)ecast1158;
+              int32_t ecast1160;
+              xfer += iprot->readI32(ecast1160);
+              this->values[_i1159] = (ClientCapability::type)ecast1160;
             }
             xfer += iprot->readListEnd();
           }
@@ -31147,10 +31195,10 @@ uint32_t ClientCapabilities::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("values", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->values.size()));
-    std::vector<ClientCapability::type> ::const_iterator _iter1159;
-    for (_iter1159 = this->values.begin(); _iter1159 != this->values.end(); ++_iter1159)
+    std::vector<ClientCapability::type> ::const_iterator _iter1161;
+    for (_iter1161 = this->values.begin(); _iter1161 != this->values.end(); ++_iter1161)
     {
-      xfer += oprot->writeI32((int32_t)(*_iter1159));
+      xfer += oprot->writeI32((int32_t)(*_iter1161));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31166,11 +31214,11 @@ void swap(ClientCapabilities &a, ClientCapabilities &b) {
   swap(a.values, b.values);
 }
 
-ClientCapabilities::ClientCapabilities(const ClientCapabilities& other1160) {
-  values = other1160.values;
+ClientCapabilities::ClientCapabilities(const ClientCapabilities& other1162) {
+  values = other1162.values;
 }
-ClientCapabilities& ClientCapabilities::operator=(const ClientCapabilities& other1161) {
-  values = other1161.values;
+ClientCapabilities& ClientCapabilities::operator=(const ClientCapabilities& other1163) {
+  values = other1163.values;
   return *this;
 }
 void ClientCapabilities::printTo(std::ostream& out) const {
@@ -31228,14 +31276,14 @@ uint32_t GetProjectionsSpec::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fieldList.clear();
-            uint32_t _size1162;
-            ::apache::thrift::protocol::TType _etype1165;
-            xfer += iprot->readListBegin(_etype1165, _size1162);
-            this->fieldList.resize(_size1162);
-            uint32_t _i1166;
-            for (_i1166 = 0; _i1166 < _size1162; ++_i1166)
+            uint32_t _size1164;
+            ::apache::thrift::protocol::TType _etype1167;
+            xfer += iprot->readListBegin(_etype1167, _size1164);
+            this->fieldList.resize(_size1164);
+            uint32_t _i1168;
+            for (_i1168 = 0; _i1168 < _size1164; ++_i1168)
             {
-              xfer += iprot->readString(this->fieldList[_i1166]);
+              xfer += iprot->readString(this->fieldList[_i1168]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31280,10 +31328,10 @@ uint32_t GetProjectionsSpec::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("fieldList", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->fieldList.size()));
-    std::vector<std::string> ::const_iterator _iter1167;
-    for (_iter1167 = this->fieldList.begin(); _iter1167 != this->fieldList.end(); ++_iter1167)
+    std::vector<std::string> ::const_iterator _iter1169;
+    for (_iter1169 = this->fieldList.begin(); _iter1169 != this->fieldList.end(); ++_iter1169)
     {
-      xfer += oprot->writeString((*_iter1167));
+      xfer += oprot->writeString((*_iter1169));
     }
     xfer += oprot->writeListEnd();
   }
@@ -31310,17 +31358,17 @@ void swap(GetProjectionsSpec &a, GetProjectionsSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetProjectionsSpec::GetProjectionsSpec(const GetProjectionsSpec& other1168) {
-  fieldList = other1168.fieldList;
-  includeParamKeyPattern = other1168.includeParamKeyPattern;
-  excludeParamKeyPattern = other1168.excludeParamKeyPattern;
-  __isset = other1168.__isset;
+GetProjectionsSpec::GetProjectionsSpec(const GetProjectionsSpec& other1170) {
+  fieldList = other1170.fieldList;
+  includeParamKeyPattern = other1170.includeParamKeyPattern;
+  excludeParamKeyPattern = other1170.excludeParamKeyPattern;
+  __isset = other1170.__isset;
 }
-GetProjectionsSpec& GetProjectionsSpec::operator=(const GetProjectionsSpec& other1169) {
-  fieldList = other1169.fieldList;
-  includeParamKeyPattern = other1169.includeParamKeyPattern;
-  excludeParamKeyPattern = other1169.excludeParamKeyPattern;
-  __isset = other1169.__isset;
+GetProjectionsSpec& GetProjectionsSpec::operator=(const GetProjectionsSpec& other1171) {
+  fieldList = other1171.fieldList;
+  includeParamKeyPattern = other1171.includeParamKeyPattern;
+  excludeParamKeyPattern = other1171.excludeParamKeyPattern;
+  __isset = other1171.__isset;
   return *this;
 }
 void GetProjectionsSpec::printTo(std::ostream& out) const {
@@ -31466,14 +31514,14 @@ uint32_t GetTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1170;
-            ::apache::thrift::protocol::TType _etype1173;
-            xfer += iprot->readListBegin(_etype1173, _size1170);
-            this->processorCapabilities.resize(_size1170);
-            uint32_t _i1174;
-            for (_i1174 = 0; _i1174 < _size1170; ++_i1174)
+            uint32_t _size1172;
+            ::apache::thrift::protocol::TType _etype1175;
+            xfer += iprot->readListBegin(_etype1175, _size1172);
+            this->processorCapabilities.resize(_size1172);
+            uint32_t _i1176;
+            for (_i1176 = 0; _i1176 < _size1172; ++_i1176)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1174]);
+              xfer += iprot->readString(this->processorCapabilities[_i1176]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31559,10 +31607,10 @@ uint32_t GetTableRequest::write(::apache::thrift::protocol::TProtocol* oprot) co
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1175;
-      for (_iter1175 = this->processorCapabilities.begin(); _iter1175 != this->processorCapabilities.end(); ++_iter1175)
+      std::vector<std::string> ::const_iterator _iter1177;
+      for (_iter1177 = this->processorCapabilities.begin(); _iter1177 != this->processorCapabilities.end(); ++_iter1177)
       {
-        xfer += oprot->writeString((*_iter1175));
+        xfer += oprot->writeString((*_iter1177));
       }
       xfer += oprot->writeListEnd();
     }
@@ -31603,31 +31651,31 @@ void swap(GetTableRequest &a, GetTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTableRequest::GetTableRequest(const GetTableRequest& other1176) {
-  dbName = other1176.dbName;
-  tblName = other1176.tblName;
-  capabilities = other1176.capabilities;
-  catName = other1176.catName;
-  validWriteIdList = other1176.validWriteIdList;
-  getColumnStats = other1176.getColumnStats;
-  processorCapabilities = other1176.processorCapabilities;
-  processorIdentifier = other1176.processorIdentifier;
-  engine = other1176.engine;
-  id = other1176.id;
-  __isset = other1176.__isset;
+GetTableRequest::GetTableRequest(const GetTableRequest& other1178) {
+  dbName = other1178.dbName;
+  tblName = other1178.tblName;
+  capabilities = other1178.capabilities;
+  catName = other1178.catName;
+  validWriteIdList = other1178.validWriteIdList;
+  getColumnStats = other1178.getColumnStats;
+  processorCapabilities = other1178.processorCapabilities;
+  processorIdentifier = other1178.processorIdentifier;
+  engine = other1178.engine;
+  id = other1178.id;
+  __isset = other1178.__isset;
 }
-GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other1177) {
-  dbName = other1177.dbName;
-  tblName = other1177.tblName;
-  capabilities = other1177.capabilities;
-  catName = other1177.catName;
-  validWriteIdList = other1177.validWriteIdList;
-  getColumnStats = other1177.getColumnStats;
-  processorCapabilities = other1177.processorCapabilities;
-  processorIdentifier = other1177.processorIdentifier;
-  engine = other1177.engine;
-  id = other1177.id;
-  __isset = other1177.__isset;
+GetTableRequest& GetTableRequest::operator=(const GetTableRequest& other1179) {
+  dbName = other1179.dbName;
+  tblName = other1179.tblName;
+  capabilities = other1179.capabilities;
+  catName = other1179.catName;
+  validWriteIdList = other1179.validWriteIdList;
+  getColumnStats = other1179.getColumnStats;
+  processorCapabilities = other1179.processorCapabilities;
+  processorIdentifier = other1179.processorIdentifier;
+  engine = other1179.engine;
+  id = other1179.id;
+  __isset = other1179.__isset;
   return *this;
 }
 void GetTableRequest::printTo(std::ostream& out) const {
@@ -31744,15 +31792,15 @@ void swap(GetTableResult &a, GetTableResult &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTableResult::GetTableResult(const GetTableResult& other1178) {
-  table = other1178.table;
-  isStatsCompliant = other1178.isStatsCompliant;
-  __isset = other1178.__isset;
+GetTableResult::GetTableResult(const GetTableResult& other1180) {
+  table = other1180.table;
+  isStatsCompliant = other1180.isStatsCompliant;
+  __isset = other1180.__isset;
 }
-GetTableResult& GetTableResult::operator=(const GetTableResult& other1179) {
-  table = other1179.table;
-  isStatsCompliant = other1179.isStatsCompliant;
-  __isset = other1179.__isset;
+GetTableResult& GetTableResult::operator=(const GetTableResult& other1181) {
+  table = other1181.table;
+  isStatsCompliant = other1181.isStatsCompliant;
+  __isset = other1181.__isset;
   return *this;
 }
 void GetTableResult::printTo(std::ostream& out) const {
@@ -31847,14 +31895,14 @@ uint32_t GetTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tblNames.clear();
-            uint32_t _size1180;
-            ::apache::thrift::protocol::TType _etype1183;
-            xfer += iprot->readListBegin(_etype1183, _size1180);
-            this->tblNames.resize(_size1180);
-            uint32_t _i1184;
-            for (_i1184 = 0; _i1184 < _size1180; ++_i1184)
+            uint32_t _size1182;
+            ::apache::thrift::protocol::TType _etype1185;
+            xfer += iprot->readListBegin(_etype1185, _size1182);
+            this->tblNames.resize(_size1182);
+            uint32_t _i1186;
+            for (_i1186 = 0; _i1186 < _size1182; ++_i1186)
             {
-              xfer += iprot->readString(this->tblNames[_i1184]);
+              xfer += iprot->readString(this->tblNames[_i1186]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31883,14 +31931,14 @@ uint32_t GetTablesRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1185;
-            ::apache::thrift::protocol::TType _etype1188;
-            xfer += iprot->readListBegin(_etype1188, _size1185);
-            this->processorCapabilities.resize(_size1185);
-            uint32_t _i1189;
-            for (_i1189 = 0; _i1189 < _size1185; ++_i1189)
+            uint32_t _size1187;
+            ::apache::thrift::protocol::TType _etype1190;
+            xfer += iprot->readListBegin(_etype1190, _size1187);
+            this->processorCapabilities.resize(_size1187);
+            uint32_t _i1191;
+            for (_i1191 = 0; _i1191 < _size1187; ++_i1191)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1189]);
+              xfer += iprot->readString(this->processorCapabilities[_i1191]);
             }
             xfer += iprot->readListEnd();
           }
@@ -31950,10 +31998,10 @@ uint32_t GetTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("tblNames", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->tblNames.size()));
-      std::vector<std::string> ::const_iterator _iter1190;
-      for (_iter1190 = this->tblNames.begin(); _iter1190 != this->tblNames.end(); ++_iter1190)
+      std::vector<std::string> ::const_iterator _iter1192;
+      for (_iter1192 = this->tblNames.begin(); _iter1192 != this->tblNames.end(); ++_iter1192)
       {
-        xfer += oprot->writeString((*_iter1190));
+        xfer += oprot->writeString((*_iter1192));
       }
       xfer += oprot->writeListEnd();
     }
@@ -31973,10 +32021,10 @@ uint32_t GetTablesRequest::write(::apache::thrift::protocol::TProtocol* oprot) c
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1191;
-      for (_iter1191 = this->processorCapabilities.begin(); _iter1191 != this->processorCapabilities.end(); ++_iter1191)
+      std::vector<std::string> ::const_iterator _iter1193;
+      for (_iter1193 = this->processorCapabilities.begin(); _iter1193 != this->processorCapabilities.end(); ++_iter1193)
       {
-        xfer += oprot->writeString((*_iter1191));
+        xfer += oprot->writeString((*_iter1193));
       }
       xfer += oprot->writeListEnd();
     }
@@ -32015,27 +32063,27 @@ void swap(GetTablesRequest &a, GetTablesRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTablesRequest::GetTablesRequest(const GetTablesRequest& other1192) {
-  dbName = other1192.dbName;
-  tblNames = other1192.tblNames;
-  capabilities = other1192.capabilities;
-  catName = other1192.catName;
-  processorCapabilities = other1192.processorCapabilities;
-  processorIdentifier = other1192.processorIdentifier;
-  projectionSpec = other1192.projectionSpec;
-  tablesPattern = other1192.tablesPattern;
-  __isset = other1192.__isset;
+GetTablesRequest::GetTablesRequest(const GetTablesRequest& other1194) {
+  dbName = other1194.dbName;
+  tblNames = other1194.tblNames;
+  capabilities = other1194.capabilities;
+  catName = other1194.catName;
+  processorCapabilities = other1194.processorCapabilities;
+  processorIdentifier = other1194.processorIdentifier;
+  projectionSpec = other1194.projectionSpec;
+  tablesPattern = other1194.tablesPattern;
+  __isset = other1194.__isset;
 }
-GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1193) {
-  dbName = other1193.dbName;
-  tblNames = other1193.tblNames;
-  capabilities = other1193.capabilities;
-  catName = other1193.catName;
-  processorCapabilities = other1193.processorCapabilities;
-  processorIdentifier = other1193.processorIdentifier;
-  projectionSpec = other1193.projectionSpec;
-  tablesPattern = other1193.tablesPattern;
-  __isset = other1193.__isset;
+GetTablesRequest& GetTablesRequest::operator=(const GetTablesRequest& other1195) {
+  dbName = other1195.dbName;
+  tblNames = other1195.tblNames;
+  capabilities = other1195.capabilities;
+  catName = other1195.catName;
+  processorCapabilities = other1195.processorCapabilities;
+  processorIdentifier = other1195.processorIdentifier;
+  projectionSpec = other1195.projectionSpec;
+  tablesPattern = other1195.tablesPattern;
+  __isset = other1195.__isset;
   return *this;
 }
 void GetTablesRequest::printTo(std::ostream& out) const {
@@ -32093,14 +32141,14 @@ uint32_t GetTablesResult::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->tables.clear();
-            uint32_t _size1194;
-            ::apache::thrift::protocol::TType _etype1197;
-            xfer += iprot->readListBegin(_etype1197, _size1194);
-            this->tables.resize(_size1194);
-            uint32_t _i1198;
-            for (_i1198 = 0; _i1198 < _size1194; ++_i1198)
+            uint32_t _size1196;
+            ::apache::thrift::protocol::TType _etype1199;
+            xfer += iprot->readListBegin(_etype1199, _size1196);
+            this->tables.resize(_size1196);
+            uint32_t _i1200;
+            for (_i1200 = 0; _i1200 < _size1196; ++_i1200)
             {
-              xfer += this->tables[_i1198].read(iprot);
+              xfer += this->tables[_i1200].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -32131,10 +32179,10 @@ uint32_t GetTablesResult::write(::apache::thrift::protocol::TProtocol* oprot) co
   xfer += oprot->writeFieldBegin("tables", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->tables.size()));
-    std::vector<Table> ::const_iterator _iter1199;
-    for (_iter1199 = this->tables.begin(); _iter1199 != this->tables.end(); ++_iter1199)
+    std::vector<Table> ::const_iterator _iter1201;
+    for (_iter1201 = this->tables.begin(); _iter1201 != this->tables.end(); ++_iter1201)
     {
-      xfer += (*_iter1199).write(oprot);
+      xfer += (*_iter1201).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -32150,11 +32198,11 @@ void swap(GetTablesResult &a, GetTablesResult &b) {
   swap(a.tables, b.tables);
 }
 
-GetTablesResult::GetTablesResult(const GetTablesResult& other1200) {
-  tables = other1200.tables;
+GetTablesResult::GetTablesResult(const GetTablesResult& other1202) {
+  tables = other1202.tables;
 }
-GetTablesResult& GetTablesResult::operator=(const GetTablesResult& other1201) {
-  tables = other1201.tables;
+GetTablesResult& GetTablesResult::operator=(const GetTablesResult& other1203) {
+  tables = other1203.tables;
   return *this;
 }
 void GetTablesResult::printTo(std::ostream& out) const {
@@ -32275,14 +32323,14 @@ uint32_t GetTablesExtRequest::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1202;
-            ::apache::thrift::protocol::TType _etype1205;
-            xfer += iprot->readListBegin(_etype1205, _size1202);
-            this->processorCapabilities.resize(_size1202);
-            uint32_t _i1206;
-            for (_i1206 = 0; _i1206 < _size1202; ++_i1206)
+            uint32_t _size1204;
+            ::apache::thrift::protocol::TType _etype1207;
+            xfer += iprot->readListBegin(_etype1207, _size1204);
+            this->processorCapabilities.resize(_size1204);
+            uint32_t _i1208;
+            for (_i1208 = 0; _i1208 < _size1204; ++_i1208)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1206]);
+              xfer += iprot->readString(this->processorCapabilities[_i1208]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32349,10 +32397,10 @@ uint32_t GetTablesExtRequest::write(::apache::thrift::protocol::TProtocol* oprot
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1207;
-      for (_iter1207 = this->processorCapabilities.begin(); _iter1207 != this->processorCapabilities.end(); ++_iter1207)
+      std::vector<std::string> ::const_iterator _iter1209;
+      for (_iter1209 = this->processorCapabilities.begin(); _iter1209 != this->processorCapabilities.end(); ++_iter1209)
       {
-        xfer += oprot->writeString((*_iter1207));
+        xfer += oprot->writeString((*_iter1209));
       }
       xfer += oprot->writeListEnd();
     }
@@ -32380,25 +32428,25 @@ void swap(GetTablesExtRequest &a, GetTablesExtRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetTablesExtRequest::GetTablesExtRequest(const GetTablesExtRequest& other1208) {
-  catalog = other1208.catalog;
-  database = other1208.database;
-  tableNamePattern = other1208.tableNamePattern;
-  requestedFields = other1208.requestedFields;
-  limit = other1208.limit;
-  processorCapabilities = other1208.processorCapabilities;
-  processorIdentifier = other1208.processorIdentifier;
-  __isset = other1208.__isset;
+GetTablesExtRequest::GetTablesExtRequest(const GetTablesExtRequest& other1210) {
+  catalog = other1210.catalog;
+  database = other1210.database;
+  tableNamePattern = other1210.tableNamePattern;
+  requestedFields = other1210.requestedFields;
+  limit = other1210.limit;
+  processorCapabilities = other1210.processorCapabilities;
+  processorIdentifier = other1210.processorIdentifier;
+  __isset = other1210.__isset;
 }
-GetTablesExtRequest& GetTablesExtRequest::operator=(const GetTablesExtRequest& other1209) {
-  catalog = other1209.catalog;
-  database = other1209.database;
-  tableNamePattern = other1209.tableNamePattern;
-  requestedFields = other1209.requestedFields;
-  limit = other1209.limit;
-  processorCapabilities = other1209.processorCapabilities;
-  processorIdentifier = other1209.processorIdentifier;
-  __isset = other1209.__isset;
+GetTablesExtRequest& GetTablesExtRequest::operator=(const GetTablesExtRequest& other1211) {
+  catalog = other1211.catalog;
+  database = other1211.database;
+  tableNamePattern = other1211.tableNamePattern;
+  requestedFields = other1211.requestedFields;
+  limit = other1211.limit;
+  processorCapabilities = other1211.processorCapabilities;
+  processorIdentifier = other1211.processorIdentifier;
+  __isset = other1211.__isset;
   return *this;
 }
 void GetTablesExtRequest::printTo(std::ostream& out) const {
@@ -32486,14 +32534,14 @@ uint32_t ExtendedTableInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredReadCapabilities.clear();
-            uint32_t _size1210;
-            ::apache::thrift::protocol::TType _etype1213;
-            xfer += iprot->readListBegin(_etype1213, _size1210);
-            this->requiredReadCapabilities.resize(_size1210);
-            uint32_t _i1214;
-            for (_i1214 = 0; _i1214 < _size1210; ++_i1214)
+            uint32_t _size1212;
+            ::apache::thrift::protocol::TType _etype1215;
+            xfer += iprot->readListBegin(_etype1215, _size1212);
+            this->requiredReadCapabilities.resize(_size1212);
+            uint32_t _i1216;
+            for (_i1216 = 0; _i1216 < _size1212; ++_i1216)
             {
-              xfer += iprot->readString(this->requiredReadCapabilities[_i1214]);
+              xfer += iprot->readString(this->requiredReadCapabilities[_i1216]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32506,14 +32554,14 @@ uint32_t ExtendedTableInfo::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->requiredWriteCapabilities.clear();
-            uint32_t _size1215;
-            ::apache::thrift::protocol::TType _etype1218;
-            xfer += iprot->readListBegin(_etype1218, _size1215);
-            this->requiredWriteCapabilities.resize(_size1215);
-            uint32_t _i1219;
-            for (_i1219 = 0; _i1219 < _size1215; ++_i1219)
+            uint32_t _size1217;
+            ::apache::thrift::protocol::TType _etype1220;
+            xfer += iprot->readListBegin(_etype1220, _size1217);
+            this->requiredWriteCapabilities.resize(_size1217);
+            uint32_t _i1221;
+            for (_i1221 = 0; _i1221 < _size1217; ++_i1221)
             {
-              xfer += iprot->readString(this->requiredWriteCapabilities[_i1219]);
+              xfer += iprot->readString(this->requiredWriteCapabilities[_i1221]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32554,10 +32602,10 @@ uint32_t ExtendedTableInfo::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("requiredReadCapabilities", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredReadCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1220;
-      for (_iter1220 = this->requiredReadCapabilities.begin(); _iter1220 != this->requiredReadCapabilities.end(); ++_iter1220)
+      std::vector<std::string> ::const_iterator _iter1222;
+      for (_iter1222 = this->requiredReadCapabilities.begin(); _iter1222 != this->requiredReadCapabilities.end(); ++_iter1222)
       {
-        xfer += oprot->writeString((*_iter1220));
+        xfer += oprot->writeString((*_iter1222));
       }
       xfer += oprot->writeListEnd();
     }
@@ -32567,10 +32615,10 @@ uint32_t ExtendedTableInfo::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("requiredWriteCapabilities", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->requiredWriteCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1221;
-      for (_iter1221 = this->requiredWriteCapabilities.begin(); _iter1221 != this->requiredWriteCapabilities.end(); ++_iter1221)
+      std::vector<std::string> ::const_iterator _iter1223;
+      for (_iter1223 = this->requiredWriteCapabilities.begin(); _iter1223 != this->requiredWriteCapabilities.end(); ++_iter1223)
       {
-        xfer += oprot->writeString((*_iter1221));
+        xfer += oprot->writeString((*_iter1223));
       }
       xfer += oprot->writeListEnd();
     }
@@ -32590,19 +32638,19 @@ void swap(ExtendedTableInfo &a, ExtendedTableInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ExtendedTableInfo::ExtendedTableInfo(const ExtendedTableInfo& other1222) {
-  tblName = other1222.tblName;
-  accessType = other1222.accessType;
-  requiredReadCapabilities = other1222.requiredReadCapabilities;
-  requiredWriteCapabilities = other1222.requiredWriteCapabilities;
-  __isset = other1222.__isset;
+ExtendedTableInfo::ExtendedTableInfo(const ExtendedTableInfo& other1224) {
+  tblName = other1224.tblName;
+  accessType = other1224.accessType;
+  requiredReadCapabilities = other1224.requiredReadCapabilities;
+  requiredWriteCapabilities = other1224.requiredWriteCapabilities;
+  __isset = other1224.__isset;
 }
-ExtendedTableInfo& ExtendedTableInfo::operator=(const ExtendedTableInfo& other1223) {
-  tblName = other1223.tblName;
-  accessType = other1223.accessType;
-  requiredReadCapabilities = other1223.requiredReadCapabilities;
-  requiredWriteCapabilities = other1223.requiredWriteCapabilities;
-  __isset = other1223.__isset;
+ExtendedTableInfo& ExtendedTableInfo::operator=(const ExtendedTableInfo& other1225) {
+  tblName = other1225.tblName;
+  accessType = other1225.accessType;
+  requiredReadCapabilities = other1225.requiredReadCapabilities;
+  requiredWriteCapabilities = other1225.requiredWriteCapabilities;
+  __isset = other1225.__isset;
   return *this;
 }
 void ExtendedTableInfo::printTo(std::ostream& out) const {
@@ -32687,14 +32735,14 @@ uint32_t GetDatabaseRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1224;
-            ::apache::thrift::protocol::TType _etype1227;
-            xfer += iprot->readListBegin(_etype1227, _size1224);
-            this->processorCapabilities.resize(_size1224);
-            uint32_t _i1228;
-            for (_i1228 = 0; _i1228 < _size1224; ++_i1228)
+            uint32_t _size1226;
+            ::apache::thrift::protocol::TType _etype1229;
+            xfer += iprot->readListBegin(_etype1229, _size1226);
+            this->processorCapabilities.resize(_size1226);
+            uint32_t _i1230;
+            for (_i1230 = 0; _i1230 < _size1226; ++_i1230)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1228]);
+              xfer += iprot->readString(this->processorCapabilities[_i1230]);
             }
             xfer += iprot->readListEnd();
           }
@@ -32742,10 +32790,10 @@ uint32_t GetDatabaseRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1229;
-      for (_iter1229 = this->processorCapabilities.begin(); _iter1229 != this->processorCapabilities.end(); ++_iter1229)
+      std::vector<std::string> ::const_iterator _iter1231;
+      for (_iter1231 = this->processorCapabilities.begin(); _iter1231 != this->processorCapabilities.end(); ++_iter1231)
       {
-        xfer += oprot->writeString((*_iter1229));
+        xfer += oprot->writeString((*_iter1231));
       }
       xfer += oprot->writeListEnd();
     }
@@ -32770,19 +32818,19 @@ void swap(GetDatabaseRequest &a, GetDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other1230) {
-  name = other1230.name;
-  catalogName = other1230.catalogName;
-  processorCapabilities = other1230.processorCapabilities;
-  processorIdentifier = other1230.processorIdentifier;
-  __isset = other1230.__isset;
+GetDatabaseRequest::GetDatabaseRequest(const GetDatabaseRequest& other1232) {
+  name = other1232.name;
+  catalogName = other1232.catalogName;
+  processorCapabilities = other1232.processorCapabilities;
+  processorIdentifier = other1232.processorIdentifier;
+  __isset = other1232.__isset;
 }
-GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other1231) {
-  name = other1231.name;
-  catalogName = other1231.catalogName;
-  processorCapabilities = other1231.processorCapabilities;
-  processorIdentifier = other1231.processorIdentifier;
-  __isset = other1231.__isset;
+GetDatabaseRequest& GetDatabaseRequest::operator=(const GetDatabaseRequest& other1233) {
+  name = other1233.name;
+  catalogName = other1233.catalogName;
+  processorCapabilities = other1233.processorCapabilities;
+  processorIdentifier = other1233.processorIdentifier;
+  __isset = other1233.__isset;
   return *this;
 }
 void GetDatabaseRequest::printTo(std::ostream& out) const {
@@ -32893,13 +32941,13 @@ void swap(CmRecycleRequest &a, CmRecycleRequest &b) {
   swap(a.purge, b.purge);
 }
 
-CmRecycleRequest::CmRecycleRequest(const CmRecycleRequest& other1232) {
-  dataPath = other1232.dataPath;
-  purge = other1232.purge;
+CmRecycleRequest::CmRecycleRequest(const CmRecycleRequest& other1234) {
+  dataPath = other1234.dataPath;
+  purge = other1234.purge;
 }
-CmRecycleRequest& CmRecycleRequest::operator=(const CmRecycleRequest& other1233) {
-  dataPath = other1233.dataPath;
-  purge = other1233.purge;
+CmRecycleRequest& CmRecycleRequest::operator=(const CmRecycleRequest& other1235) {
+  dataPath = other1235.dataPath;
+  purge = other1235.purge;
   return *this;
 }
 void CmRecycleRequest::printTo(std::ostream& out) const {
@@ -32965,11 +33013,11 @@ void swap(CmRecycleResponse &a, CmRecycleResponse &b) {
   (void) b;
 }
 
-CmRecycleResponse::CmRecycleResponse(const CmRecycleResponse& other1234) {
-  (void) other1234;
+CmRecycleResponse::CmRecycleResponse(const CmRecycleResponse& other1236) {
+  (void) other1236;
 }
-CmRecycleResponse& CmRecycleResponse::operator=(const CmRecycleResponse& other1235) {
-  (void) other1235;
+CmRecycleResponse& CmRecycleResponse::operator=(const CmRecycleResponse& other1237) {
+  (void) other1237;
   return *this;
 }
 void CmRecycleResponse::printTo(std::ostream& out) const {
@@ -33135,21 +33183,21 @@ void swap(TableMeta &a, TableMeta &b) {
   swap(a.__isset, b.__isset);
 }
 
-TableMeta::TableMeta(const TableMeta& other1236) {
-  dbName = other1236.dbName;
-  tableName = other1236.tableName;
-  tableType = other1236.tableType;
-  comments = other1236.comments;
-  catName = other1236.catName;
-  __isset = other1236.__isset;
+TableMeta::TableMeta(const TableMeta& other1238) {
+  dbName = other1238.dbName;
+  tableName = other1238.tableName;
+  tableType = other1238.tableType;
+  comments = other1238.comments;
+  catName = other1238.catName;
+  __isset = other1238.__isset;
 }
-TableMeta& TableMeta::operator=(const TableMeta& other1237) {
-  dbName = other1237.dbName;
-  tableName = other1237.tableName;
-  tableType = other1237.tableType;
-  comments = other1237.comments;
-  catName = other1237.catName;
-  __isset = other1237.__isset;
+TableMeta& TableMeta::operator=(const TableMeta& other1239) {
+  dbName = other1239.dbName;
+  tableName = other1239.tableName;
+  tableType = other1239.tableType;
+  comments = other1239.comments;
+  catName = other1239.catName;
+  __isset = other1239.__isset;
   return *this;
 }
 void TableMeta::printTo(std::ostream& out) const {
@@ -33261,13 +33309,13 @@ void swap(Materialization &a, Materialization &b) {
   swap(a.sourceTablesCompacted, b.sourceTablesCompacted);
 }
 
-Materialization::Materialization(const Materialization& other1238) {
-  sourceTablesUpdateDeleteModified = other1238.sourceTablesUpdateDeleteModified;
-  sourceTablesCompacted = other1238.sourceTablesCompacted;
+Materialization::Materialization(const Materialization& other1240) {
+  sourceTablesUpdateDeleteModified = other1240.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1240.sourceTablesCompacted;
 }
-Materialization& Materialization::operator=(const Materialization& other1239) {
-  sourceTablesUpdateDeleteModified = other1239.sourceTablesUpdateDeleteModified;
-  sourceTablesCompacted = other1239.sourceTablesCompacted;
+Materialization& Materialization::operator=(const Materialization& other1241) {
+  sourceTablesUpdateDeleteModified = other1241.sourceTablesUpdateDeleteModified;
+  sourceTablesCompacted = other1241.sourceTablesCompacted;
   return *this;
 }
 void Materialization::printTo(std::ostream& out) const {
@@ -33345,9 +33393,9 @@ uint32_t WMResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1240;
-          xfer += iprot->readI32(ecast1240);
-          this->status = (WMResourcePlanStatus::type)ecast1240;
+          int32_t ecast1242;
+          xfer += iprot->readI32(ecast1242);
+          this->status = (WMResourcePlanStatus::type)ecast1242;
           this->__isset.status = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -33435,21 +33483,21 @@ void swap(WMResourcePlan &a, WMResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMResourcePlan::WMResourcePlan(const WMResourcePlan& other1241) {
-  name = other1241.name;
-  status = other1241.status;
-  queryParallelism = other1241.queryParallelism;
-  defaultPoolPath = other1241.defaultPoolPath;
-  ns = other1241.ns;
-  __isset = other1241.__isset;
+WMResourcePlan::WMResourcePlan(const WMResourcePlan& other1243) {
+  name = other1243.name;
+  status = other1243.status;
+  queryParallelism = other1243.queryParallelism;
+  defaultPoolPath = other1243.defaultPoolPath;
+  ns = other1243.ns;
+  __isset = other1243.__isset;
 }
-WMResourcePlan& WMResourcePlan::operator=(const WMResourcePlan& other1242) {
-  name = other1242.name;
-  status = other1242.status;
-  queryParallelism = other1242.queryParallelism;
-  defaultPoolPath = other1242.defaultPoolPath;
-  ns = other1242.ns;
-  __isset = other1242.__isset;
+WMResourcePlan& WMResourcePlan::operator=(const WMResourcePlan& other1244) {
+  name = other1244.name;
+  status = other1244.status;
+  queryParallelism = other1244.queryParallelism;
+  defaultPoolPath = other1244.defaultPoolPath;
+  ns = other1244.ns;
+  __isset = other1244.__isset;
   return *this;
 }
 void WMResourcePlan::printTo(std::ostream& out) const {
@@ -33540,9 +33588,9 @@ uint32_t WMNullableResourcePlan::read(::apache::thrift::protocol::TProtocol* ipr
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1243;
-          xfer += iprot->readI32(ecast1243);
-          this->status = (WMResourcePlanStatus::type)ecast1243;
+          int32_t ecast1245;
+          xfer += iprot->readI32(ecast1245);
+          this->status = (WMResourcePlanStatus::type)ecast1245;
           this->__isset.status = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -33657,25 +33705,25 @@ void swap(WMNullableResourcePlan &a, WMNullableResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMNullableResourcePlan::WMNullableResourcePlan(const WMNullableResourcePlan& other1244) {
-  name = other1244.name;
-  status = other1244.status;
-  queryParallelism = other1244.queryParallelism;
-  isSetQueryParallelism = other1244.isSetQueryParallelism;
-  defaultPoolPath = other1244.defaultPoolPath;
-  isSetDefaultPoolPath = other1244.isSetDefaultPoolPath;
-  ns = other1244.ns;
-  __isset = other1244.__isset;
+WMNullableResourcePlan::WMNullableResourcePlan(const WMNullableResourcePlan& other1246) {
+  name = other1246.name;
+  status = other1246.status;
+  queryParallelism = other1246.queryParallelism;
+  isSetQueryParallelism = other1246.isSetQueryParallelism;
+  defaultPoolPath = other1246.defaultPoolPath;
+  isSetDefaultPoolPath = other1246.isSetDefaultPoolPath;
+  ns = other1246.ns;
+  __isset = other1246.__isset;
 }
-WMNullableResourcePlan& WMNullableResourcePlan::operator=(const WMNullableResourcePlan& other1245) {
-  name = other1245.name;
-  status = other1245.status;
-  queryParallelism = other1245.queryParallelism;
-  isSetQueryParallelism = other1245.isSetQueryParallelism;
-  defaultPoolPath = other1245.defaultPoolPath;
-  isSetDefaultPoolPath = other1245.isSetDefaultPoolPath;
-  ns = other1245.ns;
-  __isset = other1245.__isset;
+WMNullableResourcePlan& WMNullableResourcePlan::operator=(const WMNullableResourcePlan& other1247) {
+  name = other1247.name;
+  status = other1247.status;
+  queryParallelism = other1247.queryParallelism;
+  isSetQueryParallelism = other1247.isSetQueryParallelism;
+  defaultPoolPath = other1247.defaultPoolPath;
+  isSetDefaultPoolPath = other1247.isSetDefaultPoolPath;
+  ns = other1247.ns;
+  __isset = other1247.__isset;
   return *this;
 }
 void WMNullableResourcePlan::printTo(std::ostream& out) const {
@@ -33866,23 +33914,23 @@ void swap(WMPool &a, WMPool &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMPool::WMPool(const WMPool& other1246) {
-  resourcePlanName = other1246.resourcePlanName;
-  poolPath = other1246.poolPath;
-  allocFraction = other1246.allocFraction;
-  queryParallelism = other1246.queryParallelism;
-  schedulingPolicy = other1246.schedulingPolicy;
-  ns = other1246.ns;
-  __isset = other1246.__isset;
+WMPool::WMPool(const WMPool& other1248) {
+  resourcePlanName = other1248.resourcePlanName;
+  poolPath = other1248.poolPath;
+  allocFraction = other1248.allocFraction;
+  queryParallelism = other1248.queryParallelism;
+  schedulingPolicy = other1248.schedulingPolicy;
+  ns = other1248.ns;
+  __isset = other1248.__isset;
 }
-WMPool& WMPool::operator=(const WMPool& other1247) {
-  resourcePlanName = other1247.resourcePlanName;
-  poolPath = other1247.poolPath;
-  allocFraction = other1247.allocFraction;
-  queryParallelism = other1247.queryParallelism;
-  schedulingPolicy = other1247.schedulingPolicy;
-  ns = other1247.ns;
-  __isset = other1247.__isset;
+WMPool& WMPool::operator=(const WMPool& other1249) {
+  resourcePlanName = other1249.resourcePlanName;
+  poolPath = other1249.poolPath;
+  allocFraction = other1249.allocFraction;
+  queryParallelism = other1249.queryParallelism;
+  schedulingPolicy = other1249.schedulingPolicy;
+  ns = other1249.ns;
+  __isset = other1249.__isset;
   return *this;
 }
 void WMPool::printTo(std::ostream& out) const {
@@ -34091,25 +34139,25 @@ void swap(WMNullablePool &a, WMNullablePool &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMNullablePool::WMNullablePool(const WMNullablePool& other1248) {
-  resourcePlanName = other1248.resourcePlanName;
-  poolPath = other1248.poolPath;
-  allocFraction = other1248.allocFraction;
-  queryParallelism = other1248.queryParallelism;
-  schedulingPolicy = other1248.schedulingPolicy;
-  isSetSchedulingPolicy = other1248.isSetSchedulingPolicy;
-  ns = other1248.ns;
-  __isset = other1248.__isset;
+WMNullablePool::WMNullablePool(const WMNullablePool& other1250) {
+  resourcePlanName = other1250.resourcePlanName;
+  poolPath = other1250.poolPath;
+  allocFraction = other1250.allocFraction;
+  queryParallelism = other1250.queryParallelism;
+  schedulingPolicy = other1250.schedulingPolicy;
+  isSetSchedulingPolicy = other1250.isSetSchedulingPolicy;
+  ns = other1250.ns;
+  __isset = other1250.__isset;
 }
-WMNullablePool& WMNullablePool::operator=(const WMNullablePool& other1249) {
-  resourcePlanName = other1249.resourcePlanName;
-  poolPath = other1249.poolPath;
-  allocFraction = other1249.allocFraction;
-  queryParallelism = other1249.queryParallelism;
-  schedulingPolicy = other1249.schedulingPolicy;
-  isSetSchedulingPolicy = other1249.isSetSchedulingPolicy;
-  ns = other1249.ns;
-  __isset = other1249.__isset;
+WMNullablePool& WMNullablePool::operator=(const WMNullablePool& other1251) {
+  resourcePlanName = other1251.resourcePlanName;
+  poolPath = other1251.poolPath;
+  allocFraction = other1251.allocFraction;
+  queryParallelism = other1251.queryParallelism;
+  schedulingPolicy = other1251.schedulingPolicy;
+  isSetSchedulingPolicy = other1251.isSetSchedulingPolicy;
+  ns = other1251.ns;
+  __isset = other1251.__isset;
   return *this;
 }
 void WMNullablePool::printTo(std::ostream& out) const {
@@ -34300,23 +34348,23 @@ void swap(WMTrigger &a, WMTrigger &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMTrigger::WMTrigger(const WMTrigger& other1250) {
-  resourcePlanName = other1250.resourcePlanName;
-  triggerName = other1250.triggerName;
-  triggerExpression = other1250.triggerExpression;
-  actionExpression = other1250.actionExpression;
-  isInUnmanaged = other1250.isInUnmanaged;
-  ns = other1250.ns;
-  __isset = other1250.__isset;
+WMTrigger::WMTrigger(const WMTrigger& other1252) {
+  resourcePlanName = other1252.resourcePlanName;
+  triggerName = other1252.triggerName;
+  triggerExpression = other1252.triggerExpression;
+  actionExpression = other1252.actionExpression;
+  isInUnmanaged = other1252.isInUnmanaged;
+  ns = other1252.ns;
+  __isset = other1252.__isset;
 }
-WMTrigger& WMTrigger::operator=(const WMTrigger& other1251) {
-  resourcePlanName = other1251.resourcePlanName;
-  triggerName = other1251.triggerName;
-  triggerExpression = other1251.triggerExpression;
-  actionExpression = other1251.actionExpression;
-  isInUnmanaged = other1251.isInUnmanaged;
-  ns = other1251.ns;
-  __isset = other1251.__isset;
+WMTrigger& WMTrigger::operator=(const WMTrigger& other1253) {
+  resourcePlanName = other1253.resourcePlanName;
+  triggerName = other1253.triggerName;
+  triggerExpression = other1253.triggerExpression;
+  actionExpression = other1253.actionExpression;
+  isInUnmanaged = other1253.isInUnmanaged;
+  ns = other1253.ns;
+  __isset = other1253.__isset;
   return *this;
 }
 void WMTrigger::printTo(std::ostream& out) const {
@@ -34507,23 +34555,23 @@ void swap(WMMapping &a, WMMapping &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMMapping::WMMapping(const WMMapping& other1252) {
-  resourcePlanName = other1252.resourcePlanName;
-  entityType = other1252.entityType;
-  entityName = other1252.entityName;
-  poolPath = other1252.poolPath;
-  ordering = other1252.ordering;
-  ns = other1252.ns;
-  __isset = other1252.__isset;
+WMMapping::WMMapping(const WMMapping& other1254) {
+  resourcePlanName = other1254.resourcePlanName;
+  entityType = other1254.entityType;
+  entityName = other1254.entityName;
+  poolPath = other1254.poolPath;
+  ordering = other1254.ordering;
+  ns = other1254.ns;
+  __isset = other1254.__isset;
 }
-WMMapping& WMMapping::operator=(const WMMapping& other1253) {
-  resourcePlanName = other1253.resourcePlanName;
-  entityType = other1253.entityType;
-  entityName = other1253.entityName;
-  poolPath = other1253.poolPath;
-  ordering = other1253.ordering;
-  ns = other1253.ns;
-  __isset = other1253.__isset;
+WMMapping& WMMapping::operator=(const WMMapping& other1255) {
+  resourcePlanName = other1255.resourcePlanName;
+  entityType = other1255.entityType;
+  entityName = other1255.entityName;
+  poolPath = other1255.poolPath;
+  ordering = other1255.ordering;
+  ns = other1255.ns;
+  __isset = other1255.__isset;
   return *this;
 }
 void WMMapping::printTo(std::ostream& out) const {
@@ -34656,17 +34704,17 @@ void swap(WMPoolTrigger &a, WMPoolTrigger &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMPoolTrigger::WMPoolTrigger(const WMPoolTrigger& other1254) {
-  pool = other1254.pool;
-  trigger = other1254.trigger;
-  ns = other1254.ns;
-  __isset = other1254.__isset;
+WMPoolTrigger::WMPoolTrigger(const WMPoolTrigger& other1256) {
+  pool = other1256.pool;
+  trigger = other1256.trigger;
+  ns = other1256.ns;
+  __isset = other1256.__isset;
 }
-WMPoolTrigger& WMPoolTrigger::operator=(const WMPoolTrigger& other1255) {
-  pool = other1255.pool;
-  trigger = other1255.trigger;
-  ns = other1255.ns;
-  __isset = other1255.__isset;
+WMPoolTrigger& WMPoolTrigger::operator=(const WMPoolTrigger& other1257) {
+  pool = other1257.pool;
+  trigger = other1257.trigger;
+  ns = other1257.ns;
+  __isset = other1257.__isset;
   return *this;
 }
 void WMPoolTrigger::printTo(std::ostream& out) const {
@@ -34747,14 +34795,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->pools.clear();
-            uint32_t _size1256;
-            ::apache::thrift::protocol::TType _etype1259;
-            xfer += iprot->readListBegin(_etype1259, _size1256);
-            this->pools.resize(_size1256);
-            uint32_t _i1260;
-            for (_i1260 = 0; _i1260 < _size1256; ++_i1260)
+            uint32_t _size1258;
+            ::apache::thrift::protocol::TType _etype1261;
+            xfer += iprot->readListBegin(_etype1261, _size1258);
+            this->pools.resize(_size1258);
+            uint32_t _i1262;
+            for (_i1262 = 0; _i1262 < _size1258; ++_i1262)
             {
-              xfer += this->pools[_i1260].read(iprot);
+              xfer += this->pools[_i1262].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -34767,14 +34815,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->mappings.clear();
-            uint32_t _size1261;
-            ::apache::thrift::protocol::TType _etype1264;
-            xfer += iprot->readListBegin(_etype1264, _size1261);
-            this->mappings.resize(_size1261);
-            uint32_t _i1265;
-            for (_i1265 = 0; _i1265 < _size1261; ++_i1265)
+            uint32_t _size1263;
+            ::apache::thrift::protocol::TType _etype1266;
+            xfer += iprot->readListBegin(_etype1266, _size1263);
+            this->mappings.resize(_size1263);
+            uint32_t _i1267;
+            for (_i1267 = 0; _i1267 < _size1263; ++_i1267)
             {
-              xfer += this->mappings[_i1265].read(iprot);
+              xfer += this->mappings[_i1267].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -34787,14 +34835,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->triggers.clear();
-            uint32_t _size1266;
-            ::apache::thrift::protocol::TType _etype1269;
-            xfer += iprot->readListBegin(_etype1269, _size1266);
-            this->triggers.resize(_size1266);
-            uint32_t _i1270;
-            for (_i1270 = 0; _i1270 < _size1266; ++_i1270)
+            uint32_t _size1268;
+            ::apache::thrift::protocol::TType _etype1271;
+            xfer += iprot->readListBegin(_etype1271, _size1268);
+            this->triggers.resize(_size1268);
+            uint32_t _i1272;
+            for (_i1272 = 0; _i1272 < _size1268; ++_i1272)
             {
-              xfer += this->triggers[_i1270].read(iprot);
+              xfer += this->triggers[_i1272].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -34807,14 +34855,14 @@ uint32_t WMFullResourcePlan::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->poolTriggers.clear();
-            uint32_t _size1271;
-            ::apache::thrift::protocol::TType _etype1274;
-            xfer += iprot->readListBegin(_etype1274, _size1271);
-            this->poolTriggers.resize(_size1271);
-            uint32_t _i1275;
-            for (_i1275 = 0; _i1275 < _size1271; ++_i1275)
+            uint32_t _size1273;
+            ::apache::thrift::protocol::TType _etype1276;
+            xfer += iprot->readListBegin(_etype1276, _size1273);
+            this->poolTriggers.resize(_size1273);
+            uint32_t _i1277;
+            for (_i1277 = 0; _i1277 < _size1273; ++_i1277)
             {
-              xfer += this->poolTriggers[_i1275].read(iprot);
+              xfer += this->poolTriggers[_i1277].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -34851,10 +34899,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("pools", ::apache::thrift::protocol::T_LIST, 2);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->pools.size()));
-    std::vector<WMPool> ::const_iterator _iter1276;
-    for (_iter1276 = this->pools.begin(); _iter1276 != this->pools.end(); ++_iter1276)
+    std::vector<WMPool> ::const_iterator _iter1278;
+    for (_iter1278 = this->pools.begin(); _iter1278 != this->pools.end(); ++_iter1278)
     {
-      xfer += (*_iter1276).write(oprot);
+      xfer += (*_iter1278).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -34864,10 +34912,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("mappings", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->mappings.size()));
-      std::vector<WMMapping> ::const_iterator _iter1277;
-      for (_iter1277 = this->mappings.begin(); _iter1277 != this->mappings.end(); ++_iter1277)
+      std::vector<WMMapping> ::const_iterator _iter1279;
+      for (_iter1279 = this->mappings.begin(); _iter1279 != this->mappings.end(); ++_iter1279)
       {
-        xfer += (*_iter1277).write(oprot);
+        xfer += (*_iter1279).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -34877,10 +34925,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("triggers", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->triggers.size()));
-      std::vector<WMTrigger> ::const_iterator _iter1278;
-      for (_iter1278 = this->triggers.begin(); _iter1278 != this->triggers.end(); ++_iter1278)
+      std::vector<WMTrigger> ::const_iterator _iter1280;
+      for (_iter1280 = this->triggers.begin(); _iter1280 != this->triggers.end(); ++_iter1280)
       {
-        xfer += (*_iter1278).write(oprot);
+        xfer += (*_iter1280).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -34890,10 +34938,10 @@ uint32_t WMFullResourcePlan::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("poolTriggers", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->poolTriggers.size()));
-      std::vector<WMPoolTrigger> ::const_iterator _iter1279;
-      for (_iter1279 = this->poolTriggers.begin(); _iter1279 != this->poolTriggers.end(); ++_iter1279)
+      std::vector<WMPoolTrigger> ::const_iterator _iter1281;
+      for (_iter1281 = this->poolTriggers.begin(); _iter1281 != this->poolTriggers.end(); ++_iter1281)
       {
-        xfer += (*_iter1279).write(oprot);
+        xfer += (*_iter1281).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -34914,21 +34962,21 @@ void swap(WMFullResourcePlan &a, WMFullResourcePlan &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMFullResourcePlan::WMFullResourcePlan(const WMFullResourcePlan& other1280) {
-  plan = other1280.plan;
-  pools = other1280.pools;
-  mappings = other1280.mappings;
-  triggers = other1280.triggers;
-  poolTriggers = other1280.poolTriggers;
-  __isset = other1280.__isset;
+WMFullResourcePlan::WMFullResourcePlan(const WMFullResourcePlan& other1282) {
+  plan = other1282.plan;
+  pools = other1282.pools;
+  mappings = other1282.mappings;
+  triggers = other1282.triggers;
+  poolTriggers = other1282.poolTriggers;
+  __isset = other1282.__isset;
 }
-WMFullResourcePlan& WMFullResourcePlan::operator=(const WMFullResourcePlan& other1281) {
-  plan = other1281.plan;
-  pools = other1281.pools;
-  mappings = other1281.mappings;
-  triggers = other1281.triggers;
-  poolTriggers = other1281.poolTriggers;
-  __isset = other1281.__isset;
+WMFullResourcePlan& WMFullResourcePlan::operator=(const WMFullResourcePlan& other1283) {
+  plan = other1283.plan;
+  pools = other1283.pools;
+  mappings = other1283.mappings;
+  triggers = other1283.triggers;
+  poolTriggers = other1283.poolTriggers;
+  __isset = other1283.__isset;
   return *this;
 }
 void WMFullResourcePlan::printTo(std::ostream& out) const {
@@ -35039,15 +35087,15 @@ void swap(WMCreateResourcePlanRequest &a, WMCreateResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreateResourcePlanRequest::WMCreateResourcePlanRequest(const WMCreateResourcePlanRequest& other1282) {
-  resourcePlan = other1282.resourcePlan;
-  copyFrom = other1282.copyFrom;
-  __isset = other1282.__isset;
+WMCreateResourcePlanRequest::WMCreateResourcePlanRequest(const WMCreateResourcePlanRequest& other1284) {
+  resourcePlan = other1284.resourcePlan;
+  copyFrom = other1284.copyFrom;
+  __isset = other1284.__isset;
 }
-WMCreateResourcePlanRequest& WMCreateResourcePlanRequest::operator=(const WMCreateResourcePlanRequest& other1283) {
-  resourcePlan = other1283.resourcePlan;
-  copyFrom = other1283.copyFrom;
-  __isset = other1283.__isset;
+WMCreateResourcePlanRequest& WMCreateResourcePlanRequest::operator=(const WMCreateResourcePlanRequest& other1285) {
+  resourcePlan = other1285.resourcePlan;
+  copyFrom = other1285.copyFrom;
+  __isset = other1285.__isset;
   return *this;
 }
 void WMCreateResourcePlanRequest::printTo(std::ostream& out) const {
@@ -35113,11 +35161,11 @@ void swap(WMCreateResourcePlanResponse &a, WMCreateResourcePlanResponse &b) {
   (void) b;
 }
 
-WMCreateResourcePlanResponse::WMCreateResourcePlanResponse(const WMCreateResourcePlanResponse& other1284) {
-  (void) other1284;
+WMCreateResourcePlanResponse::WMCreateResourcePlanResponse(const WMCreateResourcePlanResponse& other1286) {
+  (void) other1286;
 }
-WMCreateResourcePlanResponse& WMCreateResourcePlanResponse::operator=(const WMCreateResourcePlanResponse& other1285) {
-  (void) other1285;
+WMCreateResourcePlanResponse& WMCreateResourcePlanResponse::operator=(const WMCreateResourcePlanResponse& other1287) {
+  (void) other1287;
   return *this;
 }
 void WMCreateResourcePlanResponse::printTo(std::ostream& out) const {
@@ -35204,13 +35252,13 @@ void swap(WMGetActiveResourcePlanRequest &a, WMGetActiveResourcePlanRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMGetActiveResourcePlanRequest::WMGetActiveResourcePlanRequest(const WMGetActiveResourcePlanRequest& other1286) {
-  ns = other1286.ns;
-  __isset = other1286.__isset;
+WMGetActiveResourcePlanRequest::WMGetActiveResourcePlanRequest(const WMGetActiveResourcePlanRequest& other1288) {
+  ns = other1288.ns;
+  __isset = other1288.__isset;
 }
-WMGetActiveResourcePlanRequest& WMGetActiveResourcePlanRequest::operator=(const WMGetActiveResourcePlanRequest& other1287) {
-  ns = other1287.ns;
-  __isset = other1287.__isset;
+WMGetActiveResourcePlanRequest& WMGetActiveResourcePlanRequest::operator=(const WMGetActiveResourcePlanRequest& other1289) {
+  ns = other1289.ns;
+  __isset = other1289.__isset;
   return *this;
 }
 void WMGetActiveResourcePlanRequest::printTo(std::ostream& out) const {
@@ -35298,13 +35346,13 @@ void swap(WMGetActiveResourcePlanResponse &a, WMGetActiveResourcePlanResponse &b
   swap(a.__isset, b.__isset);
 }
 
-WMGetActiveResourcePlanResponse::WMGetActiveResourcePlanResponse(const WMGetActiveResourcePlanResponse& other1288) {
-  resourcePlan = other1288.resourcePlan;
-  __isset = other1288.__isset;
+WMGetActiveResourcePlanResponse::WMGetActiveResourcePlanResponse(const WMGetActiveResourcePlanResponse& other1290) {
+  resourcePlan = other1290.resourcePlan;
+  __isset = other1290.__isset;
 }
-WMGetActiveResourcePlanResponse& WMGetActiveResourcePlanResponse::operator=(const WMGetActiveResourcePlanResponse& other1289) {
-  resourcePlan = other1289.resourcePlan;
-  __isset = other1289.__isset;
+WMGetActiveResourcePlanResponse& WMGetActiveResourcePlanResponse::operator=(const WMGetActiveResourcePlanResponse& other1291) {
+  resourcePlan = other1291.resourcePlan;
+  __isset = other1291.__isset;
   return *this;
 }
 void WMGetActiveResourcePlanResponse::printTo(std::ostream& out) const {
@@ -35411,15 +35459,15 @@ void swap(WMGetResourcePlanRequest &a, WMGetResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetResourcePlanRequest::WMGetResourcePlanRequest(const WMGetResourcePlanRequest& other1290) {
-  resourcePlanName = other1290.resourcePlanName;
-  ns = other1290.ns;
-  __isset = other1290.__isset;
+WMGetResourcePlanRequest::WMGetResourcePlanRequest(const WMGetResourcePlanRequest& other1292) {
+  resourcePlanName = other1292.resourcePlanName;
+  ns = other1292.ns;
+  __isset = other1292.__isset;
 }
-WMGetResourcePlanRequest& WMGetResourcePlanRequest::operator=(const WMGetResourcePlanRequest& other1291) {
-  resourcePlanName = other1291.resourcePlanName;
-  ns = other1291.ns;
-  __isset = other1291.__isset;
+WMGetResourcePlanRequest& WMGetResourcePlanRequest::operator=(const WMGetResourcePlanRequest& other1293) {
+  resourcePlanName = other1293.resourcePlanName;
+  ns = other1293.ns;
+  __isset = other1293.__isset;
   return *this;
 }
 void WMGetResourcePlanRequest::printTo(std::ostream& out) const {
@@ -35508,13 +35556,13 @@ void swap(WMGetResourcePlanResponse &a, WMGetResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetResourcePlanResponse::WMGetResourcePlanResponse(const WMGetResourcePlanResponse& other1292) {
-  resourcePlan = other1292.resourcePlan;
-  __isset = other1292.__isset;
+WMGetResourcePlanResponse::WMGetResourcePlanResponse(const WMGetResourcePlanResponse& other1294) {
+  resourcePlan = other1294.resourcePlan;
+  __isset = other1294.__isset;
 }
-WMGetResourcePlanResponse& WMGetResourcePlanResponse::operator=(const WMGetResourcePlanResponse& other1293) {
-  resourcePlan = other1293.resourcePlan;
-  __isset = other1293.__isset;
+WMGetResourcePlanResponse& WMGetResourcePlanResponse::operator=(const WMGetResourcePlanResponse& other1295) {
+  resourcePlan = other1295.resourcePlan;
+  __isset = other1295.__isset;
   return *this;
 }
 void WMGetResourcePlanResponse::printTo(std::ostream& out) const {
@@ -35602,13 +35650,13 @@ void swap(WMGetAllResourcePlanRequest &a, WMGetAllResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetAllResourcePlanRequest::WMGetAllResourcePlanRequest(const WMGetAllResourcePlanRequest& other1294) {
-  ns = other1294.ns;
-  __isset = other1294.__isset;
+WMGetAllResourcePlanRequest::WMGetAllResourcePlanRequest(const WMGetAllResourcePlanRequest& other1296) {
+  ns = other1296.ns;
+  __isset = other1296.__isset;
 }
-WMGetAllResourcePlanRequest& WMGetAllResourcePlanRequest::operator=(const WMGetAllResourcePlanRequest& other1295) {
-  ns = other1295.ns;
-  __isset = other1295.__isset;
+WMGetAllResourcePlanRequest& WMGetAllResourcePlanRequest::operator=(const WMGetAllResourcePlanRequest& other1297) {
+  ns = other1297.ns;
+  __isset = other1297.__isset;
   return *this;
 }
 void WMGetAllResourcePlanRequest::printTo(std::ostream& out) const {
@@ -35659,14 +35707,14 @@ uint32_t WMGetAllResourcePlanResponse::read(::apache::thrift::protocol::TProtoco
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->resourcePlans.clear();
-            uint32_t _size1296;
-            ::apache::thrift::protocol::TType _etype1299;
-            xfer += iprot->readListBegin(_etype1299, _size1296);
-            this->resourcePlans.resize(_size1296);
-            uint32_t _i1300;
-            for (_i1300 = 0; _i1300 < _size1296; ++_i1300)
+            uint32_t _size1298;
+            ::apache::thrift::protocol::TType _etype1301;
+            xfer += iprot->readListBegin(_etype1301, _size1298);
+            this->resourcePlans.resize(_size1298);
+            uint32_t _i1302;
+            for (_i1302 = 0; _i1302 < _size1298; ++_i1302)
             {
-              xfer += this->resourcePlans[_i1300].read(iprot);
+              xfer += this->resourcePlans[_i1302].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -35696,10 +35744,10 @@ uint32_t WMGetAllResourcePlanResponse::write(::apache::thrift::protocol::TProtoc
     xfer += oprot->writeFieldBegin("resourcePlans", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->resourcePlans.size()));
-      std::vector<WMResourcePlan> ::const_iterator _iter1301;
-      for (_iter1301 = this->resourcePlans.begin(); _iter1301 != this->resourcePlans.end(); ++_iter1301)
+      std::vector<WMResourcePlan> ::const_iterator _iter1303;
+      for (_iter1303 = this->resourcePlans.begin(); _iter1303 != this->resourcePlans.end(); ++_iter1303)
       {
-        xfer += (*_iter1301).write(oprot);
+        xfer += (*_iter1303).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -35716,13 +35764,13 @@ void swap(WMGetAllResourcePlanResponse &a, WMGetAllResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMGetAllResourcePlanResponse::WMGetAllResourcePlanResponse(const WMGetAllResourcePlanResponse& other1302) {
-  resourcePlans = other1302.resourcePlans;
-  __isset = other1302.__isset;
+WMGetAllResourcePlanResponse::WMGetAllResourcePlanResponse(const WMGetAllResourcePlanResponse& other1304) {
+  resourcePlans = other1304.resourcePlans;
+  __isset = other1304.__isset;
 }
-WMGetAllResourcePlanResponse& WMGetAllResourcePlanResponse::operator=(const WMGetAllResourcePlanResponse& other1303) {
-  resourcePlans = other1303.resourcePlans;
-  __isset = other1303.__isset;
+WMGetAllResourcePlanResponse& WMGetAllResourcePlanResponse::operator=(const WMGetAllResourcePlanResponse& other1305) {
+  resourcePlans = other1305.resourcePlans;
+  __isset = other1305.__isset;
   return *this;
 }
 void WMGetAllResourcePlanResponse::printTo(std::ostream& out) const {
@@ -35905,23 +35953,23 @@ void swap(WMAlterResourcePlanRequest &a, WMAlterResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterResourcePlanRequest::WMAlterResourcePlanRequest(const WMAlterResourcePlanRequest& other1304) {
-  resourcePlanName = other1304.resourcePlanName;
-  resourcePlan = other1304.resourcePlan;
-  isEnableAndActivate = other1304.isEnableAndActivate;
-  isForceDeactivate = other1304.isForceDeactivate;
-  isReplace = other1304.isReplace;
-  ns = other1304.ns;
-  __isset = other1304.__isset;
+WMAlterResourcePlanRequest::WMAlterResourcePlanRequest(const WMAlterResourcePlanRequest& other1306) {
+  resourcePlanName = other1306.resourcePlanName;
+  resourcePlan = other1306.resourcePlan;
+  isEnableAndActivate = other1306.isEnableAndActivate;
+  isForceDeactivate = other1306.isForceDeactivate;
+  isReplace = other1306.isReplace;
+  ns = other1306.ns;
+  __isset = other1306.__isset;
 }
-WMAlterResourcePlanRequest& WMAlterResourcePlanRequest::operator=(const WMAlterResourcePlanRequest& other1305) {
-  resourcePlanName = other1305.resourcePlanName;
-  resourcePlan = other1305.resourcePlan;
-  isEnableAndActivate = other1305.isEnableAndActivate;
-  isForceDeactivate = other1305.isForceDeactivate;
-  isReplace = other1305.isReplace;
-  ns = other1305.ns;
-  __isset = other1305.__isset;
+WMAlterResourcePlanRequest& WMAlterResourcePlanRequest::operator=(const WMAlterResourcePlanRequest& other1307) {
+  resourcePlanName = other1307.resourcePlanName;
+  resourcePlan = other1307.resourcePlan;
+  isEnableAndActivate = other1307.isEnableAndActivate;
+  isForceDeactivate = other1307.isForceDeactivate;
+  isReplace = other1307.isReplace;
+  ns = other1307.ns;
+  __isset = other1307.__isset;
   return *this;
 }
 void WMAlterResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36014,13 +36062,13 @@ void swap(WMAlterResourcePlanResponse &a, WMAlterResourcePlanResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterResourcePlanResponse::WMAlterResourcePlanResponse(const WMAlterResourcePlanResponse& other1306) {
-  fullResourcePlan = other1306.fullResourcePlan;
-  __isset = other1306.__isset;
+WMAlterResourcePlanResponse::WMAlterResourcePlanResponse(const WMAlterResourcePlanResponse& other1308) {
+  fullResourcePlan = other1308.fullResourcePlan;
+  __isset = other1308.__isset;
 }
-WMAlterResourcePlanResponse& WMAlterResourcePlanResponse::operator=(const WMAlterResourcePlanResponse& other1307) {
-  fullResourcePlan = other1307.fullResourcePlan;
-  __isset = other1307.__isset;
+WMAlterResourcePlanResponse& WMAlterResourcePlanResponse::operator=(const WMAlterResourcePlanResponse& other1309) {
+  fullResourcePlan = other1309.fullResourcePlan;
+  __isset = other1309.__isset;
   return *this;
 }
 void WMAlterResourcePlanResponse::printTo(std::ostream& out) const {
@@ -36127,15 +36175,15 @@ void swap(WMValidateResourcePlanRequest &a, WMValidateResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMValidateResourcePlanRequest::WMValidateResourcePlanRequest(const WMValidateResourcePlanRequest& other1308) {
-  resourcePlanName = other1308.resourcePlanName;
-  ns = other1308.ns;
-  __isset = other1308.__isset;
+WMValidateResourcePlanRequest::WMValidateResourcePlanRequest(const WMValidateResourcePlanRequest& other1310) {
+  resourcePlanName = other1310.resourcePlanName;
+  ns = other1310.ns;
+  __isset = other1310.__isset;
 }
-WMValidateResourcePlanRequest& WMValidateResourcePlanRequest::operator=(const WMValidateResourcePlanRequest& other1309) {
-  resourcePlanName = other1309.resourcePlanName;
-  ns = other1309.ns;
-  __isset = other1309.__isset;
+WMValidateResourcePlanRequest& WMValidateResourcePlanRequest::operator=(const WMValidateResourcePlanRequest& other1311) {
+  resourcePlanName = other1311.resourcePlanName;
+  ns = other1311.ns;
+  __isset = other1311.__isset;
   return *this;
 }
 void WMValidateResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36192,14 +36240,14 @@ uint32_t WMValidateResourcePlanResponse::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->errors.clear();
-            uint32_t _size1310;
-            ::apache::thrift::protocol::TType _etype1313;
-            xfer += iprot->readListBegin(_etype1313, _size1310);
-            this->errors.resize(_size1310);
-            uint32_t _i1314;
-            for (_i1314 = 0; _i1314 < _size1310; ++_i1314)
+            uint32_t _size1312;
+            ::apache::thrift::protocol::TType _etype1315;
+            xfer += iprot->readListBegin(_etype1315, _size1312);
+            this->errors.resize(_size1312);
+            uint32_t _i1316;
+            for (_i1316 = 0; _i1316 < _size1312; ++_i1316)
             {
-              xfer += iprot->readString(this->errors[_i1314]);
+              xfer += iprot->readString(this->errors[_i1316]);
             }
             xfer += iprot->readListEnd();
           }
@@ -36212,14 +36260,14 @@ uint32_t WMValidateResourcePlanResponse::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->warnings.clear();
-            uint32_t _size1315;
-            ::apache::thrift::protocol::TType _etype1318;
-            xfer += iprot->readListBegin(_etype1318, _size1315);
-            this->warnings.resize(_size1315);
-            uint32_t _i1319;
-            for (_i1319 = 0; _i1319 < _size1315; ++_i1319)
+            uint32_t _size1317;
+            ::apache::thrift::protocol::TType _etype1320;
+            xfer += iprot->readListBegin(_etype1320, _size1317);
+            this->warnings.resize(_size1317);
+            uint32_t _i1321;
+            for (_i1321 = 0; _i1321 < _size1317; ++_i1321)
             {
-              xfer += iprot->readString(this->warnings[_i1319]);
+              xfer += iprot->readString(this->warnings[_i1321]);
             }
             xfer += iprot->readListEnd();
           }
@@ -36249,10 +36297,10 @@ uint32_t WMValidateResourcePlanResponse::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("errors", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->errors.size()));
-      std::vector<std::string> ::const_iterator _iter1320;
-      for (_iter1320 = this->errors.begin(); _iter1320 != this->errors.end(); ++_iter1320)
+      std::vector<std::string> ::const_iterator _iter1322;
+      for (_iter1322 = this->errors.begin(); _iter1322 != this->errors.end(); ++_iter1322)
       {
-        xfer += oprot->writeString((*_iter1320));
+        xfer += oprot->writeString((*_iter1322));
       }
       xfer += oprot->writeListEnd();
     }
@@ -36262,10 +36310,10 @@ uint32_t WMValidateResourcePlanResponse::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("warnings", ::apache::thrift::protocol::T_LIST, 2);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->warnings.size()));
-      std::vector<std::string> ::const_iterator _iter1321;
-      for (_iter1321 = this->warnings.begin(); _iter1321 != this->warnings.end(); ++_iter1321)
+      std::vector<std::string> ::const_iterator _iter1323;
+      for (_iter1323 = this->warnings.begin(); _iter1323 != this->warnings.end(); ++_iter1323)
       {
-        xfer += oprot->writeString((*_iter1321));
+        xfer += oprot->writeString((*_iter1323));
       }
       xfer += oprot->writeListEnd();
     }
@@ -36283,15 +36331,15 @@ void swap(WMValidateResourcePlanResponse &a, WMValidateResourcePlanResponse &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMValidateResourcePlanResponse::WMValidateResourcePlanResponse(const WMValidateResourcePlanResponse& other1322) {
-  errors = other1322.errors;
-  warnings = other1322.warnings;
-  __isset = other1322.__isset;
+WMValidateResourcePlanResponse::WMValidateResourcePlanResponse(const WMValidateResourcePlanResponse& other1324) {
+  errors = other1324.errors;
+  warnings = other1324.warnings;
+  __isset = other1324.__isset;
 }
-WMValidateResourcePlanResponse& WMValidateResourcePlanResponse::operator=(const WMValidateResourcePlanResponse& other1323) {
-  errors = other1323.errors;
-  warnings = other1323.warnings;
-  __isset = other1323.__isset;
+WMValidateResourcePlanResponse& WMValidateResourcePlanResponse::operator=(const WMValidateResourcePlanResponse& other1325) {
+  errors = other1325.errors;
+  warnings = other1325.warnings;
+  __isset = other1325.__isset;
   return *this;
 }
 void WMValidateResourcePlanResponse::printTo(std::ostream& out) const {
@@ -36399,15 +36447,15 @@ void swap(WMDropResourcePlanRequest &a, WMDropResourcePlanRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropResourcePlanRequest::WMDropResourcePlanRequest(const WMDropResourcePlanRequest& other1324) {
-  resourcePlanName = other1324.resourcePlanName;
-  ns = other1324.ns;
-  __isset = other1324.__isset;
+WMDropResourcePlanRequest::WMDropResourcePlanRequest(const WMDropResourcePlanRequest& other1326) {
+  resourcePlanName = other1326.resourcePlanName;
+  ns = other1326.ns;
+  __isset = other1326.__isset;
 }
-WMDropResourcePlanRequest& WMDropResourcePlanRequest::operator=(const WMDropResourcePlanRequest& other1325) {
-  resourcePlanName = other1325.resourcePlanName;
-  ns = other1325.ns;
-  __isset = other1325.__isset;
+WMDropResourcePlanRequest& WMDropResourcePlanRequest::operator=(const WMDropResourcePlanRequest& other1327) {
+  resourcePlanName = other1327.resourcePlanName;
+  ns = other1327.ns;
+  __isset = other1327.__isset;
   return *this;
 }
 void WMDropResourcePlanRequest::printTo(std::ostream& out) const {
@@ -36473,11 +36521,11 @@ void swap(WMDropResourcePlanResponse &a, WMDropResourcePlanResponse &b) {
   (void) b;
 }
 
-WMDropResourcePlanResponse::WMDropResourcePlanResponse(const WMDropResourcePlanResponse& other1326) {
-  (void) other1326;
+WMDropResourcePlanResponse::WMDropResourcePlanResponse(const WMDropResourcePlanResponse& other1328) {
+  (void) other1328;
 }
-WMDropResourcePlanResponse& WMDropResourcePlanResponse::operator=(const WMDropResourcePlanResponse& other1327) {
-  (void) other1327;
+WMDropResourcePlanResponse& WMDropResourcePlanResponse::operator=(const WMDropResourcePlanResponse& other1329) {
+  (void) other1329;
   return *this;
 }
 void WMDropResourcePlanResponse::printTo(std::ostream& out) const {
@@ -36564,13 +36612,13 @@ void swap(WMCreateTriggerRequest &a, WMCreateTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreateTriggerRequest::WMCreateTriggerRequest(const WMCreateTriggerRequest& other1328) {
-  trigger = other1328.trigger;
-  __isset = other1328.__isset;
+WMCreateTriggerRequest::WMCreateTriggerRequest(const WMCreateTriggerRequest& other1330) {
+  trigger = other1330.trigger;
+  __isset = other1330.__isset;
 }
-WMCreateTriggerRequest& WMCreateTriggerRequest::operator=(const WMCreateTriggerRequest& other1329) {
-  trigger = other1329.trigger;
-  __isset = other1329.__isset;
+WMCreateTriggerRequest& WMCreateTriggerRequest::operator=(const WMCreateTriggerRequest& other1331) {
+  trigger = other1331.trigger;
+  __isset = other1331.__isset;
   return *this;
 }
 void WMCreateTriggerRequest::printTo(std::ostream& out) const {
@@ -36635,11 +36683,11 @@ void swap(WMCreateTriggerResponse &a, WMCreateTriggerResponse &b) {
   (void) b;
 }
 
-WMCreateTriggerResponse::WMCreateTriggerResponse(const WMCreateTriggerResponse& other1330) {
-  (void) other1330;
+WMCreateTriggerResponse::WMCreateTriggerResponse(const WMCreateTriggerResponse& other1332) {
+  (void) other1332;
 }
-WMCreateTriggerResponse& WMCreateTriggerResponse::operator=(const WMCreateTriggerResponse& other1331) {
-  (void) other1331;
+WMCreateTriggerResponse& WMCreateTriggerResponse::operator=(const WMCreateTriggerResponse& other1333) {
+  (void) other1333;
   return *this;
 }
 void WMCreateTriggerResponse::printTo(std::ostream& out) const {
@@ -36726,13 +36774,13 @@ void swap(WMAlterTriggerRequest &a, WMAlterTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterTriggerRequest::WMAlterTriggerRequest(const WMAlterTriggerRequest& other1332) {
-  trigger = other1332.trigger;
-  __isset = other1332.__isset;
+WMAlterTriggerRequest::WMAlterTriggerRequest(const WMAlterTriggerRequest& other1334) {
+  trigger = other1334.trigger;
+  __isset = other1334.__isset;
 }
-WMAlterTriggerRequest& WMAlterTriggerRequest::operator=(const WMAlterTriggerRequest& other1333) {
-  trigger = other1333.trigger;
-  __isset = other1333.__isset;
+WMAlterTriggerRequest& WMAlterTriggerRequest::operator=(const WMAlterTriggerRequest& other1335) {
+  trigger = other1335.trigger;
+  __isset = other1335.__isset;
   return *this;
 }
 void WMAlterTriggerRequest::printTo(std::ostream& out) const {
@@ -36797,11 +36845,11 @@ void swap(WMAlterTriggerResponse &a, WMAlterTriggerResponse &b) {
   (void) b;
 }
 
-WMAlterTriggerResponse::WMAlterTriggerResponse(const WMAlterTriggerResponse& other1334) {
-  (void) other1334;
+WMAlterTriggerResponse::WMAlterTriggerResponse(const WMAlterTriggerResponse& other1336) {
+  (void) other1336;
 }
-WMAlterTriggerResponse& WMAlterTriggerResponse::operator=(const WMAlterTriggerResponse& other1335) {
-  (void) other1335;
+WMAlterTriggerResponse& WMAlterTriggerResponse::operator=(const WMAlterTriggerResponse& other1337) {
+  (void) other1337;
   return *this;
 }
 void WMAlterTriggerResponse::printTo(std::ostream& out) const {
@@ -36926,17 +36974,17 @@ void swap(WMDropTriggerRequest &a, WMDropTriggerRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropTriggerRequest::WMDropTriggerRequest(const WMDropTriggerRequest& other1336) {
-  resourcePlanName = other1336.resourcePlanName;
-  triggerName = other1336.triggerName;
-  ns = other1336.ns;
-  __isset = other1336.__isset;
+WMDropTriggerRequest::WMDropTriggerRequest(const WMDropTriggerRequest& other1338) {
+  resourcePlanName = other1338.resourcePlanName;
+  triggerName = other1338.triggerName;
+  ns = other1338.ns;
+  __isset = other1338.__isset;
 }
-WMDropTriggerRequest& WMDropTriggerRequest::operator=(const WMDropTriggerRequest& other1337) {
-  resourcePlanName = other1337.resourcePlanName;
-  triggerName = other1337.triggerName;
-  ns = other1337.ns;
-  __isset = other1337.__isset;
+WMDropTriggerRequest& WMDropTriggerRequest::operator=(const WMDropTriggerRequest& other1339) {
+  resourcePlanName = other1339.resourcePlanName;
+  triggerName = other1339.triggerName;
+  ns = other1339.ns;
+  __isset = other1339.__isset;
   return *this;
 }
 void WMDropTriggerRequest::printTo(std::ostream& out) const {
@@ -37003,11 +37051,11 @@ void swap(WMDropTriggerResponse &a, WMDropTriggerResponse &b) {
   (void) b;
 }
 
-WMDropTriggerResponse::WMDropTriggerResponse(const WMDropTriggerResponse& other1338) {
-  (void) other1338;
+WMDropTriggerResponse::WMDropTriggerResponse(const WMDropTriggerResponse& other1340) {
+  (void) other1340;
 }
-WMDropTriggerResponse& WMDropTriggerResponse::operator=(const WMDropTriggerResponse& other1339) {
-  (void) other1339;
+WMDropTriggerResponse& WMDropTriggerResponse::operator=(const WMDropTriggerResponse& other1341) {
+  (void) other1341;
   return *this;
 }
 void WMDropTriggerResponse::printTo(std::ostream& out) const {
@@ -37113,15 +37161,15 @@ void swap(WMGetTriggersForResourePlanRequest &a, WMGetTriggersForResourePlanRequ
   swap(a.__isset, b.__isset);
 }
 
-WMGetTriggersForResourePlanRequest::WMGetTriggersForResourePlanRequest(const WMGetTriggersForResourePlanRequest& other1340) {
-  resourcePlanName = other1340.resourcePlanName;
-  ns = other1340.ns;
-  __isset = other1340.__isset;
+WMGetTriggersForResourePlanRequest::WMGetTriggersForResourePlanRequest(const WMGetTriggersForResourePlanRequest& other1342) {
+  resourcePlanName = other1342.resourcePlanName;
+  ns = other1342.ns;
+  __isset = other1342.__isset;
 }
-WMGetTriggersForResourePlanRequest& WMGetTriggersForResourePlanRequest::operator=(const WMGetTriggersForResourePlanRequest& other1341) {
-  resourcePlanName = other1341.resourcePlanName;
-  ns = other1341.ns;
-  __isset = other1341.__isset;
+WMGetTriggersForResourePlanRequest& WMGetTriggersForResourePlanRequest::operator=(const WMGetTriggersForResourePlanRequest& other1343) {
+  resourcePlanName = other1343.resourcePlanName;
+  ns = other1343.ns;
+  __isset = other1343.__isset;
   return *this;
 }
 void WMGetTriggersForResourePlanRequest::printTo(std::ostream& out) const {
@@ -37173,14 +37221,14 @@ uint32_t WMGetTriggersForResourePlanResponse::read(::apache::thrift::protocol::T
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->triggers.clear();
-            uint32_t _size1342;
-            ::apache::thrift::protocol::TType _etype1345;
-            xfer += iprot->readListBegin(_etype1345, _size1342);
-            this->triggers.resize(_size1342);
-            uint32_t _i1346;
-            for (_i1346 = 0; _i1346 < _size1342; ++_i1346)
+            uint32_t _size1344;
+            ::apache::thrift::protocol::TType _etype1347;
+            xfer += iprot->readListBegin(_etype1347, _size1344);
+            this->triggers.resize(_size1344);
+            uint32_t _i1348;
+            for (_i1348 = 0; _i1348 < _size1344; ++_i1348)
             {
-              xfer += this->triggers[_i1346].read(iprot);
+              xfer += this->triggers[_i1348].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -37210,10 +37258,10 @@ uint32_t WMGetTriggersForResourePlanResponse::write(::apache::thrift::protocol::
     xfer += oprot->writeFieldBegin("triggers", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->triggers.size()));
-      std::vector<WMTrigger> ::const_iterator _iter1347;
-      for (_iter1347 = this->triggers.begin(); _iter1347 != this->triggers.end(); ++_iter1347)
+      std::vector<WMTrigger> ::const_iterator _iter1349;
+      for (_iter1349 = this->triggers.begin(); _iter1349 != this->triggers.end(); ++_iter1349)
       {
-        xfer += (*_iter1347).write(oprot);
+        xfer += (*_iter1349).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -37230,13 +37278,13 @@ void swap(WMGetTriggersForResourePlanResponse &a, WMGetTriggersForResourePlanRes
   swap(a.__isset, b.__isset);
 }
 
-WMGetTriggersForResourePlanResponse::WMGetTriggersForResourePlanResponse(const WMGetTriggersForResourePlanResponse& other1348) {
-  triggers = other1348.triggers;
-  __isset = other1348.__isset;
+WMGetTriggersForResourePlanResponse::WMGetTriggersForResourePlanResponse(const WMGetTriggersForResourePlanResponse& other1350) {
+  triggers = other1350.triggers;
+  __isset = other1350.__isset;
 }
-WMGetTriggersForResourePlanResponse& WMGetTriggersForResourePlanResponse::operator=(const WMGetTriggersForResourePlanResponse& other1349) {
-  triggers = other1349.triggers;
-  __isset = other1349.__isset;
+WMGetTriggersForResourePlanResponse& WMGetTriggersForResourePlanResponse::operator=(const WMGetTriggersForResourePlanResponse& other1351) {
+  triggers = other1351.triggers;
+  __isset = other1351.__isset;
   return *this;
 }
 void WMGetTriggersForResourePlanResponse::printTo(std::ostream& out) const {
@@ -37324,13 +37372,13 @@ void swap(WMCreatePoolRequest &a, WMCreatePoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMCreatePoolRequest::WMCreatePoolRequest(const WMCreatePoolRequest& other1350) {
-  pool = other1350.pool;
-  __isset = other1350.__isset;
+WMCreatePoolRequest::WMCreatePoolRequest(const WMCreatePoolRequest& other1352) {
+  pool = other1352.pool;
+  __isset = other1352.__isset;
 }
-WMCreatePoolRequest& WMCreatePoolRequest::operator=(const WMCreatePoolRequest& other1351) {
-  pool = other1351.pool;
-  __isset = other1351.__isset;
+WMCreatePoolRequest& WMCreatePoolRequest::operator=(const WMCreatePoolRequest& other1353) {
+  pool = other1353.pool;
+  __isset = other1353.__isset;
   return *this;
 }
 void WMCreatePoolRequest::printTo(std::ostream& out) const {
@@ -37395,11 +37443,11 @@ void swap(WMCreatePoolResponse &a, WMCreatePoolResponse &b) {
   (void) b;
 }
 
-WMCreatePoolResponse::WMCreatePoolResponse(const WMCreatePoolResponse& other1352) {
-  (void) other1352;
+WMCreatePoolResponse::WMCreatePoolResponse(const WMCreatePoolResponse& other1354) {
+  (void) other1354;
 }
-WMCreatePoolResponse& WMCreatePoolResponse::operator=(const WMCreatePoolResponse& other1353) {
-  (void) other1353;
+WMCreatePoolResponse& WMCreatePoolResponse::operator=(const WMCreatePoolResponse& other1355) {
+  (void) other1355;
   return *this;
 }
 void WMCreatePoolResponse::printTo(std::ostream& out) const {
@@ -37505,15 +37553,15 @@ void swap(WMAlterPoolRequest &a, WMAlterPoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMAlterPoolRequest::WMAlterPoolRequest(const WMAlterPoolRequest& other1354) {
-  pool = other1354.pool;
-  poolPath = other1354.poolPath;
-  __isset = other1354.__isset;
+WMAlterPoolRequest::WMAlterPoolRequest(const WMAlterPoolRequest& other1356) {
+  pool = other1356.pool;
+  poolPath = other1356.poolPath;
+  __isset = other1356.__isset;
 }
-WMAlterPoolRequest& WMAlterPoolRequest::operator=(const WMAlterPoolRequest& other1355) {
-  pool = other1355.pool;
-  poolPath = other1355.poolPath;
-  __isset = other1355.__isset;
+WMAlterPoolRequest& WMAlterPoolRequest::operator=(const WMAlterPoolRequest& other1357) {
+  pool = other1357.pool;
+  poolPath = other1357.poolPath;
+  __isset = other1357.__isset;
   return *this;
 }
 void WMAlterPoolRequest::printTo(std::ostream& out) const {
@@ -37579,11 +37627,11 @@ void swap(WMAlterPoolResponse &a, WMAlterPoolResponse &b) {
   (void) b;
 }
 
-WMAlterPoolResponse::WMAlterPoolResponse(const WMAlterPoolResponse& other1356) {
-  (void) other1356;
+WMAlterPoolResponse::WMAlterPoolResponse(const WMAlterPoolResponse& other1358) {
+  (void) other1358;
 }
-WMAlterPoolResponse& WMAlterPoolResponse::operator=(const WMAlterPoolResponse& other1357) {
-  (void) other1357;
+WMAlterPoolResponse& WMAlterPoolResponse::operator=(const WMAlterPoolResponse& other1359) {
+  (void) other1359;
   return *this;
 }
 void WMAlterPoolResponse::printTo(std::ostream& out) const {
@@ -37708,17 +37756,17 @@ void swap(WMDropPoolRequest &a, WMDropPoolRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropPoolRequest::WMDropPoolRequest(const WMDropPoolRequest& other1358) {
-  resourcePlanName = other1358.resourcePlanName;
-  poolPath = other1358.poolPath;
-  ns = other1358.ns;
-  __isset = other1358.__isset;
+WMDropPoolRequest::WMDropPoolRequest(const WMDropPoolRequest& other1360) {
+  resourcePlanName = other1360.resourcePlanName;
+  poolPath = other1360.poolPath;
+  ns = other1360.ns;
+  __isset = other1360.__isset;
 }
-WMDropPoolRequest& WMDropPoolRequest::operator=(const WMDropPoolRequest& other1359) {
-  resourcePlanName = other1359.resourcePlanName;
-  poolPath = other1359.poolPath;
-  ns = other1359.ns;
-  __isset = other1359.__isset;
+WMDropPoolRequest& WMDropPoolRequest::operator=(const WMDropPoolRequest& other1361) {
+  resourcePlanName = other1361.resourcePlanName;
+  poolPath = other1361.poolPath;
+  ns = other1361.ns;
+  __isset = other1361.__isset;
   return *this;
 }
 void WMDropPoolRequest::printTo(std::ostream& out) const {
@@ -37785,11 +37833,11 @@ void swap(WMDropPoolResponse &a, WMDropPoolResponse &b) {
   (void) b;
 }
 
-WMDropPoolResponse::WMDropPoolResponse(const WMDropPoolResponse& other1360) {
-  (void) other1360;
+WMDropPoolResponse::WMDropPoolResponse(const WMDropPoolResponse& other1362) {
+  (void) other1362;
 }
-WMDropPoolResponse& WMDropPoolResponse::operator=(const WMDropPoolResponse& other1361) {
-  (void) other1361;
+WMDropPoolResponse& WMDropPoolResponse::operator=(const WMDropPoolResponse& other1363) {
+  (void) other1363;
   return *this;
 }
 void WMDropPoolResponse::printTo(std::ostream& out) const {
@@ -37895,15 +37943,15 @@ void swap(WMCreateOrUpdateMappingRequest &a, WMCreateOrUpdateMappingRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-WMCreateOrUpdateMappingRequest::WMCreateOrUpdateMappingRequest(const WMCreateOrUpdateMappingRequest& other1362) {
-  mapping = other1362.mapping;
-  update = other1362.update;
-  __isset = other1362.__isset;
+WMCreateOrUpdateMappingRequest::WMCreateOrUpdateMappingRequest(const WMCreateOrUpdateMappingRequest& other1364) {
+  mapping = other1364.mapping;
+  update = other1364.update;
+  __isset = other1364.__isset;
 }
-WMCreateOrUpdateMappingRequest& WMCreateOrUpdateMappingRequest::operator=(const WMCreateOrUpdateMappingRequest& other1363) {
-  mapping = other1363.mapping;
-  update = other1363.update;
-  __isset = other1363.__isset;
+WMCreateOrUpdateMappingRequest& WMCreateOrUpdateMappingRequest::operator=(const WMCreateOrUpdateMappingRequest& other1365) {
+  mapping = other1365.mapping;
+  update = other1365.update;
+  __isset = other1365.__isset;
   return *this;
 }
 void WMCreateOrUpdateMappingRequest::printTo(std::ostream& out) const {
@@ -37969,11 +38017,11 @@ void swap(WMCreateOrUpdateMappingResponse &a, WMCreateOrUpdateMappingResponse &b
   (void) b;
 }
 
-WMCreateOrUpdateMappingResponse::WMCreateOrUpdateMappingResponse(const WMCreateOrUpdateMappingResponse& other1364) {
-  (void) other1364;
+WMCreateOrUpdateMappingResponse::WMCreateOrUpdateMappingResponse(const WMCreateOrUpdateMappingResponse& other1366) {
+  (void) other1366;
 }
-WMCreateOrUpdateMappingResponse& WMCreateOrUpdateMappingResponse::operator=(const WMCreateOrUpdateMappingResponse& other1365) {
-  (void) other1365;
+WMCreateOrUpdateMappingResponse& WMCreateOrUpdateMappingResponse::operator=(const WMCreateOrUpdateMappingResponse& other1367) {
+  (void) other1367;
   return *this;
 }
 void WMCreateOrUpdateMappingResponse::printTo(std::ostream& out) const {
@@ -38060,13 +38108,13 @@ void swap(WMDropMappingRequest &a, WMDropMappingRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-WMDropMappingRequest::WMDropMappingRequest(const WMDropMappingRequest& other1366) {
-  mapping = other1366.mapping;
-  __isset = other1366.__isset;
+WMDropMappingRequest::WMDropMappingRequest(const WMDropMappingRequest& other1368) {
+  mapping = other1368.mapping;
+  __isset = other1368.__isset;
 }
-WMDropMappingRequest& WMDropMappingRequest::operator=(const WMDropMappingRequest& other1367) {
-  mapping = other1367.mapping;
-  __isset = other1367.__isset;
+WMDropMappingRequest& WMDropMappingRequest::operator=(const WMDropMappingRequest& other1369) {
+  mapping = other1369.mapping;
+  __isset = other1369.__isset;
   return *this;
 }
 void WMDropMappingRequest::printTo(std::ostream& out) const {
@@ -38131,11 +38179,11 @@ void swap(WMDropMappingResponse &a, WMDropMappingResponse &b) {
   (void) b;
 }
 
-WMDropMappingResponse::WMDropMappingResponse(const WMDropMappingResponse& other1368) {
-  (void) other1368;
+WMDropMappingResponse::WMDropMappingResponse(const WMDropMappingResponse& other1370) {
+  (void) other1370;
 }
-WMDropMappingResponse& WMDropMappingResponse::operator=(const WMDropMappingResponse& other1369) {
-  (void) other1369;
+WMDropMappingResponse& WMDropMappingResponse::operator=(const WMDropMappingResponse& other1371) {
+  (void) other1371;
   return *this;
 }
 void WMDropMappingResponse::printTo(std::ostream& out) const {
@@ -38298,21 +38346,21 @@ void swap(WMCreateOrDropTriggerToPoolMappingRequest &a, WMCreateOrDropTriggerToP
   swap(a.__isset, b.__isset);
 }
 
-WMCreateOrDropTriggerToPoolMappingRequest::WMCreateOrDropTriggerToPoolMappingRequest(const WMCreateOrDropTriggerToPoolMappingRequest& other1370) {
-  resourcePlanName = other1370.resourcePlanName;
-  triggerName = other1370.triggerName;
-  poolPath = other1370.poolPath;
-  drop = other1370.drop;
-  ns = other1370.ns;
-  __isset = other1370.__isset;
+WMCreateOrDropTriggerToPoolMappingRequest::WMCreateOrDropTriggerToPoolMappingRequest(const WMCreateOrDropTriggerToPoolMappingRequest& other1372) {
+  resourcePlanName = other1372.resourcePlanName;
+  triggerName = other1372.triggerName;
+  poolPath = other1372.poolPath;
+  drop = other1372.drop;
+  ns = other1372.ns;
+  __isset = other1372.__isset;
 }
-WMCreateOrDropTriggerToPoolMappingRequest& WMCreateOrDropTriggerToPoolMappingRequest::operator=(const WMCreateOrDropTriggerToPoolMappingRequest& other1371) {
-  resourcePlanName = other1371.resourcePlanName;
-  triggerName = other1371.triggerName;
-  poolPath = other1371.poolPath;
-  drop = other1371.drop;
-  ns = other1371.ns;
-  __isset = other1371.__isset;
+WMCreateOrDropTriggerToPoolMappingRequest& WMCreateOrDropTriggerToPoolMappingRequest::operator=(const WMCreateOrDropTriggerToPoolMappingRequest& other1373) {
+  resourcePlanName = other1373.resourcePlanName;
+  triggerName = other1373.triggerName;
+  poolPath = other1373.poolPath;
+  drop = other1373.drop;
+  ns = other1373.ns;
+  __isset = other1373.__isset;
   return *this;
 }
 void WMCreateOrDropTriggerToPoolMappingRequest::printTo(std::ostream& out) const {
@@ -38381,11 +38429,11 @@ void swap(WMCreateOrDropTriggerToPoolMappingResponse &a, WMCreateOrDropTriggerTo
   (void) b;
 }
 
-WMCreateOrDropTriggerToPoolMappingResponse::WMCreateOrDropTriggerToPoolMappingResponse(const WMCreateOrDropTriggerToPoolMappingResponse& other1372) {
-  (void) other1372;
+WMCreateOrDropTriggerToPoolMappingResponse::WMCreateOrDropTriggerToPoolMappingResponse(const WMCreateOrDropTriggerToPoolMappingResponse& other1374) {
+  (void) other1374;
 }
-WMCreateOrDropTriggerToPoolMappingResponse& WMCreateOrDropTriggerToPoolMappingResponse::operator=(const WMCreateOrDropTriggerToPoolMappingResponse& other1373) {
-  (void) other1373;
+WMCreateOrDropTriggerToPoolMappingResponse& WMCreateOrDropTriggerToPoolMappingResponse::operator=(const WMCreateOrDropTriggerToPoolMappingResponse& other1375) {
+  (void) other1375;
   return *this;
 }
 void WMCreateOrDropTriggerToPoolMappingResponse::printTo(std::ostream& out) const {
@@ -38466,9 +38514,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1374;
-          xfer += iprot->readI32(ecast1374);
-          this->schemaType = (SchemaType::type)ecast1374;
+          int32_t ecast1376;
+          xfer += iprot->readI32(ecast1376);
+          this->schemaType = (SchemaType::type)ecast1376;
           this->__isset.schemaType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -38500,9 +38548,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1375;
-          xfer += iprot->readI32(ecast1375);
-          this->compatibility = (SchemaCompatibility::type)ecast1375;
+          int32_t ecast1377;
+          xfer += iprot->readI32(ecast1377);
+          this->compatibility = (SchemaCompatibility::type)ecast1377;
           this->__isset.compatibility = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -38510,9 +38558,9 @@ uint32_t ISchema::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 6:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1376;
-          xfer += iprot->readI32(ecast1376);
-          this->validationLevel = (SchemaValidation::type)ecast1376;
+          int32_t ecast1378;
+          xfer += iprot->readI32(ecast1378);
+          this->validationLevel = (SchemaValidation::type)ecast1378;
           this->__isset.validationLevel = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -38616,29 +38664,29 @@ void swap(ISchema &a, ISchema &b) {
   swap(a.__isset, b.__isset);
 }
 
-ISchema::ISchema(const ISchema& other1377) {
-  schemaType = other1377.schemaType;
-  name = other1377.name;
-  catName = other1377.catName;
-  dbName = other1377.dbName;
-  compatibility = other1377.compatibility;
-  validationLevel = other1377.validationLevel;
-  canEvolve = other1377.canEvolve;
-  schemaGroup = other1377.schemaGroup;
-  description = other1377.description;
-  __isset = other1377.__isset;
+ISchema::ISchema(const ISchema& other1379) {
+  schemaType = other1379.schemaType;
+  name = other1379.name;
+  catName = other1379.catName;
+  dbName = other1379.dbName;
+  compatibility = other1379.compatibility;
+  validationLevel = other1379.validationLevel;
+  canEvolve = other1379.canEvolve;
+  schemaGroup = other1379.schemaGroup;
+  description = other1379.description;
+  __isset = other1379.__isset;
 }
-ISchema& ISchema::operator=(const ISchema& other1378) {
-  schemaType = other1378.schemaType;
-  name = other1378.name;
-  catName = other1378.catName;
-  dbName = other1378.dbName;
-  compatibility = other1378.compatibility;
-  validationLevel = other1378.validationLevel;
-  canEvolve = other1378.canEvolve;
-  schemaGroup = other1378.schemaGroup;
-  description = other1378.description;
-  __isset = other1378.__isset;
+ISchema& ISchema::operator=(const ISchema& other1380) {
+  schemaType = other1380.schemaType;
+  name = other1380.name;
+  catName = other1380.catName;
+  dbName = other1380.dbName;
+  compatibility = other1380.compatibility;
+  validationLevel = other1380.validationLevel;
+  canEvolve = other1380.canEvolve;
+  schemaGroup = other1380.schemaGroup;
+  description = other1380.description;
+  __isset = other1380.__isset;
   return *this;
 }
 void ISchema::printTo(std::ostream& out) const {
@@ -38766,17 +38814,17 @@ void swap(ISchemaName &a, ISchemaName &b) {
   swap(a.__isset, b.__isset);
 }
 
-ISchemaName::ISchemaName(const ISchemaName& other1379) {
-  catName = other1379.catName;
-  dbName = other1379.dbName;
-  schemaName = other1379.schemaName;
-  __isset = other1379.__isset;
+ISchemaName::ISchemaName(const ISchemaName& other1381) {
+  catName = other1381.catName;
+  dbName = other1381.dbName;
+  schemaName = other1381.schemaName;
+  __isset = other1381.__isset;
 }
-ISchemaName& ISchemaName::operator=(const ISchemaName& other1380) {
-  catName = other1380.catName;
-  dbName = other1380.dbName;
-  schemaName = other1380.schemaName;
-  __isset = other1380.__isset;
+ISchemaName& ISchemaName::operator=(const ISchemaName& other1382) {
+  catName = other1382.catName;
+  dbName = other1382.dbName;
+  schemaName = other1382.schemaName;
+  __isset = other1382.__isset;
   return *this;
 }
 void ISchemaName::printTo(std::ostream& out) const {
@@ -38881,15 +38929,15 @@ void swap(AlterISchemaRequest &a, AlterISchemaRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterISchemaRequest::AlterISchemaRequest(const AlterISchemaRequest& other1381) {
-  name = other1381.name;
-  newSchema = other1381.newSchema;
-  __isset = other1381.__isset;
+AlterISchemaRequest::AlterISchemaRequest(const AlterISchemaRequest& other1383) {
+  name = other1383.name;
+  newSchema = other1383.newSchema;
+  __isset = other1383.__isset;
 }
-AlterISchemaRequest& AlterISchemaRequest::operator=(const AlterISchemaRequest& other1382) {
-  name = other1382.name;
-  newSchema = other1382.newSchema;
-  __isset = other1382.__isset;
+AlterISchemaRequest& AlterISchemaRequest::operator=(const AlterISchemaRequest& other1384) {
+  name = other1384.name;
+  newSchema = other1384.newSchema;
+  __isset = other1384.__isset;
   return *this;
 }
 void AlterISchemaRequest::printTo(std::ostream& out) const {
@@ -39006,14 +39054,14 @@ uint32_t SchemaVersion::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->cols.clear();
-            uint32_t _size1383;
-            ::apache::thrift::protocol::TType _etype1386;
-            xfer += iprot->readListBegin(_etype1386, _size1383);
-            this->cols.resize(_size1383);
-            uint32_t _i1387;
-            for (_i1387 = 0; _i1387 < _size1383; ++_i1387)
+            uint32_t _size1385;
+            ::apache::thrift::protocol::TType _etype1388;
+            xfer += iprot->readListBegin(_etype1388, _size1385);
+            this->cols.resize(_size1385);
+            uint32_t _i1389;
+            for (_i1389 = 0; _i1389 < _size1385; ++_i1389)
             {
-              xfer += this->cols[_i1387].read(iprot);
+              xfer += this->cols[_i1389].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -39024,9 +39072,9 @@ uint32_t SchemaVersion::read(::apache::thrift::protocol::TProtocol* iprot) {
         break;
       case 5:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1388;
-          xfer += iprot->readI32(ecast1388);
-          this->state = (SchemaVersionState::type)ecast1388;
+          int32_t ecast1390;
+          xfer += iprot->readI32(ecast1390);
+          this->state = (SchemaVersionState::type)ecast1390;
           this->__isset.state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -39104,10 +39152,10 @@ uint32_t SchemaVersion::write(::apache::thrift::protocol::TProtocol* oprot) cons
   xfer += oprot->writeFieldBegin("cols", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->cols.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1389;
-    for (_iter1389 = this->cols.begin(); _iter1389 != this->cols.end(); ++_iter1389)
+    std::vector<FieldSchema> ::const_iterator _iter1391;
+    for (_iter1391 = this->cols.begin(); _iter1391 != this->cols.end(); ++_iter1391)
     {
-      xfer += (*_iter1389).write(oprot);
+      xfer += (*_iter1391).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -39163,31 +39211,31 @@ void swap(SchemaVersion &a, SchemaVersion &b) {
   swap(a.__isset, b.__isset);
 }
 
-SchemaVersion::SchemaVersion(const SchemaVersion& other1390) {
-  schema = other1390.schema;
-  version = other1390.version;
-  createdAt = other1390.createdAt;
-  cols = other1390.cols;
-  state = other1390.state;
-  description = other1390.description;
-  schemaText = other1390.schemaText;
-  fingerprint = other1390.fingerprint;
-  name = other1390.name;
-  serDe = other1390.serDe;
-  __isset = other1390.__isset;
+SchemaVersion::SchemaVersion(const SchemaVersion& other1392) {
+  schema = other1392.schema;
+  version = other1392.version;
+  createdAt = other1392.createdAt;
+  cols = other1392.cols;
+  state = other1392.state;
+  description = other1392.description;
+  schemaText = other1392.schemaText;
+  fingerprint = other1392.fingerprint;
+  name = other1392.name;
+  serDe = other1392.serDe;
+  __isset = other1392.__isset;
 }
-SchemaVersion& SchemaVersion::operator=(const SchemaVersion& other1391) {
-  schema = other1391.schema;
-  version = other1391.version;
-  createdAt = other1391.createdAt;
-  cols = other1391.cols;
-  state = other1391.state;
-  description = other1391.description;
-  schemaText = other1391.schemaText;
-  fingerprint = other1391.fingerprint;
-  name = other1391.name;
-  serDe = other1391.serDe;
-  __isset = other1391.__isset;
+SchemaVersion& SchemaVersion::operator=(const SchemaVersion& other1393) {
+  schema = other1393.schema;
+  version = other1393.version;
+  createdAt = other1393.createdAt;
+  cols = other1393.cols;
+  state = other1393.state;
+  description = other1393.description;
+  schemaText = other1393.schemaText;
+  fingerprint = other1393.fingerprint;
+  name = other1393.name;
+  serDe = other1393.serDe;
+  __isset = other1393.__isset;
   return *this;
 }
 void SchemaVersion::printTo(std::ostream& out) const {
@@ -39299,15 +39347,15 @@ void swap(SchemaVersionDescriptor &a, SchemaVersionDescriptor &b) {
   swap(a.__isset, b.__isset);
 }
 
-SchemaVersionDescriptor::SchemaVersionDescriptor(const SchemaVersionDescriptor& other1392) {
-  schema = other1392.schema;
-  version = other1392.version;
-  __isset = other1392.__isset;
+SchemaVersionDescriptor::SchemaVersionDescriptor(const SchemaVersionDescriptor& other1394) {
+  schema = other1394.schema;
+  version = other1394.version;
+  __isset = other1394.__isset;
 }
-SchemaVersionDescriptor& SchemaVersionDescriptor::operator=(const SchemaVersionDescriptor& other1393) {
-  schema = other1393.schema;
-  version = other1393.version;
-  __isset = other1393.__isset;
+SchemaVersionDescriptor& SchemaVersionDescriptor::operator=(const SchemaVersionDescriptor& other1395) {
+  schema = other1395.schema;
+  version = other1395.version;
+  __isset = other1395.__isset;
   return *this;
 }
 void SchemaVersionDescriptor::printTo(std::ostream& out) const {
@@ -39434,17 +39482,17 @@ void swap(FindSchemasByColsRqst &a, FindSchemasByColsRqst &b) {
   swap(a.__isset, b.__isset);
 }
 
-FindSchemasByColsRqst::FindSchemasByColsRqst(const FindSchemasByColsRqst& other1394) {
-  colName = other1394.colName;
-  colNamespace = other1394.colNamespace;
-  type = other1394.type;
-  __isset = other1394.__isset;
+FindSchemasByColsRqst::FindSchemasByColsRqst(const FindSchemasByColsRqst& other1396) {
+  colName = other1396.colName;
+  colNamespace = other1396.colNamespace;
+  type = other1396.type;
+  __isset = other1396.__isset;
 }
-FindSchemasByColsRqst& FindSchemasByColsRqst::operator=(const FindSchemasByColsRqst& other1395) {
-  colName = other1395.colName;
-  colNamespace = other1395.colNamespace;
-  type = other1395.type;
-  __isset = other1395.__isset;
+FindSchemasByColsRqst& FindSchemasByColsRqst::operator=(const FindSchemasByColsRqst& other1397) {
+  colName = other1397.colName;
+  colNamespace = other1397.colNamespace;
+  type = other1397.type;
+  __isset = other1397.__isset;
   return *this;
 }
 void FindSchemasByColsRqst::printTo(std::ostream& out) const {
@@ -39496,14 +39544,14 @@ uint32_t FindSchemasByColsResp::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->schemaVersions.clear();
-            uint32_t _size1396;
-            ::apache::thrift::protocol::TType _etype1399;
-            xfer += iprot->readListBegin(_etype1399, _size1396);
-            this->schemaVersions.resize(_size1396);
-            uint32_t _i1400;
-            for (_i1400 = 0; _i1400 < _size1396; ++_i1400)
+            uint32_t _size1398;
+            ::apache::thrift::protocol::TType _etype1401;
+            xfer += iprot->readListBegin(_etype1401, _size1398);
+            this->schemaVersions.resize(_size1398);
+            uint32_t _i1402;
+            for (_i1402 = 0; _i1402 < _size1398; ++_i1402)
             {
-              xfer += this->schemaVersions[_i1400].read(iprot);
+              xfer += this->schemaVersions[_i1402].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -39532,10 +39580,10 @@ uint32_t FindSchemasByColsResp::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("schemaVersions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->schemaVersions.size()));
-    std::vector<SchemaVersionDescriptor> ::const_iterator _iter1401;
-    for (_iter1401 = this->schemaVersions.begin(); _iter1401 != this->schemaVersions.end(); ++_iter1401)
+    std::vector<SchemaVersionDescriptor> ::const_iterator _iter1403;
+    for (_iter1403 = this->schemaVersions.begin(); _iter1403 != this->schemaVersions.end(); ++_iter1403)
     {
-      xfer += (*_iter1401).write(oprot);
+      xfer += (*_iter1403).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -39552,13 +39600,13 @@ void swap(FindSchemasByColsResp &a, FindSchemasByColsResp &b) {
   swap(a.__isset, b.__isset);
 }
 
-FindSchemasByColsResp::FindSchemasByColsResp(const FindSchemasByColsResp& other1402) {
-  schemaVersions = other1402.schemaVersions;
-  __isset = other1402.__isset;
+FindSchemasByColsResp::FindSchemasByColsResp(const FindSchemasByColsResp& other1404) {
+  schemaVersions = other1404.schemaVersions;
+  __isset = other1404.__isset;
 }
-FindSchemasByColsResp& FindSchemasByColsResp::operator=(const FindSchemasByColsResp& other1403) {
-  schemaVersions = other1403.schemaVersions;
-  __isset = other1403.__isset;
+FindSchemasByColsResp& FindSchemasByColsResp::operator=(const FindSchemasByColsResp& other1405) {
+  schemaVersions = other1405.schemaVersions;
+  __isset = other1405.__isset;
   return *this;
 }
 void FindSchemasByColsResp::printTo(std::ostream& out) const {
@@ -39661,15 +39709,15 @@ void swap(MapSchemaVersionToSerdeRequest &a, MapSchemaVersionToSerdeRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-MapSchemaVersionToSerdeRequest::MapSchemaVersionToSerdeRequest(const MapSchemaVersionToSerdeRequest& other1404) {
-  schemaVersion = other1404.schemaVersion;
-  serdeName = other1404.serdeName;
-  __isset = other1404.__isset;
+MapSchemaVersionToSerdeRequest::MapSchemaVersionToSerdeRequest(const MapSchemaVersionToSerdeRequest& other1406) {
+  schemaVersion = other1406.schemaVersion;
+  serdeName = other1406.serdeName;
+  __isset = other1406.__isset;
 }
-MapSchemaVersionToSerdeRequest& MapSchemaVersionToSerdeRequest::operator=(const MapSchemaVersionToSerdeRequest& other1405) {
-  schemaVersion = other1405.schemaVersion;
-  serdeName = other1405.serdeName;
-  __isset = other1405.__isset;
+MapSchemaVersionToSerdeRequest& MapSchemaVersionToSerdeRequest::operator=(const MapSchemaVersionToSerdeRequest& other1407) {
+  schemaVersion = other1407.schemaVersion;
+  serdeName = other1407.serdeName;
+  __isset = other1407.__isset;
   return *this;
 }
 void MapSchemaVersionToSerdeRequest::printTo(std::ostream& out) const {
@@ -39730,9 +39778,9 @@ uint32_t SetSchemaVersionStateRequest::read(::apache::thrift::protocol::TProtoco
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1406;
-          xfer += iprot->readI32(ecast1406);
-          this->state = (SchemaVersionState::type)ecast1406;
+          int32_t ecast1408;
+          xfer += iprot->readI32(ecast1408);
+          this->state = (SchemaVersionState::type)ecast1408;
           this->__isset.state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -39775,15 +39823,15 @@ void swap(SetSchemaVersionStateRequest &a, SetSchemaVersionStateRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-SetSchemaVersionStateRequest::SetSchemaVersionStateRequest(const SetSchemaVersionStateRequest& other1407) {
-  schemaVersion = other1407.schemaVersion;
-  state = other1407.state;
-  __isset = other1407.__isset;
+SetSchemaVersionStateRequest::SetSchemaVersionStateRequest(const SetSchemaVersionStateRequest& other1409) {
+  schemaVersion = other1409.schemaVersion;
+  state = other1409.state;
+  __isset = other1409.__isset;
 }
-SetSchemaVersionStateRequest& SetSchemaVersionStateRequest::operator=(const SetSchemaVersionStateRequest& other1408) {
-  schemaVersion = other1408.schemaVersion;
-  state = other1408.state;
-  __isset = other1408.__isset;
+SetSchemaVersionStateRequest& SetSchemaVersionStateRequest::operator=(const SetSchemaVersionStateRequest& other1410) {
+  schemaVersion = other1410.schemaVersion;
+  state = other1410.state;
+  __isset = other1410.__isset;
   return *this;
 }
 void SetSchemaVersionStateRequest::printTo(std::ostream& out) const {
@@ -39870,13 +39918,13 @@ void swap(GetSerdeRequest &a, GetSerdeRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetSerdeRequest::GetSerdeRequest(const GetSerdeRequest& other1409) {
-  serdeName = other1409.serdeName;
-  __isset = other1409.__isset;
+GetSerdeRequest::GetSerdeRequest(const GetSerdeRequest& other1411) {
+  serdeName = other1411.serdeName;
+  __isset = other1411.__isset;
 }
-GetSerdeRequest& GetSerdeRequest::operator=(const GetSerdeRequest& other1410) {
-  serdeName = other1410.serdeName;
-  __isset = other1410.__isset;
+GetSerdeRequest& GetSerdeRequest::operator=(const GetSerdeRequest& other1412) {
+  serdeName = other1412.serdeName;
+  __isset = other1412.__isset;
   return *this;
 }
 void GetSerdeRequest::printTo(std::ostream& out) const {
@@ -40004,17 +40052,17 @@ void swap(RuntimeStat &a, RuntimeStat &b) {
   swap(a.__isset, b.__isset);
 }
 
-RuntimeStat::RuntimeStat(const RuntimeStat& other1411) {
-  createTime = other1411.createTime;
-  weight = other1411.weight;
-  payload = other1411.payload;
-  __isset = other1411.__isset;
+RuntimeStat::RuntimeStat(const RuntimeStat& other1413) {
+  createTime = other1413.createTime;
+  weight = other1413.weight;
+  payload = other1413.payload;
+  __isset = other1413.__isset;
 }
-RuntimeStat& RuntimeStat::operator=(const RuntimeStat& other1412) {
-  createTime = other1412.createTime;
-  weight = other1412.weight;
-  payload = other1412.payload;
-  __isset = other1412.__isset;
+RuntimeStat& RuntimeStat::operator=(const RuntimeStat& other1414) {
+  createTime = other1414.createTime;
+  weight = other1414.weight;
+  payload = other1414.payload;
+  __isset = other1414.__isset;
   return *this;
 }
 void RuntimeStat::printTo(std::ostream& out) const {
@@ -40124,13 +40172,13 @@ void swap(GetRuntimeStatsRequest &a, GetRuntimeStatsRequest &b) {
   swap(a.maxCreateTime, b.maxCreateTime);
 }
 
-GetRuntimeStatsRequest::GetRuntimeStatsRequest(const GetRuntimeStatsRequest& other1413) {
-  maxWeight = other1413.maxWeight;
-  maxCreateTime = other1413.maxCreateTime;
+GetRuntimeStatsRequest::GetRuntimeStatsRequest(const GetRuntimeStatsRequest& other1415) {
+  maxWeight = other1415.maxWeight;
+  maxCreateTime = other1415.maxCreateTime;
 }
-GetRuntimeStatsRequest& GetRuntimeStatsRequest::operator=(const GetRuntimeStatsRequest& other1414) {
-  maxWeight = other1414.maxWeight;
-  maxCreateTime = other1414.maxCreateTime;
+GetRuntimeStatsRequest& GetRuntimeStatsRequest::operator=(const GetRuntimeStatsRequest& other1416) {
+  maxWeight = other1416.maxWeight;
+  maxCreateTime = other1416.maxCreateTime;
   return *this;
 }
 void GetRuntimeStatsRequest::printTo(std::ostream& out) const {
@@ -40243,14 +40291,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->primaryKeys.clear();
-            uint32_t _size1415;
-            ::apache::thrift::protocol::TType _etype1418;
-            xfer += iprot->readListBegin(_etype1418, _size1415);
-            this->primaryKeys.resize(_size1415);
-            uint32_t _i1419;
-            for (_i1419 = 0; _i1419 < _size1415; ++_i1419)
+            uint32_t _size1417;
+            ::apache::thrift::protocol::TType _etype1420;
+            xfer += iprot->readListBegin(_etype1420, _size1417);
+            this->primaryKeys.resize(_size1417);
+            uint32_t _i1421;
+            for (_i1421 = 0; _i1421 < _size1417; ++_i1421)
             {
-              xfer += this->primaryKeys[_i1419].read(iprot);
+              xfer += this->primaryKeys[_i1421].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40263,14 +40311,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->foreignKeys.clear();
-            uint32_t _size1420;
-            ::apache::thrift::protocol::TType _etype1423;
-            xfer += iprot->readListBegin(_etype1423, _size1420);
-            this->foreignKeys.resize(_size1420);
-            uint32_t _i1424;
-            for (_i1424 = 0; _i1424 < _size1420; ++_i1424)
+            uint32_t _size1422;
+            ::apache::thrift::protocol::TType _etype1425;
+            xfer += iprot->readListBegin(_etype1425, _size1422);
+            this->foreignKeys.resize(_size1422);
+            uint32_t _i1426;
+            for (_i1426 = 0; _i1426 < _size1422; ++_i1426)
             {
-              xfer += this->foreignKeys[_i1424].read(iprot);
+              xfer += this->foreignKeys[_i1426].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40283,14 +40331,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->uniqueConstraints.clear();
-            uint32_t _size1425;
-            ::apache::thrift::protocol::TType _etype1428;
-            xfer += iprot->readListBegin(_etype1428, _size1425);
-            this->uniqueConstraints.resize(_size1425);
-            uint32_t _i1429;
-            for (_i1429 = 0; _i1429 < _size1425; ++_i1429)
+            uint32_t _size1427;
+            ::apache::thrift::protocol::TType _etype1430;
+            xfer += iprot->readListBegin(_etype1430, _size1427);
+            this->uniqueConstraints.resize(_size1427);
+            uint32_t _i1431;
+            for (_i1431 = 0; _i1431 < _size1427; ++_i1431)
             {
-              xfer += this->uniqueConstraints[_i1429].read(iprot);
+              xfer += this->uniqueConstraints[_i1431].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40303,14 +40351,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->notNullConstraints.clear();
-            uint32_t _size1430;
-            ::apache::thrift::protocol::TType _etype1433;
-            xfer += iprot->readListBegin(_etype1433, _size1430);
-            this->notNullConstraints.resize(_size1430);
-            uint32_t _i1434;
-            for (_i1434 = 0; _i1434 < _size1430; ++_i1434)
+            uint32_t _size1432;
+            ::apache::thrift::protocol::TType _etype1435;
+            xfer += iprot->readListBegin(_etype1435, _size1432);
+            this->notNullConstraints.resize(_size1432);
+            uint32_t _i1436;
+            for (_i1436 = 0; _i1436 < _size1432; ++_i1436)
             {
-              xfer += this->notNullConstraints[_i1434].read(iprot);
+              xfer += this->notNullConstraints[_i1436].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40323,14 +40371,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->defaultConstraints.clear();
-            uint32_t _size1435;
-            ::apache::thrift::protocol::TType _etype1438;
-            xfer += iprot->readListBegin(_etype1438, _size1435);
-            this->defaultConstraints.resize(_size1435);
-            uint32_t _i1439;
-            for (_i1439 = 0; _i1439 < _size1435; ++_i1439)
+            uint32_t _size1437;
+            ::apache::thrift::protocol::TType _etype1440;
+            xfer += iprot->readListBegin(_etype1440, _size1437);
+            this->defaultConstraints.resize(_size1437);
+            uint32_t _i1441;
+            for (_i1441 = 0; _i1441 < _size1437; ++_i1441)
             {
-              xfer += this->defaultConstraints[_i1439].read(iprot);
+              xfer += this->defaultConstraints[_i1441].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40343,14 +40391,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->checkConstraints.clear();
-            uint32_t _size1440;
-            ::apache::thrift::protocol::TType _etype1443;
-            xfer += iprot->readListBegin(_etype1443, _size1440);
-            this->checkConstraints.resize(_size1440);
-            uint32_t _i1444;
-            for (_i1444 = 0; _i1444 < _size1440; ++_i1444)
+            uint32_t _size1442;
+            ::apache::thrift::protocol::TType _etype1445;
+            xfer += iprot->readListBegin(_etype1445, _size1442);
+            this->checkConstraints.resize(_size1442);
+            uint32_t _i1446;
+            for (_i1446 = 0; _i1446 < _size1442; ++_i1446)
             {
-              xfer += this->checkConstraints[_i1444].read(iprot);
+              xfer += this->checkConstraints[_i1446].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -40363,14 +40411,14 @@ uint32_t CreateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1445;
-            ::apache::thrift::protocol::TType _etype1448;
-            xfer += iprot->readListBegin(_etype1448, _size1445);
-            this->processorCapabilities.resize(_size1445);
-            uint32_t _i1449;
-            for (_i1449 = 0; _i1449 < _size1445; ++_i1449)
+            uint32_t _size1447;
+            ::apache::thrift::protocol::TType _etype1450;
+            xfer += iprot->readListBegin(_etype1450, _size1447);
+            this->processorCapabilities.resize(_size1447);
+            uint32_t _i1451;
+            for (_i1451 = 0; _i1451 < _size1447; ++_i1451)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1449]);
+              xfer += iprot->readString(this->processorCapabilities[_i1451]);
             }
             xfer += iprot->readListEnd();
           }
@@ -40419,10 +40467,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("primaryKeys", ::apache::thrift::protocol::T_LIST, 3);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->primaryKeys.size()));
-      std::vector<SQLPrimaryKey> ::const_iterator _iter1450;
-      for (_iter1450 = this->primaryKeys.begin(); _iter1450 != this->primaryKeys.end(); ++_iter1450)
+      std::vector<SQLPrimaryKey> ::const_iterator _iter1452;
+      for (_iter1452 = this->primaryKeys.begin(); _iter1452 != this->primaryKeys.end(); ++_iter1452)
       {
-        xfer += (*_iter1450).write(oprot);
+        xfer += (*_iter1452).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40432,10 +40480,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("foreignKeys", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->foreignKeys.size()));
-      std::vector<SQLForeignKey> ::const_iterator _iter1451;
-      for (_iter1451 = this->foreignKeys.begin(); _iter1451 != this->foreignKeys.end(); ++_iter1451)
+      std::vector<SQLForeignKey> ::const_iterator _iter1453;
+      for (_iter1453 = this->foreignKeys.begin(); _iter1453 != this->foreignKeys.end(); ++_iter1453)
       {
-        xfer += (*_iter1451).write(oprot);
+        xfer += (*_iter1453).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40445,10 +40493,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("uniqueConstraints", ::apache::thrift::protocol::T_LIST, 5);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->uniqueConstraints.size()));
-      std::vector<SQLUniqueConstraint> ::const_iterator _iter1452;
-      for (_iter1452 = this->uniqueConstraints.begin(); _iter1452 != this->uniqueConstraints.end(); ++_iter1452)
+      std::vector<SQLUniqueConstraint> ::const_iterator _iter1454;
+      for (_iter1454 = this->uniqueConstraints.begin(); _iter1454 != this->uniqueConstraints.end(); ++_iter1454)
       {
-        xfer += (*_iter1452).write(oprot);
+        xfer += (*_iter1454).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40458,10 +40506,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("notNullConstraints", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->notNullConstraints.size()));
-      std::vector<SQLNotNullConstraint> ::const_iterator _iter1453;
-      for (_iter1453 = this->notNullConstraints.begin(); _iter1453 != this->notNullConstraints.end(); ++_iter1453)
+      std::vector<SQLNotNullConstraint> ::const_iterator _iter1455;
+      for (_iter1455 = this->notNullConstraints.begin(); _iter1455 != this->notNullConstraints.end(); ++_iter1455)
       {
-        xfer += (*_iter1453).write(oprot);
+        xfer += (*_iter1455).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40471,10 +40519,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("defaultConstraints", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->defaultConstraints.size()));
-      std::vector<SQLDefaultConstraint> ::const_iterator _iter1454;
-      for (_iter1454 = this->defaultConstraints.begin(); _iter1454 != this->defaultConstraints.end(); ++_iter1454)
+      std::vector<SQLDefaultConstraint> ::const_iterator _iter1456;
+      for (_iter1456 = this->defaultConstraints.begin(); _iter1456 != this->defaultConstraints.end(); ++_iter1456)
       {
-        xfer += (*_iter1454).write(oprot);
+        xfer += (*_iter1456).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40484,10 +40532,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("checkConstraints", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->checkConstraints.size()));
-      std::vector<SQLCheckConstraint> ::const_iterator _iter1455;
-      for (_iter1455 = this->checkConstraints.begin(); _iter1455 != this->checkConstraints.end(); ++_iter1455)
+      std::vector<SQLCheckConstraint> ::const_iterator _iter1457;
+      for (_iter1457 = this->checkConstraints.begin(); _iter1457 != this->checkConstraints.end(); ++_iter1457)
       {
-        xfer += (*_iter1455).write(oprot);
+        xfer += (*_iter1457).write(oprot);
       }
       xfer += oprot->writeListEnd();
     }
@@ -40497,10 +40545,10 @@ uint32_t CreateTableRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 9);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1456;
-      for (_iter1456 = this->processorCapabilities.begin(); _iter1456 != this->processorCapabilities.end(); ++_iter1456)
+      std::vector<std::string> ::const_iterator _iter1458;
+      for (_iter1458 = this->processorCapabilities.begin(); _iter1458 != this->processorCapabilities.end(); ++_iter1458)
       {
-        xfer += oprot->writeString((*_iter1456));
+        xfer += oprot->writeString((*_iter1458));
       }
       xfer += oprot->writeListEnd();
     }
@@ -40531,31 +40579,31 @@ void swap(CreateTableRequest &a, CreateTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateTableRequest::CreateTableRequest(const CreateTableRequest& other1457) {
-  table = other1457.table;
-  envContext = other1457.envContext;
-  primaryKeys = other1457.primaryKeys;
-  foreignKeys = other1457.foreignKeys;
-  uniqueConstraints = other1457.uniqueConstraints;
-  notNullConstraints = other1457.notNullConstraints;
-  defaultConstraints = other1457.defaultConstraints;
-  checkConstraints = other1457.checkConstraints;
-  processorCapabilities = other1457.processorCapabilities;
-  processorIdentifier = other1457.processorIdentifier;
-  __isset = other1457.__isset;
+CreateTableRequest::CreateTableRequest(const CreateTableRequest& other1459) {
+  table = other1459.table;
+  envContext = other1459.envContext;
+  primaryKeys = other1459.primaryKeys;
+  foreignKeys = other1459.foreignKeys;
+  uniqueConstraints = other1459.uniqueConstraints;
+  notNullConstraints = other1459.notNullConstraints;
+  defaultConstraints = other1459.defaultConstraints;
+  checkConstraints = other1459.checkConstraints;
+  processorCapabilities = other1459.processorCapabilities;
+  processorIdentifier = other1459.processorIdentifier;
+  __isset = other1459.__isset;
 }
-CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other1458) {
-  table = other1458.table;
-  envContext = other1458.envContext;
-  primaryKeys = other1458.primaryKeys;
-  foreignKeys = other1458.foreignKeys;
-  uniqueConstraints = other1458.uniqueConstraints;
-  notNullConstraints = other1458.notNullConstraints;
-  defaultConstraints = other1458.defaultConstraints;
-  checkConstraints = other1458.checkConstraints;
-  processorCapabilities = other1458.processorCapabilities;
-  processorIdentifier = other1458.processorIdentifier;
-  __isset = other1458.__isset;
+CreateTableRequest& CreateTableRequest::operator=(const CreateTableRequest& other1460) {
+  table = other1460.table;
+  envContext = other1460.envContext;
+  primaryKeys = other1460.primaryKeys;
+  foreignKeys = other1460.foreignKeys;
+  uniqueConstraints = other1460.uniqueConstraints;
+  notNullConstraints = other1460.notNullConstraints;
+  defaultConstraints = other1460.defaultConstraints;
+  checkConstraints = other1460.checkConstraints;
+  processorCapabilities = other1460.processorCapabilities;
+  processorIdentifier = other1460.processorIdentifier;
+  __isset = other1460.__isset;
   return *this;
 }
 void CreateTableRequest::printTo(std::ostream& out) const {
@@ -40694,17 +40742,17 @@ uint32_t CreateDatabaseRequest::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_MAP) {
           {
             this->parameters.clear();
-            uint32_t _size1459;
-            ::apache::thrift::protocol::TType _ktype1460;
-            ::apache::thrift::protocol::TType _vtype1461;
-            xfer += iprot->readMapBegin(_ktype1460, _vtype1461, _size1459);
-            uint32_t _i1463;
-            for (_i1463 = 0; _i1463 < _size1459; ++_i1463)
+            uint32_t _size1461;
+            ::apache::thrift::protocol::TType _ktype1462;
+            ::apache::thrift::protocol::TType _vtype1463;
+            xfer += iprot->readMapBegin(_ktype1462, _vtype1463, _size1461);
+            uint32_t _i1465;
+            for (_i1465 = 0; _i1465 < _size1461; ++_i1465)
             {
-              std::string _key1464;
-              xfer += iprot->readString(_key1464);
-              std::string& _val1465 = this->parameters[_key1464];
-              xfer += iprot->readString(_val1465);
+              std::string _key1466;
+              xfer += iprot->readString(_key1466);
+              std::string& _val1467 = this->parameters[_key1466];
+              xfer += iprot->readString(_val1467);
             }
             xfer += iprot->readMapEnd();
           }
@@ -40731,9 +40779,9 @@ uint32_t CreateDatabaseRequest::read(::apache::thrift::protocol::TProtocol* ipro
         break;
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1466;
-          xfer += iprot->readI32(ecast1466);
-          this->ownerType = (PrincipalType::type)ecast1466;
+          int32_t ecast1468;
+          xfer += iprot->readI32(ecast1468);
+          this->ownerType = (PrincipalType::type)ecast1468;
           this->__isset.ownerType = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -40816,11 +40864,11 @@ uint32_t CreateDatabaseRequest::write(::apache::thrift::protocol::TProtocol* opr
     xfer += oprot->writeFieldBegin("parameters", ::apache::thrift::protocol::T_MAP, 4);
     {
       xfer += oprot->writeMapBegin(::apache::thrift::protocol::T_STRING, ::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->parameters.size()));
-      std::map<std::string, std::string> ::const_iterator _iter1467;
-      for (_iter1467 = this->parameters.begin(); _iter1467 != this->parameters.end(); ++_iter1467)
+      std::map<std::string, std::string> ::const_iterator _iter1469;
+      for (_iter1469 = this->parameters.begin(); _iter1469 != this->parameters.end(); ++_iter1469)
       {
-        xfer += oprot->writeString(_iter1467->first);
-        xfer += oprot->writeString(_iter1467->second);
+        xfer += oprot->writeString(_iter1469->first);
+        xfer += oprot->writeString(_iter1469->second);
       }
       xfer += oprot->writeMapEnd();
     }
@@ -40888,35 +40936,35 @@ void swap(CreateDatabaseRequest &a, CreateDatabaseRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other1468) {
-  databaseName = other1468.databaseName;
-  description = other1468.description;
-  locationUri = other1468.locationUri;
-  parameters = other1468.parameters;
-  privileges = other1468.privileges;
-  ownerName = other1468.ownerName;
-  ownerType = other1468.ownerType;
-  catalogName = other1468.catalogName;
-  createTime = other1468.createTime;
-  managedLocationUri = other1468.managedLocationUri;
-  type = other1468.type;
-  dataConnectorName = other1468.dataConnectorName;
-  __isset = other1468.__isset;
+CreateDatabaseRequest::CreateDatabaseRequest(const CreateDatabaseRequest& other1470) {
+  databaseName = other1470.databaseName;
+  description = other1470.description;
+  locationUri = other1470.locationUri;
+  parameters = other1470.parameters;
+  privileges = other1470.privileges;
+  ownerName = other1470.ownerName;
+  ownerType = other1470.ownerType;
+  catalogName = other1470.catalogName;
+  createTime = other1470.createTime;
+  managedLocationUri = other1470.managedLocationUri;
+  type = other1470.type;
+  dataConnectorName = other1470.dataConnectorName;
+  __isset = other1470.__isset;
 }
-CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other1469) {
-  databaseName = other1469.databaseName;
-  description = other1469.description;
-  locationUri = other1469.locationUri;
-  parameters = other1469.parameters;
-  privileges = other1469.privileges;
-  ownerName = other1469.ownerName;
-  ownerType = other1469.ownerType;
-  catalogName = other1469.catalogName;
-  createTime = other1469.createTime;
-  managedLocationUri = other1469.managedLocationUri;
-  type = other1469.type;
-  dataConnectorName = other1469.dataConnectorName;
-  __isset = other1469.__isset;
+CreateDatabaseRequest& CreateDatabaseRequest::operator=(const CreateDatabaseRequest& other1471) {
+  databaseName = other1471.databaseName;
+  description = other1471.description;
+  locationUri = other1471.locationUri;
+  parameters = other1471.parameters;
+  privileges = other1471.privileges;
+  ownerName = other1471.ownerName;
+  ownerType = other1471.ownerType;
+  catalogName = other1471.catalogName;
+  createTime = other1471.createTime;
+  managedLocationUri = other1471.managedLocationUri;
+  type = other1471.type;
+  dataConnectorName = other1471.dataConnectorName;
+  __isset = other1471.__isset;
   return *this;
 }
 void CreateDatabaseRequest::printTo(std::ostream& out) const {
@@ -41013,13 +41061,13 @@ void swap(CreateDataConnectorRequest &a, CreateDataConnectorRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-CreateDataConnectorRequest::CreateDataConnectorRequest(const CreateDataConnectorRequest& other1470) {
-  connector = other1470.connector;
-  __isset = other1470.__isset;
+CreateDataConnectorRequest::CreateDataConnectorRequest(const CreateDataConnectorRequest& other1472) {
+  connector = other1472.connector;
+  __isset = other1472.__isset;
 }
-CreateDataConnectorRequest& CreateDataConnectorRequest::operator=(const CreateDataConnectorRequest& other1471) {
-  connector = other1471.connector;
-  __isset = other1471.__isset;
+CreateDataConnectorRequest& CreateDataConnectorRequest::operator=(const CreateDataConnectorRequest& other1473) {
+  connector = other1473.connector;
+  __isset = other1473.__isset;
   return *this;
 }
 void CreateDataConnectorRequest::printTo(std::ostream& out) const {
@@ -41107,11 +41155,11 @@ void swap(GetDataConnectorRequest &a, GetDataConnectorRequest &b) {
   swap(a.connectorName, b.connectorName);
 }
 
-GetDataConnectorRequest::GetDataConnectorRequest(const GetDataConnectorRequest& other1472) {
-  connectorName = other1472.connectorName;
+GetDataConnectorRequest::GetDataConnectorRequest(const GetDataConnectorRequest& other1474) {
+  connectorName = other1474.connectorName;
 }
-GetDataConnectorRequest& GetDataConnectorRequest::operator=(const GetDataConnectorRequest& other1473) {
-  connectorName = other1473.connectorName;
+GetDataConnectorRequest& GetDataConnectorRequest::operator=(const GetDataConnectorRequest& other1475) {
+  connectorName = other1475.connectorName;
   return *this;
 }
 void GetDataConnectorRequest::printTo(std::ostream& out) const {
@@ -41199,11 +41247,11 @@ void swap(ScheduledQueryPollRequest &a, ScheduledQueryPollRequest &b) {
   swap(a.clusterNamespace, b.clusterNamespace);
 }
 
-ScheduledQueryPollRequest::ScheduledQueryPollRequest(const ScheduledQueryPollRequest& other1474) {
-  clusterNamespace = other1474.clusterNamespace;
+ScheduledQueryPollRequest::ScheduledQueryPollRequest(const ScheduledQueryPollRequest& other1476) {
+  clusterNamespace = other1476.clusterNamespace;
 }
-ScheduledQueryPollRequest& ScheduledQueryPollRequest::operator=(const ScheduledQueryPollRequest& other1475) {
-  clusterNamespace = other1475.clusterNamespace;
+ScheduledQueryPollRequest& ScheduledQueryPollRequest::operator=(const ScheduledQueryPollRequest& other1477) {
+  clusterNamespace = other1477.clusterNamespace;
   return *this;
 }
 void ScheduledQueryPollRequest::printTo(std::ostream& out) const {
@@ -41311,13 +41359,13 @@ void swap(ScheduledQueryKey &a, ScheduledQueryKey &b) {
   swap(a.clusterNamespace, b.clusterNamespace);
 }
 
-ScheduledQueryKey::ScheduledQueryKey(const ScheduledQueryKey& other1476) {
-  scheduleName = other1476.scheduleName;
-  clusterNamespace = other1476.clusterNamespace;
+ScheduledQueryKey::ScheduledQueryKey(const ScheduledQueryKey& other1478) {
+  scheduleName = other1478.scheduleName;
+  clusterNamespace = other1478.clusterNamespace;
 }
-ScheduledQueryKey& ScheduledQueryKey::operator=(const ScheduledQueryKey& other1477) {
-  scheduleName = other1477.scheduleName;
-  clusterNamespace = other1477.clusterNamespace;
+ScheduledQueryKey& ScheduledQueryKey::operator=(const ScheduledQueryKey& other1479) {
+  scheduleName = other1479.scheduleName;
+  clusterNamespace = other1479.clusterNamespace;
   return *this;
 }
 void ScheduledQueryKey::printTo(std::ostream& out) const {
@@ -41463,19 +41511,19 @@ void swap(ScheduledQueryPollResponse &a, ScheduledQueryPollResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQueryPollResponse::ScheduledQueryPollResponse(const ScheduledQueryPollResponse& other1478) {
-  scheduleKey = other1478.scheduleKey;
-  executionId = other1478.executionId;
-  query = other1478.query;
-  user = other1478.user;
-  __isset = other1478.__isset;
+ScheduledQueryPollResponse::ScheduledQueryPollResponse(const ScheduledQueryPollResponse& other1480) {
+  scheduleKey = other1480.scheduleKey;
+  executionId = other1480.executionId;
+  query = other1480.query;
+  user = other1480.user;
+  __isset = other1480.__isset;
 }
-ScheduledQueryPollResponse& ScheduledQueryPollResponse::operator=(const ScheduledQueryPollResponse& other1479) {
-  scheduleKey = other1479.scheduleKey;
-  executionId = other1479.executionId;
-  query = other1479.query;
-  user = other1479.user;
-  __isset = other1479.__isset;
+ScheduledQueryPollResponse& ScheduledQueryPollResponse::operator=(const ScheduledQueryPollResponse& other1481) {
+  scheduleKey = other1481.scheduleKey;
+  executionId = other1481.executionId;
+  query = other1481.query;
+  user = other1481.user;
+  __isset = other1481.__isset;
   return *this;
 }
 void ScheduledQueryPollResponse::printTo(std::ostream& out) const {
@@ -41662,23 +41710,23 @@ void swap(ScheduledQuery &a, ScheduledQuery &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQuery::ScheduledQuery(const ScheduledQuery& other1480) {
-  scheduleKey = other1480.scheduleKey;
-  enabled = other1480.enabled;
-  schedule = other1480.schedule;
-  user = other1480.user;
-  query = other1480.query;
-  nextExecution = other1480.nextExecution;
-  __isset = other1480.__isset;
+ScheduledQuery::ScheduledQuery(const ScheduledQuery& other1482) {
+  scheduleKey = other1482.scheduleKey;
+  enabled = other1482.enabled;
+  schedule = other1482.schedule;
+  user = other1482.user;
+  query = other1482.query;
+  nextExecution = other1482.nextExecution;
+  __isset = other1482.__isset;
 }
-ScheduledQuery& ScheduledQuery::operator=(const ScheduledQuery& other1481) {
-  scheduleKey = other1481.scheduleKey;
-  enabled = other1481.enabled;
-  schedule = other1481.schedule;
-  user = other1481.user;
-  query = other1481.query;
-  nextExecution = other1481.nextExecution;
-  __isset = other1481.__isset;
+ScheduledQuery& ScheduledQuery::operator=(const ScheduledQuery& other1483) {
+  scheduleKey = other1483.scheduleKey;
+  enabled = other1483.enabled;
+  schedule = other1483.schedule;
+  user = other1483.user;
+  query = other1483.query;
+  nextExecution = other1483.nextExecution;
+  __isset = other1483.__isset;
   return *this;
 }
 void ScheduledQuery::printTo(std::ostream& out) const {
@@ -41737,9 +41785,9 @@ uint32_t ScheduledQueryMaintenanceRequest::read(::apache::thrift::protocol::TPro
     {
       case 1:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1482;
-          xfer += iprot->readI32(ecast1482);
-          this->type = (ScheduledQueryMaintenanceRequestType::type)ecast1482;
+          int32_t ecast1484;
+          xfer += iprot->readI32(ecast1484);
+          this->type = (ScheduledQueryMaintenanceRequestType::type)ecast1484;
           isset_type = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -41793,13 +41841,13 @@ void swap(ScheduledQueryMaintenanceRequest &a, ScheduledQueryMaintenanceRequest 
   swap(a.scheduledQuery, b.scheduledQuery);
 }
 
-ScheduledQueryMaintenanceRequest::ScheduledQueryMaintenanceRequest(const ScheduledQueryMaintenanceRequest& other1483) {
-  type = other1483.type;
-  scheduledQuery = other1483.scheduledQuery;
+ScheduledQueryMaintenanceRequest::ScheduledQueryMaintenanceRequest(const ScheduledQueryMaintenanceRequest& other1485) {
+  type = other1485.type;
+  scheduledQuery = other1485.scheduledQuery;
 }
-ScheduledQueryMaintenanceRequest& ScheduledQueryMaintenanceRequest::operator=(const ScheduledQueryMaintenanceRequest& other1484) {
-  type = other1484.type;
-  scheduledQuery = other1484.scheduledQuery;
+ScheduledQueryMaintenanceRequest& ScheduledQueryMaintenanceRequest::operator=(const ScheduledQueryMaintenanceRequest& other1486) {
+  type = other1486.type;
+  scheduledQuery = other1486.scheduledQuery;
   return *this;
 }
 void ScheduledQueryMaintenanceRequest::printTo(std::ostream& out) const {
@@ -41872,9 +41920,9 @@ uint32_t ScheduledQueryProgressInfo::read(::apache::thrift::protocol::TProtocol*
         break;
       case 2:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1485;
-          xfer += iprot->readI32(ecast1485);
-          this->state = (QueryState::type)ecast1485;
+          int32_t ecast1487;
+          xfer += iprot->readI32(ecast1487);
+          this->state = (QueryState::type)ecast1487;
           isset_state = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -41950,19 +41998,19 @@ void swap(ScheduledQueryProgressInfo &a, ScheduledQueryProgressInfo &b) {
   swap(a.__isset, b.__isset);
 }
 
-ScheduledQueryProgressInfo::ScheduledQueryProgressInfo(const ScheduledQueryProgressInfo& other1486) {
-  scheduledExecutionId = other1486.scheduledExecutionId;
-  state = other1486.state;
-  executorQueryId = other1486.executorQueryId;
-  errorMessage = other1486.errorMessage;
-  __isset = other1486.__isset;
+ScheduledQueryProgressInfo::ScheduledQueryProgressInfo(const ScheduledQueryProgressInfo& other1488) {
+  scheduledExecutionId = other1488.scheduledExecutionId;
+  state = other1488.state;
+  executorQueryId = other1488.executorQueryId;
+  errorMessage = other1488.errorMessage;
+  __isset = other1488.__isset;
 }
-ScheduledQueryProgressInfo& ScheduledQueryProgressInfo::operator=(const ScheduledQueryProgressInfo& other1487) {
-  scheduledExecutionId = other1487.scheduledExecutionId;
-  state = other1487.state;
-  executorQueryId = other1487.executorQueryId;
-  errorMessage = other1487.errorMessage;
-  __isset = other1487.__isset;
+ScheduledQueryProgressInfo& ScheduledQueryProgressInfo::operator=(const ScheduledQueryProgressInfo& other1489) {
+  scheduledExecutionId = other1489.scheduledExecutionId;
+  state = other1489.state;
+  executorQueryId = other1489.executorQueryId;
+  errorMessage = other1489.errorMessage;
+  __isset = other1489.__isset;
   return *this;
 }
 void ScheduledQueryProgressInfo::printTo(std::ostream& out) const {
@@ -42070,14 +42118,14 @@ uint32_t AlterPartitionsRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1488;
-            ::apache::thrift::protocol::TType _etype1491;
-            xfer += iprot->readListBegin(_etype1491, _size1488);
-            this->partitions.resize(_size1488);
-            uint32_t _i1492;
-            for (_i1492 = 0; _i1492 < _size1488; ++_i1492)
+            uint32_t _size1490;
+            ::apache::thrift::protocol::TType _etype1493;
+            xfer += iprot->readListBegin(_etype1493, _size1490);
+            this->partitions.resize(_size1490);
+            uint32_t _i1494;
+            for (_i1494 = 0; _i1494 < _size1490; ++_i1494)
             {
-              xfer += this->partitions[_i1492].read(iprot);
+              xfer += this->partitions[_i1494].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -42149,10 +42197,10 @@ uint32_t AlterPartitionsRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1493;
-    for (_iter1493 = this->partitions.begin(); _iter1493 != this->partitions.end(); ++_iter1493)
+    std::vector<Partition> ::const_iterator _iter1495;
+    for (_iter1495 = this->partitions.begin(); _iter1495 != this->partitions.end(); ++_iter1495)
     {
-      xfer += (*_iter1493).write(oprot);
+      xfer += (*_iter1495).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -42190,25 +42238,25 @@ void swap(AlterPartitionsRequest &a, AlterPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterPartitionsRequest::AlterPartitionsRequest(const AlterPartitionsRequest& other1494) {
-  catName = other1494.catName;
-  dbName = other1494.dbName;
-  tableName = other1494.tableName;
-  partitions = other1494.partitions;
-  environmentContext = other1494.environmentContext;
-  writeId = other1494.writeId;
-  validWriteIdList = other1494.validWriteIdList;
-  __isset = other1494.__isset;
+AlterPartitionsRequest::AlterPartitionsRequest(const AlterPartitionsRequest& other1496) {
+  catName = other1496.catName;
+  dbName = other1496.dbName;
+  tableName = other1496.tableName;
+  partitions = other1496.partitions;
+  environmentContext = other1496.environmentContext;
+  writeId = other1496.writeId;
+  validWriteIdList = other1496.validWriteIdList;
+  __isset = other1496.__isset;
 }
-AlterPartitionsRequest& AlterPartitionsRequest::operator=(const AlterPartitionsRequest& other1495) {
-  catName = other1495.catName;
-  dbName = other1495.dbName;
-  tableName = other1495.tableName;
-  partitions = other1495.partitions;
-  environmentContext = other1495.environmentContext;
-  writeId = other1495.writeId;
-  validWriteIdList = other1495.validWriteIdList;
-  __isset = other1495.__isset;
+AlterPartitionsRequest& AlterPartitionsRequest::operator=(const AlterPartitionsRequest& other1497) {
+  catName = other1497.catName;
+  dbName = other1497.dbName;
+  tableName = other1497.tableName;
+  partitions = other1497.partitions;
+  environmentContext = other1497.environmentContext;
+  writeId = other1497.writeId;
+  validWriteIdList = other1497.validWriteIdList;
+  __isset = other1497.__isset;
   return *this;
 }
 void AlterPartitionsRequest::printTo(std::ostream& out) const {
@@ -42279,11 +42327,11 @@ void swap(AlterPartitionsResponse &a, AlterPartitionsResponse &b) {
   (void) b;
 }
 
-AlterPartitionsResponse::AlterPartitionsResponse(const AlterPartitionsResponse& other1496) {
-  (void) other1496;
+AlterPartitionsResponse::AlterPartitionsResponse(const AlterPartitionsResponse& other1498) {
+  (void) other1498;
 }
-AlterPartitionsResponse& AlterPartitionsResponse::operator=(const AlterPartitionsResponse& other1497) {
-  (void) other1497;
+AlterPartitionsResponse& AlterPartitionsResponse::operator=(const AlterPartitionsResponse& other1499) {
+  (void) other1499;
   return *this;
 }
 void AlterPartitionsResponse::printTo(std::ostream& out) const {
@@ -42382,14 +42430,14 @@ uint32_t RenamePartitionRequest::read(::apache::thrift::protocol::TProtocol* ipr
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1498;
-            ::apache::thrift::protocol::TType _etype1501;
-            xfer += iprot->readListBegin(_etype1501, _size1498);
-            this->partVals.resize(_size1498);
-            uint32_t _i1502;
-            for (_i1502 = 0; _i1502 < _size1498; ++_i1502)
+            uint32_t _size1500;
+            ::apache::thrift::protocol::TType _etype1503;
+            xfer += iprot->readListBegin(_etype1503, _size1500);
+            this->partVals.resize(_size1500);
+            uint32_t _i1504;
+            for (_i1504 = 0; _i1504 < _size1500; ++_i1504)
             {
-              xfer += iprot->readString(this->partVals[_i1502]);
+              xfer += iprot->readString(this->partVals[_i1504]);
             }
             xfer += iprot->readListEnd();
           }
@@ -42455,10 +42503,10 @@ uint32_t RenamePartitionRequest::write(::apache::thrift::protocol::TProtocol* op
   xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-    std::vector<std::string> ::const_iterator _iter1503;
-    for (_iter1503 = this->partVals.begin(); _iter1503 != this->partVals.end(); ++_iter1503)
+    std::vector<std::string> ::const_iterator _iter1505;
+    for (_iter1505 = this->partVals.begin(); _iter1505 != this->partVals.end(); ++_iter1505)
     {
-      xfer += oprot->writeString((*_iter1503));
+      xfer += oprot->writeString((*_iter1505));
     }
     xfer += oprot->writeListEnd();
   }
@@ -42489,23 +42537,23 @@ void swap(RenamePartitionRequest &a, RenamePartitionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-RenamePartitionRequest::RenamePartitionRequest(const RenamePartitionRequest& other1504) {
-  catName = other1504.catName;
-  dbName = other1504.dbName;
-  tableName = other1504.tableName;
-  partVals = other1504.partVals;
-  newPart = other1504.newPart;
-  validWriteIdList = other1504.validWriteIdList;
-  __isset = other1504.__isset;
+RenamePartitionRequest::RenamePartitionRequest(const RenamePartitionRequest& other1506) {
+  catName = other1506.catName;
+  dbName = other1506.dbName;
+  tableName = other1506.tableName;
+  partVals = other1506.partVals;
+  newPart = other1506.newPart;
+  validWriteIdList = other1506.validWriteIdList;
+  __isset = other1506.__isset;
 }
-RenamePartitionRequest& RenamePartitionRequest::operator=(const RenamePartitionRequest& other1505) {
-  catName = other1505.catName;
-  dbName = other1505.dbName;
-  tableName = other1505.tableName;
-  partVals = other1505.partVals;
-  newPart = other1505.newPart;
-  validWriteIdList = other1505.validWriteIdList;
-  __isset = other1505.__isset;
+RenamePartitionRequest& RenamePartitionRequest::operator=(const RenamePartitionRequest& other1507) {
+  catName = other1507.catName;
+  dbName = other1507.dbName;
+  tableName = other1507.tableName;
+  partVals = other1507.partVals;
+  newPart = other1507.newPart;
+  validWriteIdList = other1507.validWriteIdList;
+  __isset = other1507.__isset;
   return *this;
 }
 void RenamePartitionRequest::printTo(std::ostream& out) const {
@@ -42575,11 +42623,11 @@ void swap(RenamePartitionResponse &a, RenamePartitionResponse &b) {
   (void) b;
 }
 
-RenamePartitionResponse::RenamePartitionResponse(const RenamePartitionResponse& other1506) {
-  (void) other1506;
+RenamePartitionResponse::RenamePartitionResponse(const RenamePartitionResponse& other1508) {
+  (void) other1508;
 }
-RenamePartitionResponse& RenamePartitionResponse::operator=(const RenamePartitionResponse& other1507) {
-  (void) other1507;
+RenamePartitionResponse& RenamePartitionResponse::operator=(const RenamePartitionResponse& other1509) {
+  (void) other1509;
   return *this;
 }
 void RenamePartitionResponse::printTo(std::ostream& out) const {
@@ -42725,14 +42773,14 @@ uint32_t AlterTableRequest::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1508;
-            ::apache::thrift::protocol::TType _etype1511;
-            xfer += iprot->readListBegin(_etype1511, _size1508);
-            this->processorCapabilities.resize(_size1508);
-            uint32_t _i1512;
-            for (_i1512 = 0; _i1512 < _size1508; ++_i1512)
+            uint32_t _size1510;
+            ::apache::thrift::protocol::TType _etype1513;
+            xfer += iprot->readListBegin(_etype1513, _size1510);
+            this->processorCapabilities.resize(_size1510);
+            uint32_t _i1514;
+            for (_i1514 = 0; _i1514 < _size1510; ++_i1514)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1512]);
+              xfer += iprot->readString(this->processorCapabilities[_i1514]);
             }
             xfer += iprot->readListEnd();
           }
@@ -42808,10 +42856,10 @@ uint32_t AlterTableRequest::write(::apache::thrift::protocol::TProtocol* oprot) 
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1513;
-      for (_iter1513 = this->processorCapabilities.begin(); _iter1513 != this->processorCapabilities.end(); ++_iter1513)
+      std::vector<std::string> ::const_iterator _iter1515;
+      for (_iter1515 = this->processorCapabilities.begin(); _iter1515 != this->processorCapabilities.end(); ++_iter1515)
       {
-        xfer += oprot->writeString((*_iter1513));
+        xfer += oprot->writeString((*_iter1515));
       }
       xfer += oprot->writeListEnd();
     }
@@ -42841,29 +42889,29 @@ void swap(AlterTableRequest &a, AlterTableRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlterTableRequest::AlterTableRequest(const AlterTableRequest& other1514) {
-  catName = other1514.catName;
-  dbName = other1514.dbName;
-  tableName = other1514.tableName;
-  table = other1514.table;
-  environmentContext = other1514.environmentContext;
-  writeId = other1514.writeId;
-  validWriteIdList = other1514.validWriteIdList;
-  processorCapabilities = other1514.processorCapabilities;
-  processorIdentifier = other1514.processorIdentifier;
-  __isset = other1514.__isset;
+AlterTableRequest::AlterTableRequest(const AlterTableRequest& other1516) {
+  catName = other1516.catName;
+  dbName = other1516.dbName;
+  tableName = other1516.tableName;
+  table = other1516.table;
+  environmentContext = other1516.environmentContext;
+  writeId = other1516.writeId;
+  validWriteIdList = other1516.validWriteIdList;
+  processorCapabilities = other1516.processorCapabilities;
+  processorIdentifier = other1516.processorIdentifier;
+  __isset = other1516.__isset;
 }
-AlterTableRequest& AlterTableRequest::operator=(const AlterTableRequest& other1515) {
-  catName = other1515.catName;
-  dbName = other1515.dbName;
-  tableName = other1515.tableName;
-  table = other1515.table;
-  environmentContext = other1515.environmentContext;
-  writeId = other1515.writeId;
-  validWriteIdList = other1515.validWriteIdList;
-  processorCapabilities = other1515.processorCapabilities;
-  processorIdentifier = other1515.processorIdentifier;
-  __isset = other1515.__isset;
+AlterTableRequest& AlterTableRequest::operator=(const AlterTableRequest& other1517) {
+  catName = other1517.catName;
+  dbName = other1517.dbName;
+  tableName = other1517.tableName;
+  table = other1517.table;
+  environmentContext = other1517.environmentContext;
+  writeId = other1517.writeId;
+  validWriteIdList = other1517.validWriteIdList;
+  processorCapabilities = other1517.processorCapabilities;
+  processorIdentifier = other1517.processorIdentifier;
+  __isset = other1517.__isset;
   return *this;
 }
 void AlterTableRequest::printTo(std::ostream& out) const {
@@ -42936,11 +42984,11 @@ void swap(AlterTableResponse &a, AlterTableResponse &b) {
   (void) b;
 }
 
-AlterTableResponse::AlterTableResponse(const AlterTableResponse& other1516) {
-  (void) other1516;
+AlterTableResponse::AlterTableResponse(const AlterTableResponse& other1518) {
+  (void) other1518;
 }
-AlterTableResponse& AlterTableResponse::operator=(const AlterTableResponse& other1517) {
-  (void) other1517;
+AlterTableResponse& AlterTableResponse::operator=(const AlterTableResponse& other1519) {
+  (void) other1519;
   return *this;
 }
 void AlterTableResponse::printTo(std::ostream& out) const {
@@ -42993,9 +43041,9 @@ uint32_t GetPartitionsFilterSpec::read(::apache::thrift::protocol::TProtocol* ip
     {
       case 7:
         if (ftype == ::apache::thrift::protocol::T_I32) {
-          int32_t ecast1518;
-          xfer += iprot->readI32(ecast1518);
-          this->filterMode = (PartitionFilterMode::type)ecast1518;
+          int32_t ecast1520;
+          xfer += iprot->readI32(ecast1520);
+          this->filterMode = (PartitionFilterMode::type)ecast1520;
           this->__isset.filterMode = true;
         } else {
           xfer += iprot->skip(ftype);
@@ -43005,14 +43053,14 @@ uint32_t GetPartitionsFilterSpec::read(::apache::thrift::protocol::TProtocol* ip
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->filters.clear();
-            uint32_t _size1519;
-            ::apache::thrift::protocol::TType _etype1522;
-            xfer += iprot->readListBegin(_etype1522, _size1519);
-            this->filters.resize(_size1519);
-            uint32_t _i1523;
-            for (_i1523 = 0; _i1523 < _size1519; ++_i1523)
+            uint32_t _size1521;
+            ::apache::thrift::protocol::TType _etype1524;
+            xfer += iprot->readListBegin(_etype1524, _size1521);
+            this->filters.resize(_size1521);
+            uint32_t _i1525;
+            for (_i1525 = 0; _i1525 < _size1521; ++_i1525)
             {
-              xfer += iprot->readString(this->filters[_i1523]);
+              xfer += iprot->readString(this->filters[_i1525]);
             }
             xfer += iprot->readListEnd();
           }
@@ -43047,10 +43095,10 @@ uint32_t GetPartitionsFilterSpec::write(::apache::thrift::protocol::TProtocol* o
     xfer += oprot->writeFieldBegin("filters", ::apache::thrift::protocol::T_LIST, 8);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->filters.size()));
-      std::vector<std::string> ::const_iterator _iter1524;
-      for (_iter1524 = this->filters.begin(); _iter1524 != this->filters.end(); ++_iter1524)
+      std::vector<std::string> ::const_iterator _iter1526;
+      for (_iter1526 = this->filters.begin(); _iter1526 != this->filters.end(); ++_iter1526)
       {
-        xfer += oprot->writeString((*_iter1524));
+        xfer += oprot->writeString((*_iter1526));
       }
       xfer += oprot->writeListEnd();
     }
@@ -43068,15 +43116,15 @@ void swap(GetPartitionsFilterSpec &a, GetPartitionsFilterSpec &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsFilterSpec::GetPartitionsFilterSpec(const GetPartitionsFilterSpec& other1525) {
-  filterMode = other1525.filterMode;
-  filters = other1525.filters;
-  __isset = other1525.__isset;
+GetPartitionsFilterSpec::GetPartitionsFilterSpec(const GetPartitionsFilterSpec& other1527) {
+  filterMode = other1527.filterMode;
+  filters = other1527.filters;
+  __isset = other1527.__isset;
 }
-GetPartitionsFilterSpec& GetPartitionsFilterSpec::operator=(const GetPartitionsFilterSpec& other1526) {
-  filterMode = other1526.filterMode;
-  filters = other1526.filters;
-  __isset = other1526.__isset;
+GetPartitionsFilterSpec& GetPartitionsFilterSpec::operator=(const GetPartitionsFilterSpec& other1528) {
+  filterMode = other1528.filterMode;
+  filters = other1528.filters;
+  __isset = other1528.__isset;
   return *this;
 }
 void GetPartitionsFilterSpec::printTo(std::ostream& out) const {
@@ -43127,14 +43175,14 @@ uint32_t GetPartitionsResponse::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitionSpec.clear();
-            uint32_t _size1527;
-            ::apache::thrift::protocol::TType _etype1530;
-            xfer += iprot->readListBegin(_etype1530, _size1527);
-            this->partitionSpec.resize(_size1527);
-            uint32_t _i1531;
-            for (_i1531 = 0; _i1531 < _size1527; ++_i1531)
+            uint32_t _size1529;
+            ::apache::thrift::protocol::TType _etype1532;
+            xfer += iprot->readListBegin(_etype1532, _size1529);
+            this->partitionSpec.resize(_size1529);
+            uint32_t _i1533;
+            for (_i1533 = 0; _i1533 < _size1529; ++_i1533)
             {
-              xfer += this->partitionSpec[_i1531].read(iprot);
+              xfer += this->partitionSpec[_i1533].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -43163,10 +43211,10 @@ uint32_t GetPartitionsResponse::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("partitionSpec", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitionSpec.size()));
-    std::vector<PartitionSpec> ::const_iterator _iter1532;
-    for (_iter1532 = this->partitionSpec.begin(); _iter1532 != this->partitionSpec.end(); ++_iter1532)
+    std::vector<PartitionSpec> ::const_iterator _iter1534;
+    for (_iter1534 = this->partitionSpec.begin(); _iter1534 != this->partitionSpec.end(); ++_iter1534)
     {
-      xfer += (*_iter1532).write(oprot);
+      xfer += (*_iter1534).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -43183,13 +43231,13 @@ void swap(GetPartitionsResponse &a, GetPartitionsResponse &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsResponse::GetPartitionsResponse(const GetPartitionsResponse& other1533) {
-  partitionSpec = other1533.partitionSpec;
-  __isset = other1533.__isset;
+GetPartitionsResponse::GetPartitionsResponse(const GetPartitionsResponse& other1535) {
+  partitionSpec = other1535.partitionSpec;
+  __isset = other1535.__isset;
 }
-GetPartitionsResponse& GetPartitionsResponse::operator=(const GetPartitionsResponse& other1534) {
-  partitionSpec = other1534.partitionSpec;
-  __isset = other1534.__isset;
+GetPartitionsResponse& GetPartitionsResponse::operator=(const GetPartitionsResponse& other1536) {
+  partitionSpec = other1536.partitionSpec;
+  __isset = other1536.__isset;
   return *this;
 }
 void GetPartitionsResponse::printTo(std::ostream& out) const {
@@ -43326,14 +43374,14 @@ uint32_t GetPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->groupNames.clear();
-            uint32_t _size1535;
-            ::apache::thrift::protocol::TType _etype1538;
-            xfer += iprot->readListBegin(_etype1538, _size1535);
-            this->groupNames.resize(_size1535);
-            uint32_t _i1539;
-            for (_i1539 = 0; _i1539 < _size1535; ++_i1539)
+            uint32_t _size1537;
+            ::apache::thrift::protocol::TType _etype1540;
+            xfer += iprot->readListBegin(_etype1540, _size1537);
+            this->groupNames.resize(_size1537);
+            uint32_t _i1541;
+            for (_i1541 = 0; _i1541 < _size1537; ++_i1541)
             {
-              xfer += iprot->readString(this->groupNames[_i1539]);
+              xfer += iprot->readString(this->groupNames[_i1541]);
             }
             xfer += iprot->readListEnd();
           }
@@ -43362,14 +43410,14 @@ uint32_t GetPartitionsRequest::read(::apache::thrift::protocol::TProtocol* iprot
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->processorCapabilities.clear();
-            uint32_t _size1540;
-            ::apache::thrift::protocol::TType _etype1543;
-            xfer += iprot->readListBegin(_etype1543, _size1540);
-            this->processorCapabilities.resize(_size1540);
-            uint32_t _i1544;
-            for (_i1544 = 0; _i1544 < _size1540; ++_i1544)
+            uint32_t _size1542;
+            ::apache::thrift::protocol::TType _etype1545;
+            xfer += iprot->readListBegin(_etype1545, _size1542);
+            this->processorCapabilities.resize(_size1542);
+            uint32_t _i1546;
+            for (_i1546 = 0; _i1546 < _size1542; ++_i1546)
             {
-              xfer += iprot->readString(this->processorCapabilities[_i1544]);
+              xfer += iprot->readString(this->processorCapabilities[_i1546]);
             }
             xfer += iprot->readListEnd();
           }
@@ -43438,10 +43486,10 @@ uint32_t GetPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("groupNames", ::apache::thrift::protocol::T_LIST, 6);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->groupNames.size()));
-      std::vector<std::string> ::const_iterator _iter1545;
-      for (_iter1545 = this->groupNames.begin(); _iter1545 != this->groupNames.end(); ++_iter1545)
+      std::vector<std::string> ::const_iterator _iter1547;
+      for (_iter1547 = this->groupNames.begin(); _iter1547 != this->groupNames.end(); ++_iter1547)
       {
-        xfer += oprot->writeString((*_iter1545));
+        xfer += oprot->writeString((*_iter1547));
       }
       xfer += oprot->writeListEnd();
     }
@@ -43459,10 +43507,10 @@ uint32_t GetPartitionsRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeFieldBegin("processorCapabilities", ::apache::thrift::protocol::T_LIST, 9);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->processorCapabilities.size()));
-      std::vector<std::string> ::const_iterator _iter1546;
-      for (_iter1546 = this->processorCapabilities.begin(); _iter1546 != this->processorCapabilities.end(); ++_iter1546)
+      std::vector<std::string> ::const_iterator _iter1548;
+      for (_iter1548 = this->processorCapabilities.begin(); _iter1548 != this->processorCapabilities.end(); ++_iter1548)
       {
-        xfer += oprot->writeString((*_iter1546));
+        xfer += oprot->writeString((*_iter1548));
       }
       xfer += oprot->writeListEnd();
     }
@@ -43499,33 +43547,33 @@ void swap(GetPartitionsRequest &a, GetPartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsRequest::GetPartitionsRequest(const GetPartitionsRequest& other1547) {
-  catName = other1547.catName;
-  dbName = other1547.dbName;
-  tblName = other1547.tblName;
-  withAuth = other1547.withAuth;
-  user = other1547.user;
-  groupNames = other1547.groupNames;
-  projectionSpec = other1547.projectionSpec;
-  filterSpec = other1547.filterSpec;
-  processorCapabilities = other1547.processorCapabilities;
-  processorIdentifier = other1547.processorIdentifier;
-  validWriteIdList = other1547.validWriteIdList;
-  __isset = other1547.__isset;
+GetPartitionsRequest::GetPartitionsRequest(const GetPartitionsRequest& other1549) {
+  catName = other1549.catName;
+  dbName = other1549.dbName;
+  tblName = other1549.tblName;
+  withAuth = other1549.withAuth;
+  user = other1549.user;
+  groupNames = other1549.groupNames;
+  projectionSpec = other1549.projectionSpec;
+  filterSpec = other1549.filterSpec;
+  processorCapabilities = other1549.processorCapabilities;
+  processorIdentifier = other1549.processorIdentifier;
+  validWriteIdList = other1549.validWriteIdList;
+  __isset = other1549.__isset;
 }
-GetPartitionsRequest& GetPartitionsRequest::operator=(const GetPartitionsRequest& other1548) {
-  catName = other1548.catName;
-  dbName = other1548.dbName;
-  tblName = other1548.tblName;
-  withAuth = other1548.withAuth;
-  user = other1548.user;
-  groupNames = other1548.groupNames;
-  projectionSpec = other1548.projectionSpec;
-  filterSpec = other1548.filterSpec;
-  processorCapabilities = other1548.processorCapabilities;
-  processorIdentifier = other1548.processorIdentifier;
-  validWriteIdList = other1548.validWriteIdList;
-  __isset = other1548.__isset;
+GetPartitionsRequest& GetPartitionsRequest::operator=(const GetPartitionsRequest& other1550) {
+  catName = other1550.catName;
+  dbName = other1550.dbName;
+  tblName = other1550.tblName;
+  withAuth = other1550.withAuth;
+  user = other1550.user;
+  groupNames = other1550.groupNames;
+  projectionSpec = other1550.projectionSpec;
+  filterSpec = other1550.filterSpec;
+  processorCapabilities = other1550.processorCapabilities;
+  processorIdentifier = other1550.processorIdentifier;
+  validWriteIdList = other1550.validWriteIdList;
+  __isset = other1550.__isset;
   return *this;
 }
 void GetPartitionsRequest::printTo(std::ostream& out) const {
@@ -43720,23 +43768,23 @@ void swap(GetFieldsRequest &a, GetFieldsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetFieldsRequest::GetFieldsRequest(const GetFieldsRequest& other1549) {
-  catName = other1549.catName;
-  dbName = other1549.dbName;
-  tblName = other1549.tblName;
-  envContext = other1549.envContext;
-  validWriteIdList = other1549.validWriteIdList;
-  id = other1549.id;
-  __isset = other1549.__isset;
+GetFieldsRequest::GetFieldsRequest(const GetFieldsRequest& other1551) {
+  catName = other1551.catName;
+  dbName = other1551.dbName;
+  tblName = other1551.tblName;
+  envContext = other1551.envContext;
+  validWriteIdList = other1551.validWriteIdList;
+  id = other1551.id;
+  __isset = other1551.__isset;
 }
-GetFieldsRequest& GetFieldsRequest::operator=(const GetFieldsRequest& other1550) {
-  catName = other1550.catName;
-  dbName = other1550.dbName;
-  tblName = other1550.tblName;
-  envContext = other1550.envContext;
-  validWriteIdList = other1550.validWriteIdList;
-  id = other1550.id;
-  __isset = other1550.__isset;
+GetFieldsRequest& GetFieldsRequest::operator=(const GetFieldsRequest& other1552) {
+  catName = other1552.catName;
+  dbName = other1552.dbName;
+  tblName = other1552.tblName;
+  envContext = other1552.envContext;
+  validWriteIdList = other1552.validWriteIdList;
+  id = other1552.id;
+  __isset = other1552.__isset;
   return *this;
 }
 void GetFieldsRequest::printTo(std::ostream& out) const {
@@ -43792,14 +43840,14 @@ uint32_t GetFieldsResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size1551;
-            ::apache::thrift::protocol::TType _etype1554;
-            xfer += iprot->readListBegin(_etype1554, _size1551);
-            this->fields.resize(_size1551);
-            uint32_t _i1555;
-            for (_i1555 = 0; _i1555 < _size1551; ++_i1555)
+            uint32_t _size1553;
+            ::apache::thrift::protocol::TType _etype1556;
+            xfer += iprot->readListBegin(_etype1556, _size1553);
+            this->fields.resize(_size1553);
+            uint32_t _i1557;
+            for (_i1557 = 0; _i1557 < _size1553; ++_i1557)
             {
-              xfer += this->fields[_i1555].read(iprot);
+              xfer += this->fields[_i1557].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -43830,10 +43878,10 @@ uint32_t GetFieldsResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1556;
-    for (_iter1556 = this->fields.begin(); _iter1556 != this->fields.end(); ++_iter1556)
+    std::vector<FieldSchema> ::const_iterator _iter1558;
+    for (_iter1558 = this->fields.begin(); _iter1558 != this->fields.end(); ++_iter1558)
     {
-      xfer += (*_iter1556).write(oprot);
+      xfer += (*_iter1558).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -43849,11 +43897,11 @@ void swap(GetFieldsResponse &a, GetFieldsResponse &b) {
   swap(a.fields, b.fields);
 }
 
-GetFieldsResponse::GetFieldsResponse(const GetFieldsResponse& other1557) {
-  fields = other1557.fields;
+GetFieldsResponse::GetFieldsResponse(const GetFieldsResponse& other1559) {
+  fields = other1559.fields;
 }
-GetFieldsResponse& GetFieldsResponse::operator=(const GetFieldsResponse& other1558) {
-  fields = other1558.fields;
+GetFieldsResponse& GetFieldsResponse::operator=(const GetFieldsResponse& other1560) {
+  fields = other1560.fields;
   return *this;
 }
 void GetFieldsResponse::printTo(std::ostream& out) const {
@@ -44038,23 +44086,23 @@ void swap(GetSchemaRequest &a, GetSchemaRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetSchemaRequest::GetSchemaRequest(const GetSchemaRequest& other1559) {
-  catName = other1559.catName;
-  dbName = other1559.dbName;
-  tblName = other1559.tblName;
-  envContext = other1559.envContext;
-  validWriteIdList = other1559.validWriteIdList;
-  id = other1559.id;
-  __isset = other1559.__isset;
+GetSchemaRequest::GetSchemaRequest(const GetSchemaRequest& other1561) {
+  catName = other1561.catName;
+  dbName = other1561.dbName;
+  tblName = other1561.tblName;
+  envContext = other1561.envContext;
+  validWriteIdList = other1561.validWriteIdList;
+  id = other1561.id;
+  __isset = other1561.__isset;
 }
-GetSchemaRequest& GetSchemaRequest::operator=(const GetSchemaRequest& other1560) {
-  catName = other1560.catName;
-  dbName = other1560.dbName;
-  tblName = other1560.tblName;
-  envContext = other1560.envContext;
-  validWriteIdList = other1560.validWriteIdList;
-  id = other1560.id;
-  __isset = other1560.__isset;
+GetSchemaRequest& GetSchemaRequest::operator=(const GetSchemaRequest& other1562) {
+  catName = other1562.catName;
+  dbName = other1562.dbName;
+  tblName = other1562.tblName;
+  envContext = other1562.envContext;
+  validWriteIdList = other1562.validWriteIdList;
+  id = other1562.id;
+  __isset = other1562.__isset;
   return *this;
 }
 void GetSchemaRequest::printTo(std::ostream& out) const {
@@ -44110,14 +44158,14 @@ uint32_t GetSchemaResponse::read(::apache::thrift::protocol::TProtocol* iprot) {
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->fields.clear();
-            uint32_t _size1561;
-            ::apache::thrift::protocol::TType _etype1564;
-            xfer += iprot->readListBegin(_etype1564, _size1561);
-            this->fields.resize(_size1561);
-            uint32_t _i1565;
-            for (_i1565 = 0; _i1565 < _size1561; ++_i1565)
+            uint32_t _size1563;
+            ::apache::thrift::protocol::TType _etype1566;
+            xfer += iprot->readListBegin(_etype1566, _size1563);
+            this->fields.resize(_size1563);
+            uint32_t _i1567;
+            for (_i1567 = 0; _i1567 < _size1563; ++_i1567)
             {
-              xfer += this->fields[_i1565].read(iprot);
+              xfer += this->fields[_i1567].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -44148,10 +44196,10 @@ uint32_t GetSchemaResponse::write(::apache::thrift::protocol::TProtocol* oprot) 
   xfer += oprot->writeFieldBegin("fields", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->fields.size()));
-    std::vector<FieldSchema> ::const_iterator _iter1566;
-    for (_iter1566 = this->fields.begin(); _iter1566 != this->fields.end(); ++_iter1566)
+    std::vector<FieldSchema> ::const_iterator _iter1568;
+    for (_iter1568 = this->fields.begin(); _iter1568 != this->fields.end(); ++_iter1568)
     {
-      xfer += (*_iter1566).write(oprot);
+      xfer += (*_iter1568).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -44167,11 +44215,11 @@ void swap(GetSchemaResponse &a, GetSchemaResponse &b) {
   swap(a.fields, b.fields);
 }
 
-GetSchemaResponse::GetSchemaResponse(const GetSchemaResponse& other1567) {
-  fields = other1567.fields;
+GetSchemaResponse::GetSchemaResponse(const GetSchemaResponse& other1569) {
+  fields = other1569.fields;
 }
-GetSchemaResponse& GetSchemaResponse::operator=(const GetSchemaResponse& other1568) {
-  fields = other1568.fields;
+GetSchemaResponse& GetSchemaResponse::operator=(const GetSchemaResponse& other1570) {
+  fields = other1570.fields;
   return *this;
 }
 void GetSchemaResponse::printTo(std::ostream& out) const {
@@ -44271,14 +44319,14 @@ uint32_t GetPartitionRequest::read(::apache::thrift::protocol::TProtocol* iprot)
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1569;
-            ::apache::thrift::protocol::TType _etype1572;
-            xfer += iprot->readListBegin(_etype1572, _size1569);
-            this->partVals.resize(_size1569);
-            uint32_t _i1573;
-            for (_i1573 = 0; _i1573 < _size1569; ++_i1573)
+            uint32_t _size1571;
+            ::apache::thrift::protocol::TType _etype1574;
+            xfer += iprot->readListBegin(_etype1574, _size1571);
+            this->partVals.resize(_size1571);
+            uint32_t _i1575;
+            for (_i1575 = 0; _i1575 < _size1571; ++_i1575)
             {
-              xfer += iprot->readString(this->partVals[_i1573]);
+              xfer += iprot->readString(this->partVals[_i1575]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44342,10 +44390,10 @@ uint32_t GetPartitionRequest::write(::apache::thrift::protocol::TProtocol* oprot
   xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-    std::vector<std::string> ::const_iterator _iter1574;
-    for (_iter1574 = this->partVals.begin(); _iter1574 != this->partVals.end(); ++_iter1574)
+    std::vector<std::string> ::const_iterator _iter1576;
+    for (_iter1576 = this->partVals.begin(); _iter1576 != this->partVals.end(); ++_iter1576)
     {
-      xfer += oprot->writeString((*_iter1574));
+      xfer += oprot->writeString((*_iter1576));
     }
     xfer += oprot->writeListEnd();
   }
@@ -44377,23 +44425,23 @@ void swap(GetPartitionRequest &a, GetPartitionRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionRequest::GetPartitionRequest(const GetPartitionRequest& other1575) {
-  catName = other1575.catName;
-  dbName = other1575.dbName;
-  tblName = other1575.tblName;
-  partVals = other1575.partVals;
-  validWriteIdList = other1575.validWriteIdList;
-  id = other1575.id;
-  __isset = other1575.__isset;
+GetPartitionRequest::GetPartitionRequest(const GetPartitionRequest& other1577) {
+  catName = other1577.catName;
+  dbName = other1577.dbName;
+  tblName = other1577.tblName;
+  partVals = other1577.partVals;
+  validWriteIdList = other1577.validWriteIdList;
+  id = other1577.id;
+  __isset = other1577.__isset;
 }
-GetPartitionRequest& GetPartitionRequest::operator=(const GetPartitionRequest& other1576) {
-  catName = other1576.catName;
-  dbName = other1576.dbName;
-  tblName = other1576.tblName;
-  partVals = other1576.partVals;
-  validWriteIdList = other1576.validWriteIdList;
-  id = other1576.id;
-  __isset = other1576.__isset;
+GetPartitionRequest& GetPartitionRequest::operator=(const GetPartitionRequest& other1578) {
+  catName = other1578.catName;
+  dbName = other1578.dbName;
+  tblName = other1578.tblName;
+  partVals = other1578.partVals;
+  validWriteIdList = other1578.validWriteIdList;
+  id = other1578.id;
+  __isset = other1578.__isset;
   return *this;
 }
 void GetPartitionRequest::printTo(std::ostream& out) const {
@@ -44486,11 +44534,11 @@ void swap(GetPartitionResponse &a, GetPartitionResponse &b) {
   swap(a.partition, b.partition);
 }
 
-GetPartitionResponse::GetPartitionResponse(const GetPartitionResponse& other1577) {
-  partition = other1577.partition;
+GetPartitionResponse::GetPartitionResponse(const GetPartitionResponse& other1579) {
+  partition = other1579.partition;
 }
-GetPartitionResponse& GetPartitionResponse::operator=(const GetPartitionResponse& other1578) {
-  partition = other1578.partition;
+GetPartitionResponse& GetPartitionResponse::operator=(const GetPartitionResponse& other1580) {
+  partition = other1580.partition;
   return *this;
 }
 void GetPartitionResponse::printTo(std::ostream& out) const {
@@ -44675,23 +44723,23 @@ void swap(PartitionsRequest &a, PartitionsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-PartitionsRequest::PartitionsRequest(const PartitionsRequest& other1579) {
-  catName = other1579.catName;
-  dbName = other1579.dbName;
-  tblName = other1579.tblName;
-  maxParts = other1579.maxParts;
-  validWriteIdList = other1579.validWriteIdList;
-  id = other1579.id;
-  __isset = other1579.__isset;
+PartitionsRequest::PartitionsRequest(const PartitionsRequest& other1581) {
+  catName = other1581.catName;
+  dbName = other1581.dbName;
+  tblName = other1581.tblName;
+  maxParts = other1581.maxParts;
+  validWriteIdList = other1581.validWriteIdList;
+  id = other1581.id;
+  __isset = other1581.__isset;
 }
-PartitionsRequest& PartitionsRequest::operator=(const PartitionsRequest& other1580) {
-  catName = other1580.catName;
-  dbName = other1580.dbName;
-  tblName = other1580.tblName;
-  maxParts = other1580.maxParts;
-  validWriteIdList = other1580.validWriteIdList;
-  id = other1580.id;
-  __isset = other1580.__isset;
+PartitionsRequest& PartitionsRequest::operator=(const PartitionsRequest& other1582) {
+  catName = other1582.catName;
+  dbName = other1582.dbName;
+  tblName = other1582.tblName;
+  maxParts = other1582.maxParts;
+  validWriteIdList = other1582.validWriteIdList;
+  id = other1582.id;
+  __isset = other1582.__isset;
   return *this;
 }
 void PartitionsRequest::printTo(std::ostream& out) const {
@@ -44747,14 +44795,14 @@ uint32_t PartitionsResponse::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1581;
-            ::apache::thrift::protocol::TType _etype1584;
-            xfer += iprot->readListBegin(_etype1584, _size1581);
-            this->partitions.resize(_size1581);
-            uint32_t _i1585;
-            for (_i1585 = 0; _i1585 < _size1581; ++_i1585)
+            uint32_t _size1583;
+            ::apache::thrift::protocol::TType _etype1586;
+            xfer += iprot->readListBegin(_etype1586, _size1583);
+            this->partitions.resize(_size1583);
+            uint32_t _i1587;
+            for (_i1587 = 0; _i1587 < _size1583; ++_i1587)
             {
-              xfer += this->partitions[_i1585].read(iprot);
+              xfer += this->partitions[_i1587].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -44785,10 +44833,10 @@ uint32_t PartitionsResponse::write(::apache::thrift::protocol::TProtocol* oprot)
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1586;
-    for (_iter1586 = this->partitions.begin(); _iter1586 != this->partitions.end(); ++_iter1586)
+    std::vector<Partition> ::const_iterator _iter1588;
+    for (_iter1588 = this->partitions.begin(); _iter1588 != this->partitions.end(); ++_iter1588)
     {
-      xfer += (*_iter1586).write(oprot);
+      xfer += (*_iter1588).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -44804,11 +44852,11 @@ void swap(PartitionsResponse &a, PartitionsResponse &b) {
   swap(a.partitions, b.partitions);
 }
 
-PartitionsResponse::PartitionsResponse(const PartitionsResponse& other1587) {
-  partitions = other1587.partitions;
+PartitionsResponse::PartitionsResponse(const PartitionsResponse& other1589) {
+  partitions = other1589.partitions;
 }
-PartitionsResponse& PartitionsResponse::operator=(const PartitionsResponse& other1588) {
-  partitions = other1588.partitions;
+PartitionsResponse& PartitionsResponse::operator=(const PartitionsResponse& other1590) {
+  partitions = other1590.partitions;
   return *this;
 }
 void PartitionsResponse::printTo(std::ostream& out) const {
@@ -44913,14 +44961,14 @@ uint32_t GetPartitionNamesPsRequest::read(::apache::thrift::protocol::TProtocol*
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partValues.clear();
-            uint32_t _size1589;
-            ::apache::thrift::protocol::TType _etype1592;
-            xfer += iprot->readListBegin(_etype1592, _size1589);
-            this->partValues.resize(_size1589);
-            uint32_t _i1593;
-            for (_i1593 = 0; _i1593 < _size1589; ++_i1593)
+            uint32_t _size1591;
+            ::apache::thrift::protocol::TType _etype1594;
+            xfer += iprot->readListBegin(_etype1594, _size1591);
+            this->partValues.resize(_size1591);
+            uint32_t _i1595;
+            for (_i1595 = 0; _i1595 < _size1591; ++_i1595)
             {
-              xfer += iprot->readString(this->partValues[_i1593]);
+              xfer += iprot->readString(this->partValues[_i1595]);
             }
             xfer += iprot->readListEnd();
           }
@@ -44991,10 +45039,10 @@ uint32_t GetPartitionNamesPsRequest::write(::apache::thrift::protocol::TProtocol
     xfer += oprot->writeFieldBegin("partValues", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partValues.size()));
-      std::vector<std::string> ::const_iterator _iter1594;
-      for (_iter1594 = this->partValues.begin(); _iter1594 != this->partValues.end(); ++_iter1594)
+      std::vector<std::string> ::const_iterator _iter1596;
+      for (_iter1596 = this->partValues.begin(); _iter1596 != this->partValues.end(); ++_iter1596)
       {
-        xfer += oprot->writeString((*_iter1594));
+        xfer += oprot->writeString((*_iter1596));
       }
       xfer += oprot->writeListEnd();
     }
@@ -45032,25 +45080,25 @@ void swap(GetPartitionNamesPsRequest &a, GetPartitionNamesPsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionNamesPsRequest::GetPartitionNamesPsRequest(const GetPartitionNamesPsRequest& other1595) {
-  catName = other1595.catName;
-  dbName = other1595.dbName;
-  tblName = other1595.tblName;
-  partValues = other1595.partValues;
-  maxParts = other1595.maxParts;
-  validWriteIdList = other1595.validWriteIdList;
-  id = other1595.id;
-  __isset = other1595.__isset;
+GetPartitionNamesPsRequest::GetPartitionNamesPsRequest(const GetPartitionNamesPsRequest& other1597) {
+  catName = other1597.catName;
+  dbName = other1597.dbName;
+  tblName = other1597.tblName;
+  partValues = other1597.partValues;
+  maxParts = other1597.maxParts;
+  validWriteIdList = other1597.validWriteIdList;
+  id = other1597.id;
+  __isset = other1597.__isset;
 }
-GetPartitionNamesPsRequest& GetPartitionNamesPsRequest::operator=(const GetPartitionNamesPsRequest& other1596) {
-  catName = other1596.catName;
-  dbName = other1596.dbName;
-  tblName = other1596.tblName;
-  partValues = other1596.partValues;
-  maxParts = other1596.maxParts;
-  validWriteIdList = other1596.validWriteIdList;
-  id = other1596.id;
-  __isset = other1596.__isset;
+GetPartitionNamesPsRequest& GetPartitionNamesPsRequest::operator=(const GetPartitionNamesPsRequest& other1598) {
+  catName = other1598.catName;
+  dbName = other1598.dbName;
+  tblName = other1598.tblName;
+  partValues = other1598.partValues;
+  maxParts = other1598.maxParts;
+  validWriteIdList = other1598.validWriteIdList;
+  id = other1598.id;
+  __isset = other1598.__isset;
   return *this;
 }
 void GetPartitionNamesPsRequest::printTo(std::ostream& out) const {
@@ -45107,14 +45155,14 @@ uint32_t GetPartitionNamesPsResponse::read(::apache::thrift::protocol::TProtocol
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->names.clear();
-            uint32_t _size1597;
-            ::apache::thrift::protocol::TType _etype1600;
-            xfer += iprot->readListBegin(_etype1600, _size1597);
-            this->names.resize(_size1597);
-            uint32_t _i1601;
-            for (_i1601 = 0; _i1601 < _size1597; ++_i1601)
+            uint32_t _size1599;
+            ::apache::thrift::protocol::TType _etype1602;
+            xfer += iprot->readListBegin(_etype1602, _size1599);
+            this->names.resize(_size1599);
+            uint32_t _i1603;
+            for (_i1603 = 0; _i1603 < _size1599; ++_i1603)
             {
-              xfer += iprot->readString(this->names[_i1601]);
+              xfer += iprot->readString(this->names[_i1603]);
             }
             xfer += iprot->readListEnd();
           }
@@ -45145,10 +45193,10 @@ uint32_t GetPartitionNamesPsResponse::write(::apache::thrift::protocol::TProtoco
   xfer += oprot->writeFieldBegin("names", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->names.size()));
-    std::vector<std::string> ::const_iterator _iter1602;
-    for (_iter1602 = this->names.begin(); _iter1602 != this->names.end(); ++_iter1602)
+    std::vector<std::string> ::const_iterator _iter1604;
+    for (_iter1604 = this->names.begin(); _iter1604 != this->names.end(); ++_iter1604)
     {
-      xfer += oprot->writeString((*_iter1602));
+      xfer += oprot->writeString((*_iter1604));
     }
     xfer += oprot->writeListEnd();
   }
@@ -45164,11 +45212,11 @@ void swap(GetPartitionNamesPsResponse &a, GetPartitionNamesPsResponse &b) {
   swap(a.names, b.names);
 }
 
-GetPartitionNamesPsResponse::GetPartitionNamesPsResponse(const GetPartitionNamesPsResponse& other1603) {
-  names = other1603.names;
+GetPartitionNamesPsResponse::GetPartitionNamesPsResponse(const GetPartitionNamesPsResponse& other1605) {
+  names = other1605.names;
 }
-GetPartitionNamesPsResponse& GetPartitionNamesPsResponse::operator=(const GetPartitionNamesPsResponse& other1604) {
-  names = other1604.names;
+GetPartitionNamesPsResponse& GetPartitionNamesPsResponse::operator=(const GetPartitionNamesPsResponse& other1606) {
+  names = other1606.names;
   return *this;
 }
 void GetPartitionNamesPsResponse::printTo(std::ostream& out) const {
@@ -45283,14 +45331,14 @@ uint32_t GetPartitionsPsWithAuthRequest::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partVals.clear();
-            uint32_t _size1605;
-            ::apache::thrift::protocol::TType _etype1608;
-            xfer += iprot->readListBegin(_etype1608, _size1605);
-            this->partVals.resize(_size1605);
-            uint32_t _i1609;
-            for (_i1609 = 0; _i1609 < _size1605; ++_i1609)
+            uint32_t _size1607;
+            ::apache::thrift::protocol::TType _etype1610;
+            xfer += iprot->readListBegin(_etype1610, _size1607);
+            this->partVals.resize(_size1607);
+            uint32_t _i1611;
+            for (_i1611 = 0; _i1611 < _size1607; ++_i1611)
             {
-              xfer += iprot->readString(this->partVals[_i1609]);
+              xfer += iprot->readString(this->partVals[_i1611]);
             }
             xfer += iprot->readListEnd();
           }
@@ -45319,14 +45367,14 @@ uint32_t GetPartitionsPsWithAuthRequest::read(::apache::thrift::protocol::TProto
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->groupNames.clear();
-            uint32_t _size1610;
-            ::apache::thrift::protocol::TType _etype1613;
-            xfer += iprot->readListBegin(_etype1613, _size1610);
-            this->groupNames.resize(_size1610);
-            uint32_t _i1614;
-            for (_i1614 = 0; _i1614 < _size1610; ++_i1614)
+            uint32_t _size1612;
+            ::apache::thrift::protocol::TType _etype1615;
+            xfer += iprot->readListBegin(_etype1615, _size1612);
+            this->groupNames.resize(_size1612);
+            uint32_t _i1616;
+            for (_i1616 = 0; _i1616 < _size1612; ++_i1616)
             {
-              xfer += iprot->readString(this->groupNames[_i1614]);
+              xfer += iprot->readString(this->groupNames[_i1616]);
             }
             xfer += iprot->readListEnd();
           }
@@ -45389,10 +45437,10 @@ uint32_t GetPartitionsPsWithAuthRequest::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("partVals", ::apache::thrift::protocol::T_LIST, 4);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->partVals.size()));
-      std::vector<std::string> ::const_iterator _iter1615;
-      for (_iter1615 = this->partVals.begin(); _iter1615 != this->partVals.end(); ++_iter1615)
+      std::vector<std::string> ::const_iterator _iter1617;
+      for (_iter1617 = this->partVals.begin(); _iter1617 != this->partVals.end(); ++_iter1617)
       {
-        xfer += oprot->writeString((*_iter1615));
+        xfer += oprot->writeString((*_iter1617));
       }
       xfer += oprot->writeListEnd();
     }
@@ -45412,10 +45460,10 @@ uint32_t GetPartitionsPsWithAuthRequest::write(::apache::thrift::protocol::TProt
     xfer += oprot->writeFieldBegin("groupNames", ::apache::thrift::protocol::T_LIST, 7);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRING, static_cast<uint32_t>(this->groupNames.size()));
-      std::vector<std::string> ::const_iterator _iter1616;
-      for (_iter1616 = this->groupNames.begin(); _iter1616 != this->groupNames.end(); ++_iter1616)
+      std::vector<std::string> ::const_iterator _iter1618;
+      for (_iter1618 = this->groupNames.begin(); _iter1618 != this->groupNames.end(); ++_iter1618)
       {
-        xfer += oprot->writeString((*_iter1616));
+        xfer += oprot->writeString((*_iter1618));
       }
       xfer += oprot->writeListEnd();
     }
@@ -45450,29 +45498,29 @@ void swap(GetPartitionsPsWithAuthRequest &a, GetPartitionsPsWithAuthRequest &b) 
   swap(a.__isset, b.__isset);
 }
 
-GetPartitionsPsWithAuthRequest::GetPartitionsPsWithAuthRequest(const GetPartitionsPsWithAuthRequest& other1617) {
-  catName = other1617.catName;
-  dbName = other1617.dbName;
-  tblName = other1617.tblName;
-  partVals = other1617.partVals;
-  maxParts = other1617.maxParts;
-  userName = other1617.userName;
-  groupNames = other1617.groupNames;
-  validWriteIdList = other1617.validWriteIdList;
-  id = other1617.id;
-  __isset = other1617.__isset;
+GetPartitionsPsWithAuthRequest::GetPartitionsPsWithAuthRequest(const GetPartitionsPsWithAuthRequest& other1619) {
+  catName = other1619.catName;
+  dbName = other1619.dbName;
+  tblName = other1619.tblName;
+  partVals = other1619.partVals;
+  maxParts = other1619.maxParts;
+  userName = other1619.userName;
+  groupNames = other1619.groupNames;
+  validWriteIdList = other1619.validWriteIdList;
+  id = other1619.id;
+  __isset = other1619.__isset;
 }
-GetPartitionsPsWithAuthRequest& GetPartitionsPsWithAuthRequest::operator=(const GetPartitionsPsWithAuthRequest& other1618) {
-  catName = other1618.catName;
-  dbName = other1618.dbName;
-  tblName = other1618.tblName;
-  partVals = other1618.partVals;
-  maxParts = other1618.maxParts;
-  userName = other1618.userName;
-  groupNames = other1618.groupNames;
-  validWriteIdList = other1618.validWriteIdList;
-  id = other1618.id;
-  __isset = other1618.__isset;
+GetPartitionsPsWithAuthRequest& GetPartitionsPsWithAuthRequest::operator=(const GetPartitionsPsWithAuthRequest& other1620) {
+  catName = other1620.catName;
+  dbName = other1620.dbName;
+  tblName = other1620.tblName;
+  partVals = other1620.partVals;
+  maxParts = other1620.maxParts;
+  userName = other1620.userName;
+  groupNames = other1620.groupNames;
+  validWriteIdList = other1620.validWriteIdList;
+  id = other1620.id;
+  __isset = other1620.__isset;
   return *this;
 }
 void GetPartitionsPsWithAuthRequest::printTo(std::ostream& out) const {
@@ -45531,14 +45579,14 @@ uint32_t GetPartitionsPsWithAuthResponse::read(::apache::thrift::protocol::TProt
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->partitions.clear();
-            uint32_t _size1619;
-            ::apache::thrift::protocol::TType _etype1622;
-            xfer += iprot->readListBegin(_etype1622, _size1619);
-            this->partitions.resize(_size1619);
-            uint32_t _i1623;
-            for (_i1623 = 0; _i1623 < _size1619; ++_i1623)
+            uint32_t _size1621;
+            ::apache::thrift::protocol::TType _etype1624;
+            xfer += iprot->readListBegin(_etype1624, _size1621);
+            this->partitions.resize(_size1621);
+            uint32_t _i1625;
+            for (_i1625 = 0; _i1625 < _size1621; ++_i1625)
             {
-              xfer += this->partitions[_i1623].read(iprot);
+              xfer += this->partitions[_i1625].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -45569,10 +45617,10 @@ uint32_t GetPartitionsPsWithAuthResponse::write(::apache::thrift::protocol::TPro
   xfer += oprot->writeFieldBegin("partitions", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->partitions.size()));
-    std::vector<Partition> ::const_iterator _iter1624;
-    for (_iter1624 = this->partitions.begin(); _iter1624 != this->partitions.end(); ++_iter1624)
+    std::vector<Partition> ::const_iterator _iter1626;
+    for (_iter1626 = this->partitions.begin(); _iter1626 != this->partitions.end(); ++_iter1626)
     {
-      xfer += (*_iter1624).write(oprot);
+      xfer += (*_iter1626).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -45588,11 +45636,11 @@ void swap(GetPartitionsPsWithAuthResponse &a, GetPartitionsPsWithAuthResponse &b
   swap(a.partitions, b.partitions);
 }
 
-GetPartitionsPsWithAuthResponse::GetPartitionsPsWithAuthResponse(const GetPartitionsPsWithAuthResponse& other1625) {
-  partitions = other1625.partitions;
+GetPartitionsPsWithAuthResponse::GetPartitionsPsWithAuthResponse(const GetPartitionsPsWithAuthResponse& other1627) {
+  partitions = other1627.partitions;
 }
-GetPartitionsPsWithAuthResponse& GetPartitionsPsWithAuthResponse::operator=(const GetPartitionsPsWithAuthResponse& other1626) {
-  partitions = other1626.partitions;
+GetPartitionsPsWithAuthResponse& GetPartitionsPsWithAuthResponse::operator=(const GetPartitionsPsWithAuthResponse& other1628) {
+  partitions = other1628.partitions;
   return *this;
 }
 void GetPartitionsPsWithAuthResponse::printTo(std::ostream& out) const {
@@ -45759,21 +45807,21 @@ void swap(ReplicationMetrics &a, ReplicationMetrics &b) {
   swap(a.__isset, b.__isset);
 }
 
-ReplicationMetrics::ReplicationMetrics(const ReplicationMetrics& other1627) {
-  scheduledExecutionId = other1627.scheduledExecutionId;
-  policy = other1627.policy;
-  dumpExecutionId = other1627.dumpExecutionId;
-  metadata = other1627.metadata;
-  progress = other1627.progress;
-  __isset = other1627.__isset;
+ReplicationMetrics::ReplicationMetrics(const ReplicationMetrics& other1629) {
+  scheduledExecutionId = other1629.scheduledExecutionId;
+  policy = other1629.policy;
+  dumpExecutionId = other1629.dumpExecutionId;
+  metadata = other1629.metadata;
+  progress = other1629.progress;
+  __isset = other1629.__isset;
 }
-ReplicationMetrics& ReplicationMetrics::operator=(const ReplicationMetrics& other1628) {
-  scheduledExecutionId = other1628.scheduledExecutionId;
-  policy = other1628.policy;
-  dumpExecutionId = other1628.dumpExecutionId;
-  metadata = other1628.metadata;
-  progress = other1628.progress;
-  __isset = other1628.__isset;
+ReplicationMetrics& ReplicationMetrics::operator=(const ReplicationMetrics& other1630) {
+  scheduledExecutionId = other1630.scheduledExecutionId;
+  policy = other1630.policy;
+  dumpExecutionId = other1630.dumpExecutionId;
+  metadata = other1630.metadata;
+  progress = other1630.progress;
+  __isset = other1630.__isset;
   return *this;
 }
 void ReplicationMetrics::printTo(std::ostream& out) const {
@@ -45828,14 +45876,14 @@ uint32_t ReplicationMetricList::read(::apache::thrift::protocol::TProtocol* ipro
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->replicationMetricList.clear();
-            uint32_t _size1629;
-            ::apache::thrift::protocol::TType _etype1632;
-            xfer += iprot->readListBegin(_etype1632, _size1629);
-            this->replicationMetricList.resize(_size1629);
-            uint32_t _i1633;
-            for (_i1633 = 0; _i1633 < _size1629; ++_i1633)
+            uint32_t _size1631;
+            ::apache::thrift::protocol::TType _etype1634;
+            xfer += iprot->readListBegin(_etype1634, _size1631);
+            this->replicationMetricList.resize(_size1631);
+            uint32_t _i1635;
+            for (_i1635 = 0; _i1635 < _size1631; ++_i1635)
             {
-              xfer += this->replicationMetricList[_i1633].read(iprot);
+              xfer += this->replicationMetricList[_i1635].read(iprot);
             }
             xfer += iprot->readListEnd();
           }
@@ -45866,10 +45914,10 @@ uint32_t ReplicationMetricList::write(::apache::thrift::protocol::TProtocol* opr
   xfer += oprot->writeFieldBegin("replicationMetricList", ::apache::thrift::protocol::T_LIST, 1);
   {
     xfer += oprot->writeListBegin(::apache::thrift::protocol::T_STRUCT, static_cast<uint32_t>(this->replicationMetricList.size()));
-    std::vector<ReplicationMetrics> ::const_iterator _iter1634;
-    for (_iter1634 = this->replicationMetricList.begin(); _iter1634 != this->replicationMetricList.end(); ++_iter1634)
+    std::vector<ReplicationMetrics> ::const_iterator _iter1636;
+    for (_iter1636 = this->replicationMetricList.begin(); _iter1636 != this->replicationMetricList.end(); ++_iter1636)
     {
-      xfer += (*_iter1634).write(oprot);
+      xfer += (*_iter1636).write(oprot);
     }
     xfer += oprot->writeListEnd();
   }
@@ -45885,11 +45933,11 @@ void swap(ReplicationMetricList &a, ReplicationMetricList &b) {
   swap(a.replicationMetricList, b.replicationMetricList);
 }
 
-ReplicationMetricList::ReplicationMetricList(const ReplicationMetricList& other1635) {
-  replicationMetricList = other1635.replicationMetricList;
+ReplicationMetricList::ReplicationMetricList(const ReplicationMetricList& other1637) {
+  replicationMetricList = other1637.replicationMetricList;
 }
-ReplicationMetricList& ReplicationMetricList::operator=(const ReplicationMetricList& other1636) {
-  replicationMetricList = other1636.replicationMetricList;
+ReplicationMetricList& ReplicationMetricList::operator=(const ReplicationMetricList& other1638) {
+  replicationMetricList = other1638.replicationMetricList;
   return *this;
 }
 void ReplicationMetricList::printTo(std::ostream& out) const {
@@ -46015,17 +46063,17 @@ void swap(GetReplicationMetricsRequest &a, GetReplicationMetricsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetReplicationMetricsRequest::GetReplicationMetricsRequest(const GetReplicationMetricsRequest& other1637) {
-  scheduledExecutionId = other1637.scheduledExecutionId;
-  policy = other1637.policy;
-  dumpExecutionId = other1637.dumpExecutionId;
-  __isset = other1637.__isset;
+GetReplicationMetricsRequest::GetReplicationMetricsRequest(const GetReplicationMetricsRequest& other1639) {
+  scheduledExecutionId = other1639.scheduledExecutionId;
+  policy = other1639.policy;
+  dumpExecutionId = other1639.dumpExecutionId;
+  __isset = other1639.__isset;
 }
-GetReplicationMetricsRequest& GetReplicationMetricsRequest::operator=(const GetReplicationMetricsRequest& other1638) {
-  scheduledExecutionId = other1638.scheduledExecutionId;
-  policy = other1638.policy;
-  dumpExecutionId = other1638.dumpExecutionId;
-  __isset = other1638.__isset;
+GetReplicationMetricsRequest& GetReplicationMetricsRequest::operator=(const GetReplicationMetricsRequest& other1640) {
+  scheduledExecutionId = other1640.scheduledExecutionId;
+  policy = other1640.policy;
+  dumpExecutionId = other1640.dumpExecutionId;
+  __isset = other1640.__isset;
   return *this;
 }
 void GetReplicationMetricsRequest::printTo(std::ostream& out) const {
@@ -46078,16 +46126,16 @@ uint32_t GetOpenTxnsRequest::read(::apache::thrift::protocol::TProtocol* iprot) 
         if (ftype == ::apache::thrift::protocol::T_LIST) {
           {
             this->excludeTxnTypes.clear();
-            uint32_t _size1639;
-            ::apache::thrift::protocol::TType _etype1642;
-            xfer += iprot->readListBegin(_etype1642, _size1639);
-            this->excludeTxnTypes.resize(_size1639);
-            uint32_t _i1643;
-            for (_i1643 = 0; _i1643 < _size1639; ++_i1643)
+            uint32_t _size1641;
+            ::apache::thrift::protocol::TType _etype1644;
+            xfer += iprot->readListBegin(_etype1644, _size1641);
+            this->excludeTxnTypes.resize(_size1641);
+            uint32_t _i1645;
+            for (_i1645 = 0; _i1645 < _size1641; ++_i1645)
             {
-              int32_t ecast1644;
-              xfer += iprot->readI32(ecast1644);
-              this->excludeTxnTypes[_i1643] = (TxnType::type)ecast1644;
+              int32_t ecast1646;
+              xfer += iprot->readI32(ecast1646);
+              this->excludeTxnTypes[_i1645] = (TxnType::type)ecast1646;
             }
             xfer += iprot->readListEnd();
           }
@@ -46117,10 +46165,10 @@ uint32_t GetOpenTxnsRequest::write(::apache::thrift::protocol::TProtocol* oprot)
     xfer += oprot->writeFieldBegin("excludeTxnTypes", ::apache::thrift::protocol::T_LIST, 1);
     {
       xfer += oprot->writeListBegin(::apache::thrift::protocol::T_I32, static_cast<uint32_t>(this->excludeTxnTypes.size()));
-      std::vector<TxnType::type> ::const_iterator _iter1645;
-      for (_iter1645 = this->excludeTxnTypes.begin(); _iter1645 != this->excludeTxnTypes.end(); ++_iter1645)
+      std::vector<TxnType::type> ::const_iterator _iter1647;
+      for (_iter1647 = this->excludeTxnTypes.begin(); _iter1647 != this->excludeTxnTypes.end(); ++_iter1647)
       {
-        xfer += oprot->writeI32((int32_t)(*_iter1645));
+        xfer += oprot->writeI32((int32_t)(*_iter1647));
       }
       xfer += oprot->writeListEnd();
     }
@@ -46137,13 +46185,13 @@ void swap(GetOpenTxnsRequest &a, GetOpenTxnsRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-GetOpenTxnsRequest::GetOpenTxnsRequest(const GetOpenTxnsRequest& other1646) {
-  excludeTxnTypes = other1646.excludeTxnTypes;
-  __isset = other1646.__isset;
+GetOpenTxnsRequest::GetOpenTxnsRequest(const GetOpenTxnsRequest& other1648) {
+  excludeTxnTypes = other1648.excludeTxnTypes;
+  __isset = other1648.__isset;
 }
-GetOpenTxnsRequest& GetOpenTxnsRequest::operator=(const GetOpenTxnsRequest& other1647) {
-  excludeTxnTypes = other1647.excludeTxnTypes;
-  __isset = other1647.__isset;
+GetOpenTxnsRequest& GetOpenTxnsRequest::operator=(const GetOpenTxnsRequest& other1649) {
+  excludeTxnTypes = other1649.excludeTxnTypes;
+  __isset = other1649.__isset;
   return *this;
 }
 void GetOpenTxnsRequest::printTo(std::ostream& out) const {
@@ -46271,15 +46319,15 @@ void swap(StoredProcedureRequest &a, StoredProcedureRequest &b) {
   swap(a.procName, b.procName);
 }
 
-StoredProcedureRequest::StoredProcedureRequest(const StoredProcedureRequest& other1648) {
-  catName = other1648.catName;
-  dbName = other1648.dbName;
-  procName = other1648.procName;
+StoredProcedureRequest::StoredProcedureRequest(const StoredProcedureRequest& other1650) {
+  catName = other1650.catName;
+  dbName = other1650.dbName;
+  procName = other1650.procName;
 }
-StoredProcedureRequest& StoredProcedureRequest::operator=(const StoredProcedureRequest& other1649) {
-  catName = other1649.catName;
-  dbName = other1649.dbName;
-  procName = other1649.procName;
+StoredProcedureRequest& StoredProcedureRequest::operator=(const StoredProcedureRequest& other1651) {
+  catName = other1651.catName;
+  dbName = other1651.dbName;
+  procName = other1651.procName;
   return *this;
 }
 void StoredProcedureRequest::printTo(std::ostream& out) const {
@@ -46389,15 +46437,15 @@ void swap(ListStoredProcedureRequest &a, ListStoredProcedureRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ListStoredProcedureRequest::ListStoredProcedureRequest(const ListStoredProcedureRequest& other1650) {
-  catName = other1650.catName;
-  dbName = other1650.dbName;
-  __isset = other1650.__isset;
+ListStoredProcedureRequest::ListStoredProcedureRequest(const ListStoredProcedureRequest& other1652) {
+  catName = other1652.catName;
+  dbName = other1652.dbName;
+  __isset = other1652.__isset;
 }
-ListStoredProcedureRequest& ListStoredProcedureRequest::operator=(const ListStoredProcedureRequest& other1651) {
-  catName = other1651.catName;
-  dbName = other1651.dbName;
-  __isset = other1651.__isset;
+ListStoredProcedureRequest& ListStoredProcedureRequest::operator=(const ListStoredProcedureRequest& other1653) {
+  catName = other1653.catName;
+  dbName = other1653.dbName;
+  __isset = other1653.__isset;
   return *this;
 }
 void ListStoredProcedureRequest::printTo(std::ostream& out) const {
@@ -46552,21 +46600,21 @@ void swap(StoredProcedure &a, StoredProcedure &b) {
   swap(a.__isset, b.__isset);
 }
 
-StoredProcedure::StoredProcedure(const StoredProcedure& other1652) {
-  name = other1652.name;
-  dbName = other1652.dbName;
-  catName = other1652.catName;
-  ownerName = other1652.ownerName;
-  source = other1652.source;
-  __isset = other1652.__isset;
+StoredProcedure::StoredProcedure(const StoredProcedure& other1654) {
+  name = other1654.name;
+  dbName = other1654.dbName;
+  catName = other1654.catName;
+  ownerName = other1654.ownerName;
+  source = other1654.source;
+  __isset = other1654.__isset;
 }
-StoredProcedure& StoredProcedure::operator=(const StoredProcedure& other1653) {
-  name = other1653.name;
-  dbName = other1653.dbName;
-  catName = other1653.catName;
-  ownerName = other1653.ownerName;
-  source = other1653.source;
-  __isset = other1653.__isset;
+StoredProcedure& StoredProcedure::operator=(const StoredProcedure& other1655) {
+  name = other1655.name;
+  dbName = other1655.dbName;
+  catName = other1655.catName;
+  ownerName = other1655.ownerName;
+  source = other1655.source;
+  __isset = other1655.__isset;
   return *this;
 }
 void StoredProcedure::printTo(std::ostream& out) const {
@@ -46741,23 +46789,23 @@ void swap(AddPackageRequest &a, AddPackageRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-AddPackageRequest::AddPackageRequest(const AddPackageRequest& other1654) {
-  catName = other1654.catName;
-  dbName = other1654.dbName;
-  packageName = other1654.packageName;
-  ownerName = other1654.ownerName;
-  header = other1654.header;
-  body = other1654.body;
-  __isset = other1654.__isset;
+AddPackageRequest::AddPackageRequest(const AddPackageRequest& other1656) {
+  catName = other1656.catName;
+  dbName = other1656.dbName;
+  packageName = other1656.packageName;
+  ownerName = other1656.ownerName;
+  header = other1656.header;
+  body = other1656.body;
+  __isset = other1656.__isset;
 }
-AddPackageRequest& AddPackageRequest::operator=(const AddPackageRequest& other1655) {
-  catName = other1655.catName;
-  dbName = other1655.dbName;
-  packageName = other1655.packageName;
-  ownerName = other1655.ownerName;
-  header = other1655.header;
-  body = other1655.body;
-  __isset = other1655.__isset;
+AddPackageRequest& AddPackageRequest::operator=(const AddPackageRequest& other1657) {
+  catName = other1657.catName;
+  dbName = other1657.dbName;
+  packageName = other1657.packageName;
+  ownerName = other1657.ownerName;
+  header = other1657.header;
+  body = other1657.body;
+  __isset = other1657.__isset;
   return *this;
 }
 void AddPackageRequest::printTo(std::ostream& out) const {
@@ -46890,15 +46938,15 @@ void swap(GetPackageRequest &a, GetPackageRequest &b) {
   swap(a.packageName, b.packageName);
 }
 
-GetPackageRequest::GetPackageRequest(const GetPackageRequest& other1656) {
-  catName = other1656.catName;
-  dbName = other1656.dbName;
-  packageName = other1656.packageName;
+GetPackageRequest::GetPackageRequest(const GetPackageRequest& other1658) {
+  catName = other1658.catName;
+  dbName = other1658.dbName;
+  packageName = other1658.packageName;
 }
-GetPackageRequest& GetPackageRequest::operator=(const GetPackageRequest& other1657) {
-  catName = other1657.catName;
-  dbName = other1657.dbName;
-  packageName = other1657.packageName;
+GetPackageRequest& GetPackageRequest::operator=(const GetPackageRequest& other1659) {
+  catName = other1659.catName;
+  dbName = other1659.dbName;
+  packageName = other1659.packageName;
   return *this;
 }
 void GetPackageRequest::printTo(std::ostream& out) const {
@@ -47028,15 +47076,15 @@ void swap(DropPackageRequest &a, DropPackageRequest &b) {
   swap(a.packageName, b.packageName);
 }
 
-DropPackageRequest::DropPackageRequest(const DropPackageRequest& other1658) {
-  catName = other1658.catName;
-  dbName = other1658.dbName;
-  packageName = other1658.packageName;
+DropPackageRequest::DropPackageRequest(const DropPackageRequest& other1660) {
+  catName = other1660.catName;
+  dbName = other1660.dbName;
+  packageName = other1660.packageName;
 }
-DropPackageRequest& DropPackageRequest::operator=(const DropPackageRequest& other1659) {
-  catName = other1659.catName;
-  dbName = other1659.dbName;
-  packageName = other1659.packageName;
+DropPackageRequest& DropPackageRequest::operator=(const DropPackageRequest& other1661) {
+  catName = other1661.catName;
+  dbName = other1661.dbName;
+  packageName = other1661.packageName;
   return *this;
 }
 void DropPackageRequest::printTo(std::ostream& out) const {
@@ -47146,15 +47194,15 @@ void swap(ListPackageRequest &a, ListPackageRequest &b) {
   swap(a.__isset, b.__isset);
 }
 
-ListPackageRequest::ListPackageRequest(const ListPackageRequest& other1660) {
-  catName = other1660.catName;
-  dbName = other1660.dbName;
-  __isset = other1660.__isset;
+ListPackageRequest::ListPackageRequest(const ListPackageRequest& other1662) {
+  catName = other1662.catName;
+  dbName = other1662.dbName;
+  __isset = other1662.__isset;
 }
-ListPackageRequest& ListPackageRequest::operator=(const ListPackageRequest& other1661) {
-  catName = other1661.catName;
-  dbName = other1661.dbName;
-  __isset = other1661.__isset;
+ListPackageRequest& ListPackageRequest::operator=(const ListPackageRequest& other1663) {
+  catName = other1663.catName;
+  dbName = other1663.dbName;
+  __isset = other1663.__isset;
   return *this;
 }
 void ListPackageRequest::printTo(std::ostream& out) const {
@@ -47326,23 +47374,23 @@ void swap(Package &a, Package &b) {
   swap(a.__isset, b.__isset);
 }
 
-Package::Package(const Package& other1662) {
-  catName = other1662.catName;
-  dbName = other1662.dbName;
-  packageName = other1662.packageName;
-  ownerName = other1662.ownerName;
-  header = other1662.header;
-  body = other1662.body;
-  __isset = other1662.__isset;
+Package::Package(const Package& other1664) {
+  catName = other1664.catName;
+  dbName = other1664.dbName;
+  packageName = other1664.packageName;
+  ownerName = other1664.ownerName;
+  header = other1664.header;
+  body = other1664.body;
+  __isset = other1664.__isset;
 }
-Package& Package::operator=(const Package& other1663) {
-  catName = other1663.catName;
-  dbName = other1663.dbName;
-  packageName = other1663.packageName;
-  ownerName = other1663.ownerName;
-  header = other1663.header;
-  body = other1663.body;
-  __isset = other1663.__isset;
+Package& Package::operator=(const Package& other1665) {
+  catName = other1665.catName;
+  dbName = other1665.dbName;
+  packageName = other1665.packageName;
+  ownerName = other1665.ownerName;
+  header = other1665.header;
+  body = other1665.body;
+  __isset = other1665.__isset;
   return *this;
 }
 void Package::printTo(std::ostream& out) const {
@@ -47433,13 +47481,13 @@ void swap(MetaException &a, MetaException &b) {
   swap(a.__isset, b.__isset);
 }
 
-MetaException::MetaException(const MetaException& other1664) : TException() {
-  message = other1664.message;
-  __isset = other1664.__isset;
+MetaException::MetaException(const MetaException& other1666) : TException() {
+  message = other1666.message;
+  __isset = other1666.__isset;
 }
-MetaException& MetaException::operator=(const MetaException& other1665) {
-  message = other1665.message;
-  __isset = other1665.__isset;
+MetaException& MetaException::operator=(const MetaException& other1667) {
+  message = other1667.message;
+  __isset = other1667.__isset;
   return *this;
 }
 void MetaException::printTo(std::ostream& out) const {
@@ -47536,13 +47584,13 @@ void swap(UnknownTableException &a, UnknownTableException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownTableException::UnknownTableException(const UnknownTableException& other1666) : TException() {
-  message = other1666.message;
-  __isset = other1666.__isset;
+UnknownTableException::UnknownTableException(const UnknownTableException& other1668) : TException() {
+  message = other1668.message;
+  __isset = other1668.__isset;
 }
-UnknownTableException& UnknownTableException::operator=(const UnknownTableException& other1667) {
-  message = other1667.message;
-  __isset = other1667.__isset;
+UnknownTableException& UnknownTableException::operator=(const UnknownTableException& other1669) {
+  message = other1669.message;
+  __isset = other1669.__isset;
   return *this;
 }
 void UnknownTableException::printTo(std::ostream& out) const {
@@ -47639,13 +47687,13 @@ void swap(UnknownDBException &a, UnknownDBException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownDBException::UnknownDBException(const UnknownDBException& other1668) : TException() {
-  message = other1668.message;
-  __isset = other1668.__isset;
+UnknownDBException::UnknownDBException(const UnknownDBException& other1670) : TException() {
+  message = other1670.message;
+  __isset = other1670.__isset;
 }
-UnknownDBException& UnknownDBException::operator=(const UnknownDBException& other1669) {
-  message = other1669.message;
-  __isset = other1669.__isset;
+UnknownDBException& UnknownDBException::operator=(const UnknownDBException& other1671) {
+  message = other1671.message;
+  __isset = other1671.__isset;
   return *this;
 }
 void UnknownDBException::printTo(std::ostream& out) const {
@@ -47742,13 +47790,13 @@ void swap(AlreadyExistsException &a, AlreadyExistsException &b) {
   swap(a.__isset, b.__isset);
 }
 
-AlreadyExistsException::AlreadyExistsException(const AlreadyExistsException& other1670) : TException() {
-  message = other1670.message;
-  __isset = other1670.__isset;
+AlreadyExistsException::AlreadyExistsException(const AlreadyExistsException& other1672) : TException() {
+  message = other1672.message;
+  __isset = other1672.__isset;
 }
-AlreadyExistsException& AlreadyExistsException::operator=(const AlreadyExistsException& other1671) {
-  message = other1671.message;
-  __isset = other1671.__isset;
+AlreadyExistsException& AlreadyExistsException::operator=(const AlreadyExistsException& other1673) {
+  message = other1673.message;
+  __isset = other1673.__isset;
   return *this;
 }
 void AlreadyExistsException::printTo(std::ostream& out) const {
@@ -47845,13 +47893,13 @@ void swap(InvalidPartitionException &a, InvalidPartitionException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidPartitionException::InvalidPartitionException(const InvalidPartitionException& other1672) : TException() {
-  message = other1672.message;
-  __isset = other1672.__isset;
+InvalidPartitionException::InvalidPartitionException(const InvalidPartitionException& other1674) : TException() {
+  message = other1674.message;
+  __isset = other1674.__isset;
 }
-InvalidPartitionException& InvalidPartitionException::operator=(const InvalidPartitionException& other1673) {
-  message = other1673.message;
-  __isset = other1673.__isset;
+InvalidPartitionException& InvalidPartitionException::operator=(const InvalidPartitionException& other1675) {
+  message = other1675.message;
+  __isset = other1675.__isset;
   return *this;
 }
 void InvalidPartitionException::printTo(std::ostream& out) const {
@@ -47948,13 +47996,13 @@ void swap(UnknownPartitionException &a, UnknownPartitionException &b) {
   swap(a.__isset, b.__isset);
 }
 
-UnknownPartitionException::UnknownPartitionException(const UnknownPartitionException& other1674) : TException() {
-  message = other1674.message;
-  __isset = other1674.__isset;
+UnknownPartitionException::UnknownPartitionException(const UnknownPartitionException& other1676) : TException() {
+  message = other1676.message;
+  __isset = other1676.__isset;
 }
-UnknownPartitionException& UnknownPartitionException::operator=(const UnknownPartitionException& other1675) {
-  message = other1675.message;
-  __isset = other1675.__isset;
+UnknownPartitionException& UnknownPartitionException::operator=(const UnknownPartitionException& other1677) {
+  message = other1677.message;
+  __isset = other1677.__isset;
   return *this;
 }
 void UnknownPartitionException::printTo(std::ostream& out) const {
@@ -48051,13 +48099,13 @@ void swap(InvalidObjectException &a, InvalidObjectException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidObjectException::InvalidObjectException(const InvalidObjectException& other1676) : TException() {
-  message = other1676.message;
-  __isset = other1676.__isset;
+InvalidObjectException::InvalidObjectException(const InvalidObjectException& other1678) : TException() {
+  message = other1678.message;
+  __isset = other1678.__isset;
 }
-InvalidObjectException& InvalidObjectException::operator=(const InvalidObjectException& other1677) {
-  message = other1677.message;
-  __isset = other1677.__isset;
+InvalidObjectException& InvalidObjectException::operator=(const InvalidObjectException& other1679) {
+  message = other1679.message;
+  __isset = other1679.__isset;
   return *this;
 }
 void InvalidObjectException::printTo(std::ostream& out) const {
@@ -48154,13 +48202,13 @@ void swap(NoSuchObjectException &a, NoSuchObjectException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchObjectException::NoSuchObjectException(const NoSuchObjectException& other1678) : TException() {
-  message = other1678.message;
-  __isset = other1678.__isset;
+NoSuchObjectException::NoSuchObjectException(const NoSuchObjectException& other1680) : TException() {
+  message = other1680.message;
+  __isset = other1680.__isset;
 }
-NoSuchObjectException& NoSuchObjectException::operator=(const NoSuchObjectException& other1679) {
-  message = other1679.message;
-  __isset = other1679.__isset;
+NoSuchObjectException& NoSuchObjectException::operator=(const NoSuchObjectException& other1681) {
+  message = other1681.message;
+  __isset = other1681.__isset;
   return *this;
 }
 void NoSuchObjectException::printTo(std::ostream& out) const {
@@ -48257,13 +48305,13 @@ void swap(InvalidOperationException &a, InvalidOperationException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidOperationException::InvalidOperationException(const InvalidOperationException& other1680) : TException() {
-  message = other1680.message;
-  __isset = other1680.__isset;
+InvalidOperationException::InvalidOperationException(const InvalidOperationException& other1682) : TException() {
+  message = other1682.message;
+  __isset = other1682.__isset;
 }
-InvalidOperationException& InvalidOperationException::operator=(const InvalidOperationException& other1681) {
-  message = other1681.message;
-  __isset = other1681.__isset;
+InvalidOperationException& InvalidOperationException::operator=(const InvalidOperationException& other1683) {
+  message = other1683.message;
+  __isset = other1683.__isset;
   return *this;
 }
 void InvalidOperationException::printTo(std::ostream& out) const {
@@ -48360,13 +48408,13 @@ void swap(ConfigValSecurityException &a, ConfigValSecurityException &b) {
   swap(a.__isset, b.__isset);
 }
 
-ConfigValSecurityException::ConfigValSecurityException(const ConfigValSecurityException& other1682) : TException() {
-  message = other1682.message;
-  __isset = other1682.__isset;
+ConfigValSecurityException::ConfigValSecurityException(const ConfigValSecurityException& other1684) : TException() {
+  message = other1684.message;
+  __isset = other1684.__isset;
 }
-ConfigValSecurityException& ConfigValSecurityException::operator=(const ConfigValSecurityException& other1683) {
-  message = other1683.message;
-  __isset = other1683.__isset;
+ConfigValSecurityException& ConfigValSecurityException::operator=(const ConfigValSecurityException& other1685) {
+  message = other1685.message;
+  __isset = other1685.__isset;
   return *this;
 }
 void ConfigValSecurityException::printTo(std::ostream& out) const {
@@ -48463,13 +48511,13 @@ void swap(InvalidInputException &a, InvalidInputException &b) {
   swap(a.__isset, b.__isset);
 }
 
-InvalidInputException::InvalidInputException(const InvalidInputException& other1684) : TException() {
-  message = other1684.message;
-  __isset = other1684.__isset;
+InvalidInputException::InvalidInputException(const InvalidInputException& other1686) : TException() {
+  message = other1686.message;
+  __isset = other1686.__isset;
 }
-InvalidInputException& InvalidInputException::operator=(const InvalidInputException& other1685) {
-  message = other1685.message;
-  __isset = other1685.__isset;
+InvalidInputException& InvalidInputException::operator=(const InvalidInputException& other1687) {
+  message = other1687.message;
+  __isset = other1687.__isset;
   return *this;
 }
 void InvalidInputException::printTo(std::ostream& out) const {
@@ -48566,13 +48614,13 @@ void swap(NoSuchTxnException &a, NoSuchTxnException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchTxnException::NoSuchTxnException(const NoSuchTxnException& other1686) : TException() {
-  message = other1686.message;
-  __isset = other1686.__isset;
+NoSuchTxnException::NoSuchTxnException(const NoSuchTxnException& other1688) : TException() {
+  message = other1688.message;
+  __isset = other1688.__isset;
 }
-NoSuchTxnException& NoSuchTxnException::operator=(const NoSuchTxnException& other1687) {
-  message = other1687.message;
-  __isset = other1687.__isset;
+NoSuchTxnException& NoSuchTxnException::operator=(const NoSuchTxnException& other1689) {
+  message = other1689.message;
+  __isset = other1689.__isset;
   return *this;
 }
 void NoSuchTxnException::printTo(std::ostream& out) const {
@@ -48669,13 +48717,13 @@ void swap(TxnAbortedException &a, TxnAbortedException &b) {
   swap(a.__isset, b.__isset);
 }
 
-TxnAbortedException::TxnAbortedException(const TxnAbortedException& other1688) : TException() {
-  message = other1688.message;
-  __isset = other1688.__isset;
+TxnAbortedException::TxnAbortedException(const TxnAbortedException& other1690) : TException() {
+  message = other1690.message;
+  __isset = other1690.__isset;
 }
-TxnAbortedException& TxnAbortedException::operator=(const TxnAbortedException& other1689) {
-  message = other1689.message;
-  __isset = other1689.__isset;
+TxnAbortedException& TxnAbortedException::operator=(const TxnAbortedException& other1691) {
+  message = other1691.message;
+  __isset = other1691.__isset;
   return *this;
 }
 void TxnAbortedException::printTo(std::ostream& out) const {
@@ -48772,13 +48820,13 @@ void swap(TxnOpenException &a, TxnOpenException &b) {
   swap(a.__isset, b.__isset);
 }
 
-TxnOpenException::TxnOpenException(const TxnOpenException& other1690) : TException() {
-  message = other1690.message;
-  __isset = other1690.__isset;
+TxnOpenException::TxnOpenException(const TxnOpenException& other1692) : TException() {
+  message = other1692.message;
+  __isset = other1692.__isset;
 }
-TxnOpenException& TxnOpenException::operator=(const TxnOpenException& other1691) {
-  message = other1691.message;
-  __isset = other1691.__isset;
+TxnOpenException& TxnOpenException::operator=(const TxnOpenException& other1693) {
+  message = other1693.message;
+  __isset = other1693.__isset;
   return *this;
 }
 void TxnOpenException::printTo(std::ostream& out) const {
@@ -48875,13 +48923,13 @@ void swap(NoSuchLockException &a, NoSuchLockException &b) {
   swap(a.__isset, b.__isset);
 }
 
-NoSuchLockException::NoSuchLockException(const NoSuchLockException& other1692) : TException() {
-  message = other1692.message;
-  __isset = other1692.__isset;
+NoSuchLockException::NoSuchLockException(const NoSuchLockException& other1694) : TException() {
+  message = other1694.message;
+  __isset = other1694.__isset;
 }
-NoSuchLockException& NoSuchLockException::operator=(const NoSuchLockException& other1693) {
-  message = other1693.message;
-  __isset = other1693.__isset;
+NoSuchLockException& NoSuchLockException::operator=(const NoSuchLockException& other1695) {
+  message = other1695.message;
+  __isset = other1695.__isset;
   return *this;
 }
 void NoSuchLockException::printTo(std::ostream& out) const {

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -7919,8 +7919,9 @@ void swap(OpenTxnsResponse &a, OpenTxnsResponse &b);
 std::ostream& operator<<(std::ostream& out, const OpenTxnsResponse& obj);
 
 typedef struct _AbortTxnRequest__isset {
-  _AbortTxnRequest__isset() : replPolicy(false) {}
+  _AbortTxnRequest__isset() : replPolicy(false), txn_type(false) {}
   bool replPolicy :1;
+  bool txn_type :1;
 } _AbortTxnRequest__isset;
 
 class AbortTxnRequest : public virtual ::apache::thrift::TBase {
@@ -7928,18 +7929,21 @@ class AbortTxnRequest : public virtual ::apache::thrift::TBase {
 
   AbortTxnRequest(const AbortTxnRequest&);
   AbortTxnRequest& operator=(const AbortTxnRequest&);
-  AbortTxnRequest() : txnid(0), replPolicy() {
+  AbortTxnRequest() : txnid(0), replPolicy(), txn_type((TxnType::type)0) {
   }
 
   virtual ~AbortTxnRequest() noexcept;
   int64_t txnid;
   std::string replPolicy;
+  TxnType::type txn_type;
 
   _AbortTxnRequest__isset __isset;
 
   void __set_txnid(const int64_t val);
 
   void __set_replPolicy(const std::string& val);
+
+  void __set_txn_type(const TxnType::type val);
 
   bool operator == (const AbortTxnRequest & rhs) const
   {
@@ -7948,6 +7952,10 @@ class AbortTxnRequest : public virtual ::apache::thrift::TBase {
     if (__isset.replPolicy != rhs.__isset.replPolicy)
       return false;
     else if (__isset.replPolicy && !(replPolicy == rhs.replPolicy))
+      return false;
+    if (__isset.txn_type != rhs.__isset.txn_type)
+      return false;
+    else if (__isset.txn_type && !(txn_type == rhs.txn_type))
       return false;
     return true;
   }
@@ -8200,12 +8208,13 @@ void swap(ReplLastIdInfo &a, ReplLastIdInfo &b);
 std::ostream& operator<<(std::ostream& out, const ReplLastIdInfo& obj);
 
 typedef struct _CommitTxnRequest__isset {
-  _CommitTxnRequest__isset() : replPolicy(false), writeEventInfos(false), replLastIdInfo(false), keyValue(false), exclWriteEnabled(true) {}
+  _CommitTxnRequest__isset() : replPolicy(false), writeEventInfos(false), replLastIdInfo(false), keyValue(false), exclWriteEnabled(true), txn_type(false) {}
   bool replPolicy :1;
   bool writeEventInfos :1;
   bool replLastIdInfo :1;
   bool keyValue :1;
   bool exclWriteEnabled :1;
+  bool txn_type :1;
 } _CommitTxnRequest__isset;
 
 class CommitTxnRequest : public virtual ::apache::thrift::TBase {
@@ -8213,7 +8222,7 @@ class CommitTxnRequest : public virtual ::apache::thrift::TBase {
 
   CommitTxnRequest(const CommitTxnRequest&);
   CommitTxnRequest& operator=(const CommitTxnRequest&);
-  CommitTxnRequest() : txnid(0), replPolicy(), exclWriteEnabled(true) {
+  CommitTxnRequest() : txnid(0), replPolicy(), exclWriteEnabled(true), txn_type((TxnType::type)0) {
   }
 
   virtual ~CommitTxnRequest() noexcept;
@@ -8223,6 +8232,7 @@ class CommitTxnRequest : public virtual ::apache::thrift::TBase {
   ReplLastIdInfo replLastIdInfo;
   CommitTxnKeyValue keyValue;
   bool exclWriteEnabled;
+  TxnType::type txn_type;
 
   _CommitTxnRequest__isset __isset;
 
@@ -8237,6 +8247,8 @@ class CommitTxnRequest : public virtual ::apache::thrift::TBase {
   void __set_keyValue(const CommitTxnKeyValue& val);
 
   void __set_exclWriteEnabled(const bool val);
+
+  void __set_txn_type(const TxnType::type val);
 
   bool operator == (const CommitTxnRequest & rhs) const
   {
@@ -8261,6 +8273,10 @@ class CommitTxnRequest : public virtual ::apache::thrift::TBase {
     if (__isset.exclWriteEnabled != rhs.__isset.exclWriteEnabled)
       return false;
     else if (__isset.exclWriteEnabled && !(exclWriteEnabled == rhs.exclWriteEnabled))
+      return false;
+    if (__isset.txn_type != rhs.__isset.txn_type)
+      return false;
+    else if (__isset.txn_type && !(txn_type == rhs.txn_type))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/AbortTxnRequest.java
@@ -13,17 +13,24 @@ package org.apache.hadoop.hive.metastore.api;
 
   private static final org.apache.thrift.protocol.TField TXNID_FIELD_DESC = new org.apache.thrift.protocol.TField("txnid", org.apache.thrift.protocol.TType.I64, (short)1);
   private static final org.apache.thrift.protocol.TField REPL_POLICY_FIELD_DESC = new org.apache.thrift.protocol.TField("replPolicy", org.apache.thrift.protocol.TType.STRING, (short)2);
+  private static final org.apache.thrift.protocol.TField TXN_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("txn_type", org.apache.thrift.protocol.TType.I32, (short)3);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new AbortTxnRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new AbortTxnRequestTupleSchemeFactory();
 
   private long txnid; // required
   private @org.apache.thrift.annotation.Nullable java.lang.String replPolicy; // optional
+  private @org.apache.thrift.annotation.Nullable TxnType txn_type; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
     TXNID((short)1, "txnid"),
-    REPL_POLICY((short)2, "replPolicy");
+    REPL_POLICY((short)2, "replPolicy"),
+    /**
+     * 
+     * @see TxnType
+     */
+    TXN_TYPE((short)3, "txn_type");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -43,6 +50,8 @@ package org.apache.hadoop.hive.metastore.api;
           return TXNID;
         case 2: // REPL_POLICY
           return REPL_POLICY;
+        case 3: // TXN_TYPE
+          return TXN_TYPE;
         default:
           return null;
       }
@@ -86,7 +95,7 @@ package org.apache.hadoop.hive.metastore.api;
   // isset id assignments
   private static final int __TXNID_ISSET_ID = 0;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.REPL_POLICY};
+  private static final _Fields optionals[] = {_Fields.REPL_POLICY,_Fields.TXN_TYPE};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -94,6 +103,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.REPL_POLICY, new org.apache.thrift.meta_data.FieldMetaData("replPolicy", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.TXN_TYPE, new org.apache.thrift.meta_data.FieldMetaData("txn_type", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.EnumMetaData(org.apache.thrift.protocol.TType.ENUM, TxnType.class)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(AbortTxnRequest.class, metaDataMap);
   }
@@ -118,6 +129,9 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetReplPolicy()) {
       this.replPolicy = other.replPolicy;
     }
+    if (other.isSetTxn_type()) {
+      this.txn_type = other.txn_type;
+    }
   }
 
   public AbortTxnRequest deepCopy() {
@@ -129,6 +143,7 @@ package org.apache.hadoop.hive.metastore.api;
     setTxnidIsSet(false);
     this.txnid = 0;
     this.replPolicy = null;
+    this.txn_type = null;
   }
 
   public long getTxnid() {
@@ -177,6 +192,38 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  /**
+   * 
+   * @see TxnType
+   */
+  @org.apache.thrift.annotation.Nullable
+  public TxnType getTxn_type() {
+    return this.txn_type;
+  }
+
+  /**
+   * 
+   * @see TxnType
+   */
+  public void setTxn_type(@org.apache.thrift.annotation.Nullable TxnType txn_type) {
+    this.txn_type = txn_type;
+  }
+
+  public void unsetTxn_type() {
+    this.txn_type = null;
+  }
+
+  /** Returns true if field txn_type is set (has been assigned a value) and false otherwise */
+  public boolean isSetTxn_type() {
+    return this.txn_type != null;
+  }
+
+  public void setTxn_typeIsSet(boolean value) {
+    if (!value) {
+      this.txn_type = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case TXNID:
@@ -195,6 +242,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case TXN_TYPE:
+      if (value == null) {
+        unsetTxn_type();
+      } else {
+        setTxn_type((TxnType)value);
+      }
+      break;
+
     }
   }
 
@@ -206,6 +261,9 @@ package org.apache.hadoop.hive.metastore.api;
 
     case REPL_POLICY:
       return getReplPolicy();
+
+    case TXN_TYPE:
+      return getTxn_type();
 
     }
     throw new java.lang.IllegalStateException();
@@ -222,6 +280,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetTxnid();
     case REPL_POLICY:
       return isSetReplPolicy();
+    case TXN_TYPE:
+      return isSetTxn_type();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -259,6 +319,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_txn_type = true && this.isSetTxn_type();
+    boolean that_present_txn_type = true && that.isSetTxn_type();
+    if (this_present_txn_type || that_present_txn_type) {
+      if (!(this_present_txn_type && that_present_txn_type))
+        return false;
+      if (!this.txn_type.equals(that.txn_type))
+        return false;
+    }
+
     return true;
   }
 
@@ -271,6 +340,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetReplPolicy()) ? 131071 : 524287);
     if (isSetReplPolicy())
       hashCode = hashCode * 8191 + replPolicy.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetTxn_type()) ? 131071 : 524287);
+    if (isSetTxn_type())
+      hashCode = hashCode * 8191 + txn_type.getValue();
 
     return hashCode;
   }
@@ -299,6 +372,16 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetReplPolicy()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.replPolicy, other.replPolicy);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.valueOf(isSetTxn_type()).compareTo(other.isSetTxn_type());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetTxn_type()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.txn_type, other.txn_type);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -334,6 +417,16 @@ package org.apache.hadoop.hive.metastore.api;
         sb.append("null");
       } else {
         sb.append(this.replPolicy);
+      }
+      first = false;
+    }
+    if (isSetTxn_type()) {
+      if (!first) sb.append(", ");
+      sb.append("txn_type:");
+      if (this.txn_type == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.txn_type);
       }
       first = false;
     }
@@ -402,6 +495,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 3: // TXN_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+              struct.setTxn_typeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -422,6 +523,13 @@ package org.apache.hadoop.hive.metastore.api;
         if (struct.isSetReplPolicy()) {
           oprot.writeFieldBegin(REPL_POLICY_FIELD_DESC);
           oprot.writeString(struct.replPolicy);
+          oprot.writeFieldEnd();
+        }
+      }
+      if (struct.txn_type != null) {
+        if (struct.isSetTxn_type()) {
+          oprot.writeFieldBegin(TXN_TYPE_FIELD_DESC);
+          oprot.writeI32(struct.txn_type.getValue());
           oprot.writeFieldEnd();
         }
       }
@@ -447,9 +555,15 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetReplPolicy()) {
         optionals.set(0);
       }
-      oprot.writeBitSet(optionals, 1);
+      if (struct.isSetTxn_type()) {
+        optionals.set(1);
+      }
+      oprot.writeBitSet(optionals, 2);
       if (struct.isSetReplPolicy()) {
         oprot.writeString(struct.replPolicy);
+      }
+      if (struct.isSetTxn_type()) {
+        oprot.writeI32(struct.txn_type.getValue());
       }
     }
 
@@ -458,10 +572,14 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       struct.txnid = iprot.readI64();
       struct.setTxnidIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(1);
+      java.util.BitSet incoming = iprot.readBitSet(2);
       if (incoming.get(0)) {
         struct.replPolicy = iprot.readString();
         struct.setReplPolicyIsSet(true);
+      }
+      if (incoming.get(1)) {
+        struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+        struct.setTxn_typeIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/CommitTxnRequest.java
@@ -17,6 +17,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField REPL_LAST_ID_INFO_FIELD_DESC = new org.apache.thrift.protocol.TField("replLastIdInfo", org.apache.thrift.protocol.TType.STRUCT, (short)4);
   private static final org.apache.thrift.protocol.TField KEY_VALUE_FIELD_DESC = new org.apache.thrift.protocol.TField("keyValue", org.apache.thrift.protocol.TType.STRUCT, (short)5);
   private static final org.apache.thrift.protocol.TField EXCL_WRITE_ENABLED_FIELD_DESC = new org.apache.thrift.protocol.TField("exclWriteEnabled", org.apache.thrift.protocol.TType.BOOL, (short)6);
+  private static final org.apache.thrift.protocol.TField TXN_TYPE_FIELD_DESC = new org.apache.thrift.protocol.TField("txn_type", org.apache.thrift.protocol.TType.I32, (short)7);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new CommitTxnRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new CommitTxnRequestTupleSchemeFactory();
@@ -27,6 +28,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable ReplLastIdInfo replLastIdInfo; // optional
   private @org.apache.thrift.annotation.Nullable CommitTxnKeyValue keyValue; // optional
   private boolean exclWriteEnabled; // optional
+  private @org.apache.thrift.annotation.Nullable TxnType txn_type; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -35,7 +37,12 @@ package org.apache.hadoop.hive.metastore.api;
     WRITE_EVENT_INFOS((short)3, "writeEventInfos"),
     REPL_LAST_ID_INFO((short)4, "replLastIdInfo"),
     KEY_VALUE((short)5, "keyValue"),
-    EXCL_WRITE_ENABLED((short)6, "exclWriteEnabled");
+    EXCL_WRITE_ENABLED((short)6, "exclWriteEnabled"),
+    /**
+     * 
+     * @see TxnType
+     */
+    TXN_TYPE((short)7, "txn_type");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -63,6 +70,8 @@ package org.apache.hadoop.hive.metastore.api;
           return KEY_VALUE;
         case 6: // EXCL_WRITE_ENABLED
           return EXCL_WRITE_ENABLED;
+        case 7: // TXN_TYPE
+          return TXN_TYPE;
         default:
           return null;
       }
@@ -107,7 +116,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final int __TXNID_ISSET_ID = 0;
   private static final int __EXCLWRITEENABLED_ISSET_ID = 1;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.REPL_POLICY,_Fields.WRITE_EVENT_INFOS,_Fields.REPL_LAST_ID_INFO,_Fields.KEY_VALUE,_Fields.EXCL_WRITE_ENABLED};
+  private static final _Fields optionals[] = {_Fields.REPL_POLICY,_Fields.WRITE_EVENT_INFOS,_Fields.REPL_LAST_ID_INFO,_Fields.KEY_VALUE,_Fields.EXCL_WRITE_ENABLED,_Fields.TXN_TYPE};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -124,6 +133,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.StructMetaData(org.apache.thrift.protocol.TType.STRUCT, CommitTxnKeyValue.class)));
     tmpMap.put(_Fields.EXCL_WRITE_ENABLED, new org.apache.thrift.meta_data.FieldMetaData("exclWriteEnabled", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.BOOL)));
+    tmpMap.put(_Fields.TXN_TYPE, new org.apache.thrift.meta_data.FieldMetaData("txn_type", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.EnumMetaData(org.apache.thrift.protocol.TType.ENUM, TxnType.class)));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(CommitTxnRequest.class, metaDataMap);
   }
@@ -164,6 +175,9 @@ package org.apache.hadoop.hive.metastore.api;
       this.keyValue = new CommitTxnKeyValue(other.keyValue);
     }
     this.exclWriteEnabled = other.exclWriteEnabled;
+    if (other.isSetTxn_type()) {
+      this.txn_type = other.txn_type;
+    }
   }
 
   public CommitTxnRequest deepCopy() {
@@ -180,6 +194,7 @@ package org.apache.hadoop.hive.metastore.api;
     this.keyValue = null;
     this.exclWriteEnabled = true;
 
+    this.txn_type = null;
   }
 
   public long getTxnid() {
@@ -338,6 +353,38 @@ package org.apache.hadoop.hive.metastore.api;
     __isset_bitfield = org.apache.thrift.EncodingUtils.setBit(__isset_bitfield, __EXCLWRITEENABLED_ISSET_ID, value);
   }
 
+  /**
+   * 
+   * @see TxnType
+   */
+  @org.apache.thrift.annotation.Nullable
+  public TxnType getTxn_type() {
+    return this.txn_type;
+  }
+
+  /**
+   * 
+   * @see TxnType
+   */
+  public void setTxn_type(@org.apache.thrift.annotation.Nullable TxnType txn_type) {
+    this.txn_type = txn_type;
+  }
+
+  public void unsetTxn_type() {
+    this.txn_type = null;
+  }
+
+  /** Returns true if field txn_type is set (has been assigned a value) and false otherwise */
+  public boolean isSetTxn_type() {
+    return this.txn_type != null;
+  }
+
+  public void setTxn_typeIsSet(boolean value) {
+    if (!value) {
+      this.txn_type = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case TXNID:
@@ -388,6 +435,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case TXN_TYPE:
+      if (value == null) {
+        unsetTxn_type();
+      } else {
+        setTxn_type((TxnType)value);
+      }
+      break;
+
     }
   }
 
@@ -412,6 +467,9 @@ package org.apache.hadoop.hive.metastore.api;
     case EXCL_WRITE_ENABLED:
       return isExclWriteEnabled();
 
+    case TXN_TYPE:
+      return getTxn_type();
+
     }
     throw new java.lang.IllegalStateException();
   }
@@ -435,6 +493,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetKeyValue();
     case EXCL_WRITE_ENABLED:
       return isSetExclWriteEnabled();
+    case TXN_TYPE:
+      return isSetTxn_type();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -508,6 +568,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_txn_type = true && this.isSetTxn_type();
+    boolean that_present_txn_type = true && that.isSetTxn_type();
+    if (this_present_txn_type || that_present_txn_type) {
+      if (!(this_present_txn_type && that_present_txn_type))
+        return false;
+      if (!this.txn_type.equals(that.txn_type))
+        return false;
+    }
+
     return true;
   }
 
@@ -536,6 +605,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetExclWriteEnabled()) ? 131071 : 524287);
     if (isSetExclWriteEnabled())
       hashCode = hashCode * 8191 + ((exclWriteEnabled) ? 131071 : 524287);
+
+    hashCode = hashCode * 8191 + ((isSetTxn_type()) ? 131071 : 524287);
+    if (isSetTxn_type())
+      hashCode = hashCode * 8191 + txn_type.getValue();
 
     return hashCode;
   }
@@ -608,6 +681,16 @@ package org.apache.hadoop.hive.metastore.api;
         return lastComparison;
       }
     }
+    lastComparison = java.lang.Boolean.valueOf(isSetTxn_type()).compareTo(other.isSetTxn_type());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetTxn_type()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.txn_type, other.txn_type);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
     return 0;
   }
 
@@ -676,6 +759,16 @@ package org.apache.hadoop.hive.metastore.api;
       if (!first) sb.append(", ");
       sb.append("exclWriteEnabled:");
       sb.append(this.exclWriteEnabled);
+      first = false;
+    }
+    if (isSetTxn_type()) {
+      if (!first) sb.append(", ");
+      sb.append("txn_type:");
+      if (this.txn_type == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.txn_type);
+      }
       first = false;
     }
     sb.append(")");
@@ -794,6 +887,14 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 7: // TXN_TYPE
+            if (schemeField.type == org.apache.thrift.protocol.TType.I32) {
+              struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+              struct.setTxn_typeIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -850,6 +951,13 @@ package org.apache.hadoop.hive.metastore.api;
         oprot.writeBool(struct.exclWriteEnabled);
         oprot.writeFieldEnd();
       }
+      if (struct.txn_type != null) {
+        if (struct.isSetTxn_type()) {
+          oprot.writeFieldBegin(TXN_TYPE_FIELD_DESC);
+          oprot.writeI32(struct.txn_type.getValue());
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -884,7 +992,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetExclWriteEnabled()) {
         optionals.set(4);
       }
-      oprot.writeBitSet(optionals, 5);
+      if (struct.isSetTxn_type()) {
+        optionals.set(5);
+      }
+      oprot.writeBitSet(optionals, 6);
       if (struct.isSetReplPolicy()) {
         oprot.writeString(struct.replPolicy);
       }
@@ -906,6 +1017,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetExclWriteEnabled()) {
         oprot.writeBool(struct.exclWriteEnabled);
       }
+      if (struct.isSetTxn_type()) {
+        oprot.writeI32(struct.txn_type.getValue());
+      }
     }
 
     @Override
@@ -913,7 +1027,7 @@ package org.apache.hadoop.hive.metastore.api;
       org.apache.thrift.protocol.TTupleProtocol iprot = (org.apache.thrift.protocol.TTupleProtocol) prot;
       struct.txnid = iprot.readI64();
       struct.setTxnidIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(5);
+      java.util.BitSet incoming = iprot.readBitSet(6);
       if (incoming.get(0)) {
         struct.replPolicy = iprot.readString();
         struct.setReplPolicyIsSet(true);
@@ -945,6 +1059,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(4)) {
         struct.exclWriteEnabled = iprot.readBool();
         struct.setExclWriteEnabledIsSet(true);
+      }
+      if (incoming.get(5)) {
+        struct.txn_type = org.apache.hadoop.hive.metastore.api.TxnType.findByValue(iprot.readI32());
+        struct.setTxn_typeIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AbortTxnRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/AbortTxnRequest.php
@@ -31,6 +31,11 @@ class AbortTxnRequest
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        3 => array(
+            'var' => 'txn_type',
+            'isRequired' => false,
+            'type' => TType::I32,
+        ),
     );
 
     /**
@@ -41,6 +46,10 @@ class AbortTxnRequest
      * @var string
      */
     public $replPolicy = null;
+    /**
+     * @var int
+     */
+    public $txn_type = null;
 
     public function __construct($vals = null)
     {
@@ -50,6 +59,9 @@ class AbortTxnRequest
             }
             if (isset($vals['replPolicy'])) {
                 $this->replPolicy = $vals['replPolicy'];
+            }
+            if (isset($vals['txn_type'])) {
+                $this->txn_type = $vals['txn_type'];
             }
         }
     }
@@ -87,6 +99,13 @@ class AbortTxnRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 3:
+                    if ($ftype == TType::I32) {
+                        $xfer += $input->readI32($this->txn_type);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -109,6 +128,11 @@ class AbortTxnRequest
         if ($this->replPolicy !== null) {
             $xfer += $output->writeFieldBegin('replPolicy', TType::STRING, 2);
             $xfer += $output->writeString($this->replPolicy);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->txn_type !== null) {
+            $xfer += $output->writeFieldBegin('txn_type', TType::I32, 3);
+            $xfer += $output->writeI32($this->txn_type);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CommitTxnRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/CommitTxnRequest.php
@@ -58,6 +58,11 @@ class CommitTxnRequest
             'isRequired' => false,
             'type' => TType::BOOL,
         ),
+        7 => array(
+            'var' => 'txn_type',
+            'isRequired' => false,
+            'type' => TType::I32,
+        ),
     );
 
     /**
@@ -84,6 +89,10 @@ class CommitTxnRequest
      * @var bool
      */
     public $exclWriteEnabled = true;
+    /**
+     * @var int
+     */
+    public $txn_type = null;
 
     public function __construct($vals = null)
     {
@@ -105,6 +114,9 @@ class CommitTxnRequest
             }
             if (isset($vals['exclWriteEnabled'])) {
                 $this->exclWriteEnabled = $vals['exclWriteEnabled'];
+            }
+            if (isset($vals['txn_type'])) {
+                $this->txn_type = $vals['txn_type'];
             }
         }
     }
@@ -182,6 +194,13 @@ class CommitTxnRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 7:
+                    if ($ftype == TType::I32) {
+                        $xfer += $input->readI32($this->txn_type);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -237,6 +256,11 @@ class CommitTxnRequest
         if ($this->exclWriteEnabled !== null) {
             $xfer += $output->writeFieldBegin('exclWriteEnabled', TType::BOOL, 6);
             $xfer += $output->writeBool($this->exclWriteEnabled);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->txn_type !== null) {
+            $xfer += $output->writeFieldBegin('txn_type', TType::I32, 7);
+            $xfer += $output->writeI32($this->txn_type);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -11926,13 +11926,15 @@ class AbortTxnRequest(object):
     Attributes:
      - txnid
      - replPolicy
+     - txn_type
 
     """
 
 
-    def __init__(self, txnid=None, replPolicy=None,):
+    def __init__(self, txnid=None, replPolicy=None, txn_type=None,):
         self.txnid = txnid
         self.replPolicy = replPolicy
+        self.txn_type = txn_type
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -11953,6 +11955,11 @@ class AbortTxnRequest(object):
                     self.replPolicy = iprot.readString().decode('utf-8') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 3:
+                if ftype == TType.I32:
+                    self.txn_type = iprot.readI32()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -11970,6 +11977,10 @@ class AbortTxnRequest(object):
         if self.replPolicy is not None:
             oprot.writeFieldBegin('replPolicy', TType.STRING, 2)
             oprot.writeString(self.replPolicy.encode('utf-8') if sys.version_info[0] == 2 else self.replPolicy)
+            oprot.writeFieldEnd()
+        if self.txn_type is not None:
+            oprot.writeFieldBegin('txn_type', TType.I32, 3)
+            oprot.writeI32(self.txn_type)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -12396,17 +12407,19 @@ class CommitTxnRequest(object):
      - replLastIdInfo
      - keyValue
      - exclWriteEnabled
+     - txn_type
 
     """
 
 
-    def __init__(self, txnid=None, replPolicy=None, writeEventInfos=None, replLastIdInfo=None, keyValue=None, exclWriteEnabled=True,):
+    def __init__(self, txnid=None, replPolicy=None, writeEventInfos=None, replLastIdInfo=None, keyValue=None, exclWriteEnabled=True, txn_type=None,):
         self.txnid = txnid
         self.replPolicy = replPolicy
         self.writeEventInfos = writeEventInfos
         self.replLastIdInfo = replLastIdInfo
         self.keyValue = keyValue
         self.exclWriteEnabled = exclWriteEnabled
+        self.txn_type = txn_type
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -12455,6 +12468,11 @@ class CommitTxnRequest(object):
                     self.exclWriteEnabled = iprot.readBool()
                 else:
                     iprot.skip(ftype)
+            elif fid == 7:
+                if ftype == TType.I32:
+                    self.txn_type = iprot.readI32()
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -12491,6 +12509,10 @@ class CommitTxnRequest(object):
         if self.exclWriteEnabled is not None:
             oprot.writeFieldBegin('exclWriteEnabled', TType.BOOL, 6)
             oprot.writeBool(self.exclWriteEnabled)
+            oprot.writeFieldEnd()
+        if self.txn_type is not None:
+            oprot.writeFieldBegin('txn_type', TType.I32, 7)
+            oprot.writeI32(self.txn_type)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28993,6 +29015,7 @@ AbortTxnRequest.thrift_spec = (
     None,  # 0
     (1, TType.I64, 'txnid', None, None, ),  # 1
     (2, TType.STRING, 'replPolicy', 'UTF8', None, ),  # 2
+    (3, TType.I32, 'txn_type', None, None, ),  # 3
 )
 all_structs.append(AbortTxnsRequest)
 AbortTxnsRequest.thrift_spec = (
@@ -29035,6 +29058,7 @@ CommitTxnRequest.thrift_spec = (
     (4, TType.STRUCT, 'replLastIdInfo', [ReplLastIdInfo, None], None, ),  # 4
     (5, TType.STRUCT, 'keyValue', [CommitTxnKeyValue, None], None, ),  # 5
     (6, TType.BOOL, 'exclWriteEnabled', None, True, ),  # 6
+    (7, TType.I32, 'txn_type', None, None, ),  # 7
 )
 all_structs.append(ReplTblWriteIdStateRequest)
 ReplTblWriteIdStateRequest.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -3594,16 +3594,21 @@ class AbortTxnRequest
   include ::Thrift::Struct, ::Thrift::Struct_Union
   TXNID = 1
   REPLPOLICY = 2
+  TXN_TYPE = 3
 
   FIELDS = {
     TXNID => {:type => ::Thrift::Types::I64, :name => 'txnid'},
-    REPLPOLICY => {:type => ::Thrift::Types::STRING, :name => 'replPolicy', :optional => true}
+    REPLPOLICY => {:type => ::Thrift::Types::STRING, :name => 'replPolicy', :optional => true},
+    TXN_TYPE => {:type => ::Thrift::Types::I32, :name => 'txn_type', :optional => true, :enum_class => ::TxnType}
   }
 
   def struct_fields; FIELDS; end
 
   def validate
     raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field txnid is unset!') unless @txnid
+    unless @txn_type.nil? || ::TxnType::VALID_VALUES.include?(@txn_type)
+      raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Invalid value of field txn_type!')
+    end
   end
 
   ::Thrift::Struct.generate_accessors self
@@ -3715,6 +3720,7 @@ class CommitTxnRequest
   REPLLASTIDINFO = 4
   KEYVALUE = 5
   EXCLWRITEENABLED = 6
+  TXN_TYPE = 7
 
   FIELDS = {
     TXNID => {:type => ::Thrift::Types::I64, :name => 'txnid'},
@@ -3722,13 +3728,17 @@ class CommitTxnRequest
     WRITEEVENTINFOS => {:type => ::Thrift::Types::LIST, :name => 'writeEventInfos', :element => {:type => ::Thrift::Types::STRUCT, :class => ::WriteEventInfo}, :optional => true},
     REPLLASTIDINFO => {:type => ::Thrift::Types::STRUCT, :name => 'replLastIdInfo', :class => ::ReplLastIdInfo, :optional => true},
     KEYVALUE => {:type => ::Thrift::Types::STRUCT, :name => 'keyValue', :class => ::CommitTxnKeyValue, :optional => true},
-    EXCLWRITEENABLED => {:type => ::Thrift::Types::BOOL, :name => 'exclWriteEnabled', :default => true, :optional => true}
+    EXCLWRITEENABLED => {:type => ::Thrift::Types::BOOL, :name => 'exclWriteEnabled', :default => true, :optional => true},
+    TXN_TYPE => {:type => ::Thrift::Types::I32, :name => 'txn_type', :optional => true, :enum_class => ::TxnType}
   }
 
   def struct_fields; FIELDS; end
 
   def validate
     raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Required field txnid is unset!') unless @txnid
+    unless @txn_type.nil? || ::TxnType::VALID_VALUES.include?(@txn_type)
+      raise ::Thrift::ProtocolException.new(::Thrift::ProtocolException::UNKNOWN, 'Invalid value of field txn_type!')
+    end
   end
 
   ::Thrift::Struct.generate_accessors self

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -3821,10 +3821,11 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   }
 
   @Override
-  public List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user) throws TException {
+  public List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user, TxnType txnType) throws TException {
     // As this is called from replication task, the user is the user who has fired the repl command.
     // This is required for standalone metastore authentication.
-    OpenTxnsResponse txns = openTxnsIntr(user, srcTxnIds != null ? srcTxnIds.size() : 1, replPolicy, srcTxnIds, null);
+    OpenTxnsResponse txns = openTxnsIntr(user, srcTxnIds != null ? srcTxnIds.size() : 1,
+                                        replPolicy, srcTxnIds, txnType);
     return txns.getTxn_ids();
   }
 
@@ -3844,11 +3845,12 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     OpenTxnRequest rqst = new OpenTxnRequest(numTxns, user, hostname);
     if (replPolicy != null) {
-      assert srcTxnIds != null;
-      assert numTxns == srcTxnIds.size();
-      // need to set this only for replication tasks
       rqst.setReplPolicy(replPolicy);
-      rqst.setReplSrcTxnIds(srcTxnIds);
+      if (txnType == TxnType.REPL_CREATED) {
+        assert srcTxnIds != null;
+        assert numTxns == srcTxnIds.size();
+        rqst.setReplSrcTxnIds(srcTxnIds);
+      }
     } else {
       assert srcTxnIds == null;
     }
@@ -3864,9 +3866,10 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   }
 
   @Override
-  public void replRollbackTxn(long srcTxnId, String replPolicy) throws NoSuchTxnException, TException {
+  public void replRollbackTxn(long srcTxnId, String replPolicy, TxnType txnType) throws NoSuchTxnException, TException {
     AbortTxnRequest rqst = new AbortTxnRequest(srcTxnId);
     rqst.setReplPolicy(replPolicy);
+    rqst.setTxn_type(txnType);
     client.abort_txn(rqst);
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -3185,7 +3185,7 @@ public interface IMetaStoreClient {
    * @return transaction identifiers
    * @throws TException
    */
-  List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user) throws TException;
+  List<Long> replOpenTxn(String replPolicy, List<Long> srcTxnIds, String user, TxnType txnType) throws TException;
 
   /**
    * Initiate a batch of transactions.  It is not guaranteed that the
@@ -3235,7 +3235,7 @@ public interface IMetaStoreClient {
    * deleted.
    * @throws TException
    */
-  void replRollbackTxn(long srcTxnid, String replPolicy) throws NoSuchTxnException, TException;
+  void replRollbackTxn(long srcTxnid, String replPolicy, TxnType txnType) throws NoSuchTxnException, TException;
 
   /**
    * Commit a transaction.  This will also unlock any locks associated with

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -3178,7 +3178,7 @@ public interface IMetaStoreClient {
   long openTxn(String user, TxnType txnType) throws TException;
 
   /**
-   * Initiate a transaction at the target cluster or dump/load transactions.
+   * Initiate a repl replayed or hive replication transaction (dump/load).
    * @param replPolicy Contains replication policy to uniquely identify the source cluster in case of repl replayed txns
    *                   or database under replication name for hive replication txns
    * @param srcTxnIds The list of transaction ids at the source cluster in case of repl replayed transactions
@@ -3234,7 +3234,7 @@ public interface IMetaStoreClient {
    * Rollback a transaction.  This will also unlock any locks associated with
    * this transaction.
    * @param srcTxnid id of transaction at source while is rolled back and to be replicated
-   *                 or null incase of hive replication transactions
+   *                 or null in case of hive replication transactions
    * @param replPolicy Contains replication policy to uniquely identify the source cluster in case of repl replayed txns
    *                   or database under replication name for hive replication txns
    * @param txnType Type of transaction to Rollback: REPL_CREATED for repl replayed transactions

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreClient.java
@@ -3178,10 +3178,15 @@ public interface IMetaStoreClient {
   long openTxn(String user, TxnType txnType) throws TException;
 
   /**
-   * Initiate a transaction at the target cluster.
-   * @param replPolicy The replication policy to uniquely identify the source cluster.
-   * @param srcTxnIds The list of transaction ids at the source cluster
-   * @param user The user who has fired the repl load command.
+   * Initiate a transaction at the target cluster or dump/load transactions.
+   * @param replPolicy Contains replication policy to uniquely identify the source cluster in case of repl replayed txns
+   *                   or database under replication name for hive replication txns
+   * @param srcTxnIds The list of transaction ids at the source cluster in case of repl replayed transactions
+   *                 or null in case of hive replication transactions.
+   * @param user The user who has fired the command.
+   *
+   * @param txnType Type of transaction to open: REPL_CREATED for repl replayed transactions
+   *                                             DEFAULT for hive replication transactions.
    * @return transaction identifiers
    * @throws TException
    */
@@ -3228,8 +3233,12 @@ public interface IMetaStoreClient {
   /**
    * Rollback a transaction.  This will also unlock any locks associated with
    * this transaction.
-   * @param srcTxnid id of transaction at source while is rolled back and to be replicated.
-   * @param replPolicy the replication policy to identify the source cluster
+   * @param srcTxnid id of transaction at source while is rolled back and to be replicated
+   *                 or null incase of hive replication transactions
+   * @param replPolicy Contains replication policy to uniquely identify the source cluster in case of repl replayed txns
+   *                   or database under replication name for hive replication txns
+   * @param txnType Type of transaction to Rollback: REPL_CREATED for repl replayed transactions
+    *                                                DEFAULT for hive replication transactions.
    * @throws NoSuchTxnException if the requested transaction does not exist.
    * Note that this can result from the transaction having timed out and been
    * deleted.

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -1014,6 +1014,7 @@ struct OpenTxnsResponse {
 struct AbortTxnRequest {
     1: required i64 txnid,
     2: optional string replPolicy,
+    3: optional TxnType txn_type,
 }
 
 struct AbortTxnsRequest {
@@ -1053,7 +1054,8 @@ struct CommitTxnRequest {
     4: optional ReplLastIdInfo replLastIdInfo,
     // An optional key/value to store atomically with the transaction
     5: optional CommitTxnKeyValue keyValue,
-    6: optional bool exclWriteEnabled = true
+    6: optional bool exclWriteEnabled = true,
+    7: optional TxnType txn_type,
 }
 
 struct ReplTblWriteIdStateRequest {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -8592,7 +8592,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public OpenTxnsResponse open_txns(OpenTxnRequest rqst) throws TException {
     OpenTxnsResponse response = getTxnHandler().openTxns(rqst);
     List<Long> txnIds = response.getTxn_ids();
-    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && TxnType.DEFAULT.equals(rqst.getTxn_type());
     if (txnIds != null && listeners != null && !listeners.isEmpty() && !isHiveReplTxn) {
       MetaStoreListenerNotifier.notifyEvent(listeners, EventType.OPEN_TXN,
           new OpenTxnEvent(txnIds, this));
@@ -8603,7 +8603,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   @Override
   public void abort_txn(AbortTxnRequest rqst) throws TException {
     getTxnHandler().abortTxn(rqst);
-    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && TxnType.DEFAULT.equals(rqst.getTxn_type());
     if (listeners != null && !listeners.isEmpty() && !isHiveReplTxn) {
       MetaStoreListenerNotifier.notifyEvent(listeners, EventType.ABORT_TXN,
           new AbortTxnEvent(rqst.getTxnid(), this));
@@ -8628,8 +8628,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
   @Override
   public void commit_txn(CommitTxnRequest rqst) throws TException {
-    boolean isReplayedReplTxn = rqst.getTxn_type() == TxnType.REPL_CREATED;
-    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    boolean isReplayedReplTxn = TxnType.REPL_CREATED.equals(rqst.getTxn_type());
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && TxnType.DEFAULT.equals(rqst.getTxn_type());
     // in replication flow, the write notification log table will be updated here.
     if (rqst.isSetWriteEventInfos() && isReplayedReplTxn) {
       assert (rqst.isSetReplPolicy());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -8592,7 +8592,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public OpenTxnsResponse open_txns(OpenTxnRequest rqst) throws TException {
     OpenTxnsResponse response = getTxnHandler().openTxns(rqst);
     List<Long> txnIds = response.getTxn_ids();
-    if (txnIds != null && listeners != null && !listeners.isEmpty()) {
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    if (txnIds != null && listeners != null && !listeners.isEmpty() && !isHiveReplTxn) {
       MetaStoreListenerNotifier.notifyEvent(listeners, EventType.OPEN_TXN,
           new OpenTxnEvent(txnIds, this));
     }
@@ -8602,7 +8603,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   @Override
   public void abort_txn(AbortTxnRequest rqst) throws TException {
     getTxnHandler().abortTxn(rqst);
-    if (listeners != null && !listeners.isEmpty()) {
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    if (listeners != null && !listeners.isEmpty() && !isHiveReplTxn) {
       MetaStoreListenerNotifier.notifyEvent(listeners, EventType.ABORT_TXN,
           new AbortTxnEvent(rqst.getTxnid(), this));
     }
@@ -8626,8 +8628,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
   @Override
   public void commit_txn(CommitTxnRequest rqst) throws TException {
+    boolean isReplayedReplTxn = rqst.getTxn_type() == TxnType.REPL_CREATED;
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
     // in replication flow, the write notification log table will be updated here.
-    if (rqst.isSetWriteEventInfos()) {
+    if (rqst.isSetWriteEventInfos() && isReplayedReplTxn) {
+      assert (rqst.isSetReplPolicy());
       long targetTxnId = getTxnHandler().getTargetTxnId(rqst.getReplPolicy(), rqst.getTxnid());
       if (targetTxnId < 0) {
         //looks like a retry
@@ -8676,9 +8681,9 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
     }
     getTxnHandler().commitTxn(rqst);
-    if (listeners != null && !listeners.isEmpty()) {
+    if (listeners != null && !listeners.isEmpty() && !isHiveReplTxn) {
       MetaStoreListenerNotifier.notifyEvent(listeners, EventType.COMMIT_TXN,
-          new CommitTxnEvent(rqst.getTxnid(), this));
+              new CommitTxnEvent(rqst.getTxnid(), this));
       Optional<CompactionInfo> compactionInfo = getTxnHandler().getCompactionByTxnId(rqst.getTxnid());
       if (compactionInfo.isPresent()) {
         MetaStoreListenerNotifier.notifyEvent(listeners, EventType.COMMIT_COMPACTION,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/TxnHandler.java
@@ -970,8 +970,8 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
   public void abortTxn(AbortTxnRequest rqst) throws NoSuchTxnException, MetaException, TxnAbortedException {
     long txnid = rqst.getTxnid();
     long sourceTxnId = -1;
-    boolean isReplayedReplTxn = rqst.getTxn_type() == TxnType.REPL_CREATED;
-    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    boolean isReplayedReplTxn = TxnType.REPL_CREATED.equals(rqst.getTxn_type());
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && TxnType.DEFAULT.equals(rqst.getTxn_type());
     try {
       Connection dbConn = null;
       Statement stmt = null;
@@ -1293,8 +1293,8 @@ abstract class TxnHandler implements TxnStore, TxnStore.MutexAPI {
     char isUpdateDelete = 'N';
     long txnid = rqst.getTxnid();
     long sourceTxnId = -1;
-    boolean isReplayedReplTxn = rqst.getTxn_type() == TxnType.REPL_CREATED;
-    boolean isHiveReplTxn = rqst.isSetReplPolicy() && rqst.getTxn_type() == TxnType.DEFAULT;
+    boolean isReplayedReplTxn = TxnType.REPL_CREATED.equals(rqst.getTxn_type());
+    boolean isHiveReplTxn = rqst.isSetReplPolicy() && TxnType.DEFAULT.equals(rqst.getTxn_type());
     try {
       Connection dbConn = null;
       Statement stmt = null;


### PR DESCRIPTION
What changes were proposed in this pull request?
Skip the repl events from getting logged in notification log

Why are the changes needed?
Currently REPL dump events are logged and replicated as a part of replication policy. Whenever one replication cycle completed, we always have one transaction left open on the target corresponding to repl dump operation. This will never be caught up without manually dealing with the transaction on target cluster.

Does this PR introduce any user-facing change?
No

How was this patch tested?