### PR TITLE
HIVE-24943: Initiator: Optimise when tables/partitions are not eligib…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -451,12 +451,13 @@ public class Initiator extends MetaStoreCompactorThread {
       ShowCompactResponse currentCompactions, Set<String> skipDBs, Set<String> skipTables) {
     try {
       if (skipDBs.contains(ci.dbname)) {
-        LOG.debug("Skipping {}::{}, skipDBs:{}", ci.dbname, ci.tableName, skipDBs);
+        LOG.info("Skipping {}::{}, skipDBs::size:{}", ci.dbname, ci.tableName, skipDBs.size());
         return false;
       } else {
         if (replIsCompactionDisabledForDatabase(ci.dbname)) {
           skipDBs.add(ci.dbname);
-          LOG.debug("Skipping {}::{}, skipDBs:{}", ci.dbname, ci.tableName, skipDBs);
+          LOG.debug("Skipping {} as compaction is disabled due to repl; skipDBs::size:{}",
+              ci.dbname, skipDBs.size());
           return false;
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -456,7 +456,7 @@ public class Initiator extends MetaStoreCompactorThread {
       } else {
         if (replIsCompactionDisabledForDatabase(ci.dbname)) {
           skipDBs.add(ci.dbname);
-          LOG.debug("Skipping {} as compaction is disabled due to repl; skipDBs::size:{}",
+          LOG.info("Skipping {} as compaction is disabled due to repl; skipDBs::size:{}",
               ci.dbname, skipDBs.size());
           return false;
         }


### PR DESCRIPTION
HIVE-24943: Initiator: Optimise when tables/partitions are not eligible for compaction
https://issues.apache.org/jira/browse/HIVE-24943

### What changes were proposed in this pull request?
https://github.com/apache/hive/blob/master/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/MetaStoreCompactorThread.java#L73 

When large number of databases & tables are present, HMS spends good amount of time and CPU in gathering table details. 

Initiator should be able to detect such databases and reduce load on HMS for such tables & databases. This PR tries to avoid such databases/tables in Initiator.


### Why are the changes needed?
To reduce load on HMS. When large number of DBs & tables are present, HMS spends good amount of time & CPU in this codepath.

### Does this PR introduce _any_ user-facing change?
Np

### How was this patch tested?
small internal cluster