### PR TITLE
HIVE-25012: Parsing table alias is failing if query has table properties specified

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -500,21 +500,54 @@ public abstract class BaseSemanticAnalyzer {
     if (node.getToken().getType() == HiveParser.TOK_PTBLFUNCTION) {
       return unescapeIdentifier(node.getChild(1).getText().toLowerCase());
     }
-    if (node.getChildCount() == 1) {
-      return getUnescapedUnqualifiedTableName((ASTNode) node.getChild(0)).toLowerCase();
-    }
-    for (int i = node.getChildCount() - 1; i >= 0; --i) {
-      Tree child = node.getChild(i);
-      if (child.getType() == HiveParser.TOK_TABNAME) {
-        return getUnescapedUnqualifiedTableName((ASTNode) node.getChild(0)).toLowerCase();
-      } else if (child.getType() == HiveParser.Identifier) {
-        return unescapeIdentifier(child.getText().toLowerCase());
-      }
-    }
-
-    throw new SemanticException("No table alias or table name found.");
+    return getSimpleTableNameBase(node);
   }
 
+  protected static String getSimpleTableNameBase(ASTNode n) throws SemanticException {
+    switch (n.getType()) {
+    case HiveParser.TOK_TABREF:
+      int aliasIndex = findTabRefIdxs(n)[0];
+      if (aliasIndex != 0) {
+        return n.getChild(aliasIndex).getText(); //the alias
+      }
+      return getSimpleTableNameBase((ASTNode) n.getChild(0));
+    case HiveParser.TOK_TABNAME:
+      if (n.getChildCount() == 2) {
+        //db.table -> return table
+        return n.getChild(1).getText();
+      }
+      return n.getChild(0).getText();
+    case HiveParser.TOK_SUBQUERY:
+      return n.getChild(1).getText(); //the alias
+    default:
+      throw raiseWrongType("TOK_TABREF|TOK_TABNAME|TOK_SUBQUERY", n);
+    }
+  }
+
+  protected static IllegalArgumentException raiseWrongType(String expectedTokName, ASTNode n) {
+    return new IllegalArgumentException("Expected " + expectedTokName + "; got " + n.getType());
+  }
+
+  protected static int[] findTabRefIdxs(ASTNode tabref) {
+    assert tabref.getType() == HiveParser.TOK_TABREF;
+    int aliasIndex = 0;
+    int propsIndex = -1;
+    int tsampleIndex = -1;
+    int ssampleIndex = -1;
+    for (int index = 1; index < tabref.getChildCount(); index++) {
+      ASTNode ct = (ASTNode) tabref.getChild(index);
+      if (ct.getToken().getType() == HiveParser.TOK_TABLEBUCKETSAMPLE) {
+        tsampleIndex = index;
+      } else if (ct.getToken().getType() == HiveParser.TOK_TABLESPLITSAMPLE) {
+        ssampleIndex = index;
+      } else if (ct.getToken().getType() == HiveParser.TOK_TABLEPROPERTIES) {
+        propsIndex = index;
+      } else {
+        aliasIndex = index;
+      }
+    }
+    return new int[] {aliasIndex, propsIndex, tsampleIndex, ssampleIndex};
+  }
 
   /**
    * Remove the encapsulating "`" pair from the identifier. We allow users to

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -500,7 +500,8 @@ public abstract class BaseSemanticAnalyzer {
     if (node.getToken().getType() == HiveParser.TOK_PTBLFUNCTION) {
       return unescapeIdentifier(node.getChild(1).getText().toLowerCase());
     }
-    return getSimpleTableNameBase(node);
+    String alias = getSimpleTableNameBase(node);
+    return alias != null ? alias.toLowerCase() : null;
   }
 
   protected static String getSimpleTableNameBase(ASTNode n) throws SemanticException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/RewriteSemanticAnalyzer.java
@@ -414,27 +414,6 @@ public abstract class RewriteSemanticAnalyzer extends CalcitePlanner {
     return HiveUtils.unparseIdentifier(getSimpleTableNameBase(n), this.conf);
   }
 
-  protected String getSimpleTableNameBase(ASTNode n) throws SemanticException {
-    switch (n.getType()) {
-    case HiveParser.TOK_TABREF:
-      int aliasIndex = findTabRefIdxs(n)[0];
-      if (aliasIndex != 0) {
-        return n.getChild(aliasIndex).getText(); //the alias
-      }
-      return getSimpleTableNameBase((ASTNode) n.getChild(0));
-    case HiveParser.TOK_TABNAME:
-      if (n.getChildCount() == 2) {
-        //db.table -> return table
-        return n.getChild(1).getText();
-      }
-      return n.getChild(0).getText();
-    case HiveParser.TOK_SUBQUERY:
-      return n.getChild(1).getText(); //the alias
-    default:
-      throw raiseWrongType("TOK_TABREF|TOK_TABNAME|TOK_SUBQUERY", n);
-    }
-  }
-
   protected static final class ReparseResult {
     final ASTNode rewrittenTree;
     final Context rewrittenCtx;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1064,27 +1064,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     this.ast = newAST;
   }
 
-  int[] findTabRefIdxs(ASTNode tabref) {
-    assert tabref.getType() == HiveParser.TOK_TABREF;
-    int aliasIndex = 0;
-    int propsIndex = -1;
-    int tsampleIndex = -1;
-    int ssampleIndex = -1;
-    for (int index = 1; index < tabref.getChildCount(); index++) {
-      ASTNode ct = (ASTNode) tabref.getChild(index);
-      if (ct.getToken().getType() == HiveParser.TOK_TABLEBUCKETSAMPLE) {
-        tsampleIndex = index;
-      } else if (ct.getToken().getType() == HiveParser.TOK_TABLESPLITSAMPLE) {
-        ssampleIndex = index;
-      } else if (ct.getToken().getType() == HiveParser.TOK_TABLEPROPERTIES) {
-        propsIndex = index;
-      } else {
-        aliasIndex = index;
-      }
-    }
-    return new int[] {aliasIndex, propsIndex, tsampleIndex, ssampleIndex};
-  }
-
   private String findSimpleTableName(ASTNode tabref, int aliasIndex) throws SemanticException {
     assert tabref.getType() == HiveParser.TOK_TABREF;
     ASTNode tableTree = (ASTNode) (tabref.getChild(0));
@@ -15301,10 +15280,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     default:
       throw raiseWrongType("TOK_TABNAME", n);
     }
-  }
-
-  static IllegalArgumentException raiseWrongType(String expectedTokName, ASTNode n) {
-    return new IllegalArgumentException("Expected " + expectedTokName + "; got " + n.getType());
   }
 
   /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
Move `getSimpleTableNameBase` and `findTabRefIdxs` to allow using them from `BaseSemanticAnalyzer.getTableAlias `

### Why are the changes needed?
See jira.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=fetch_deleted_rows.q -pl itests/qtest -Pitests
```