### PR TITLE
HIVE-25027: Hide Iceberg module behind a profile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,7 @@ export MAVEN_OPTS="-Xmx2g"
 export -n HIVE_CONF_DIR
 cp $SETTINGS .git/settings.xml
 OPTS=" -s $PWD/.git/settings.xml -B -Dtest.groups= "
-OPTS+=" -Pitests,qsplits,dist,errorProne"
+OPTS+=" -Pitests,qsplits,dist,errorProne,iceberg"
 OPTS+=" -Dorg.slf4j.simpleLogger.log.org.apache.maven.plugin.surefire.SurefirePlugin=INFO"
 OPTS+=" -Dmaven.repo.local=$PWD/.git/m2"
 git config extra.mavenOpts "$OPTS"

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -147,6 +147,22 @@
         </plugins>
       </build>
     </profile>
+    <!-- Add iceberg dependencies only with iceberg build -->
+    <profile>
+      <id>iceberg</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-iceberg-catalog</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hive</groupId>
+          <artifactId>hive-iceberg-handler</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
 
@@ -226,16 +242,6 @@
     <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-druid-handler</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-iceberg-catalog</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hive</groupId>
-      <artifactId>hive-iceberg-handler</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,6 @@
     <module>standalone-metastore</module>
     <module>upgrade-acid</module>
     <module>kafka-handler</module>
-    <module>iceberg</module>
   </modules>
 
   <properties>
@@ -1836,6 +1835,12 @@
       <id>itests</id>
       <modules>
         <module>itests</module>
+      </modules>
+    </profile>
+    <profile>
+      <id>iceberg</id>
+      <modules>
+        <module>iceberg</module>
       </modules>
     </profile>
     <profile>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Hide Iceberg module behind a profile

### Why are the changes needed?
After creating patched-iceberg-core and patched-iceberg-api modules the maven build works fine, but IntelliJ needs manual classpath setup for the build in the IntelliJ to succeed.

Most of the community does not use Iceberg and eventually the "patched" modules will be removed as the Hive-Iceberg integration stabilizes and the Iceberg project releases the changes we need. In the meantime we just hide the whole Iceberg module behind a profile which is only used on the CI and if the developer specifically sets it. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Rebuilt the project in maven and in IntelliJ