### PR TITLE
HIVE-24935: Remove outdated check for correlated exists subqueries with full aggregate

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQuery.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQuery.java
@@ -595,10 +595,10 @@ public class QBSubQuery implements ISubQueryJoinInfo {
     }
 
     // figure out if there is group by
-    boolean noImplicityGby = true;
+    boolean hasExplicitGby = false;
     for(int i=0; i<insertClause.getChildCount(); i++) {
       if(insertClause.getChild(i).getType() == HiveParser.TOK_GROUPBY) {
-        noImplicityGby = false;
+        hasExplicitGby = true;
         break;
       }
     }
@@ -615,34 +615,18 @@ public class QBSubQuery implements ISubQueryJoinInfo {
     /*
      * Restriction.13.m :: In the case of an implied Group By on a
      * correlated SubQuery, the SubQuery always returns 1 row.
-     * An exists on a SubQuery with an implied GBy will always return true.
-     * Whereas Algebraically transforming to a Join may not return true. See
-     * Specification doc for details.
-     * Similarly a not exists on a SubQuery with a implied GBY will always return false.
      */
-      // Following is special cases for different type of subqueries which have aggregate and no implicit group by
+      // Following is special cases for different type of subqueries which have aggregate and implicit group by
       // and are correlatd
-      // * EXISTS/NOT EXISTS - NOT allowed, throw an error for now. We plan to allow this later
       // * SCALAR - This should return true since later in subquery remove
       //              rule we need to know about this case.
       // * IN - always allowed, BUT returns true for cases with aggregate other than COUNT since later in subquery remove
       //        rule we need to know about this case.
       // * NOT IN - always allow, but always return true because later subq remove rule will generate diff plan for this case
       if (hasAggreateExprs &&
-              noImplicityGby) {
+              !hasExplicitGby) {
 
-        if(operator.getType() == SubQueryType.EXISTS
-                || operator.getType() == SubQueryType.NOT_EXISTS) {
-          if(hasCorrelation) {
-            throw new CalciteSubquerySemanticException(
-                ASTErrorUtils.getMsg(
-                    ErrorMsg.INVALID_SUBQUERY_EXPRESSION.getMsg(),
-                    subQueryAST,
-                    "A predicate on EXISTS/NOT EXISTS SubQuery with implicit Aggregation(no Group By clause) " +
-                            "cannot be rewritten."));
-          }
-        }
-        else if(operator.getType() == SubQueryType.SCALAR) {
+        if(operator.getType() == SubQueryType.SCALAR) {
             if(!hasWindowing) {
               subqueryConfig[1] = true;
             }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQueryParseInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBSubQueryParseInfo.java
@@ -43,30 +43,30 @@ public class QBSubQueryParseInfo {
       hasAggregateExprs = hasAggregateExprs | ( r == 1 | r== 2 );
     }
 
-    boolean noImplicityGby = true;
+    boolean hasExplicitGby = false;
     for(int i=0; i<insertClause.getChildCount(); i++) {
       if(insertClause.getChild(i).getType() == HiveParser.TOK_GROUPBY) {
-        noImplicityGby = false;
+        hasExplicitGby = true;
         break;
       }
     }
 
-    return new QBSubQueryParseInfo(hasAggregateExprs, noImplicityGby, buildSQOperator(subQueryOperatorAST));
+    return new QBSubQueryParseInfo(hasAggregateExprs, hasExplicitGby, buildSQOperator(subQueryOperatorAST));
   }
 
-  public QBSubQueryParseInfo(boolean hasAggregateExprs, boolean noImplicityGby, QBSubQuery.SubQueryTypeDef operator) {
+  public QBSubQueryParseInfo(boolean hasAggregateExprs, boolean hasExplicitGby, QBSubQuery.SubQueryTypeDef operator) {
     this.hasAggregateExprs = hasAggregateExprs;
-    this.noImplicityGby = noImplicityGby;
+    this.hasExplicitGby = hasExplicitGby;
     this.operator = operator;
   }
 
   private final boolean hasAggregateExprs;
-  private final boolean noImplicityGby;
+  private final boolean hasExplicitGby;
   private final QBSubQuery.SubQueryTypeDef operator;
   private RelNode subQueryRelNode;
 
   public boolean hasFullAggregate() {
-    return hasAggregateExprs && noImplicityGby;
+    return hasAggregateExprs && !hasExplicitGby;
   }
 
   public QBSubQuery.SubQueryTypeDef getOperator() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Remove outdated comment lines and if condition which was moved to `QBSubQueryParseInfo` and implementations of `ExprFactory.createSubqueryExpr`
2. Renamed boolean variable `noImplicityGby` -> `hasExplicitGby` and negate its semantics.

### Why are the changes needed?
Code cleanup. This is a follow-up of: #2039

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=subquery_full_aggregate.q -pl itests/qtest -Pitests
```