### PR TITLE
Backport HIVE-24851: Fix reader leak in AvroGenericRecordReader to branch-3.1

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
@@ -87,20 +87,36 @@ public class AvroGenericRecordReader implements
     }
 
     if (split.getLength() == 0) {
-      this.isEmptyInput = true;
-      this.start = 0;
       this.reader = null;
-    }
-    else {
-      this.isEmptyInput = false;
+      this.isEmptyInput = true;
+    } else {
       this.reader = new DataFileReader<GenericRecord>(new FsInput(split.getPath(), job), gdr);
-      this.reader.sync(split.getStart());
-      this.start = reader.tell();
+      this.isEmptyInput = false;
     }
-    this.stop = split.getStart() + split.getLength();
-    this.recordReaderID = new UID();
 
-    this.writerTimezone = extractWriterTimezoneFromMetadata(job, split, gdr);
+    try {
+      if (this.isEmptyInput) {
+        this.start = 0;
+      } else {
+        this.reader.sync(split.getStart());
+        this.start = reader.tell();
+      }
+      this.stop = split.getStart() + split.getLength();
+      this.recordReaderID = new UID();
+
+      this.writerTimezone = extractWriterTimezoneFromMetadata(job, split, gdr);
+    } catch (Exception e) {
+      if (this.reader != null) {
+        try {
+          this.reader.close();
+        } catch (Exception closeException) {
+          if (closeException != e) {
+            e.addSuppressed(closeException);
+          }
+        }
+      }
+      throw e;
+    }
   }
 
   /**


### PR DESCRIPTION
This is a cherry-pick of #2040 (https://issues.apache.org/jira/browse/HIVE-24851) to branch-3.1

Followup after cherry-pick to `branch-3` from https://github.com/apache/hive/pull/2104.