### PR TITLE
HIVE-25047: Remove unused fields/methods and deprecated calls in HiveProject

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
@@ -100,26 +100,6 @@ import com.google.common.collect.Sets;
 
 public class HiveCalciteUtil {
 
-  /**
-   * Get list of virtual columns from the given list of projections.
-   * <p>
-   *
-   * @param exps
-   *          list of rex nodes representing projections
-   * @return List of Virtual Columns, will not be null.
-   */
-  public static List<Integer> getVirtualCols(List<? extends RexNode> exps) {
-    List<Integer> vCols = new ArrayList<Integer>();
-
-    for (int i = 0; i < exps.size(); i++) {
-      if (!(exps.get(i) instanceof RexInputRef)) {
-        vCols.add(i);
-      }
-    }
-
-    return vCols;
-  }
-
   public static boolean validateASTForUnsupportedTokens(ASTNode ast) {
     if (ParseUtils.containsTokenOfType(ast, HiveParser.TOK_CHARSETLITERAL, HiveParser.TOK_TABLESPLITSAMPLE)) {
       return false;

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveProject.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveProject.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hive.ql.optimizer.calcite.reloperators;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -28,31 +27,22 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeField;
-import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexUtil;
 import org.apache.calcite.rex.RexOver;
 import org.apache.calcite.sql.validate.SqlValidatorUtil;
 import org.apache.calcite.util.Util;
-import org.apache.calcite.util.mapping.Mapping;
-import org.apache.calcite.util.mapping.MappingType;
 import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException;
 import org.apache.hadoop.hive.ql.optimizer.calcite.CalciteSemanticException.UnsupportedFeature;
-import org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelShuttle;
 import org.apache.hadoop.hive.ql.optimizer.calcite.TraitsUtil;
 
-import com.google.common.collect.ImmutableList;
-
 public class HiveProject extends Project implements HiveRelNode {
 
-  private final List<Integer>        virtualCols;
   private boolean isSysnthetic;
 
   /**
    * Creates a HiveProject.
-   *
    * @param cluster
    *          Cluster this relational expression belongs to
    * @param child
@@ -61,14 +51,11 @@ public class HiveProject extends Project implements HiveRelNode {
    *          List of expressions for the input columns
    * @param rowType
    *          output row type
-   * @param flags
-   *          values as in {@link Project.Flags}
    */
-  public HiveProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode child,
-      List<? extends RexNode> exps, RelDataType rowType, int flags) {
-    super(cluster, traitSet, child, exps, rowType, flags);
+  public HiveProject(RelOptCluster cluster, RelTraitSet traitSet, RelNode child, List<? extends RexNode> exps,
+      RelDataType rowType) {
+    super(cluster, traitSet, child, exps, rowType);
     assert traitSet.containsIfApplicable(HiveRelNode.CONVENTION);
-    virtualCols = ImmutableList.copyOf(HiveCalciteUtil.getVirtualCols(exps));
   }
 
   /**
@@ -101,7 +88,7 @@ public class HiveProject extends Project implements HiveRelNode {
   public static HiveProject create(RelOptCluster cluster, RelNode child, List<? extends RexNode> exps,
       RelDataType rowType, final List<RelCollation> collationList) {
     RelTraitSet traitSet = TraitsUtil.getDefaultTraitSet(cluster);
-    return new HiveProject(cluster, traitSet, child, exps, rowType, Flags.BOXED);
+    return new HiveProject(cluster, traitSet, child, exps, rowType);
   }
 
   /**
@@ -109,65 +96,13 @@ public class HiveProject extends Project implements HiveRelNode {
    */
   public static HiveProject create(RelOptCluster cluster, RelNode child, List<? extends RexNode> exps,
       RelDataType rowType, RelTraitSet traitSet, final List<RelCollation> collationList) {
-    return new HiveProject(cluster, traitSet, child, exps, rowType, Flags.BOXED);
-  }
-
-  /**
-   * Creates a relational expression which projects the output fields of a
-   * relational expression according to a partial mapping.
-   *
-   * <p>
-   * A partial mapping is weaker than a permutation: every target has one
-   * source, but a source may have 0, 1 or more than one targets. Usually the
-   * result will have fewer fields than the source, unless some source fields
-   * are projected multiple times.
-   *
-   * <p>
-   * This method could optimize the result as permute does, but does
-   * not at present.
-   *
-   * @param rel
-   *          Relational expression
-   * @param mapping
-   *          Mapping from source fields to target fields. The mapping type must
-   *          obey the constraints {@link MappingType#isMandatorySource()} and
-   *          {@link MappingType#isSingleSource()}, as does
-   *          {@link MappingType#INVERSE_FUNCTION}.
-   * @param fieldNames
-   *          Field names; if null, or if a particular entry is null, the name
-   *          of the permuted field is used
-   * @return relational expression which projects a subset of the input fields
-   * @throws CalciteSemanticException
-   */
-  public static RelNode projectMapping(RelNode rel, Mapping mapping, List<String> fieldNames) throws CalciteSemanticException {
-    assert mapping.getMappingType().isSingleSource();
-    assert mapping.getMappingType().isMandatorySource();
-
-    if (mapping.isIdentity()) {
-      return rel;
-    }
-
-    final List<String> outputNameList = new ArrayList<String>();
-    final List<RexNode> outputProjList = new ArrayList<RexNode>();
-    final List<RelDataTypeField> fields = rel.getRowType().getFieldList();
-    final RexBuilder rexBuilder = rel.getCluster().getRexBuilder();
-
-    for (int i = 0; i < mapping.getTargetCount(); i++) {
-      int source = mapping.getSource(i);
-      final RelDataTypeField sourceField = fields.get(source);
-      outputNameList
-          .add(((fieldNames == null) || (fieldNames.size() <= i) || (fieldNames.get(i) == null)) ? sourceField
-              .getName() : fieldNames.get(i));
-      outputProjList.add(rexBuilder.makeInputRef(rel, source));
-    }
-
-    return create(rel, outputProjList, outputNameList);
+    return new HiveProject(cluster, traitSet, child, exps, rowType);
   }
 
   @Override
   public Project copy(RelTraitSet traitSet, RelNode input, List<RexNode> exps, RelDataType rowType) {
     assert traitSet.containsIfApplicable(HiveRelNode.CONVENTION);
-    HiveProject hp = new HiveProject(getCluster(), traitSet, input, exps, rowType, getFlags());
+    HiveProject hp = new HiveProject(getCluster(), traitSet, input, exps, rowType);
     if (this.isSynthetic()) {
       hp.setSynthetic();
     }
@@ -177,10 +112,6 @@ public class HiveProject extends Project implements HiveRelNode {
 
   @Override
   public void implement(Implementor implementor) {
-  }
-
-  public List<Integer> getVirtualCols() {
-    return virtualCols;
   }
 
   // TODO: this should come through RelBuilder to the constructor as opposed to


### PR DESCRIPTION
### What changes were proposed in this pull request?
Refactor HiveProject removing unused fields/methods and deprecated calls.

### Why are the changes needed?
Improve readability.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Existing tests.
