### PR TITLE
HIVE-24981

### DIFF
--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -403,6 +403,10 @@
         <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-yaml</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.datanucleus</groupId>
       <artifactId>datanucleus-core</artifactId>
     </dependency>
@@ -1096,6 +1100,7 @@
                   <include>com.fasterxml.jackson.core:jackson-core</include>
                   <include>com.fasterxml.jackson.core:jackson-annotations</include>
                   <include>com.fasterxml.jackson.core:jackson-databind</include>
+                  <include>com.fasterxml.jackson.dataformat:jackson-dataformat-yaml</include>
                   <include>com.google.guava:guava</include>
                   <include>net.sf.opencsv:opencsv</include>
                   <include>org.apache.hive:hive-spark-client</include>

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigrationControlConfig.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigrationControlConfig.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.util;
+
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+public class HiveStrictManagedMigrationControlConfig {
+
+  private Map<String, List<String>> databaseIncludeLists = new TreeMap<String, List<String>>();
+
+  public Map<String, List<String>> getDatabaseIncludeLists() {
+    return databaseIncludeLists;
+  }
+
+  public void setDatabaseIncludeLists(Map<String, List<String>> databaseIncludeLists) {
+    this.databaseIncludeLists = databaseIncludeLists;
+  }
+
+  public void putAllFromConfig(HiveStrictManagedMigrationControlConfig other) {
+    for (String db : other.getDatabaseIncludeLists().keySet()) {
+      List<String> theseTables = this.databaseIncludeLists.get(db);
+      List<String> otherTables = other.getDatabaseIncludeLists().get(db);
+      if (theseTables == null) {
+        this.databaseIncludeLists.put(db, otherTables);
+      } else {
+        if (otherTables != null) {
+          theseTables.addAll(otherTables);
+        }
+      }
+    }
+  }
+}

--- a/ql/src/test/resources/hsmm/hsmm_cfg_01.yaml
+++ b/ql/src/test/resources/hsmm/hsmm_cfg_01.yaml
@@ -1,0 +1,9 @@
+databaseIncludeLists:
+  default:
+    - "manwhwh"
+    - "manwhnone"
+  emptydb:
+  unknowndb:
+    - "unknowntable1"
+  custdb:
+    - "custextwhwh"

--- a/ql/src/test/resources/hsmm/hsmm_cfg_02.yaml
+++ b/ql/src/test/resources/hsmm/hsmm_cfg_02.yaml
@@ -1,0 +1,5 @@
+databaseIncludeLists:
+  default:
+    - "manwhwh"
+  custdb:
+    - "custmanwhwh"


### PR DESCRIPTION
Currently HiveStrictManagedMigration supports db regex and table regex options that allow the user to specify what Hive entities it should deal with. In cases where we have thousands of tables across thousands of DBs iterating through everything takes a lot of time, while specifying a set of tables/DBs with regexes is cumbersome.

We should make it available for users to prepare control files with the lists of required items to migrate and feed this to the tool. A directory path pointing to these control files would be taken as a new option for HSMM.