### PR TITLE
HIVE-24931: Remove Read/WriteEntity parameters from TaskCompiler#optimizeOperatorPlan

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/MapReduceCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/MapReduceCompiler.java
@@ -117,8 +117,7 @@ public class MapReduceCompiler extends TaskCompiler {
   }
 
   @Override
-  protected void optimizeOperatorPlan(ParseContext pCtx, Set<ReadEntity> inputs,
-      Set<WriteEntity> outputs) throws SemanticException {
+  protected void optimizeOperatorPlan(ParseContext pCtx) throws SemanticException {
     this.runDynPartitionSortOptimizations(pCtx, conf);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/OptimizeTezProcContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/OptimizeTezProcContext.java
@@ -27,8 +27,6 @@ import org.apache.hadoop.hive.ql.exec.AppMasterEventOperator;
 import org.apache.hadoop.hive.ql.exec.Operator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
 import org.apache.hadoop.hive.ql.exec.TableScanOperator;
-import org.apache.hadoop.hive.ql.hooks.ReadEntity;
-import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
 
@@ -45,9 +43,6 @@ public class OptimizeTezProcContext implements NodeProcessorCtx {
 
   public final ParseContext parseContext;
   public final HiveConf conf;
-
-  public final Set<ReadEntity> inputs;
-  public final Set<WriteEntity> outputs;
 
   /* Two of the optimization rules, ConvertJoinMapJoin and RemoveDynamicPruningBySize, are put into
      stats dependent optimizations and run together in TezCompiler. There's no guarantee which one
@@ -72,13 +67,10 @@ public class OptimizeTezProcContext implements NodeProcessorCtx {
   // of traversal
   public Deque<Operator<? extends OperatorDesc>> rootOperators;
 
-  public OptimizeTezProcContext(HiveConf conf, ParseContext parseContext, Set<ReadEntity> inputs,
-      Set<WriteEntity> outputs) {
+  public OptimizeTezProcContext(HiveConf conf, ParseContext parseContext) {
 
     this.conf = conf;
     this.parseContext = parseContext;
-    this.inputs = inputs;
-    this.outputs = outputs;
     this.pruningOpsRemovedByPriorOpt = new HashSet<AppMasterEventOperator>();
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -158,7 +158,7 @@ public abstract class TaskCompiler {
 
     if (!pCtx.getQueryProperties().isAnalyzeCommand()) {
       LOG.debug("Skipping optimize operator plan for analyze command.");
-      optimizeOperatorPlan(pCtx, inputs, outputs);
+      optimizeOperatorPlan(pCtx);
     }
 
     /*
@@ -663,8 +663,7 @@ public abstract class TaskCompiler {
   /*
    * Called at the beginning of the compile phase to have another chance to optimize the operator plan
    */
-  protected void optimizeOperatorPlan(ParseContext pCtxSet, Set<ReadEntity> inputs,
-      Set<WriteEntity> outputs) throws SemanticException {
+  protected void optimizeOperatorPlan(ParseContext pCtxSet) throws SemanticException {
   }
 
   /*

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/OptimizeSparkProcContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/OptimizeSparkProcContext.java
@@ -21,8 +21,6 @@ package org.apache.hadoop.hive.ql.parse.spark;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.MapJoinOperator;
 import org.apache.hadoop.hive.ql.exec.ReduceSinkOperator;
-import org.apache.hadoop.hive.ql.hooks.ReadEntity;
-import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.lib.NodeProcessorCtx;
 import org.apache.hadoop.hive.ql.parse.ParseContext;
 
@@ -41,17 +39,12 @@ public class OptimizeSparkProcContext implements NodeProcessorCtx {
 
   private final ParseContext parseContext;
   private final HiveConf conf;
-  private final Set<ReadEntity> inputs;
-  private final Set<WriteEntity> outputs;
   private final Set<ReduceSinkOperator> visitedReduceSinks = new HashSet<ReduceSinkOperator>();
   private final Map<MapJoinOperator, Long> mjOpSizes = new HashMap<MapJoinOperator, Long>();
 
-  public OptimizeSparkProcContext(HiveConf conf, ParseContext parseContext,
-    Set<ReadEntity> inputs, Set<WriteEntity> outputs) {
+  public OptimizeSparkProcContext(HiveConf conf, ParseContext parseContext) {
     this.conf = conf;
     this.parseContext = parseContext;
-    this.inputs = inputs;
-    this.outputs = outputs;
   }
 
   public ParseContext getParseContext() {
@@ -60,14 +53,6 @@ public class OptimizeSparkProcContext implements NodeProcessorCtx {
 
   public HiveConf getConf() {
     return conf;
-  }
-
-  public Set<ReadEntity> getInputs() {
-    return inputs;
-  }
-
-  public Set<WriteEntity> getOutputs() {
-    return outputs;
   }
 
   public Set<ReduceSinkOperator> getVisitedReduceSinks() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/SparkCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/spark/SparkCompiler.java
@@ -107,11 +107,10 @@ public class SparkCompiler extends TaskCompiler {
   }
 
   @Override
-  protected void optimizeOperatorPlan(ParseContext pCtx, Set<ReadEntity> inputs,
-      Set<WriteEntity> outputs) throws SemanticException {
+  protected void optimizeOperatorPlan(ParseContext pCtx) throws SemanticException {
     PERF_LOGGER.perfLogBegin(CLASS_NAME, PerfLogger.SPARK_OPTIMIZE_OPERATOR_TREE);
 
-    OptimizeSparkProcContext procCtx = new OptimizeSparkProcContext(conf, pCtx, inputs, outputs);
+    OptimizeSparkProcContext procCtx = new OptimizeSparkProcContext(conf, pCtx);
 
     // Run Spark Dynamic Partition Pruning
     runDynamicPartitionPruning(procCtx);


### PR DESCRIPTION
### What changes were proposed in this pull request?
Idem with summary.

### Why are the changes needed?
Small refactoring to improve code readability.

The ReadEntity, and WriteEntity parameters in TaskCompiler#optimizeOperatorPlan are
passed in this method and various subsequent ones but they are never actually used
so they can be removed.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests