### PR TITLE
HIVE-25001: Improvement for some debug-logging guards

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/SerDeEncodedDataReader.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/encoded/SerDeEncodedDataReader.java
@@ -1228,8 +1228,8 @@ public class SerDeEncodedDataReader extends CallableWithNdc<Void>
   }
 
   private void logProcessOneSlice(int stripeIx, Object diskData, StripeData cacheData) {
-    String sliceStr = cacheData == null ? "null" : cacheData.toCoordinateString();
     if (LlapIoImpl.LOG.isDebugEnabled()) {
+      String sliceStr = cacheData == null ? "null" : cacheData.toCoordinateString();
       LlapIoImpl.LOG.debug("Processing slice #" + stripeIx + " " + sliceStr + "; has"
         + ((cacheData == null) ? " no" : "") + " cache data; has"
         + ((diskData == null) ? " no" : "") + " disk data");

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1386,8 +1386,9 @@ public class LlapTaskSchedulerService extends TaskScheduler {
    */
   private SelectHostResult selectHost(TaskInfo request) {
     String[] requestedHosts = request.requestedHosts;
-    String requestedHostsDebugStr = Arrays.toString(requestedHosts);
+    String requestedHostsDebugStr = null;
     if (LOG.isDebugEnabled()) {
+      requestedHostsDebugStr = Arrays.toString(requestedHosts);
       LOG.debug("selectingHost for task={} on hosts={}", request.task,
           requestedHostsDebugStr);
     }

--- a/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
+++ b/llap-tez/src/java/org/apache/hadoop/hive/llap/tezplugins/LlapTaskSchedulerService.java
@@ -1386,6 +1386,8 @@ public class LlapTaskSchedulerService extends TaskScheduler {
    */
   private SelectHostResult selectHost(TaskInfo request) {
     String[] requestedHosts = request.requestedHosts;
+    // The requestedHostsDebugStr is merely used by debug-logging calls,
+    //   and it is properly assigned in the following isDebugEnabled block.
     String requestedHostsDebugStr = null;
     if (LOG.isDebugEnabled()) {
       requestedHostsDebugStr = Arrays.toString(requestedHosts);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/GenMapRedUtils.java
@@ -678,9 +678,8 @@ public final class GenMapRedUtils {
         if (p == null) {
           continue;
         }
-        String path = p.toString();
         if (LOG.isDebugEnabled()) {
-          LOG.debug("Adding " + path + " of table " + alias_id);
+          LOG.debug("Adding " + p.toString() + " of table " + alias_id);
         }
 
         partDir.add(p);


### PR DESCRIPTION

### What changes were proposed in this pull request?
Moving some potential expensive statements (e.g. `Arrays.toString`) into the adjacent debug-logging guards, since these statements are merely used by the following debug-logging calls.
Note that the fix in `LlapTaskSchedulerService.java` is different with other cases in this patch, because the variable `requestedHostsDebugStr` is used by several debug-logging calls, and we have to declare and assign the variable before these debug-logging calls.


### Why are the changes needed?
Minor (performance) improvement to logging code


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Minor improvement to logging code, and no need to test.
