### PR TITLE
HIVE-24886: Support simple equality operations between MAP/LIST/STRUCT types

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/type/TypeCheckProcFactory.java
@@ -1151,9 +1151,17 @@ public class TypeCheckProcFactory<T> {
     private T interpretNode(T columnDesc, T valueDesc)
         throws SemanticException {
       if (exprFactory.isColumnRefExpr(columnDesc)) {
-        final PrimitiveTypeInfo typeInfo = TypeInfoFactory.getPrimitiveTypeInfo(
-            exprFactory.getTypeInfo(columnDesc).getTypeName().toLowerCase());
-        return interpretNodeAsConstant(typeInfo, valueDesc);
+        final TypeInfo info = exprFactory.getTypeInfo(columnDesc);
+        switch (info.getCategory()) {
+        case MAP:
+        case LIST:
+        case UNION:
+        case STRUCT:
+          return valueDesc;
+        case PRIMITIVE:
+          PrimitiveTypeInfo primitiveInfo = TypeInfoFactory.getPrimitiveTypeInfo(info.getTypeName().toLowerCase());
+          return interpretNodeAsConstant(primitiveInfo, valueDesc);
+        }
       }
       boolean columnStruct = exprFactory.isSTRUCTFuncCallExpr(columnDesc);
       if (columnStruct) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFIn.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFIn.java
@@ -88,7 +88,7 @@ public class GenericUDFIn extends GenericUDF {
     for (ObjectInspector oi : arguments) {
       if(!conversionHelper.updateForComparison(oi)) {
         StringBuilder sb = new StringBuilder();
-        sb.append("The arguments for IN should be the same type! Types are: {");
+        sb.append("Type mismatch: {");
         sb.append(arguments[0].getTypeName());
         sb.append(" IN (");
         for(int i=1; i<arguments.length; i++) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPEqual.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPEqual.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressions;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressionsSupportDecimal64;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.gen.*;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 
 /**
@@ -155,6 +156,14 @@ public class GenericUDFOPEqual extends GenericUDFBaseCompare {
           converted_o1, compareOI) == 0);
     }
     return result;
+  }
+
+  @Override
+  protected boolean supportsCategory(ObjectInspector.Category c) {
+    return super.supportsCategory(c) ||
+        c == ObjectInspector.Category.MAP ||
+        c == ObjectInspector.Category.STRUCT ||
+        c == ObjectInspector.Category.LIST;
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNotEqual.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFOPNotEqual.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressions;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedExpressionsSupportDecimal64;
 import org.apache.hadoop.hive.ql.exec.vector.expressions.gen.*;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils;
 
 /**
@@ -155,6 +156,14 @@ public class GenericUDFOPNotEqual extends GenericUDFBaseCompare {
           converted_o1, compareOI) != 0);
     }
     return result;
+  }
+
+  @Override
+  protected boolean supportsCategory(ObjectInspector.Category c) {
+    return super.supportsCategory(c) ||
+        c == ObjectInspector.Category.MAP ||
+        c == ObjectInspector.Category.STRUCT ||
+        c == ObjectInspector.Category.LIST;
   }
 
   @Override

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFInitializeOnCompareUDF.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFInitializeOnCompareUDF.java
@@ -1,0 +1,185 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.udf.generic;
+
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardListObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardMapObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardStructObjectInspector;
+import static org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorFactory.getStandardUnionObjectInspector;
+
+/**
+ * Tests for {@link GenericUDF#initialize(ObjectInspector[])} on the most common equality/comparison operators when 
+ * arguments of various types are provided.
+ * 
+ * The tests cover positive and negative cases for the following operators:
+ * <ul>
+ * <li>{@link GenericUDFOPEqual}</li>
+ * <li>{@link GenericUDFOPEqualNS}</li>
+ * <li>{@link GenericUDFOPNotEqual}</li>
+ * <li>{@link GenericUDFOPNotEqualNS}</li>
+ * <li>{@link GenericUDFOPGreaterThan}</li>
+ * <li>{@link GenericUDFOPEqualOrGreaterThan}</li>
+ * <li>{@link GenericUDFOPLessThan}</li>
+ * <li>{@link GenericUDFOPEqualOrLessThan}</li>
+ * <li>{@link GenericUDFIn}</li>
+ * </ul>
+ *
+ */
+@RunWith(Parameterized.class)
+public class TestGenericUDFInitializeOnCompareUDF {
+
+  private final UDFArguments args;
+
+  public TestGenericUDFInitializeOnCompareUDF(UDFArguments arguments) {
+    this.args = arguments;
+  }
+
+  @Parameterized.Parameters(name = "{0}")
+  public static Collection<UDFArguments> generateArguments() {
+    List<UDFArguments> arguments = new ArrayList<>();
+
+    List<ObjectInspector> primitives = new ArrayList<>();
+    for (PrimitiveObjectInspector.PrimitiveCategory l : PrimitiveObjectInspector.PrimitiveCategory.values()) {
+      if (l == PrimitiveObjectInspector.PrimitiveCategory.UNKNOWN) {
+        continue;
+      }
+      primitives.add(PrimitiveObjectInspectorFactory.getPrimitiveJavaObjectInspector(l));
+    }
+
+    List<ObjectInspector> nonPrimitives = new ArrayList<>();
+    for (ObjectInspector i : primitives) {
+      nonPrimitives.add(getStandardListObjectInspector(i));
+      nonPrimitives.add(getStandardStructObjectInspector(Arrays.asList("field1", "field2"), Arrays.asList(i, i)));
+      nonPrimitives.add(getStandardUnionObjectInspector(Arrays.asList(i, i)));
+      nonPrimitives.add(getStandardMapObjectInspector(i, i));
+    }
+
+    List<ObjectInspector> allTypes = new ArrayList<>(primitives);
+    allTypes.addAll(nonPrimitives);
+    for (ObjectInspector firstArgInspector : allTypes) {
+      for (ObjectInspector secondArgInspector : allTypes) {
+        arguments.add(new UDFArguments(firstArgInspector, secondArgInspector));
+      }
+    }
+    return arguments;
+  }
+
+  @Test
+  public void testArgsWithDifferentTypeCategoriesThrowsException() {
+    Assume.assumeFalse(args.left.getCategory().equals(args.right.getCategory()));
+    List<GenericUDF> udfs = Arrays.asList(
+        new GenericUDFOPEqual(),
+        new GenericUDFOPEqualNS(),
+        new GenericUDFOPNotEqual(),
+        new GenericUDFOPEqualNS(),
+        new GenericUDFIn(),
+        new GenericUDFOPEqualOrLessThan(),
+        new GenericUDFOPEqualOrGreaterThan(),
+        new GenericUDFOPLessThan(),
+        new GenericUDFOPGreaterThan());
+    for (GenericUDF u : udfs) {
+      try {
+        u.initialize(new ObjectInspector[] { args.left, args.right });
+      }catch (UDFArgumentException e){
+        Assert.assertTrue("Unexpected message for " + u.getUdfName(), e.getMessage().contains("Type mismatch"));
+      }
+    }
+  }
+  
+  @Test
+  public void testEqualityUDFWithSameTypeArgsSucceeds() throws UDFArgumentException {
+    TypeInfo tleft = TypeInfoUtils.getTypeInfoFromObjectInspector(args.left);
+    TypeInfo tRight = TypeInfoUtils.getTypeInfoFromObjectInspector(args.right);
+    Assume.assumeTrue("Skip arguments with different types", tleft.equals(tRight));
+    boolean unionInputs = 
+        tleft.getCategory().equals(ObjectInspector.Category.UNION) ||
+        tRight.getCategory().equals(ObjectInspector.Category.UNION); 
+    Assume.assumeFalse("Union types are not currently supported", unionInputs);
+    List<GenericUDF> udfs = Arrays.asList(
+        new GenericUDFOPEqual(),
+        new GenericUDFOPEqualNS(),
+        new GenericUDFOPNotEqual(),
+        new GenericUDFOPEqualNS(),
+        new GenericUDFIn());
+    for (GenericUDF u : udfs) {
+      u.initialize(new ObjectInspector[] { args.left, args.right });
+    }
+  }
+
+  @Test
+  public void testBaseNonEqualityUDFWithNonPrimitiveTypeArgsThrowsException() {
+    Assume.assumeTrue("Skip arguments with different categories",
+        args.left.getCategory().equals(args.right.getCategory()));
+    boolean allPrimitives =
+        args.left.getCategory().equals(ObjectInspector.Category.PRIMITIVE) &&
+        args.right.getCategory().equals(ObjectInspector.Category.PRIMITIVE);
+    Assume.assumeFalse("Skip primitive only arguments", allPrimitives);
+    List<GenericUDF> udfs = Arrays
+        .asList(new GenericUDFOPGreaterThan(), new GenericUDFOPLessThan(), new GenericUDFOPEqualOrGreaterThan(),
+            new GenericUDFOPEqualOrLessThan());
+    for (GenericUDF udf : udfs) {
+      try {
+        udf.initialize(new ObjectInspector[] { args.left, args.right });
+        Assert.fail(
+            udf.getUdfName() + " operator should not accept non primitive types [" + args.left.getCategory() + ","
+                + args.right.getCategory() + "]");
+      } catch (UDFArgumentException e) {
+        boolean isValidMessage =
+            e.getMessage().contains("not support MAP types") ||
+            e.getMessage().contains("not support LIST types") ||
+            e.getMessage().contains("not support STRUCT types") ||
+            e.getMessage().contains("not support UNION types");
+        Assert.assertTrue("Unexpected message for " + udf.getUdfName(), isValidMessage);
+      }
+    }
+  }
+
+  private static class UDFArguments {
+    final ObjectInspector left;
+    final ObjectInspector right;
+
+    UDFArguments(ObjectInspector left, ObjectInspector right) {
+      this.left = left;
+      this.right = right;
+    }
+
+    @Override
+    public String toString() {
+      TypeInfo til = TypeInfoUtils.getTypeInfoFromObjectInspector(left);
+      TypeInfo tir = TypeInfoUtils.getTypeInfoFromObjectInspector(right);
+      return "(" + til + ", " + tir + ")";
+    }
+  }
+}

--- a/ql/src/test/queries/clientpositive/equals_list_types.q
+++ b/ql/src/test/queries/clientpositive/equals_list_types.q
@@ -1,0 +1,42 @@
+-- Tests for the most common equality operations between array types
+create table table_list_types (id int, c1 array<int>, c2 array<int>);
+insert into table_list_types VALUES (1, array(1,1), array(2,1));
+insert into table_list_types VALUES (2, array(1,2), array(2,2));
+insert into table_list_types VALUES (3, array(1,3), array(2,3));
+insert into table_list_types VALUES (4, array(1,4), array(1,4));
+    
+select id from table_list_types where c1 IN (c1); 
+select id from table_list_types where c1 IN (c2); 
+select id from table_list_types where c1 IN (array(1,1)); 
+select id from table_list_types where array(1,1) IN (c1); 
+select id from table_list_types where c1 IN (array(1,1), array(1,2), array(1,3)); 
+select id from table_list_types where c1 IN (c2, array(1,1), array(1,2), array(1,3)); 
+select id from table_list_types where array(1,1) IN (c1, c2); 
+
+select id from table_list_types where c1 = c1; 
+select id from table_list_types where c1 = c2;
+select id from table_list_types where c1 = array(1,1);
+select id from table_list_types where array(1,1) = c1;
+select id from table_list_types where array(1,1) = array(1,1);
+select id from table_list_types where array(1,1) = array(1,2);
+
+select id from table_list_types where c1 <> c1; 
+select id from table_list_types where c1 <> c2; 
+select id from table_list_types where c1 <> array(1,1);
+select id from table_list_types where array(1,1) <> c1; 
+select id from table_list_types where array(1,1) <> array(1,1); 
+select id from table_list_types where array(1,1) <> array(1,2); 
+
+select id from table_list_types where c1 IS DISTINCT FROM c1;
+select id from table_list_types where c1 IS DISTINCT FROM c2;
+select id from table_list_types where c1 IS DISTINCT FROM array(1,1); 
+select id from table_list_types where array(1,1) IS DISTINCT FROM c1; 
+select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,1); 
+select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,2); 
+
+select id from table_list_types where c1 IS NOT DISTINCT FROM c1;
+select id from table_list_types where c1 IS NOT DISTINCT FROM c2;
+select id from table_list_types where c1 IS NOT DISTINCT FROM array(1,1); 
+select id from table_list_types where array(1,1) IS NOT DISTINCT FROM c1;  
+select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,1); 
+select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,2);

--- a/ql/src/test/queries/clientpositive/equals_map_types.q
+++ b/ql/src/test/queries/clientpositive/equals_map_types.q
@@ -1,0 +1,42 @@
+-- Tests for the most common equality operations between map types
+create table table_map_types (id int, c1 map<int,int>, c2 map<int,int>);
+insert into table_map_types VALUES (1, map(1,1), map(2,1));
+insert into table_map_types VALUES (2, map(1,2), map(2,2));
+insert into table_map_types VALUES (3, map(1,3), map(2,3));
+insert into table_map_types VALUES (4, map(1,4), map(1,4));
+    
+select id from table_map_types where c1 IN (c1); 
+select id from table_map_types where c1 IN (c2); 
+select id from table_map_types where c1 IN (map(1,1)); 
+select id from table_map_types where map(1,1) IN (c1); 
+select id from table_map_types where c1 IN (map(1,1), map(1,2), map(1,3)); 
+select id from table_map_types where c1 IN (c2, map(1,1), map(1,2), map(1,3)); 
+select id from table_map_types where map(1,1) IN (c1, c2); 
+
+select id from table_map_types where c1 = c1; 
+select id from table_map_types where c1 = c2;
+select id from table_map_types where c1 = map(1,1);
+select id from table_map_types where map(1,1) = c1;
+select id from table_map_types where map(1,1) = map(1,1);
+select id from table_map_types where map(1,1) = map(1,2);
+
+select id from table_map_types where c1 <> c1; 
+select id from table_map_types where c1 <> c2; 
+select id from table_map_types where c1 <> map(1,1);
+select id from table_map_types where map(1,1) <> c1; 
+select id from table_map_types where map(1,1) <> map(1,1); 
+select id from table_map_types where map(1,1) <> map(1,2); 
+
+select id from table_map_types where c1 IS DISTINCT FROM c1;
+select id from table_map_types where c1 IS DISTINCT FROM c2;
+select id from table_map_types where c1 IS DISTINCT FROM map(1,1); 
+select id from table_map_types where map(1,1) IS DISTINCT FROM c1; 
+select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,1); 
+select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,2); 
+
+select id from table_map_types where c1 IS NOT DISTINCT FROM c1;
+select id from table_map_types where c1 IS NOT DISTINCT FROM c2;
+select id from table_map_types where c1 IS NOT DISTINCT FROM map(1,1); 
+select id from table_map_types where map(1,1) IS NOT DISTINCT FROM c1;  
+select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,1); 
+select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,2);

