### PR TITLE
HIVE-24962: Implement partition pruning for Iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -231,6 +231,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
         Collection<String> filterColumns = Lists.newArrayList();
         columns(syntheticFilterPredicate, filterColumns);
 
+        // If the filter contains at least one partition column then it could be worthwhile to try dynamic partition
+        // pruning
         if (filterColumns.stream().anyMatch(partitionColumns::contains)) {
           // The filter predicate contains ExprNodeDynamicListDesc object(s) for places where we will substitute
           // dynamic values later during execution. For Example:

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -395,7 +395,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           if (child instanceof ExprNodeColumnDesc) {
             newColumn = ((ExprNodeColumnDesc) child).getColumn();
           } else {
-            newColumn = collectColumnsAndReplaceDummyValues(child, column);
+            newColumn = collectColumnAndReplaceDummyValues(child, column);
           }
 
           if (column != null && newColumn != null && !newColumn.equals(column)) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -253,7 +253,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       }
     } catch (UnsupportedOperationException uoe) {
       // If we can not convert the filter, we do not prune
-      LOG.debug(String.format("Unsupported predicate %s", syntheticFilterPredicate), uoe);
+      LOG.debug("Unsupported predicate {}", syntheticFilterPredicate, uoe);
     }
 
     // There is nothing to prune, or we could not use the filter

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -245,8 +245,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           // Check if we can convert the expression to a valid Iceberg filter
           SearchArgument sarg = ConvertAstToSearchArg.create(conf, (ExprNodeGenericFuncDesc) clone);
           HiveIcebergFilterFactory.generateFilterExpression(sarg);
-          LOG.debug("Found Iceberg partition column to prune with predicate {}",
-              syntheticFilterPredicate);
+          LOG.debug("Found Iceberg partition column to prune with predicate {}", syntheticFilterPredicate);
           return true;
         }
       }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -363,7 +363,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       columns.add(((ExprNodeColumnDesc) node).getColumn());
     } else {
       List<ExprNodeDesc> children = node.getChildren();
-      if (children != null && !children.isEmpty()) {
+      if (children != null) {
         children.forEach(child -> columns(child, columns));
       }
     }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -294,7 +294,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
   }
 
-  @Test(timeout = 100000)
+  @Test
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
@@ -317,7 +317,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     }
   }
 
-  @Test(timeout = 100000)
+  @Test
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
@@ -411,7 +411,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
   }
 
-  @Test(timeout = 100000)
+  @Test
   public void testInsertSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DynamicPartitionPruner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/DynamicPartitionPruner.java
