### PR TITLE
HIVE-24914: Improve LLAP scheduling by only traversing hosts with capacity

### DIFF
--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1822,7 +1822,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       readLock.unlock();
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("GetTotalResources: numInstancesFound={}, totalMem={}, totalVcores={} availableHosts: {}",
+      LOG.debug("ResourceAvail: numInstancesFound={}, totalMem={}, totalVcores={} availableHosts: {}",
           numInstancesFound, memory, vcores, availableHostMap.size());
     }
     return new ImmutablePair<>(Resource.newInstance(memory, vcores), availableHostMap);

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1504,11 +1504,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         }
         // rollover
         if (nextSlot == null) nextSlot = activeNodesWithFreeSlots.stream().findFirst().get();
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Assigning {} in consistent order when looking for first requested host, from #hosts={},"
-                  + " requestedHosts={}", nextSlot.toShortString(), availableHostMap.size(),
-              ((requestedHosts == null || requestedHosts.length == 0) ? "null" : requestedHostsDebugStr));
-        }
+        LOG.info("Assigning {} in consistent order when looking for first requested host, from #hosts={},"
+                + " requestedHosts={}", nextSlot.toShortString(), availableHostMap.size(),
+            ((requestedHosts == null || requestedHosts.length == 0) ? "null" : requestedHostsDebugStr));
         return new SelectHostResult(nextSlot);
       }
 
