### PR TITLE
HIVE-24980: Add timeout for failed and "not initiated" compaction cleanup

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -17,9 +17,6 @@
  */
 package org.apache.hadoop.hive.ql;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doThrow;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -880,70 +877,6 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     }
     catch (InterruptedException e) {
     }
-  }
-//frogmethod i tried to move this
-  @Test
-  public void testPurgeCompactionHistory() throws Exception {
-
-//    insert2deltas("p=2");
-
-    // 3 successful compactions on p=1
-    insertDataAndCompact("(p=1)");
-    insertDataAndCompact("(p=1)");
-    insertDataAndCompact("(p=1)");
-
-
-    // 3 failed on p=1
-    hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, true);
-    insertDataAndCompact("(p=1)");
-    insertDataAndCompact("(p=1)");
-    insertDataAndCompact("(p=1)");
-    insertDataAndCompact("(p=1)");
-    hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, false);
-
-    // 3 not initiated on p=1
-
-
-//    Initiator initiator = Mockito.spy(new Initiator());
-//    initiator.setThreadId((int) t.getId());
-//    initiator.setConf(conf);
-//    initiator.init(new AtomicBoolean(true));
-//    doThrow(new RuntimeException("This was thrown on purpose by testInitiatorFailure"))
-//            .when(initiator).resolveTable(any());
-//    initiator.run();
-
-
-
-    // 1 failed on p=2 ...
-
-
-    ShowCompactResponse resp = txnHandler.showCompact(new ShowCompactRequest());
-    Assert.assertEquals("Unexpected number of compactions in history", 10, resp.getCompactsSize()); //frogmethod is this accurate?
-
-    txnHandler.purgeCompactionHistory();
-
-    resp = txnHandler.showCompact(new ShowCompactRequest());
-    Assert.assertEquals("Unexpected number of compactions in history", 7, resp.getCompactsSize()); //frogmethod is this accurate?
-    // TODO check each compaction for type/service
-
-
-//    Assert.assertEquals("Unexpected 0 compaction state",
-//            TxnStore.CLEANING_RESPONSE, resp.getCompacts().get(0).getState());
-//    Assert.assertTrue(resp.getCompacts().get(0).getHadoopJobId().startsWith("job_local"));
-//    Assert.assertTrue(resp.getCompacts().get(0).getType().equals(CompactionType.MINOR));
-
-  }
-
-  private void insertDataAndCompact(String partition) throws Exception {
-    insert2deltas(partition);
-    runStatementOnDriver("alter table " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + " compact 'major'");
-    runWorker(hiveConf);
-  }
-
-  private void insert2deltas(String partition) throws Exception {
-    int[][] targetVals = {{1, 5}, {2, 6}};
-    runStatementOnDriver("insert into " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + makeValuesClause(targetVals));
-    runStatementOnDriver("insert into " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + makeValuesClause(targetVals));
   }
 
   @Test

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hive.ql;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -877,6 +880,70 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     }
     catch (InterruptedException e) {
     }
