### PR TITLE
HIVE-24930: Operator.setDone() short-circuit from child op is not used in vectorized codepath (if childSize == 1)

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Operator.java
@@ -917,6 +917,10 @@ public abstract class Operator<T extends OperatorDesc> implements Serializable,C
     final int childSize = childOperatorsArray.length;
     if (childSize == 1) {
       childOperatorsArray[0].process(batch, childOperatorsTag[0]);
+      // if that single child is done, this operator is also done
+      if (childOperatorsArray[0].getDone()){
+        setDone(true);
+      }
     } else {
       int childrenDone = 0;
       for (int i = 0; i < childOperatorsArray.length; i++) {

--- a/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
+++ b/ql/src/test/results/clientpositive/tez/explainanalyze_3.q.out
@@ -711,7 +711,7 @@ Stage-0
       File Output Operator [FS_12]
         Limit [LIM_11] (rows=5/5 width=178)
           Number of rows:5
-          Select Operator [SEL_10] (rows=500/36 width=178)
+          Select Operator [SEL_10] (rows=500/8 width=178)
             Output:["_col0","_col1"]
           <-Map 1 [SIMPLE_EDGE] vectorized
             SHUFFLE [RS_9]


### PR DESCRIPTION
### What changes were proposed in this pull request?
Taking child operator's done field into consideration on vectorForward.


### Why are the changes needed?
Because otherwise e.g. limit operator's setDone(true) won't help in preventing the processing of all the rows.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Precommit testing.