@@ -1822,7 +1820,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       readLock.unlock();
     }
     if (LOG.isDebugEnabled()) {
-      LOG.debug("ResourceAvail: numInstancesFound={}, totalMem={}, totalVcores={} availableHosts: {}",
+      LOG.debug("Available resources: numInstancesFound={}, totalMem={}, totalVcores={} availableHosts: {}",
           numInstancesFound, memory, vcores, availableHostMap.size());
     }
     return new ImmutablePair<>(Resource.newInstance(memory, vcores), availableHostMap);

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -17,6 +17,8 @@ package org.apache.hadoop.hive.llap.tezplugins;
 import com.google.common.io.ByteArrayDataOutput;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.hive.llap.tezplugins.metrics.LlapMetricsCollector;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.metrics2.MetricsSource;
@@ -1384,7 +1386,15 @@ public class LlapTaskSchedulerService extends TaskScheduler {
    * @param request the list of preferred hosts. null implies any host
    * @return
    */
-  private SelectHostResult selectHost(TaskInfo request) {
+  private SelectHostResult selectHost(TaskInfo request, Map<String, List<NodeInfo>> availableHostMap) {
+    // short-circuit when all nodes are busy
+    if (availableHostMap.values().isEmpty()) {
+      // reset locality delay
+      if (request.localityDelayTimeout > 0 && isRequestedHostPresent(request)) {
+        request.resetLocalityDelayInfo();
+      }
+      return SELECT_HOST_RESULT_DELAYED_RESOURCES;
+    }
     String[] requestedHosts = request.requestedHosts;
     String requestedHostsDebugStr = Arrays.toString(requestedHosts);
     if (LOG.isDebugEnabled()) {
@@ -1403,45 +1413,39 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         for (String host : requestedHosts) {
           prefHostCount++;
           // Pick the first host always. Weak attempt at cache affinity.
-          Set<LlapServiceInstance> instances = activeInstances.getByHost(host);
-          if (!instances.isEmpty()) {
-            for (LlapServiceInstance inst : instances) {
-              NodeInfo nodeInfo = instanceToNodeMap.get(inst.getWorkerIdentity());
-              if (nodeInfo != null) {
-                if  (nodeInfo.canAcceptTask()) {
-                  // Successfully scheduled.
-                  LOG.info("Assigning {} when looking for {}." +
-                          " local=true FirstRequestedHost={}, #prefLocations={}",
-                      nodeInfo.toShortString(), host,
-                      (prefHostCount == 0),
-                      requestedHosts.length);
-                  return new SelectHostResult(nodeInfo);
+          if (availableHostMap.containsKey(host)) {
+            List<NodeInfo> instances = availableHostMap.getOrDefault(host, new ArrayList<>());
+            // Host is there and there are available resources!
+            if (!instances.isEmpty()) {
+              NodeInfo nodeInfo = instances.iterator().next();
+              // Successfully scheduled.
+              LOG.info("Assigning {} when looking for {}." + " local=true FirstRequestedHost={}, #prefLocations={}",
+                  nodeInfo.toShortString(), host, (prefHostCount == 0), requestedHosts.length);
+              return new SelectHostResult(nodeInfo);
+            } else {
+              // The node cannot accept a task at the moment. (there is host -- but no resources)
+              if (shouldDelayForLocality) {
+                // Perform some checks on whether the node will become available or not.
+                if (request.shouldForceLocality()) {
+                  requestedHostsWillBecomeAvailable = true;
                 } else {
-                  // The node cannot accept a task at the moment.
-                  if (shouldDelayForLocality) {
-                    // Perform some checks on whether the node will become available or not.
-                    if (request.shouldForceLocality()) {
-                      requestedHostsWillBecomeAvailable = true;
-                    } else {
-                      if (nodeInfo.getEnableTime() > request.getLocalityDelayTimeout() &&
-                          nodeInfo.isDisabled() && nodeInfo.hadCommFailure()) {
-                        LOG.debug("Host={} will not become available within requested timeout", nodeInfo);
-                        // This node will likely be activated after the task timeout expires.
-                      } else {
-                        // Worth waiting for the timeout.
-                        requestedHostsWillBecomeAvailable = true;
-                      }
-                    }
+                  LlapServiceInstance inst = activeInstances.getByHost(host).stream().findFirst().get();
+                  NodeInfo nodeInfo = instanceToNodeMap.get(inst.getWorkerIdentity());
+                  if (nodeInfo != null && nodeInfo.getEnableTime() > request.getLocalityDelayTimeout()
+                      && nodeInfo.isDisabled() && nodeInfo.hadCommFailure()) {
+                    LOG.debug("Host={} will not become available within requested timeout", nodeInfo);
+                    // This node will likely be activated after the task timeout expires.
+                  } else {
+                    // Worth waiting for the timeout.
+                    requestedHostsWillBecomeAvailable = true;
                   }
                 }
-              } else {
-                LOG.warn(
-                    "Null NodeInfo when attempting to get host with worker {}, and host {}",
-                    inst, host);
-                // Leave requestedHostWillBecomeAvailable as is. If some other host is found - delay,
-                // else ends up allocating to a random host immediately.
               }
             }
+          } else {
+            LOG.warn("Null NodeInfo when attempting to get host {}", host);
+            // Leave requestedHostWillBecomeAvailable as is. If some other host is found - delay,
+            // else ends up allocating to a random host immediately.
           }
         }
         // Check if forcing the location is required.
@@ -1463,46 +1467,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
           }
         }
       }
-
       /* fall through - miss in locality or no locality-requested */
-      Collection<LlapServiceInstance> instances;
-      if (consistentSplits) {
-        instances = activeInstances.getAllInstancesOrdered(true);
-      } else {
-        // if consistent splits are not used we don't need the ordering as there will be no cache benefit anyways
-        instances = activeInstances.getAll();
-      }
-      List<NodeInfo> allNodes = new ArrayList<>(instances.size());
       List<NodeInfo> activeNodesWithFreeSlots = new ArrayList<>();
-      for (LlapServiceInstance inst : instances) {
-        if (inst instanceof InactiveServiceInstance) {
-          allNodes.add(null);
-        } else {
-          NodeInfo nodeInfo = instanceToNodeMap.get(inst.getWorkerIdentity());
-          if (nodeInfo == null) {
-            allNodes.add(null);
-          } else {
-            allNodes.add(nodeInfo);
-            if (nodeInfo.canAcceptTask()) {
-              activeNodesWithFreeSlots.add(nodeInfo);
-            }
-          }
-        }
-      }
-
-      if (allNodes.isEmpty()) {
-        return SELECT_HOST_RESULT_DELAYED_RESOURCES;
-      }
-
-      // When all nodes are busy, reset locality delay
-      if (activeNodesWithFreeSlots.isEmpty()) {
-        isClusterCapacityFull.set(true);
-        if (request.localityDelayTimeout > 0 && isRequestedHostPresent(request)) {
-          request.resetLocalityDelayInfo();
-        }
-      } else {
-        isClusterCapacityFull.set(false);
-      }
+      availableHostMap.values().forEach(activeNodesWithFreeSlots::addAll);
 
       // no locality-requested, randomly pick a node containing free slots
       if (requestedHosts == null || requestedHosts.length == 0) {
@@ -1514,20 +1481,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
 
       // miss in locality request, try picking consistent location with fallback to random selection
       final String firstRequestedHost = requestedHosts[0];
-      int requestedHostIdx = -1;
-      for (int i = 0; i < allNodes.size(); i++) {
-        NodeInfo nodeInfo = allNodes.get(i);
-        if (nodeInfo != null) {
-          if (nodeInfo.getHost().equals(firstRequestedHost)){
-            requestedHostIdx = i;
-            break;
-          }
-        }
-      }
-
       // requested host died or unknown host requested, fallback to random selection.
       // TODO: At this point we don't know the slot number of the requested host, so can't rollover to next available
-      if (requestedHostIdx == -1) {
+      if (!availableHostMap.containsKey(firstRequestedHost)) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Requested node [{}] in consistent order does not exist. Falling back to random selection for " +
             "request {}", firstRequestedHost, request);
@@ -1536,20 +1492,24 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       }
 
       // requested host is still alive but cannot accept task, pick the next available host in consistent order
-      for (int i = 0; i < allNodes.size(); i++) {
-        NodeInfo nodeInfo = allNodes.get((i + requestedHostIdx + 1) % allNodes.size());
-        // next node in consistent order died or does not have free slots, rollover to next
-        if (nodeInfo == null || !nodeInfo.canAcceptTask()) {
-          continue;
-        } else {
-          if (LOG.isDebugEnabled()) {
-            LOG.debug("Assigning {} in consistent order when looking for first requested host, from #hosts={},"
-                + " requestedHosts={}", nodeInfo.toShortString(), allNodes.size(),
-              ((requestedHosts == null || requestedHosts.length == 0) ? "null" :
-                requestedHostsDebugStr));
+      if (!activeNodesWithFreeSlots.isEmpty()) {
+        NodeInfo nextSlot = null;
+        boolean found = false;
+        for (Entry<String, List<NodeInfo>> entry : availableHostMap.entrySet()) {
+          if (found && !entry.getValue().isEmpty()) {
+            nextSlot = entry.getValue().iterator().next();
+            break;
           }
-          return new SelectHostResult(nodeInfo);
+          if (entry.getKey().equals(firstRequestedHost)) found = true;
         }
+        // rollover
+        if (nextSlot == null) nextSlot = activeNodesWithFreeSlots.stream().findFirst().get();
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Assigning {} in consistent order when looking for first requested host, from #hosts={},"
+                  + " requestedHosts={}", nextSlot.toShortString(), availableHostMap.size(),
+              ((requestedHosts == null || requestedHosts.length == 0) ? "null" : requestedHostsDebugStr));
+        }
+        return new SelectHostResult(nextSlot);
       }
 
       return SELECT_HOST_RESULT_DELAYED_RESOURCES;
@@ -1816,23 +1776,90 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     INADEQUATE_TOTAL_RESOURCES,
   }
 
+  private Pair<Resource, Map<String, List<NodeInfo>>> getResourceAvailability() {
+    int memory = 0;
+    int vcores = 0;
+    int numInstancesFound = 0;
+    Map<String, List<NodeInfo>> availableHostMap;
+    readLock.lock();
+    try {
+      // maintain insertion order (needed for Next slot in locality miss)
+      availableHostMap = new LinkedHashMap<>(instanceToNodeMap.size());
+      Collection<LlapServiceInstance> instances = consistentSplits ?
+          // might also include Inactive instances
+          activeInstances.getAllInstancesOrdered(true):
+          // if consistent splits are NOT used we don't need the ordering as there will be no cache benefit anyways
+          activeInstances.getAll();
+      boolean foundSlot = false;
+      for (LlapServiceInstance inst : instances) {
+        NodeInfo nodeInfo = instanceToNodeMap.get(inst.getWorkerIdentity());
+        if (nodeInfo != null) {
+          List<NodeInfo> hostList = availableHostMap.get(nodeInfo.getHost());
+          if (hostList == null) {
+            hostList = new ArrayList<>();
+            availableHostMap.put(nodeInfo.getHost(), hostList);
+          }
+          if (!(inst instanceof InactiveServiceInstance)) {
+            Resource r = inst.getResource();
+            memory += r.getMemory();
+            vcores += r.getVirtualCores();
+            numInstancesFound++;
+            // Only add to List Nodes with available resources
+            // Hosts, however, exist even for nodes that do not currently have resources
+            if (nodeInfo.canAcceptTask()) {
+              foundSlot = true;
+              hostList.add(nodeInfo);
+            }
+          }
+        }
+      }
+      // isClusterCapacityFull will be set to false on every trySchedulingPendingTasks call
+      // set it false here to bail out early when we know there are no resources available.
+      if (!foundSlot) {
+        isClusterCapacityFull.set(true);
+      }
+    } finally {
+      readLock.unlock();
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("GetTotalResources: numInstancesFound={}, totalMem={}, totalVcores={} availableHosts: {}",
+          numInstancesFound, memory, vcores, availableHostMap.size());
+    }
+    return new ImmutablePair<>(Resource.newInstance(memory, vcores), availableHostMap);
+  }
+
+  /**
+   * Should cycle when:
+   *  1. There are available Resources OR
+   *  2. There is a pending task with higher pri than running ones
+   * @param availableHostMap
+   * @return
+   */
+  private boolean shouldCycle(Map<String, List<NodeInfo>> availableHostMap) {
+    // short-circuit on resource availability
+    if (!availableHostMap.values().isEmpty()) return true;
+    // check if pending Pri is lower than existing tasks pri
+    int specMax = speculativeTasks.isEmpty() ? Integer.MIN_VALUE : speculativeTasks.lastKey();
+    int guarMax = guaranteedTasks.isEmpty() ? Integer.MIN_VALUE : guaranteedTasks.lastKey();
+    return pendingTasks.firstKey().getPriority() < Math.max(specMax, guarMax);
+  }
 
   @VisibleForTesting
   protected void schedulePendingTasks() throws InterruptedException {
-    // Early exit where there are no slots available
+    // Early exit for scheduler calls that came **before** the end of this run and no resources are available.
+    // Preemption and locality delay will be taken care of in the first run.
     if (isClusterCapacityFull.get()) {
       return;
     }
     Ref<TaskInfo> downgradedTask = new Ref<>(null);
+    Pair<Resource, Map<String, List<NodeInfo>>> availabilityPair = getResourceAvailability();
     writeLock.lock();
     try {
       if (LOG.isDebugEnabled()) {
         LOG.debug("ScheduleRun: {}", constructPendingTaskCountsLogMessage());
       }
-      Iterator<Entry<Priority, List<TaskInfo>>> pendingIterator =
-          pendingTasks.entrySet().iterator();
-      Resource totalResource = getTotalResources();
-      while (pendingIterator.hasNext()) {
+      Iterator<Entry<Priority, List<TaskInfo>>> pendingIterator = pendingTasks.entrySet().iterator();
+      while (pendingIterator.hasNext() && shouldCycle(availabilityPair.getRight())) {
         Entry<Priority, List<TaskInfo>> entry = pendingIterator.next();
         List<TaskInfo> taskListAtPriority = entry.getValue();
         Iterator<TaskInfo> taskIter = taskListAtPriority.iterator();
@@ -1843,7 +1870,7 @@ public class LlapTaskSchedulerService extends TaskScheduler {
             dagStats.registerDelayedAllocation();
           }
           taskInfo.triedAssigningTask();
-          ScheduleResult scheduleResult = scheduleTask(taskInfo, totalResource, downgradedTask);
+          ScheduleResult scheduleResult = scheduleTask(taskInfo, availabilityPair, downgradedTask);
           // Note: we must handle downgradedTask after this. We do it at the end, outside the lock.
           if (LOG.isDebugEnabled()) {
             LOG.debug("ScheduleResult for Task: {} = {}", taskInfo, scheduleResult);
@@ -1984,20 +2011,20 @@ public class LlapTaskSchedulerService extends TaskScheduler {
     return sb.toString();
   }
 
-  private ScheduleResult scheduleTask(TaskInfo taskInfo, Resource totalResource,
+  private ScheduleResult scheduleTask(TaskInfo taskInfo, Pair<Resource, Map<String, List<NodeInfo>>> availabilityPair,
       Ref<TaskInfo> downgradedTask) {
-    Preconditions.checkNotNull(totalResource, "totalResource can not be null");
-    // If there's no memory available, fail
-    if (totalResource.getMemory() <= 0) {
+    Preconditions.checkNotNull(availabilityPair.getLeft(), "totalResource can not be null");
+    // If there's no memory available at the cluster, fail
+    if (availabilityPair.getLeft().getMemory() <= 0) {
       return SELECT_HOST_RESULT_INADEQUATE_TOTAL_CAPACITY.scheduleResult;
     }
-    SelectHostResult selectHostResult = selectHost(taskInfo);
+    SelectHostResult selectHostResult = selectHost(taskInfo, availabilityPair.getRight());
     if (selectHostResult.scheduleResult != ScheduleResult.SCHEDULED) {
       return selectHostResult.scheduleResult;
     }
     boolean isGuaranteed = false;
     if (unusedGuaranteed > 0) {
-      boolean wasGuaranteed = false;
+      boolean wasGuaranteed;
       synchronized (taskInfo) {
         assert !taskInfo.isPendingUpdate; // No updates before it's running.
         wasGuaranteed = taskInfo.isGuaranteed;
@@ -2055,6 +2082,10 @@ public class LlapTaskSchedulerService extends TaskScheduler {
       taskInfo.setAssignmentInfo(nodeInfo, container.getId(), clock.getTime());
       registerRunningTask(taskInfo);
       nodeInfo.registerTaskScheduled();
+      // if no more resources on Node -> remove
+      if (!nodeInfo.canAcceptTask()) {
+        availabilityPair.getRight().get(nodeInfo.getHost()).remove(nodeInfo);
+      }
     } finally {
       writeLock.unlock();
     }
@@ -2470,8 +2501,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
         // will be handled in the next run.
         // A new request may come in right after this is set to false, but before the actual scheduling.
         // This will be handled in this run, but will cause an immediate run after, which is harmless.
-        // This is mainly to handle a trySchedue request while in the middle of a run - since the event
-        // which triggered it may not be processed for all tasks in the run.
+        // isClusterCapacityFull helps in such runs bailing out when we know no resources are available.
+        // pendingScheduleInvocations is mainly to handle a trySchedulingPendingTasks request while in the middle of
+        // a run - since the event which triggered it may not be processed for all tasks in the run.
         pendingScheduleInvocations.set(false);
         // Schedule outside of the scheduleLock - which should only be used to wait on the condition.
         try {

--- a/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
+++ b/llap-tez/src/test/org/apache/hadoop/hive/llap/tezplugins/TestLlapTaskSchedulerService.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -1056,7 +1057,7 @@ public class TestLlapTaskSchedulerService {
       // 3rd task requested host2, got host1 as host2 and host3 are full
       assertEquals(HOST1, argumentCaptor2.getAllValues().get(2).getNodeId().getHost());
 
-      verify(tsWrapper.mockServiceInstanceSet, times(2)).getAllInstancesOrdered(true);
+      verify(tsWrapper.mockServiceInstanceSet, atLeast(2)).getAllInstancesOrdered(true);
 
       assertEquals(0, tsWrapper.ts.dagStats.numAllocationsNoLocalityRequest);
       assertEquals(1, tsWrapper.ts.dagStats.numLocalAllocations);
@@ -1115,7 +1116,7 @@ public class TestLlapTaskSchedulerService {
       // 3rd task requested host3, got host1 since host3 is dead and host4 is full
       assertEquals(HOST1, argumentCaptor2.getAllValues().get(2).getNodeId().getHost());
 
-      verify(tsWrapper.mockServiceInstanceSet, times(2)).getAllInstancesOrdered(true);
+      verify(tsWrapper.mockServiceInstanceSet, atLeast(2)).getAllInstancesOrdered(true);
 
       assertEquals(0, tsWrapper.ts.dagStats.numAllocationsNoLocalityRequest);
       assertEquals(1, tsWrapper.ts.dagStats.numLocalAllocations);
@@ -1822,7 +1823,7 @@ public class TestLlapTaskSchedulerService {
     String [] hostsH1 = new String[] {HOST1};
 
     // Node disable timeout higher than locality delay.
-    TestTaskSchedulerServiceWrapper tsWrapper = new TestTaskSchedulerServiceWrapper(20000, hosts, 1, 1, 10000l);
+    TestTaskSchedulerServiceWrapper tsWrapper = new TestTaskSchedulerServiceWrapper(20000, hosts, 1, 1, 9000l);
 
     // Fill up host1 with tasks. Leave host2 empty.
     try {
@@ -1857,7 +1858,7 @@ public class TestLlapTaskSchedulerService {
       long thirdAllocateTime = tsWrapper.getClock().getTime();
       long diff = thirdAllocateTime - startTime;
       // diffAfterSleep < total sleepTime
-      assertTrue("Task not allocated in expected time window: duration=" + diff, diff < 10000l);
+      assertTrue("Task not allocated in expected time window: duration=" + diff, diff < 9000l);
 
       verify(tsWrapper.mockAppCallback, never()).preemptContainer(any(ContainerId.class));
       argumentCaptor = ArgumentCaptor.forClass(Object.class);
@@ -2014,12 +2015,14 @@ public class TestLlapTaskSchedulerService {
           if (host == null) {
             LlapServiceInstance mockInactive = mock(InactiveServiceInstance.class);
             doReturn(host).when(mockInactive).getHost();
+            doReturn(Resource.newInstance(100, 1)).when(mockInactive).getResource();
             doReturn("inactive-host-" + host).when(mockInactive).getWorkerIdentity();
             doReturn(ImmutableSet.builder().add(mockInactive).build()).when(mockServiceInstanceSet).getByHost(host);
             liveInstances.add(mockInactive);
           } else {
             LlapServiceInstance mockActive = mock(LlapServiceInstance.class);
             doReturn(host).when(mockActive).getHost();
+            doReturn(Resource.newInstance(100, 1)).when(mockActive).getResource();
             doReturn("host-" + host).when(mockActive).getWorkerIdentity();
             doReturn(ImmutableSet.builder().add(mockActive).build()).when(mockServiceInstanceSet).getByHost(host);
             liveInstances.add(mockActive);


### PR DESCRIPTION
### What changes were proposed in this pull request?
schedulePendingTasks on the LlapTaskScheduler currently goes through all the pending tasks and tries to allocate them based on their Priority – if a priority can not be scheduled completely, we bail out as lower priorities would not be able to get allocations either.

Optimize by only walking through the nodes with capacity (if any) ,and not all available hosts, for scheduling these tasks based on their priority and locality preferences.

### Why are the changes needed?
Scheduling perf


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
TestLlapTaskSchedulingService