+  }
+//frogmethod i tried to move this
+  @Test
+  public void testPurgeCompactionHistory() throws Exception {
+
+//    insert2deltas("p=2");
+
+    // 3 successful compactions on p=1
+    insertDataAndCompact("(p=1)");
+    insertDataAndCompact("(p=1)");
+    insertDataAndCompact("(p=1)");
+
+
+    // 3 failed on p=1
+    hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, true);
+    insertDataAndCompact("(p=1)");
+    insertDataAndCompact("(p=1)");
+    insertDataAndCompact("(p=1)");
+    insertDataAndCompact("(p=1)");
+    hiveConf.setBoolVar(HiveConf.ConfVars.HIVETESTMODEFAILCOMPACTION, false);
+
+    // 3 not initiated on p=1
+
+
+//    Initiator initiator = Mockito.spy(new Initiator());
+//    initiator.setThreadId((int) t.getId());
+//    initiator.setConf(conf);
+//    initiator.init(new AtomicBoolean(true));
+//    doThrow(new RuntimeException("This was thrown on purpose by testInitiatorFailure"))
+//            .when(initiator).resolveTable(any());
+//    initiator.run();
+
+
+
+    // 1 failed on p=2 ...
+
+
+    ShowCompactResponse resp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals("Unexpected number of compactions in history", 10, resp.getCompactsSize()); //frogmethod is this accurate?
+
+    txnHandler.purgeCompactionHistory();
+
+    resp = txnHandler.showCompact(new ShowCompactRequest());
+    Assert.assertEquals("Unexpected number of compactions in history", 7, resp.getCompactsSize()); //frogmethod is this accurate?
+    // TODO check each compaction for type/service
+
+
+//    Assert.assertEquals("Unexpected 0 compaction state",
+//            TxnStore.CLEANING_RESPONSE, resp.getCompacts().get(0).getState());
+//    Assert.assertTrue(resp.getCompacts().get(0).getHadoopJobId().startsWith("job_local"));
+//    Assert.assertTrue(resp.getCompacts().get(0).getType().equals(CompactionType.MINOR));
+
+  }
+
+  private void insertDataAndCompact(String partition) throws Exception {
+    insert2deltas(partition);
+    runStatementOnDriver("alter table " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + " compact 'major'");
+    runWorker(hiveConf);
+  }
+
+  private void insert2deltas(String partition) throws Exception {
+    int[][] targetVals = {{1, 5}, {2, 6}};
+    runStatementOnDriver("insert into " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + makeValuesClause(targetVals));
+    runStatementOnDriver("insert into " + TestTxnCommands2.Table.ACIDTBLPART + " " + partition + makeValuesClause(targetVals));
   }
 
   @Test

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -415,6 +415,10 @@ public class MetastoreConf {
         "hive.compactor.history.retention.succeeded", 3,
         new RangeValidator(0, 100), "Determines how many successful compaction records will be " +
         "retained in compaction history for a given table/partition."),
+    COMPACTOR_HISTORY_RETENTION_TIMEOUT("metastore.compactor.history.retention.timeout",
+            "hive.compactor.history.retention.timeout", 7, TimeUnit.DAYS,
+            "Determines how long failed and not initiated compaction records will be " +
+            "retained in compaction history if there is a more recent succeeded compaction on the table/partition."),
     COMPACTOR_INITIATOR_FAILED_THRESHOLD("metastore.compactor.initiator.failed.compacts.threshold",
         "hive.compactor.initiator.failed.compacts.threshold", 2,
         new RangeValidator(1, 20), "Number of consecutive compaction failures (per table/partition) " +

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/txn/CompactionTxnHandler.java
@@ -907,6 +907,8 @@ class CompactionTxnHandler extends TxnHandler {
     ResultSet rs = null;
     List<Long> deleteSet = new ArrayList<>();
     RetentionCounters rc = null;
+    long timeoutThreshold = System.currentTimeMillis() -
+            MetastoreConf.getTimeVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_TIMEOUT, TimeUnit.MILLISECONDS);
     try {
       try {
         dbConn = getDbConn(Connection.TRANSACTION_READ_COMMITTED);
@@ -940,8 +942,7 @@ class CompactionTxnHandler extends TxnHandler {
                 getFailedCompactionRetention(),
                 MetastoreConf.getIntVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_SUCCEEDED));
           }
-          checkForDeletion(deleteSet, ci, rc, System.currentTimeMillis() -
-                  MetastoreConf.getTimeVar(conf, ConfVars.COMPACTOR_HISTORY_RETENTION_TIMEOUT, TimeUnit.MILLISECONDS));
+          checkForDeletion(deleteSet, ci, rc, timeoutThreshold);
         }
         close(rs);
 


### PR DESCRIPTION

### What changes were proposed in this pull request?
Clear failed and not initiated compactions from COMPLETED_COMPACTIONS that are older than a week (configurable) if there already is a newer successful compaction on the table/partition and either (1) the succeeded compaction is major or (2) it is minor and the not initiated or failed compaction is also minor –– so a minor succeeded compaction will not cause the deletion of a major not initiated or failed compaction from history.


### Why are the changes needed?
Make completed compactions more legible


### Does this PR introduce _any_ user-facing change?
Yes

### How was this patch tested?
Unit tests