--- a/ql/src/test/queries/clientpositive/equals_struct_types.q
+++ b/ql/src/test/queries/clientpositive/equals_struct_types.q
@@ -1,0 +1,42 @@
+-- Tests for the most common equality operations between struct types
+create table table_struct_types (id int, c1 struct<f1: int,f2: int>, c2 struct<f1: int,f2: int>);
+insert into table_struct_types VALUES (1, named_struct("f1",1,"f2",1), named_struct("f1",2,"f2",1));
+insert into table_struct_types VALUES (2, named_struct("f1",1,"f2",2), named_struct("f1",2,"f2",2));
+insert into table_struct_types VALUES (3, named_struct("f1",1,"f2",3), named_struct("f1",2,"f2",3));
+insert into table_struct_types VALUES (4, named_struct("f1",1,"f2",4), named_struct("f1",1,"f2",4));
+    
+select id from table_struct_types where c1 IN (c1); 
+select id from table_struct_types where c1 IN (c2); 
+select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1)); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1); 
+select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3)); 
+select id from table_struct_types where c1 IN (c2, named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3)); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1, c2); 
+
+select id from table_struct_types where c1 = c1; 
+select id from table_struct_types where c1 = c2;
+select id from table_struct_types where c1 = named_struct("f1",1,"f2",1);
+select id from table_struct_types where named_struct("f1",1,"f2",1) = c1;
+select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",1);
+select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",2);
+
+select id from table_struct_types where c1 <> c1; 
+select id from table_struct_types where c1 <> c2; 
+select id from table_struct_types where c1 <> named_struct("f1",1,"f2",1);
+select id from table_struct_types where named_struct("f1",1,"f2",1) <> c1; 
+select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",1); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",2); 
+
+select id from table_struct_types where c1 IS DISTINCT FROM c1;
+select id from table_struct_types where c1 IS DISTINCT FROM c2;
+select id from table_struct_types where c1 IS DISTINCT FROM named_struct("f1",1,"f2",1); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM c1; 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",1); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",2); 
+
+select id from table_struct_types where c1 IS NOT DISTINCT FROM c1;
+select id from table_struct_types where c1 IS NOT DISTINCT FROM c2;
+select id from table_struct_types where c1 IS NOT DISTINCT FROM named_struct("f1",1,"f2",1); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM c1;  
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",1); 
+select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",2);

