### PR TITLE
HIVE-24965: Describe table partition fetch should be configurable

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5455,6 +5455,9 @@ public class HiveConf extends Configuration {
         "Comma-separated list of class names extending EventConsumer," +
          "to handle the NotificationEvents retreived by the notification event poll."),
 
+    HIVE_DESCRIBE_PARTITIONED_TABLE_IGNORE_STATS("hive.describe.partitionedtable.ignore.stats", false,
+        "Disable partition stats collection for 'DESCRIBE FORMATTED' or 'DESCRIBE EXTENDED' commands."),
+    
     /* BLOBSTORE section */
 
     HIVE_BLOBSTORE_SUPPORTED_SCHEMES("hive.blobstore.supported.schemes", "s3,s3a,s3n",

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5456,7 +5456,7 @@ public class HiveConf extends Configuration {
          "to handle the NotificationEvents retreived by the notification event poll."),
 
     HIVE_DESCRIBE_PARTITIONED_TABLE_IGNORE_STATS("hive.describe.partitionedtable.ignore.stats", false,
-        "Disable partition stats collection for 'DESCRIBE FORMATTED' or 'DESCRIBE EXTENDED' commands."),
+        "Disable partitioned table stats collection for 'DESCRIBE FORMATTED' or 'DESCRIBE EXTENDED' commands."),
     
     /* BLOBSTORE section */
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -148,8 +148,8 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
 
     // Fetch partition statistics only for describe extended or formatted.
     if (desc.isExtended() || desc.isFormatted()) {
-      boolean should_get_part_stats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS)
-      if (table.isPartitioned() && partition == null && should_get_part_stats) {
+      boolean shouldGetPartStats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS)
+      if (table.isPartitioned() && partition == null && shouldGetPartStats) {
         // No partition specified for partitioned table, lets fetch all.
         Map<String, String> tblProps = table.getParameters() == null ?
                 new HashMap<String, String>() : table.getParameters();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.metastore.StatObjectConverter;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AggrStats;
@@ -148,8 +149,8 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
 
     // Fetch partition statistics only for describe extended or formatted.
     if (desc.isExtended() || desc.isFormatted()) {
-      boolean shouldGetPartStats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS);
-      if (table.isPartitioned() && partition == null && shouldGetPartStats) {
+      boolean disablePartitionStats = HiveConf.getBoolVar(context.getConf(), HiveConf.ConfVars.HIVE_DESCRIBE_PARTITIONED_TABLE_IGNORE_STATS);
+      if (table.isPartitioned() && partition == null && !disablePartitionStats) {
         // No partition specified for partitioned table, lets fetch all.
         Map<String, String> tblProps = table.getParameters() == null ?
                 new HashMap<String, String>() : table.getParameters();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -148,7 +148,7 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
 
     // Fetch partition statistics only for describe extended or formatted.
     if (desc.isExtended() || desc.isFormatted()) {
-      boolean shouldGetPartStats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS)
+      boolean shouldGetPartStats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS);
       if (table.isPartitioned() && partition == null && shouldGetPartStats) {
         // No partition specified for partitioned table, lets fetch all.
         Map<String, String> tblProps = table.getParameters() == null ?

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -148,7 +148,8 @@ public class DescTableOperation extends DDLOperation<DescTableDesc> {
 
     // Fetch partition statistics only for describe extended or formatted.
     if (desc.isExtended() || desc.isFormatted()) {
-      if (table.isPartitioned() && partition == null) {
+      boolean should_get_part_stats = MetastoreConf.getBoolVar(context.getConf(), MetastoreConf.ConfVars.DESCTABLE_ENABLE_PARTITION_STATS)
+      if (table.isPartitioned() && partition == null && should_get_part_stats) {
         // No partition specified for partitioned table, lets fetch all.
         Map<String, String> tblProps = table.getParameters() == null ?
                 new HashMap<String, String>() : table.getParameters();

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/info/desc/DescTableOperation.java
@@ -30,7 +30,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.StatObjectConverter;
 import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.AggrStats;

--- a/ql/src/test/queries/clientpositive/describe_table.q
+++ b/ql/src/test/queries/clientpositive/describe_table.q
@@ -1,9 +1,4 @@
 --! qt:dataset:srcpart
-set hive.describe.partitionedtable.ignore.stats=true;
-describe formatted `srcpart`;
-describe extended `srcpart`;
-set hive.describe.partitionedtable.ignore.stats=false;
-
 describe srcpart;
 describe srcpart key;
 describe srcpart PARTITION(ds='2008-04-08', hr='12');
@@ -38,6 +33,14 @@ alter table srcpart_serdeprops set serdeproperties('abcd'='2');
 alter table srcpart_serdeprops set serdeproperties('A1234'='3');
 describe formatted srcpart_serdeprops;
 drop table srcpart_serdeprops;
+
+CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int);
+INSERT INTO desc_parttable_stats values(0,1),(0,2),(0,3);
+set hive.describe.partitionedtable.ignore.stats=true;
+describe formatted desc_parttable_stats;
+set hive.describe.partitionedtable.ignore.stats=false;
+describe formatted desc_parttable_stats;
+DROP TABLE IF EXISTS desc_parttable_stats;
 
 CREATE DATABASE IF NOT EXISTS name1;
 CREATE DATABASE IF NOT EXISTS name2;

--- a/ql/src/test/queries/clientpositive/describe_table.q
+++ b/ql/src/test/queries/clientpositive/describe_table.q
@@ -1,4 +1,9 @@
 --! qt:dataset:srcpart
+set hive.describe.partitionedtable.ignore.stats=true;
+describe formatted `srcpart`;
+describe extended `srcpart`;
+set hive.describe.partitionedtable.ignore.stats=false;
+
 describe srcpart;
 describe srcpart key;
 describe srcpart PARTITION(ds='2008-04-08', hr='12');
@@ -22,7 +27,6 @@ describe formatted srcpart PARTITION(ds='2008-04-08', hr='12');
 describe formatted `srcpart`;
 describe formatted `srcpart` `key`;
 describe formatted `srcpart` PARTITION(ds='2008-04-08', hr='12');
-
 
 describe formatted `srcpart` `ds`;
 describe formatted `srcpart` `hr`;

--- a/ql/src/test/queries/clientpositive/describe_table.q
+++ b/ql/src/test/queries/clientpositive/describe_table.q
@@ -34,7 +34,7 @@ alter table srcpart_serdeprops set serdeproperties('A1234'='3');
 describe formatted srcpart_serdeprops;
 drop table srcpart_serdeprops;
 
-CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int);
+CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (yr int);
 INSERT INTO desc_parttable_stats values(0,1),(0,2),(0,3);
 set hive.describe.partitionedtable.ignore.stats=true;
 describe formatted desc_parttable_stats;

--- a/ql/src/test/results/clientpositive/llap/describe_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/describe_table.q.out
@@ -1,55 +1,3 @@
-PREHOOK: query: describe formatted `srcpart`
-PREHOOK: type: DESCTABLE
-PREHOOK: Input: default@srcpart
-POSTHOOK: query: describe formatted `srcpart`
-POSTHOOK: type: DESCTABLE
-POSTHOOK: Input: default@srcpart
-# col_name            	data_type           	comment             
-key                 	string              	default             
-value               	string              	default             
-	 	 
-# Partition Information	 	 
-# col_name            	data_type           	comment             
-ds                  	string              	                    
-hr                  	string              	                    
-	 	 
-# Detailed Table Information	 	 
-Database:           	default             	 
-#### A masked pattern was here ####
-Retention:          	0                   	 
-#### A masked pattern was here ####
-Table Type:         	MANAGED_TABLE       	 
-Table Parameters:	 	 
-	bucketing_version   	2                   
-#### A masked pattern was here ####
-	 	 
-# Storage Information	 	 
-SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
-InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
-OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
-Compressed:         	No                  	 
-Num Buckets:        	-1                  	 
-Bucket Columns:     	[]                  	 
-Sort Columns:       	[]                  	 
-Storage Desc Params:	 	 
-	serialization.format	1                   
-PREHOOK: query: describe extended `srcpart`
-PREHOOK: type: DESCTABLE
-PREHOOK: Input: default@srcpart
-POSTHOOK: query: describe extended `srcpart`
-POSTHOOK: type: DESCTABLE
-POSTHOOK: Input: default@srcpart
-key                 	string              	default             
-value               	string              	default             
-ds                  	string              	                    
-hr                  	string              	                    
-	 	 
-# Partition Information	 	 
-# col_name            	data_type           	comment             
-ds                  	string              	                    
-hr                  	string              	                    
-	 	 
-#### A masked pattern was here ####
 PREHOOK: query: describe srcpart
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@srcpart
@@ -534,6 +482,108 @@ POSTHOOK: query: drop table srcpart_serdeprops
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@srcpart_serdeprops
 POSTHOOK: Output: default@srcpart_serdeprops
+PREHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@desc_parttable_stats
+POSTHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@desc_parttable_stats
+PREHOOK: query: INSERT INTO desc_parttable_stats values(0,1),(0,2),(0,3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@desc_parttable_stats
+POSTHOOK: query: INSERT INTO desc_parttable_stats values(0,1),(0,2),(0,3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@desc_parttable_stats
+POSTHOOK: Output: default@desc_parttable_stats@yr=1
+POSTHOOK: Output: default@desc_parttable_stats@yr=2
+POSTHOOK: Output: default@desc_parttable_stats@yr=3
+POSTHOOK: Lineage: desc_parttable_stats PARTITION(yr=1).somenumber SCRIPT []
+POSTHOOK: Lineage: desc_parttable_stats PARTITION(yr=2).somenumber SCRIPT []
+POSTHOOK: Lineage: desc_parttable_stats PARTITION(yr=3).somenumber SCRIPT []
+PREHOOK: query: describe formatted desc_parttable_stats
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@desc_parttable_stats
+POSTHOOK: query: describe formatted desc_parttable_stats
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@desc_parttable_stats
+# col_name            	data_type           	comment             
+somenumber          	int                 	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+yr                  	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	bucketing_version   	2                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: describe formatted desc_parttable_stats
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@desc_parttable_stats
+POSTHOOK: query: describe formatted desc_parttable_stats
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@desc_parttable_stats
+# col_name            	data_type           	comment             
+somenumber          	int                 	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+yr                  	int                 	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	bucketing_version   	2                   
+	numFiles            	3                   
+	numPartitions       	3                   
+	numRows             	3                   
+	rawDataSize         	3                   
+	totalSize           	6                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: DROP TABLE IF EXISTS desc_parttable_stats
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@desc_parttable_stats
+PREHOOK: Output: default@desc_parttable_stats
+POSTHOOK: query: DROP TABLE IF EXISTS desc_parttable_stats
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@desc_parttable_stats
+POSTHOOK: Output: default@desc_parttable_stats
 PREHOOK: query: CREATE DATABASE IF NOT EXISTS name1
 PREHOOK: type: CREATEDATABASE
 PREHOOK: Output: database:name1

--- a/ql/src/test/results/clientpositive/llap/describe_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/describe_table.q.out
@@ -482,11 +482,11 @@ POSTHOOK: query: drop table srcpart_serdeprops
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@srcpart_serdeprops
 POSTHOOK: Output: default@srcpart_serdeprops
-PREHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int)
+PREHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (yr int)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@desc_parttable_stats
-POSTHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (`yr` int)
+POSTHOOK: query: CREATE TABLE IF NOT EXISTS desc_parttable_stats (somenumber int) PARTITIONED BY (yr int)
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@desc_parttable_stats

--- a/ql/src/test/results/clientpositive/llap/describe_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/describe_table.q.out
@@ -1,3 +1,55 @@
+PREHOOK: query: describe formatted `srcpart`
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@srcpart
+POSTHOOK: query: describe formatted `srcpart`
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@srcpart
+# col_name            	data_type           	comment             
+key                 	string              	default             
+value               	string              	default             
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+ds                  	string              	                    
+hr                  	string              	                    
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	MANAGED_TABLE       	 
+Table Parameters:	 	 
+	bucketing_version   	2                   
+#### A masked pattern was here ####
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe	 
+InputFormat:        	org.apache.hadoop.mapred.TextInputFormat	 
+OutputFormat:       	org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	-1                  	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+Storage Desc Params:	 	 
+	serialization.format	1                   
+PREHOOK: query: describe extended `srcpart`
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@srcpart
+POSTHOOK: query: describe extended `srcpart`
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@srcpart
+key                 	string              	default             
+value               	string              	default             
+ds                  	string              	                    
+hr                  	string              	                    
+	 	 
+# Partition Information	 	 
+# col_name            	data_type           	comment             
+ds                  	string              	                    
+hr                  	string              	                    
+	 	 
+#### A masked pattern was here ####
 PREHOOK: query: describe srcpart
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@srcpart

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -559,6 +559,8 @@ public class MetastoreConf {
     DELEGATION_TOKEN_STORE_CLS("metastore.cluster.delegation.token.store.class",
         "hive.cluster.delegation.token.store.class", METASTORE_DELEGATION_MANAGER_CLASS,
         "Class to store delegation tokens"),
+    DESCTABLE_ENABLE_PARTITION_STATS("desctable.enable.partitionstats", "desctable.enable.partitionstats", true, 
+        "Enable stats collection for describe formatted or extended."),
     DETACH_ALL_ON_COMMIT("javax.jdo.option.DetachAllOnCommit",
         "javax.jdo.option.DetachAllOnCommit", true,
         "Detaches all objects from session so that they can be used after transaction is committed"),

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -559,8 +559,6 @@ public class MetastoreConf {
     DELEGATION_TOKEN_STORE_CLS("metastore.cluster.delegation.token.store.class",
         "hive.cluster.delegation.token.store.class", METASTORE_DELEGATION_MANAGER_CLASS,
         "Class to store delegation tokens"),
-    DESCTABLE_ENABLE_PARTITION_STATS("desctable.enable.partitionstats", "desctable.enable.partitionstats", true, 
-        "Enable stats collection for describe formatted or extended."),
     DETACH_ALL_ON_COMMIT("javax.jdo.option.DetachAllOnCommit",
         "javax.jdo.option.DetachAllOnCommit", true,
         "Detaches all objects from session so that they can be used after transaction is committed"),


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
In certain 3rd party hive UIs, they issue a describe table command, and usually it's either "describe formatted table" or "describe extended table", and it will take a very long time for highly partitioned tables (10k+). In the UI, there is no way to change the settings (to use "describe table"), thus impairing the user experience. Prior to the feature where partition stats was gathered, the experience with using the UI had no problems.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
This will allow users to selectively change the describe formatted/extended table behavior at any time.


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. A new setting to change the behavior of describe extended/formatted on demand. Default setting of "false" will have no impact.

The describe formatted/extended will not collect stats if you change it to "true".

```
hive.describe.partitionedtable.ignore.stats = false; -- default behavior (no user impact)
```

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Manual testing and unit test