### PR TITLE
HIVE-24953: Set repl.source.for property in the db if db is under replication in incremental dump.

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/parse/TestScheduledReplicationScenarios.java
@@ -310,6 +310,20 @@ public class TestScheduledReplicationScenarios extends BaseReplicationScenariosA
           return false;
         }
       }, 100, 10000);
+
+      // Remove the SOURCE_OF_REPLICATION property from the database.
+      primary.run("ALTER DATABASE " + primaryDbName + " Set DBPROPERTIES ( '"
+              + SOURCE_OF_REPLICATION + "' = '')");
+
+      GenericTestUtils.waitFor(() -> {
+        try {
+          primary.run("DESCRIBE DATABASE EXTENDED " + primaryDbName);
+          return primary.getOutput().get(0)
+                  .contains("repl.source.for=s1_t2_new");
+        } catch (Throwable e) {
+          return false;
+        }
+      }, 100, 10000);
     } finally {
       primary.run("drop scheduled query s1_t2_new");
       replica.run("drop scheduled query s2_t2");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/ReplDumpTask.java
@@ -51,7 +51,6 @@ import org.apache.hadoop.hive.ql.exec.TaskFactory;
 import org.apache.hadoop.hive.ql.exec.repl.util.AddDependencyToLeaves;
 import org.apache.hadoop.hive.ql.exec.repl.util.FileList;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
-import org.apache.hadoop.hive.ql.exec.repl.ReplExternalTables;
 import org.apache.hadoop.hive.ql.exec.repl.util.TaskTracker;
 import org.apache.hadoop.hive.ql.exec.util.DAGTraversal;
 import org.apache.hadoop.hive.ql.exec.util.Retryable;
@@ -586,7 +585,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
         : "?";
     Database db = hiveDb.getDatabase(dbName);
     if (db != null && !HiveConf.getBoolVar(conf, REPL_DUMP_METADATA_ONLY)) {
-      checkReplSourceFor(hiveDb, dbName, db);
+      setReplSourceFor(hiveDb, dbName, db);
     }
 
     long estimatedNumEvents = evFetcher.getDbNotificationEventsCount(work.eventFrom, dbName, work.eventTo,
@@ -910,7 +909,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
         }
 
         if (db != null && !HiveConf.getBoolVar(conf, REPL_DUMP_METADATA_ONLY)) {
-          checkReplSourceFor(hiveDb, dbName, db);
+          setReplSourceFor(hiveDb, dbName, db);
         }
 
         int estimatedNumTables = Utils.getAllTables(hiveDb, dbName, work.replScope).size();
@@ -1015,7 +1014,7 @@ public class ReplDumpTask extends Task<ReplDumpWork> implements Serializable {
     }
   }
 
-  private void checkReplSourceFor(Hive hiveDb, String dbName, Database db) throws HiveException {
+  private void setReplSourceFor(Hive hiveDb, String dbName, Database db) throws HiveException {
     if (!ReplChangeManager.isSourceOfReplication(db)) {
       // Check if the schedule name is available else set the query value
       // as default.


### PR DESCRIPTION
What changes were proposed in this pull request?
Set repl.source.for property in the db if db is under replication in incremental dump.

Why are the changes needed?

Does this PR introduce any user-facing change?
No

How was this patch tested?