@@ -23,21 +23,35 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 import org.apache.commons.lang3.mutable.MutableInt;
+import org.apache.hadoop.hive.ql.exec.Operator;
+import org.apache.hadoop.hive.ql.exec.SerializationUtilities;
+import org.apache.hadoop.hive.ql.exec.TableScanOperator;
+import org.apache.hadoop.hive.ql.plan.ExprNodeConstantDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDynamicListDesc;
+import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.hadoop.fs.Path;
@@ -101,7 +115,7 @@ public class DynamicPartitionPruner {
 
   private int totalEventCount = 0;
 
-  public void prune() throws SerDeException, IOException, InterruptedException, HiveException {
+  public void prune(JobConf jobConf) throws SerDeException, IOException, InterruptedException, HiveException {
     if (sourcesWaitingForEvents.isEmpty()) {
       return;
     }
@@ -118,7 +132,7 @@ public class DynamicPartitionPruner {
     // synchronous event processing loop. Won't return until all events have
     // been processed.
     this.processEvents();
-    this.prunePartitions();
+    this.prunePartitions(jobConf);
     LOG.info("Ok to proceed.");
   }
 
@@ -151,12 +165,16 @@ public class DynamicPartitionPruner {
       List<String> columnTypes = work.getEventSourceColumnTypeMap().get(s);
       // Expression for the operation. e.g. N^2 > 10
       List<ExprNodeDesc> partKeyExprs = work.getEventSourcePartKeyExprMap().get(s);
+      // Expression for pruning
+      List<ExprNodeDesc> predicates = work.getEventSourcePredicateExprMap().get(s);
+
       // eventSourceTableDesc, eventSourceColumnName, evenSourcePartKeyExpr move in lock-step.
       // One entry is added to each at the same time
 
       Iterator<String> cit = columnNames.iterator();
       Iterator<String> typit = columnTypes.iterator();
       Iterator<ExprNodeDesc> pit = partKeyExprs.iterator();
+      Iterator<ExprNodeDesc> predit = predicates.iterator();
       // A single source can process multiple columns, and will send an event for each of them.
       for (TableDesc t : tables) {
         numExpectedEventsPerSource.get(s).decrement();
@@ -164,7 +182,8 @@ public class DynamicPartitionPruner {
         String columnName = cit.next();
         String columnType = typit.next();
         ExprNodeDesc partKeyExpr = pit.next();
-        SourceInfo si = createSourceInfo(t, partKeyExpr, columnName, columnType, jobConf);
+        ExprNodeDesc predicate = predit.next();
+        SourceInfo si = createSourceInfo(t, partKeyExpr, predicate, columnName, columnType, jobConf);
         if (!sourceInfoMap.containsKey(s)) {
           sourceInfoMap.put(s, new ArrayList<SourceInfo>());
         }
@@ -184,16 +203,34 @@ public class DynamicPartitionPruner {
     }
   }
 
-  private void prunePartitions() throws HiveException {
+  private void prunePartitions(JobConf jobConf) throws HiveException {
     int expectedEvents = 0;
+    List<ExprNodeDesc> prunerExprs = new LinkedList<>();
     for (Map.Entry<String, List<SourceInfo>> entry : this.sourceInfoMap.entrySet()) {
       String source = entry.getKey();
       for (SourceInfo si : entry.getValue()) {
         int taskNum = context.getVertexNumTasks(source);
         LOG.info("Expecting " + taskNum + " events for vertex " + source + ", for column " + si.columnName);
         expectedEvents += taskNum;
-        prunePartitionSingleSource(source, si);
+        ExprNodeDesc prunerExpr = prunePartitionSingleSource(jobConf, source, si);
+        if (prunerExpr != null) {
+          prunerExprs.add(prunerExpr);
+        }
       }
+    }
+
+    // If we have partition pruner expressions to push down then create the appropriate predicate
+    if (prunerExprs.size() != 0) {
+      ExprNodeGenericFuncDesc prunerExpr;
+      if (prunerExprs.size() == 1) {
+        prunerExpr = (ExprNodeGenericFuncDesc)prunerExprs.iterator().next();
+      } else {
+        // If we have multiple pruner expressions wrap them into an AND
+        prunerExpr = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo, new GenericUDFOPAnd(), "and", prunerExprs);
+      }
+
+      // Push the predicate to the config for further use in HiveInputFormat
+      jobConf.set(TableScanDesc.PARTITION_PRUNING_FILTER, SerializationUtilities.serializeExpression(prunerExpr));
     }
 
     // sanity check. all tasks must submit events for us to succeed.
@@ -204,14 +241,14 @@ public class DynamicPartitionPruner {
   }
 
   @VisibleForTesting
-  protected void prunePartitionSingleSource(String source, SourceInfo si)
+  protected ExprNodeDesc prunePartitionSingleSource(JobConf jobConf, String source, SourceInfo si)
       throws HiveException {
 
     if (si.skipPruning.get()) {
       // in this case we've determined that there's too much data
       // to prune dynamically.
       LOG.info("Skip pruning on " + source + ", column " + si.columnName);
-      return;
+      return null;
     }
 
     Set<Object> values = si.values;
@@ -228,23 +265,38 @@ public class DynamicPartitionPruner {
       LOG.debug(sb.toString());
     }
 
-    ObjectInspector oi =
+    PrimitiveObjectInspector oi =
         PrimitiveObjectInspectorFactory.getPrimitiveWritableObjectInspector(TypeInfoFactory
             .getPrimitiveTypeInfo(si.columnType));
 
-    Converter converter =
-        ObjectInspectorConverters.getConverter(
-            PrimitiveObjectInspectorFactory.javaStringObjectInspector, oi);
+    if (si.predicate != null) {
+      // If we have a predicate defined then use that for pruning in the TableScan filter
+      // Works for StorageHandlers where addDynamicSplitPruningEdge is defined
+      List<ExprNodeConstantDesc> dynArgs = values.stream()
+          .map(v -> new ExprNodeConstantDesc(oi.getPrimitiveJavaObject(v)))
+          .collect(Collectors.toList());
 
-    StructObjectInspector soi =
-        ObjectInspectorFactory.getStandardStructObjectInspector(
-            Collections.singletonList(columnName), Collections.singletonList(oi));
+      ExprNodeDesc clone = si.predicate.clone();
 
-    @SuppressWarnings("rawtypes")
-    ExprNodeEvaluator eval = ExprNodeEvaluatorFactory.get(si.partKey);
-    eval.initialize(soi);
+      replaceDynamicLists(clone, dynArgs);
+      return clone;
+    } else {
+      // If we have to prune the path list for split generation
+      Converter converter =
+          ObjectInspectorConverters.getConverter(
+              PrimitiveObjectInspectorFactory.javaStringObjectInspector, oi);
 
-    applyFilterToPartitions(converter, eval, columnName, values, si.mustKeepOnePartition);
+      StructObjectInspector soi =
+          ObjectInspectorFactory.getStandardStructObjectInspector(
+              Collections.singletonList(columnName), Collections.singletonList(oi));
+
+      @SuppressWarnings("rawtypes")
+      ExprNodeEvaluator eval = ExprNodeEvaluatorFactory.get(si.partKey);
+      eval.initialize(soi);
+
+      applyFilterToPartitions(converter, eval, columnName, values, si.mustKeepOnePartition);
+      return null;
+    }
   }
 
   @SuppressWarnings("rawtypes")
@@ -288,10 +340,10 @@ public class DynamicPartitionPruner {
   }
 
   @VisibleForTesting
-  protected SourceInfo createSourceInfo(TableDesc t, ExprNodeDesc partKeyExpr, String columnName,
+  protected SourceInfo createSourceInfo(TableDesc t, ExprNodeDesc partKeyExpr, ExprNodeDesc predicate, String columnName,
                                         String columnType, JobConf jobConf) throws
       SerDeException {
-    return new SourceInfo(t, partKeyExpr, columnName, columnType, jobConf);
+    return new SourceInfo(t, partKeyExpr, predicate, columnName, columnType, jobConf);
 
   }
 
@@ -299,6 +351,7 @@ public class DynamicPartitionPruner {
   @VisibleForTesting
   static class SourceInfo {
     public final ExprNodeDesc partKey;
+    public final ExprNodeDesc predicate;
     public final Deserializer deserializer;
     public final StructObjectInspector soi;
     public final StructField field;
@@ -312,8 +365,9 @@ public class DynamicPartitionPruner {
     private boolean mustKeepOnePartition;
 
     @VisibleForTesting // Only used for testing.
-    SourceInfo(TableDesc table, ExprNodeDesc partKey, String columnName, String columnType, JobConf jobConf, Object forTesting) {
+    SourceInfo(TableDesc table, ExprNodeDesc partKey, ExprNodeDesc predicate, String columnName, String columnType, JobConf jobConf, Object forTesting) {
       this.partKey = partKey;
+      this.predicate = predicate;
       this.columnName = columnName;
       this.columnType = columnType;
       this.deserializer = null;
@@ -322,12 +376,13 @@ public class DynamicPartitionPruner {
       this.fieldInspector = null;
     }
 
-    public SourceInfo(TableDesc table, ExprNodeDesc partKey, String columnName, String columnType, JobConf jobConf)
+    public SourceInfo(TableDesc table, ExprNodeDesc partKey, ExprNodeDesc predicate, String columnName, String columnType, JobConf jobConf)
         throws SerDeException {
 
       this.skipPruning.set(false);
 
       this.partKey = partKey;
+      this.predicate = predicate;
 
       this.columnName = columnName;
       this.columnType = columnType;
@@ -513,5 +568,30 @@ public class DynamicPartitionPruner {
               ", Received=" + processedEvents);
     }
     return false;
+  }
+
+  /**
+   * Recursively replaces the ExprNodeDynamicListDesc to the list of the actual values. As a result of this call the
+   * original expression is modified so it can be used for pushing down to the TableScan for filtering the data at the
+   * source.
+   * <p>
+   * Please make sure to clone the predicate if needed since the original node will be modified.
+   * @param node The node we are traversing
+   * @param dynArgs The constant values we are substituting
+   */
+  private void replaceDynamicLists(ExprNodeDesc node, Collection<ExprNodeConstantDesc> dynArgs) {
+    List<ExprNodeDesc> children = node.getChildren();
+    if (children != null && !children.isEmpty()) {
+      ListIterator<ExprNodeDesc> iterator = node.getChildren().listIterator();
+      while (iterator.hasNext()) {
+        ExprNodeDesc child = iterator.next();
+        if (child instanceof ExprNodeDynamicListDesc) {
+          iterator.remove();
+          dynArgs.forEach(iterator::add);
+        } else {
+          replaceDynamicLists(child, dynArgs);
+        }
+      }
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
@@ -171,7 +171,7 @@ public class HiveSplitGenerator extends InputInitializer {
       // perform dynamic partition pruning
       if (pruner != null) {
         pruner.initialize(getContext(), work, jobConf);
-        pruner.prune();
+        pruner.prune(jobConf);
       }
 
       InputSplitInfoMem inputSplitInfo = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/HiveSplitGenerator.java
@@ -171,7 +171,7 @@ public class HiveSplitGenerator extends InputInitializer {
       // perform dynamic partition pruning
       if (pruner != null) {
         pruner.initialize(getContext(), work, jobConf);
-        pruner.prune(jobConf);
+        pruner.prune();
       }
 
       InputSplitInfoMem inputSplitInfo = null;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -48,8 +48,11 @@ import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.Deserializer;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
@@ -74,6 +77,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -890,6 +894,24 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
     Utilities.setColumnTypeList(jobConf, tableScan);
     // push down filters
     ExprNodeGenericFuncDesc filterExpr = scanDesc.getFilterExpr();
+    String pruningFilter = jobConf.get(TableScanDesc.PARTITION_PRUNING_FILTER);
+    // If we have a pruning filter then combine it with the original
+    if (pruningFilter != null) {
+      ExprNodeGenericFuncDesc pruningExpr = SerializationUtilities.deserializeExpression(pruningFilter);
+      if (filterExpr != null) {
+        // Combine the 2 filters with AND
+        filterExpr = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo, new GenericUDFOPAnd(), "and",
+            Arrays.asList(filterExpr, pruningExpr));
+      } else {
+        // Use the pruning filter if there was no filter before
+        filterExpr = pruningExpr;
+      }
+
+      // Set the combined filter in the TableScanDesc and remove the pruning filter
+      scanDesc.setFilterExpr(filterExpr);
+      scanDesc.setSerializedFilterExpr(SerializationUtilities.serializeExpression(filterExpr));
+      jobConf.unset(TableScanDesc.PARTITION_PRUNING_FILTER);
+    }
     if (filterExpr == null) {
       return;
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/HiveInputFormat.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.HiveStoragePredicateHandler;
+import org.apache.hadoop.hive.ql.plan.ExprNodeDescUtils;
 import org.apache.hadoop.hive.ql.plan.ExprNodeGenericFuncDesc;
 import org.apache.hadoop.hive.ql.plan.MapWork;
 import org.apache.hadoop.hive.ql.plan.OperatorDesc;
@@ -48,11 +49,8 @@ import org.apache.hadoop.hive.ql.plan.PartitionDesc;
 import org.apache.hadoop.hive.ql.plan.TableDesc;
 import org.apache.hadoop.hive.ql.plan.TableScanDesc;
 import org.apache.hadoop.hive.ql.session.SessionState;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFIn;
-import org.apache.hadoop.hive.ql.udf.generic.GenericUDFOPAnd;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.hive.serde2.Deserializer;
-import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.io.WritableComparable;
 import org.apache.hadoop.io.compress.CompressionCodecFactory;
@@ -77,7 +75,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -900,8 +897,7 @@ public class HiveInputFormat<K extends WritableComparable, V extends Writable>
       ExprNodeGenericFuncDesc pruningExpr = SerializationUtilities.deserializeExpression(pruningFilter);
       if (filterExpr != null) {
         // Combine the 2 filters with AND
-        filterExpr = new ExprNodeGenericFuncDesc(TypeInfoFactory.booleanTypeInfo, new GenericUDFOPAnd(), "and",
-            Arrays.asList(filterExpr, pruningExpr));
+        filterExpr = ExprNodeDescUtils.and(filterExpr, pruningExpr);
       } else {
         // Use the pruning filter if there was no filter before
         filterExpr = pruningExpr;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -179,11 +179,13 @@ public interface HiveStorageHandler extends Configurable {
   /**
    * Test if the storage handler allows the push-down of join filter predicate to prune further the splits.
    *
+   * @param table The table to filter.
    * @param syntheticFilterPredicate Join filter predicate.
    * @return true if supports dynamic split pruning for the given predicate.
    */
 
-  default boolean addDynamicSplitPruningEdge(ExprNodeDesc syntheticFilterPredicate) {
+  default boolean addDynamicSplitPruningEdge(org.apache.hadoop.hive.ql.metadata.Table table,
+      ExprNodeDesc syntheticFilterPredicate) {
     return false;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/GenTezUtils.java
@@ -484,6 +484,12 @@ public class GenTezUtils {
     List<ExprNodeDesc> keys = work.getEventSourcePartKeyExprMap().get(sourceName);
     keys.add(eventDesc.getPartKey());
 
+    // store the partition pruning predicate in map-work, have at least a list of nulls if none applicable
+    if (!work.getEventSourcePredicateExprMap().containsKey(sourceName)) {
+      work.getEventSourcePredicateExprMap().put(sourceName, new LinkedList<ExprNodeDesc>());
+    }
+    List<ExprNodeDesc> predicates = work.getEventSourcePredicateExprMap().get(sourceName);
+    predicates.add(eventDesc.getPredicate());
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPruningEventDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPruningEventDesc.java
@@ -47,6 +47,22 @@ public class DynamicPruningEventDesc extends AppMasterEventDesc {
   // the partition column we're interested in
   private ExprNodeDesc partKey;
 
+  private ExprNodeDesc predicate;
+
+  public ExprNodeDesc getPredicate() {
+    return predicate;
+  }
+
+  public void setPredicate(ExprNodeDesc predicate) {
+    this.predicate = predicate;
+  }
+
+  @Explain(displayName = "Partition predicate expr")
+  @Signature
+  public String getPartPredicateString() {
+    return this.predicate.getExprString();
+  }
+
   public TableScanOperator getTableScan() {
     return tableScan;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPruningEventDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/DynamicPruningEventDesc.java
@@ -57,10 +57,8 @@ public class DynamicPruningEventDesc extends AppMasterEventDesc {
     this.predicate = predicate;
   }
 
-  @Explain(displayName = "Partition predicate expr")
-  @Signature
   public String getPartPredicateString() {
-    return this.predicate.getExprString();
+    return this.predicate != null ? this.predicate.getExprString() : "-";
   }
 
   public TableScanOperator getTableScan() {
@@ -128,7 +126,8 @@ public class DynamicPruningEventDesc extends AppMasterEventDesc {
       DynamicPruningEventDesc otherDesc = (DynamicPruningEventDesc) other;
       return Objects.equals(getTargetColumnName(), otherDesc.getTargetColumnName()) &&
           Objects.equals(getTargetColumnType(), otherDesc.getTargetColumnType()) &&
-          Objects.equals(getPartKeyString(), otherDesc.getPartKeyString());
+          Objects.equals(getPartKeyString(), otherDesc.getPartKeyString()) &&
+          Objects.equals(getPartPredicateString(), otherDesc.getPartPredicateString());
     }
     return false;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/MapWork.java
@@ -156,6 +156,8 @@ public class MapWork extends BaseWork {
       new LinkedHashMap<String, List<String>>();
   private Map<String, List<ExprNodeDesc>> eventSourcePartKeyExprMap =
       new LinkedHashMap<String, List<ExprNodeDesc>>();
+  private Map<String, List<ExprNodeDesc>> eventSourcePredicateExprMap =
+      new LinkedHashMap<String, List<ExprNodeDesc>>();
 
   private boolean doSplitsGrouping = true;
 
@@ -707,6 +709,14 @@ public class MapWork extends BaseWork {
 
   public void setEventSourcePartKeyExprMap(Map<String, List<ExprNodeDesc>> map) {
     this.eventSourcePartKeyExprMap = map;
+  }
+
+  public Map<String, List<ExprNodeDesc>> getEventSourcePredicateExprMap() {
+    return eventSourcePredicateExprMap;
+  }
+
+  public void setEventSourcePredicateExprMap(Map<String, List<ExprNodeDesc>> eventSourcePredicateExprMap) {
+    this.eventSourcePredicateExprMap = eventSourcePredicateExprMap;
   }
 
   public void setDoSplitsGrouping(boolean doSplitsGrouping) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/TableScanDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/TableScanDesc.java
@@ -103,6 +103,9 @@ public class TableScanDesc extends AbstractOperatorDesc implements IStatsGatherD
   public static final String FILTER_OBJECT_CONF_STR =
       "hive.io.filter.object";
 
+  public static final String PARTITION_PRUNING_FILTER =
+      "hive.io.pruning.filter";
+
   // input file name (big) to bucket number
   private Map<String, Integer> bucketFileNameMapping;
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
@@ -498,6 +498,7 @@ public class TestDynamicPartitionPruner {
     Map<String, List<String>> columnMap = new HashMap<>();
     Map<String, List<String>> typeMap = new HashMap<>();
     Map<String, List<ExprNodeDesc>> exprMap = new HashMap<>();
+    Map<String, List<ExprNodeDesc>> predMap = new HashMap<>();
 
     int count = 0;
     for (TestSource testSource : testSources) {
@@ -530,6 +531,13 @@ public class TestDynamicPartitionPruner {
           exprMap.put(testSource.vertexName, exprNodeDescList);
         }
         exprNodeDescList.add(mock(ExprNodeDesc.class));
+
+        List<ExprNodeDesc> predNodeDescList = predMap.get(testSource.vertexName);
+        if (predNodeDescList == null) {
+          predNodeDescList = new LinkedList<>();
+          predMap.put(testSource.vertexName, predNodeDescList);
+        }
+        predNodeDescList.add(mock(ExprNodeDesc.class));
       }
 
       count++;
@@ -539,6 +547,7 @@ public class TestDynamicPartitionPruner {
     doReturn(columnMap).when(mapWork).getEventSourceColumnNameMap();
     doReturn(exprMap).when(mapWork).getEventSourcePartKeyExprMap();
     doReturn(typeMap).when(mapWork).getEventSourceColumnTypeMap();
+    doReturn(predMap).when(mapWork).getEventSourcePredicateExprMap();
     return mapWork;
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
@@ -474,7 +474,7 @@ public class TestDynamicPartitionPruner {
         } finally {
           lock.unlock();
         }
-        pruner.prune(null);
+        pruner.prune();
       } catch (Exception e) {
         inError.set(true);
         exception = e;

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/tez/TestDynamicPartitionPruner.java
@@ -474,7 +474,7 @@ public class TestDynamicPartitionPruner {
         } finally {
           lock.unlock();
         }
-        pruner.prune();
+        pruner.prune(null);
       } catch (Exception e) {
         inError.set(true);
         exception = e;
@@ -558,10 +558,10 @@ public class TestDynamicPartitionPruner {
     LongAdder eventsProceessed = new LongAdder();
 
     @Override
-    protected SourceInfo createSourceInfo(TableDesc t, ExprNodeDesc partKeyExpr, String columnName, String columnType,
+    protected SourceInfo createSourceInfo(TableDesc t, ExprNodeDesc partKeyExpr, ExprNodeDesc predicate, String columnName, String columnType,
                                           JobConf jobConf) throws
         SerDeException {
-      return new SourceInfo(t, partKeyExpr, columnName, columnType, jobConf, null);
+      return new SourceInfo(t, partKeyExpr, predicate, columnName, columnType, jobConf, null);
     }
 
     @Override
@@ -572,9 +572,10 @@ public class TestDynamicPartitionPruner {
     }
 
     @Override
-    protected void prunePartitionSingleSource(String source, SourceInfo si)
+    protected ExprNodeDesc prunePartitionSingleSource(JobConf conf, String source, SourceInfo si)
         throws HiveException {
       filteredSources.increment();
+      return null;
     }
   }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
There are 3 parts of the changes here:
- Pruner changes to provide a filter instead of changing the file lists
- HiveInputFormat changes to combine the Pruning filter with the original filter
- Iceberg handler changes:
   - New method in SerDe to return the current partitioning columns
   - HiveStoragePredicateHandler implements the addDynamicSplitPruningEdge method which returns true if there is a filter for any of the partitioning columns
- Added new test for partition pruning

### Why are the changes needed?
To archive comparable performance for Iceberg tables

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Multiple queries

Plan to add more tests later, but it would be good to have them as a `qtest` and it should be done in a different PR as it is a sizable task in itself