### PR TITLE
HIVE-25026:hive sql result is duplicate data cause of same task resub…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/TaskQueue.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/TaskQueue.java
@@ -159,7 +159,7 @@ public class TaskQueue {
   public static boolean isLaunchable(Task<?> tsk) {
     // A launchable task is one that hasn't been queued, hasn't been
     // initialized, and is runnable.
-    return tsk.isNotInitialized() && tsk.isRunnable();
+    return tsk.isNotRunning() && tsk.isNotInitialized() && tsk.isRunnable();
   }
 
   public synchronized boolean addToRunnable(Task<?> tsk) throws HiveException {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Task.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Task.java
@@ -417,6 +417,10 @@ public abstract class Task<T extends Serializable> implements Serializable, Node
     return taskState.ordinal() < TaskState.INITIALIZED.ordinal();
   }
 
+  public synchronized boolean isNotRunning() {
+    return taskState.ordinal() < TaskState.RUNNING.ordinal();
+  }
+
 
   public boolean isRunnable() {
     boolean isrunnable = true;


### PR DESCRIPTION
**Hive task job will gen duplicate data cause of same task resubmission**
```
2021-04-05 06:05:52 CONSOLE# Number of reduce tasks is set to 0 since there's no reduce operator
2021-04-05 06:05:52 CONSOLE# Launching Job 5 out of 4
2021-04-05 06:05:52 CONSOLE# Number of reduce tasks is set to 0 since there's no reduce operator
```
<img src="https://user-images.githubusercontent.com/13237066/115213523-2d945800-a134-11eb-94c3-52095c748283.png" width="300" height="300">
For example,  hive sql explain 4 task. when hive.exec.parallel=true and task2/task3 is canExecuteInParallel,task4 will execute 2 times;

1.  task1 is FINISHED, task2/task3 enter Runnable queue
<img src="https://user-images.githubusercontent.com/13237066/115233371-65a69580-a14a-11eb-81fb-5a0c3582e3dc.png" width="400" height="150">
2.
<br>2.1 task2/task3 is executed in parallel and ends at the same time. Now task2/task3 is FINISHED
<img src="https://user-images.githubusercontent.com/13237066/115233876-06955080-a14b-11eb-9570-7334eff8dcad.png" width="400" height="150">

 2.2 task2 removed from running queue, task4 will enter runnable queue because of task2/task3 is FINISHED
<img src="https://user-images.githubusercontent.com/13237066/115234408-95a26880-a14b-11eb-874d-3cdd16497d50.png" width="400" height="150">

3. task4 enter running, but task4 is running when remove task3 from running queue. In this case, task4 will entry runnable again.
```
public static boolean isLaunchable(Task<?> tsk) {
    // A launchable task is one that hasn't been queued, hasn't been
    // initialized, and is runnable.
    return tsk.isNotInitialized() && tsk.isRunnable();
  }
```
<img src="https://user-images.githubusercontent.com/13237066/115234957-309b4280-a14c-11eb-9022-c35c791311f1.png" width="400" height="150">
<img src="https://user-images.githubusercontent.com/13237066/115235072-588aa600-a14c-11eb-8d40-7c94ce4663c6.png" width="400" height="150">

 