### PR TITLE
HIVE-25025:Distcp In MoveTask may cause stats info lost

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/FileUtils.java
@@ -654,7 +654,12 @@ public final class FileUtils {
                 HiveConf.ConfVars.HIVE_EXEC_COPYFILE_MAXNUMFILES) + ")");
         LOG.info("Launch distributed copy (distcp) job.");
         triedDistcp = true;
-        copied = distCp(srcFS, Collections.singletonList(src), dst, deleteSource, null, conf, shims);
+        Path dstDistcp = dst;
+        FileStatus srcFileStatus = srcFS.getFileStatus(src);
+        if(srcFileStatus.isDirectory()){
+          dstDistcp = new Path(dst, srcFileStatus.getPath().getName());
+        }
+        copied = distCp(srcFS, Collections.singletonList(src), dstDistcp, deleteSource, null, conf, shims);
       }
     }
     if (!triedDistcp) {

--- a/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
@@ -225,10 +225,10 @@ public class TestFileUtils {
     when(mockContentSummary.getLength()).thenReturn(Long.MAX_VALUE);
     when(mockFs.getContentSummary(any(Path.class))).thenReturn(mockContentSummary);
 
-     Path dstDistcp = dst;
-     FileStatus srcFileStatus = srcFS.getFileStatus(src);
-     if(copySrc.isDirectory()){
-        dstDistcp = new Path(dst, srcFileStatus.getPath().getName());
+     Path dstDistcp = copyDst;
+     FileStatus srcFileStatus = mockFs.getFileStatus(copySrc);
+     if(srcFileStatus.isDirectory()){
+        dstDistcp = new Path(copyDst, srcFileStatus.getPath().getName());
      }
     when(shims.runDistCp(Collections.singletonList(copySrc), dstDistcp, conf)).thenReturn(true);
 

--- a/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
@@ -218,14 +218,19 @@ public class TestFileUtils {
 
     FileSystem mockFs = mock(FileSystem.class);
     when(mockFs.getUri()).thenReturn(URI.create("hdfs:///"));
+    when(mockFs.getUri()).thenReturn(URI.create("hdfs:///"));
 
     ContentSummary mockContentSummary = mock(ContentSummary.class);
     when(mockContentSummary.getFileCount()).thenReturn(Long.MAX_VALUE);
     when(mockContentSummary.getLength()).thenReturn(Long.MAX_VALUE);
     when(mockFs.getContentSummary(any(Path.class))).thenReturn(mockContentSummary);
 
-    HadoopShims shims = mock(HadoopShims.class);
-    when(shims.runDistCp(Collections.singletonList(copySrc), copyDst, conf)).thenReturn(true);
+     Path dstDistcp = dst;
+     FileStatus srcFileStatus = srcFS.getFileStatus(src);
+     if(copySrc.isDirectory()){
+        dstDistcp = new Path(dst, srcFileStatus.getPath().getName());
+     }
+    when(shims.runDistCp(Collections.singletonList(copySrc), dstDistcp, conf)).thenReturn(true);
 
     Assert.assertTrue(FileUtils.copy(mockFs, copySrc, mockFs, copyDst, false, false, conf, shims));
     verify(shims).runDistCp(Collections.singletonList(copySrc), copyDst, conf);


### PR DESCRIPTION
after set  Run as end user instead of Hive user , when execute insert overwrite , In MoveTask ,if source byte > HIVE_EXEC_COPYFILE_MAXSIZE  and source file count> HIVE_EXEC_COPYFILE_MAXNUMFILES , HIve will use distcp method, it may cause tmp stats file lost. 

example:

set hive.exec.copyfile.maxsize=0;
set hive.exec.copyfile.maxnumfiles=0;

insert overwrite table abc_new select * from abc;

select count(1) from abc_new ;

select * from abc_new ;

then the  count(1) result will be 0, but select * will display real data, because stats info lost.


fix:

distcp method different from FileUtil.copy, because distcp method ignore parent directory, then may overwrite stats files,cause stats info lost.?

modify dst value, add parent directory to dst path, make distcp method run result as same as FileUtil.copy.