--- a/ql/src/test/results/clientnegative/udf_in.q.out
+++ b/ql/src/test/results/clientnegative/udf_in.q.out
@@ -1,1 +1,1 @@
-FAILED: SemanticException Line 0:-1 Wrong arguments '3': The arguments for IN should be the same type! Types are: {int IN (array<int>)}
+FAILED: SemanticException Line 0:-1 Wrong arguments '3': Type mismatch: {int IN (array<int>)}

--- a/ql/src/test/results/clientpositive/llap/equals_list_types.q.out
+++ b/ql/src/test/results/clientpositive/llap/equals_list_types.q.out
@@ -1,0 +1,363 @@
+PREHOOK: query: create table table_list_types (id int, c1 array<int>, c2 array<int>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table_list_types
+POSTHOOK: query: create table table_list_types (id int, c1 array<int>, c2 array<int>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table_list_types
+PREHOOK: query: insert into table_list_types VALUES (1, array(1,1), array(2,1))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_list_types
+POSTHOOK: query: insert into table_list_types VALUES (1, array(1,1), array(2,1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_list_types
+POSTHOOK: Lineage: table_list_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_list_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_list_types.id SCRIPT []
+PREHOOK: query: insert into table_list_types VALUES (2, array(1,2), array(2,2))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_list_types
+POSTHOOK: query: insert into table_list_types VALUES (2, array(1,2), array(2,2))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_list_types
+POSTHOOK: Lineage: table_list_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_list_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_list_types.id SCRIPT []
+PREHOOK: query: insert into table_list_types VALUES (3, array(1,3), array(2,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_list_types
+POSTHOOK: query: insert into table_list_types VALUES (3, array(1,3), array(2,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_list_types
+POSTHOOK: Lineage: table_list_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_list_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_list_types.id SCRIPT []
+PREHOOK: query: insert into table_list_types VALUES (4, array(1,4), array(1,4))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_list_types
+POSTHOOK: query: insert into table_list_types VALUES (4, array(1,4), array(1,4))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_list_types
+POSTHOOK: Lineage: table_list_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_list_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_list_types.id SCRIPT []
+PREHOOK: query: select id from table_list_types where c1 IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where c1 IN (c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IN (c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_list_types where c1 IN (array(1,1))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IN (array(1,1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where array(1,1) IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where c1 IN (array(1,1), array(1,2), array(1,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IN (array(1,1), array(1,2), array(1,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_list_types where c1 IN (c2, array(1,1), array(1,2), array(1,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IN (c2, array(1,1), array(1,2), array(1,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) IN (c1, c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IN (c1, c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where c1 = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where c1 = c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 = c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_list_types where c1 = array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 = array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where array(1,1) = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where array(1,1) = array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) = array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) = array(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) = array(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_list_types where c1 <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_list_types where c1 <> c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 <> c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_list_types where c1 <> array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 <> array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) <> array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) <> array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_list_types where array(1,1) <> array(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) <> array(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS DISTINCT FROM array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS DISTINCT FROM array(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where c1 IS NOT DISTINCT FROM array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_list_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_list_types where array(1,1) IS NOT DISTINCT FROM array(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_list_types
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/equals_map_types.q.out
+++ b/ql/src/test/results/clientpositive/llap/equals_map_types.q.out
@@ -1,0 +1,363 @@
+PREHOOK: query: create table table_map_types (id int, c1 map<int,int>, c2 map<int,int>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table_map_types
+POSTHOOK: query: create table table_map_types (id int, c1 map<int,int>, c2 map<int,int>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table_map_types
+PREHOOK: query: insert into table_map_types VALUES (1, map(1,1), map(2,1))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_map_types
+POSTHOOK: query: insert into table_map_types VALUES (1, map(1,1), map(2,1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_map_types
+POSTHOOK: Lineage: table_map_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_map_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_map_types.id SCRIPT []
+PREHOOK: query: insert into table_map_types VALUES (2, map(1,2), map(2,2))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_map_types
+POSTHOOK: query: insert into table_map_types VALUES (2, map(1,2), map(2,2))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_map_types
+POSTHOOK: Lineage: table_map_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_map_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_map_types.id SCRIPT []
+PREHOOK: query: insert into table_map_types VALUES (3, map(1,3), map(2,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_map_types
+POSTHOOK: query: insert into table_map_types VALUES (3, map(1,3), map(2,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_map_types
+POSTHOOK: Lineage: table_map_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_map_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_map_types.id SCRIPT []
+PREHOOK: query: insert into table_map_types VALUES (4, map(1,4), map(1,4))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_map_types
+POSTHOOK: query: insert into table_map_types VALUES (4, map(1,4), map(1,4))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_map_types
+POSTHOOK: Lineage: table_map_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_map_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_map_types.id SCRIPT []
+PREHOOK: query: select id from table_map_types where c1 IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where c1 IN (c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IN (c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_map_types where c1 IN (map(1,1))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IN (map(1,1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where map(1,1) IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where c1 IN (map(1,1), map(1,2), map(1,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IN (map(1,1), map(1,2), map(1,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_map_types where c1 IN (c2, map(1,1), map(1,2), map(1,3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IN (c2, map(1,1), map(1,2), map(1,3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) IN (c1, c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IN (c1, c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where c1 = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where c1 = c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 = c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_map_types where c1 = map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 = map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where map(1,1) = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where map(1,1) = map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) = map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) = map(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) = map(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_map_types where c1 <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_map_types where c1 <> c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 <> c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_map_types where c1 <> map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 <> map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) <> map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) <> map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_map_types where map(1,1) <> map(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) <> map(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS DISTINCT FROM map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS DISTINCT FROM map(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where c1 IS NOT DISTINCT FROM map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_map_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_map_types where map(1,1) IS NOT DISTINCT FROM map(1,2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_map_types
+#### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/equals_struct_types.q.out
+++ b/ql/src/test/results/clientpositive/llap/equals_struct_types.q.out
@@ -1,0 +1,363 @@
+PREHOOK: query: create table table_struct_types (id int, c1 struct<f1: int,f2: int>, c2 struct<f1: int,f2: int>)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@table_struct_types
+POSTHOOK: query: create table table_struct_types (id int, c1 struct<f1: int,f2: int>, c2 struct<f1: int,f2: int>)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@table_struct_types
+PREHOOK: query: insert into table_struct_types VALUES (1, named_struct("f1",1,"f2",1), named_struct("f1",2,"f2",1))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_struct_types
+POSTHOOK: query: insert into table_struct_types VALUES (1, named_struct("f1",1,"f2",1), named_struct("f1",2,"f2",1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_struct_types
+POSTHOOK: Lineage: table_struct_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.id SCRIPT []
+PREHOOK: query: insert into table_struct_types VALUES (2, named_struct("f1",1,"f2",2), named_struct("f1",2,"f2",2))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_struct_types
+POSTHOOK: query: insert into table_struct_types VALUES (2, named_struct("f1",1,"f2",2), named_struct("f1",2,"f2",2))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_struct_types
+POSTHOOK: Lineage: table_struct_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.id SCRIPT []
+PREHOOK: query: insert into table_struct_types VALUES (3, named_struct("f1",1,"f2",3), named_struct("f1",2,"f2",3))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_struct_types
+POSTHOOK: query: insert into table_struct_types VALUES (3, named_struct("f1",1,"f2",3), named_struct("f1",2,"f2",3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_struct_types
+POSTHOOK: Lineage: table_struct_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.id SCRIPT []
+PREHOOK: query: insert into table_struct_types VALUES (4, named_struct("f1",1,"f2",4), named_struct("f1",1,"f2",4))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@table_struct_types
+POSTHOOK: query: insert into table_struct_types VALUES (4, named_struct("f1",1,"f2",4), named_struct("f1",1,"f2",4))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@table_struct_types
+POSTHOOK: Lineage: table_struct_types.c1 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.c2 SCRIPT []
+POSTHOOK: Lineage: table_struct_types.id SCRIPT []
+PREHOOK: query: select id from table_struct_types where c1 IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where c1 IN (c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IN (c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IN (named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_struct_types where c1 IN (c2, named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3))
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IN (c2, named_struct("f1",1,"f2",1), named_struct("f1",1,"f2",2), named_struct("f1",1,"f2",3))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1, c2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IN (c1, c2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where c1 = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where c1 = c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 = c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_struct_types where c1 = named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 = named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) = named_struct("f1",1,"f2",2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_struct_types where c1 <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_struct_types where c1 <> c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 <> c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_struct_types where c1 <> named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 <> named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) <> named_struct("f1",1,"f2",2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+PREHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS DISTINCT FROM named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS DISTINCT FROM named_struct("f1",1,"f2",2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM c2
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM c2
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+4
+PREHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where c1 IS NOT DISTINCT FROM named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM c1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM c1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+1
+2
+3
+4
+PREHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",2)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####
+POSTHOOK: query: select id from table_struct_types where named_struct("f1",1,"f2",1) IS NOT DISTINCT FROM named_struct("f1",1,"f2",2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@table_struct_types
+#### A masked pattern was here ####


### PR DESCRIPTION
### What changes were proposed in this pull request?

1. Refactor GenericUDFBaseCompare#initialize to allow equalities between
MAP/LIST/STRUCT types and improve readability.
2. Add positive and negative parameterized tests for GenericUDF#initialize
method with various argument types.
3. Re-work and unify messages in UDFArgumentException when types do not
match.
4. Add positive qtests for MAP, LIST, and, STRUCT types and different UDFs.

### Why are the changes needed?
1. Allow simple comparisons between non primitive types.
2. Avoid unexpected parse and runtime exceptions when performing comparisons involving MAP, LIST, STRUCT types.
3. Extend test coverage of comparisons operators on STRUCT, LIST, MAP, and primitive types.

### Does this PR introduce _any_ user-facing change?
Allows more SQL queries and provides proper failure information when comparisons are not supported.

### How was this patch tested?
```
mvn test -Dtest=TestGenericUDFInitializeOnCompareUDF
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile="equals_map_types.q,equals_list_types.q,equals_struct_types.q" 
```