### PR TITLE
HIVE-24997. HPL/SQL udf doesn't work in tez container mode (amagyar)

### DIFF
--- a/hplsql/src/main/java/org/apache/hive/hplsql/Arguments.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/Arguments.java
@@ -37,7 +37,13 @@ public class Arguments {
   String fileName;  
   String main;
   Map<String, String> vars = new HashMap<String, String>();
-  
+
+  public static Arguments script(String str) {
+    Arguments arguments = new Arguments();
+    arguments.parse(new String[]{"-e", str});
+    return arguments;
+  }
+
   @SuppressWarnings("static-access")
   public Arguments() {
     // -e 'query'

--- a/hplsql/src/main/java/org/apache/hive/hplsql/executor/QueryExecutor.java
+++ b/hplsql/src/main/java/org/apache/hive/hplsql/executor/QueryExecutor.java
@@ -21,7 +21,12 @@
 package org.apache.hive.hplsql.executor;
 
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.apache.hive.hplsql.HplValidationException;
 
 public interface QueryExecutor {
   QueryResult executeQuery(String sql, ParserRuleContext ctx);
+
+  QueryExecutor DISABLED = (sql, ctx) -> {
+    throw new HplValidationException(ctx, "Query execution is disabled in this context. Can not execute: " + sql);
+  };
 }

--- a/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/beeline/TestHplSqlViaBeeLine.java
@@ -170,6 +170,18 @@ public class TestHplSqlViaBeeLine {
       "SELECT * FROM result;\n";
     testScriptFile(SCRIPT_TEXT, args(), "12345");
   }
+  
+  @Test
+  public void testUdf() throws Throwable {
+    String SCRIPT_TEXT =
+            "DROP TABLE IF EXISTS result;\n" +
+                    "CREATE TABLE result (s string);\n" +
+                    "INSERT INTO result VALUES('alice');\n" +
+                    "INSERT INTO result VALUES('bob');\n" +
+                    "CREATE FUNCTION hello(p STRING) RETURNS STRING BEGIN RETURN 'hello ' || p; END;\n" +
+                    "SELECT hello(s) FROM result;\n";
+    testScriptFile(SCRIPT_TEXT, args(), "hello alice.*hello bob");
+  }
 
   @Test
     public void testDbChange() throws Throwable {


### PR DESCRIPTION
HPLSQL supports stored function calls from HiveQL selects:

For example:

```
create function hello(s string) returns string;
begin
  return 'hello ' || s;
end;
```

The above stored function can be used in a select:

```
select hello(name) from employees;
```

HPLSQL translates this to a UDF call.

```
SELECT hplsql('hello(:1)', name) FROM users;
```

The hplsql UDF is going to call the hplsql interpreter to evaluate the hello function. The earlier implementation used to look up the interpreter from the session state. But this only works if the evaluation happens in compile time and the UDF is running inside the HS2 process. This is not true for general therefore the UDF should instantiate a new interpreter and use that to eval the function call.