### PR TITLE
HIVE-24944: When the default engine of the hiveserver is MR and the t…

### DIFF
--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftCLIService.java
@@ -794,11 +794,20 @@ public abstract class ThriftCLIService extends AbstractService implements TCLISe
       }
       JobProgressUpdate progressUpdate = operationStatus.jobProgressUpdate();
       ProgressMonitorStatusMapper mapper = ProgressMonitorStatusMapper.DEFAULT;
-      if ("tez".equals(hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE))) {
-        mapper = new TezProgressMonitorStatusMapper();
-      }
-      if ("spark".equals(hiveConf.getVar(ConfVars.HIVE_EXECUTION_ENGINE))) {
-        mapper = new SparkProgressMonitorStatusMapper();
+      String engineInSessionConf = cliService.getSessionManager().getOperationManager()
+              .getOperation(operationHandle)
+              .getParentSession()
+              .getHiveConf()
+              .getVar(ConfVars.HIVE_EXECUTION_ENGINE);
+      switch (engineInSessionConf) {
+        case "tez":
+          mapper = new TezProgressMonitorStatusMapper();
+          break;
+        case "spark":
+          mapper = new SparkProgressMonitorStatusMapper();
+          break;
+        default:
+          break;
       }
       TJobExecutionStatus executionStatus =
           mapper.forStatus(progressUpdate.status);


### PR DESCRIPTION
What changes were proposed in this pull request?
See the: https://issues.apache.org/jira/browse/HIVE-24944

Why are the changes needed?
When the default engine of the hiveserver is MR and the tez engine is set by the client, the client TEZ progress log cannot be printed normally

Does this PR introduce any user-facing change?
No

How was this patch tested?
Remote cluster.
