### PR TITLE
HIVE-25033. HPL/SQL thrift call fails when returning null (amagyar)

### DIFF
--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.cpp
@@ -60579,6 +60579,14 @@ uint32_t ThriftHiveMetastore_get_stored_procedure_result::read(::apache::thrift:
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->o2.read(iprot);
+          this->__isset.o2 = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -60604,6 +60612,10 @@ uint32_t ThriftHiveMetastore_get_stored_procedure_result::write(::apache::thrift
   } else if (this->__isset.o1) {
     xfer += oprot->writeFieldBegin("o1", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->o1.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.o2) {
+    xfer += oprot->writeFieldBegin("o2", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->o2.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -60649,6 +60661,14 @@ uint32_t ThriftHiveMetastore_get_stored_procedure_presult::read(::apache::thrift
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->o1.read(iprot);
           this->__isset.o1 = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->o2.read(iprot);
+          this->__isset.o2 = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -61212,6 +61232,14 @@ uint32_t ThriftHiveMetastore_find_package_result::read(::apache::thrift::protoco
           xfer += iprot->skip(ftype);
         }
         break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->o2.read(iprot);
+          this->__isset.o2 = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -61237,6 +61265,10 @@ uint32_t ThriftHiveMetastore_find_package_result::write(::apache::thrift::protoc
   } else if (this->__isset.o1) {
     xfer += oprot->writeFieldBegin("o1", ::apache::thrift::protocol::T_STRUCT, 1);
     xfer += this->o1.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  } else if (this->__isset.o2) {
+    xfer += oprot->writeFieldBegin("o2", ::apache::thrift::protocol::T_STRUCT, 2);
+    xfer += this->o2.write(oprot);
     xfer += oprot->writeFieldEnd();
   }
   xfer += oprot->writeFieldStop();
@@ -61282,6 +61314,14 @@ uint32_t ThriftHiveMetastore_find_package_presult::read(::apache::thrift::protoc
         if (ftype == ::apache::thrift::protocol::T_STRUCT) {
           xfer += this->o1.read(iprot);
           this->__isset.o1 = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
+      case 2:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->o2.read(iprot);
+          this->__isset.o2 = true;
         } else {
           xfer += iprot->skip(ftype);
         }
@@ -77941,6 +77981,9 @@ void ThriftHiveMetastoreClient::recv_get_stored_procedure(StoredProcedure& _retu
   if (result.__isset.o1) {
     throw result.o1;
   }
+  if (result.__isset.o2) {
+    throw result.o2;
+  }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "get_stored_procedure failed: unknown result");
 }
 
@@ -78118,6 +78161,9 @@ void ThriftHiveMetastoreClient::recv_find_package(Package& _return)
   }
   if (result.__isset.o1) {
     throw result.o1;
+  }
+  if (result.__isset.o2) {
+    throw result.o2;
   }
   throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "find_package failed: unknown result");
 }
@@ -93391,6 +93437,9 @@ void ThriftHiveMetastoreProcessor::process_get_stored_procedure(int32_t seqid, :
   } catch (MetaException &o1) {
     result.o1 = o1;
     result.__isset.o1 = true;
+  } catch (NoSuchObjectException &o2) {
+    result.o2 = o2;
+    result.__isset.o2 = true;
   } catch (const std::exception& e) {
     if (this->eventHandler_.get() != NULL) {
       this->eventHandler_->handlerError(ctx, "ThriftHiveMetastore.get_stored_procedure");
@@ -93561,6 +93610,9 @@ void ThriftHiveMetastoreProcessor::process_find_package(int32_t seqid, ::apache:
   } catch (MetaException &o1) {
     result.o1 = o1;
     result.__isset.o1 = true;
+  } catch (NoSuchObjectException &o2) {
+    result.o2 = o2;
+    result.__isset.o2 = true;
   } catch (const std::exception& e) {
     if (this->eventHandler_.get() != NULL) {
       this->eventHandler_->handlerError(ctx, "ThriftHiveMetastore.find_package");
@@ -116821,6 +116873,10 @@ void ThriftHiveMetastoreConcurrentClient::recv_get_stored_procedure(StoredProced
         sentry.commit();
         throw result.o1;
       }
+      if (result.__isset.o2) {
+        sentry.commit();
+        throw result.o2;
+      }
       // in a bad state, don't commit
       throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "get_stored_procedure failed: unknown result");
     }
@@ -117078,6 +117134,10 @@ void ThriftHiveMetastoreConcurrentClient::recv_find_package(Package& _return, co
       if (result.__isset.o1) {
         sentry.commit();
         throw result.o1;
+      }
+      if (result.__isset.o2) {
+        sentry.commit();
+        throw result.o2;
       }
       // in a bad state, don't commit
       throw ::apache::thrift::TApplicationException(::apache::thrift::TApplicationException::MISSING_RESULT, "find_package failed: unknown result");

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/ThriftHiveMetastore.h
@@ -31884,9 +31884,10 @@ class ThriftHiveMetastore_get_stored_procedure_pargs {
 };
 
 typedef struct _ThriftHiveMetastore_get_stored_procedure_result__isset {
-  _ThriftHiveMetastore_get_stored_procedure_result__isset() : success(false), o1(false) {}
+  _ThriftHiveMetastore_get_stored_procedure_result__isset() : success(false), o1(false), o2(false) {}
   bool success :1;
   bool o1 :1;
+  bool o2 :1;
 } _ThriftHiveMetastore_get_stored_procedure_result__isset;
 
 class ThriftHiveMetastore_get_stored_procedure_result {
@@ -31900,6 +31901,7 @@ class ThriftHiveMetastore_get_stored_procedure_result {
   virtual ~ThriftHiveMetastore_get_stored_procedure_result() noexcept;
   StoredProcedure success;
   MetaException o1;
+  NoSuchObjectException o2;
 
   _ThriftHiveMetastore_get_stored_procedure_result__isset __isset;
 
@@ -31907,11 +31909,15 @@ class ThriftHiveMetastore_get_stored_procedure_result {
 
   void __set_o1(const MetaException& val);
 
+  void __set_o2(const NoSuchObjectException& val);
+
   bool operator == (const ThriftHiveMetastore_get_stored_procedure_result & rhs) const
   {
     if (!(success == rhs.success))
       return false;
     if (!(o1 == rhs.o1))
+      return false;
+    if (!(o2 == rhs.o2))
       return false;
     return true;
   }
@@ -31927,9 +31933,10 @@ class ThriftHiveMetastore_get_stored_procedure_result {
 };
 
 typedef struct _ThriftHiveMetastore_get_stored_procedure_presult__isset {
-  _ThriftHiveMetastore_get_stored_procedure_presult__isset() : success(false), o1(false) {}
+  _ThriftHiveMetastore_get_stored_procedure_presult__isset() : success(false), o1(false), o2(false) {}
   bool success :1;
   bool o1 :1;
+  bool o2 :1;
 } _ThriftHiveMetastore_get_stored_procedure_presult__isset;
 
 class ThriftHiveMetastore_get_stored_procedure_presult {
@@ -31939,6 +31946,7 @@ class ThriftHiveMetastore_get_stored_procedure_presult {
   virtual ~ThriftHiveMetastore_get_stored_procedure_presult() noexcept;
   StoredProcedure* success;
   MetaException o1;
+  NoSuchObjectException o2;
 
   _ThriftHiveMetastore_get_stored_procedure_presult__isset __isset;
 
@@ -32212,9 +32220,10 @@ class ThriftHiveMetastore_find_package_pargs {
 };
 
 typedef struct _ThriftHiveMetastore_find_package_result__isset {
-  _ThriftHiveMetastore_find_package_result__isset() : success(false), o1(false) {}
+  _ThriftHiveMetastore_find_package_result__isset() : success(false), o1(false), o2(false) {}
   bool success :1;
   bool o1 :1;
+  bool o2 :1;
 } _ThriftHiveMetastore_find_package_result__isset;
 
 class ThriftHiveMetastore_find_package_result {
@@ -32228,6 +32237,7 @@ class ThriftHiveMetastore_find_package_result {
   virtual ~ThriftHiveMetastore_find_package_result() noexcept;
   Package success;
   MetaException o1;
+  NoSuchObjectException o2;
 
   _ThriftHiveMetastore_find_package_result__isset __isset;
 
@@ -32235,11 +32245,15 @@ class ThriftHiveMetastore_find_package_result {
 
   void __set_o1(const MetaException& val);
 
+  void __set_o2(const NoSuchObjectException& val);
+
   bool operator == (const ThriftHiveMetastore_find_package_result & rhs) const
   {
     if (!(success == rhs.success))
       return false;
     if (!(o1 == rhs.o1))
+      return false;
+    if (!(o2 == rhs.o2))
       return false;
     return true;
   }
@@ -32255,9 +32269,10 @@ class ThriftHiveMetastore_find_package_result {
 };
 
 typedef struct _ThriftHiveMetastore_find_package_presult__isset {
-  _ThriftHiveMetastore_find_package_presult__isset() : success(false), o1(false) {}
+  _ThriftHiveMetastore_find_package_presult__isset() : success(false), o1(false), o2(false) {}
   bool success :1;
   bool o1 :1;
+  bool o2 :1;
 } _ThriftHiveMetastore_find_package_presult__isset;
 
 class ThriftHiveMetastore_find_package_presult {
@@ -32267,6 +32282,7 @@ class ThriftHiveMetastore_find_package_presult {
   virtual ~ThriftHiveMetastore_find_package_presult() noexcept;
   Package* success;
   MetaException o1;
+  NoSuchObjectException o2;
 
   _ThriftHiveMetastore_find_package_presult__isset __isset;
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreClient.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreClient.php
@@ -16445,6 +16445,9 @@ class ThriftHiveMetastoreClient extends \FacebookServiceClient implements \metas
         if ($result->o1 !== null) {
             throw $result->o1;
         }
+        if ($result->o2 !== null) {
+            throw $result->o2;
+        }
         throw new \Exception("get_stored_procedure failed: unknown result");
     }
 
@@ -16627,6 +16630,9 @@ class ThriftHiveMetastoreClient extends \FacebookServiceClient implements \metas
         }
         if ($result->o1 !== null) {
             throw $result->o1;
+        }
+        if ($result->o2 !== null) {
+            throw $result->o2;
         }
         throw new \Exception("find_package failed: unknown result");
     }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreIf.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastoreIf.php
@@ -1867,6 +1867,7 @@ interface ThriftHiveMetastoreIf extends \FacebookServiceIf
      * @param \metastore\StoredProcedureRequest $request
      * @return \metastore\StoredProcedure
      * @throws \metastore\MetaException
+     * @throws \metastore\NoSuchObjectException
      */
     public function get_stored_procedure(\metastore\StoredProcedureRequest $request);
     /**
@@ -1884,6 +1885,7 @@ interface ThriftHiveMetastoreIf extends \FacebookServiceIf
      * @param \metastore\GetPackageRequest $request
      * @return \metastore\Package
      * @throws \metastore\MetaException
+     * @throws \metastore\NoSuchObjectException
      */
     public function find_package(\metastore\GetPackageRequest $request);
     /**

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_find_package_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_find_package_result.php
@@ -33,6 +33,12 @@ class ThriftHiveMetastore_find_package_result
             'type' => TType::STRUCT,
             'class' => '\metastore\MetaException',
         ),
+        2 => array(
+            'var' => 'o2',
+            'isRequired' => false,
+            'type' => TType::STRUCT,
+            'class' => '\metastore\NoSuchObjectException',
+        ),
     );
 
     /**
@@ -43,6 +49,10 @@ class ThriftHiveMetastore_find_package_result
      * @var \metastore\MetaException
      */
     public $o1 = null;
+    /**
+     * @var \metastore\NoSuchObjectException
+     */
+    public $o2 = null;
 
     public function __construct($vals = null)
     {
@@ -52,6 +62,9 @@ class ThriftHiveMetastore_find_package_result
             }
             if (isset($vals['o1'])) {
                 $this->o1 = $vals['o1'];
+            }
+            if (isset($vals['o2'])) {
+                $this->o2 = $vals['o2'];
             }
         }
     }
@@ -91,6 +104,14 @@ class ThriftHiveMetastore_find_package_result
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 2:
+                    if ($ftype == TType::STRUCT) {
+                        $this->o2 = new \metastore\NoSuchObjectException();
+                        $xfer += $this->o2->read($input);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -116,6 +137,11 @@ class ThriftHiveMetastore_find_package_result
         if ($this->o1 !== null) {
             $xfer += $output->writeFieldBegin('o1', TType::STRUCT, 1);
             $xfer += $this->o1->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->o2 !== null) {
+            $xfer += $output->writeFieldBegin('o2', TType::STRUCT, 2);
+            $xfer += $this->o2->write($output);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_stored_procedure_result.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/ThriftHiveMetastore_get_stored_procedure_result.php
@@ -33,6 +33,12 @@ class ThriftHiveMetastore_get_stored_procedure_result
             'type' => TType::STRUCT,
             'class' => '\metastore\MetaException',
         ),
+        2 => array(
+            'var' => 'o2',
+            'isRequired' => false,
+            'type' => TType::STRUCT,
+            'class' => '\metastore\NoSuchObjectException',
+        ),
     );
 
     /**
@@ -43,6 +49,10 @@ class ThriftHiveMetastore_get_stored_procedure_result
      * @var \metastore\MetaException
      */
     public $o1 = null;
+    /**
+     * @var \metastore\NoSuchObjectException
+     */
+    public $o2 = null;
 
     public function __construct($vals = null)
     {
@@ -52,6 +62,9 @@ class ThriftHiveMetastore_get_stored_procedure_result
             }
             if (isset($vals['o1'])) {
                 $this->o1 = $vals['o1'];
+            }
+            if (isset($vals['o2'])) {
+                $this->o2 = $vals['o2'];
             }
         }
     }
@@ -91,6 +104,14 @@ class ThriftHiveMetastore_get_stored_procedure_result
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 2:
+                    if ($ftype == TType::STRUCT) {
+                        $this->o2 = new \metastore\NoSuchObjectException();
+                        $xfer += $this->o2->read($input);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -116,6 +137,11 @@ class ThriftHiveMetastore_get_stored_procedure_result
         if ($this->o1 !== null) {
             $xfer += $output->writeFieldBegin('o1', TType::STRUCT, 1);
             $xfer += $this->o1->write($output);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->o2 !== null) {
+            $xfer += $output->writeFieldBegin('o2', TType::STRUCT, 2);
+            $xfer += $this->o2->write($output);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ThriftHiveMetastore.py
@@ -11491,6 +11491,8 @@ class Client(fb303.FacebookService.Client, Iface):
             return result.success
         if result.o1 is not None:
             raise result.o1
+        if result.o2 is not None:
+            raise result.o2
         raise TApplicationException(TApplicationException.MISSING_RESULT, "get_stored_procedure failed: unknown result")
 
     def drop_stored_procedure(self, request):
@@ -11591,6 +11593,8 @@ class Client(fb303.FacebookService.Client, Iface):
             return result.success
         if result.o1 is not None:
             raise result.o1
+        if result.o2 is not None:
+            raise result.o2
         raise TApplicationException(TApplicationException.MISSING_RESULT, "find_package failed: unknown result")
 
     def add_package(self, request):
@@ -19243,6 +19247,9 @@ class Processor(fb303.FacebookService.Processor, Iface, TProcessor):
         except MetaException as o1:
             msg_type = TMessageType.REPLY
             result.o1 = o1
+        except NoSuchObjectException as o2:
+            msg_type = TMessageType.REPLY
+            result.o2 = o2
         except TApplicationException as ex:
             logging.exception('TApplication exception in handler')
             msg_type = TMessageType.EXCEPTION
@@ -19321,6 +19328,9 @@ class Processor(fb303.FacebookService.Processor, Iface, TProcessor):
         except MetaException as o1:
             msg_type = TMessageType.REPLY
             result.o1 = o1
+        except NoSuchObjectException as o2:
+            msg_type = TMessageType.REPLY
+            result.o2 = o2
         except TApplicationException as ex:
             logging.exception('TApplication exception in handler')
             msg_type = TMessageType.EXCEPTION
@@ -58921,13 +58931,15 @@ class get_stored_procedure_result(object):
     Attributes:
      - success
      - o1
+     - o2
 
     """
 
 
-    def __init__(self, success=None, o1=None,):
+    def __init__(self, success=None, o1=None, o2=None,):
         self.success = success
         self.o1 = o1
+        self.o2 = o2
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -58950,6 +58962,12 @@ class get_stored_procedure_result(object):
                     self.o1.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRUCT:
+                    self.o2 = NoSuchObjectException()
+                    self.o2.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -58967,6 +58985,10 @@ class get_stored_procedure_result(object):
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
             self.o1.write(oprot)
+            oprot.writeFieldEnd()
+        if self.o2 is not None:
+            oprot.writeFieldBegin('o2', TType.STRUCT, 2)
+            self.o2.write(oprot)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -58988,6 +59010,7 @@ all_structs.append(get_stored_procedure_result)
 get_stored_procedure_result.thrift_spec = (
     (0, TType.STRUCT, 'success', [StoredProcedure, None], None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
+    (2, TType.STRUCT, 'o2', [NoSuchObjectException, None], None, ),  # 2
 )
 
 
@@ -59330,13 +59353,15 @@ class find_package_result(object):
     Attributes:
      - success
      - o1
+     - o2
 
     """
 
 
-    def __init__(self, success=None, o1=None,):
+    def __init__(self, success=None, o1=None, o2=None,):
         self.success = success
         self.o1 = o1
+        self.o2 = o2
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -59359,6 +59384,12 @@ class find_package_result(object):
                     self.o1.read(iprot)
                 else:
                     iprot.skip(ftype)
+            elif fid == 2:
+                if ftype == TType.STRUCT:
+                    self.o2 = NoSuchObjectException()
+                    self.o2.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -59376,6 +59407,10 @@ class find_package_result(object):
         if self.o1 is not None:
             oprot.writeFieldBegin('o1', TType.STRUCT, 1)
             self.o1.write(oprot)
+            oprot.writeFieldEnd()
+        if self.o2 is not None:
+            oprot.writeFieldBegin('o2', TType.STRUCT, 2)
+            self.o2.write(oprot)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -59397,6 +59432,7 @@ all_structs.append(find_package_result)
 find_package_result.thrift_spec = (
     (0, TType.STRUCT, 'success', [Package, None], None, ),  # 0
     (1, TType.STRUCT, 'o1', [MetaException, None], None, ),  # 1
+    (2, TType.STRUCT, 'o2', [NoSuchObjectException, None], None, ),  # 2
 )
 
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/thrift_hive_metastore.rb
@@ -4237,6 +4237,7 @@ module ThriftHiveMetastore
       result = receive_message(Get_stored_procedure_result)
       return result.success unless result.success.nil?
       raise result.o1 unless result.o1.nil?
+      raise result.o2 unless result.o2.nil?
       raise ::Thrift::ApplicationException.new(::Thrift::ApplicationException::MISSING_RESULT, 'get_stored_procedure failed: unknown result')
     end
 
@@ -4284,6 +4285,7 @@ module ThriftHiveMetastore
       result = receive_message(Find_package_result)
       return result.success unless result.success.nil?
       raise result.o1 unless result.o1.nil?
+      raise result.o2 unless result.o2.nil?
       raise ::Thrift::ApplicationException.new(::Thrift::ApplicationException::MISSING_RESULT, 'find_package failed: unknown result')
     end
 
@@ -7503,6 +7505,8 @@ module ThriftHiveMetastore
         result.success = @handler.get_stored_procedure(args.request)
       rescue ::MetaException => o1
         result.o1 = o1
+      rescue ::NoSuchObjectException => o2
+        result.o2 = o2
       end
       write_result(result, oprot, 'get_stored_procedure', seqid)
     end
@@ -7536,6 +7540,8 @@ module ThriftHiveMetastore
         result.success = @handler.find_package(args.request)
       rescue ::MetaException => o1
         result.o1 = o1
+      rescue ::NoSuchObjectException => o2
+        result.o2 = o2
       end
       write_result(result, oprot, 'find_package', seqid)
     end
@@ -16908,10 +16914,12 @@ module ThriftHiveMetastore
     include ::Thrift::Struct, ::Thrift::Struct_Union
     SUCCESS = 0
     O1 = 1
+    O2 = 2
 
     FIELDS = {
       SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => ::StoredProcedure},
-      O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException}
+      O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException},
+      O2 => {:type => ::Thrift::Types::STRUCT, :name => 'o2', :class => ::NoSuchObjectException}
     }
 
     def struct_fields; FIELDS; end
@@ -17008,10 +17016,12 @@ module ThriftHiveMetastore
     include ::Thrift::Struct, ::Thrift::Struct_Union
     SUCCESS = 0
     O1 = 1
+    O2 = 2
 
     FIELDS = {
       SUCCESS => {:type => ::Thrift::Types::STRUCT, :name => 'success', :class => ::Package},
-      O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException}
+      O1 => {:type => ::Thrift::Types::STRUCT, :name => 'o1', :class => ::MetaException},
+      O2 => {:type => ::Thrift::Types::STRUCT, :name => 'o2', :class => ::NoSuchObjectException}
     }
 
     def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -2958,11 +2958,11 @@ PartitionsResponse get_partitions_req(1:PartitionsRequest req)
   GetOpenTxnsResponse get_open_txns_req(1: GetOpenTxnsRequest getOpenTxnsRequest)
 
   void create_stored_procedure(1: StoredProcedure proc) throws(1:NoSuchObjectException o1, 2:MetaException o2)
-  StoredProcedure get_stored_procedure(1: StoredProcedureRequest request) throws (1:MetaException o1)
+  StoredProcedure get_stored_procedure(1: StoredProcedureRequest request) throws (1:MetaException o1, 2:NoSuchObjectException o2)
   void drop_stored_procedure(1: StoredProcedureRequest request) throws (1:MetaException o1)
   list<string> get_all_stored_procedures(1: ListStoredProcedureRequest request) throws (1:MetaException o1)
 
-  Package find_package(1: GetPackageRequest request) throws (1:MetaException o1)
+  Package find_package(1: GetPackageRequest request) throws (1:MetaException o1, 2:NoSuchObjectException o2)
   void add_package(1: AddPackageRequest request) throws (1:MetaException o1)
   list<string> get_all_packages(1: ListPackageRequest request) throws (1:MetaException o1)
   void drop_package(1: DropPackageRequest request) throws (1:MetaException o1)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/RetryingHMSHandler.java
@@ -178,7 +178,8 @@ public class RetryingHMSHandler implements InvocationHandler {
         } else if (e.getCause() instanceof NoSuchObjectException || e.getTargetException().getCause() instanceof NoSuchObjectException) {
           String methodName = method.getName();
           if (!methodName.startsWith("get_database") && !methodName.startsWith("get_table")
-              && !methodName.startsWith("get_partition") && !methodName.startsWith("get_function")) {
+              && !methodName.startsWith("get_partition") && !methodName.startsWith("get_function")
+              && !methodName.startsWith("get_stored_procedure") && !methodName.startsWith("find_package")) {
             LOG.error(ExceptionUtils.getStackTrace(e.getCause()));
           }
           throw e.getCause();


### PR DESCRIPTION
Thrift doesn't support returning null-s from functions. Instead of returning nulls, we should throw an exception.

This patch also puts back the changes which were accidentally removed by 

https://github.com/apache/hive/commit/6de2d51ac812a9393e8ff5e6de7bd911cb83f237#diff-90c669c961ab250c01087a409b31126cce7ac0672c40f465e7ee262ed7bcdadd