### PR TITLE
HIVE-25049: LlapDaemon preemption should not be triggered for same Vertex tasks

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -973,7 +973,7 @@ public class TaskExecutorService extends AbstractService
 
   /**
    * Victim Task (A) should be preempted in favor of a candidate Task (B) when:
-   *    1. A is NOT on the same DAG and Vertex as B  AND
+   *    1. A is NOT on the same Vertex as B AND
    *      1.1. B is a Guaranteed Task while A is not OR
    *      1.2. Both are guaranteed but A is not finishable and B is
    * To make sure that Victim task is not behind some upstream updates (asynchronous),
@@ -986,7 +986,7 @@ public class TaskExecutorService extends AbstractService
     if (victim == null) return false;
     SignableVertexSpec candVrtx = candidate.getTaskRunnerCallable().getFragmentInfo().getVertexSpec();
     SignableVertexSpec vicVrtx = victim.getTaskRunnerCallable().getFragmentInfo().getVertexSpec();
-    if (candVrtx.getHiveQueryId().compareTo(vicVrtx.getHiveQueryId()) == 0 &&
+    if (candVrtx.getHiveQueryId().equals(vicVrtx.getHiveQueryId()) &&
         candVrtx.getVertexIndex() == vicVrtx.getVertexIndex()) return false;
     if (candidate.isGuaranteed() && !victim.isGuaranteed()) return true;
     return ((candidate.isGuaranteed() == victim.isGuaranteed())

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorService.java
@@ -971,11 +971,26 @@ public class TaskExecutorService extends AbstractService
     }
   }
 
+  /**
+   * Victim Task (A) should be preempted in favor of a candidate Task (B) when:
+   *    1. A is NOT on the same DAG and Vertex as B  AND
+   *      1.1. B is a Guaranteed Task while A is not OR
+   *      1.2. Both are guaranteed but A is not finishable and B is
+   * To make sure that Victim task is not behind some upstream updates (asynchronous),
+   * we check its sources' state (by QueryFragmentInfo.canFinish method)
+   * @param candidate Task
+   * @param victim Task
+   * @return True when victim should be preempted in favor of candidate Task
+   */
   private static boolean canPreempt(TaskWrapper candidate, TaskWrapper victim) {
     if (victim == null) return false;
+    SignableVertexSpec candVrtx = candidate.getTaskRunnerCallable().getFragmentInfo().getVertexSpec();
+    SignableVertexSpec vicVrtx = victim.getTaskRunnerCallable().getFragmentInfo().getVertexSpec();
+    if (candVrtx.getHiveQueryId().compareTo(vicVrtx.getHiveQueryId()) == 0 &&
+        candVrtx.getVertexIndex() == vicVrtx.getVertexIndex()) return false;
     if (candidate.isGuaranteed() && !victim.isGuaranteed()) return true;
     return ((candidate.isGuaranteed() == victim.isGuaranteed())
-        && candidate.canFinishForPriority() && !victim.canFinishForPriority());
+        && candidate.canFinishForPriority() && !victim.getTaskRunnerCallable().canFinish());
   }
 
   @VisibleForTesting

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TaskExecutorTestHelpers.java
@@ -59,6 +59,13 @@ public class TaskExecutorTestHelpers {
     return createMockRequest(canFinish, canFinish, workTime, request, isGuaranteed);
   }
 
+  public static MockRequest createMockRequest(int fragmentNum, int parallelism, long firstAttemptStartTime,
+      long currentAttemptStartTime, boolean canFinish, long workTime, boolean isGuaranteed, int dagId) {
+    SubmitWorkRequestProto request = createSubmitWorkRequestProto(fragmentNum, parallelism, 0,
+        firstAttemptStartTime, currentAttemptStartTime, 1, "MockDag", dagId, isGuaranteed);
+    return createMockRequest(canFinish, canFinish, workTime, request, isGuaranteed);
+  }
+
   public static MockRequest createMockRequest(int fragmentNum, int parallelism,
                                               int withinDagPriority,
                                               long firstAttemptStartTime,
@@ -144,14 +151,21 @@ public class TaskExecutorTestHelpers {
         currentAttemptStartTime, withinDagPriority, "MockDag", isGuaranteed);
   }
 
+  private static SubmitWorkRequestProto createSubmitWorkRequestProto(
+      int fragmentNumber, int selfAndUpstreamParallelism, int selfAndUpstreamComplete, long firstAttemptStartTime,
+      long currentAttemptStartTime, int withinDagPriority, String mockDag, boolean isGuaranteed) {
+    return createSubmitWorkRequestProto(fragmentNumber, selfAndUpstreamParallelism, selfAndUpstreamComplete, firstAttemptStartTime,
+        currentAttemptStartTime, withinDagPriority, mockDag, 35, isGuaranteed);
+  }
+
   public static SubmitWorkRequestProto createSubmitWorkRequestProto(
       int fragmentNumber, int selfAndUpstreamParallelism,
       int selfAndUpstreamComplete, long firstAttemptStartTime,
-      long currentAttemptStartTime, int withinDagPriority, String dagName,
+      long currentAttemptStartTime, int withinDagPriority, String dagName, int dagId,
       boolean isGuaranteed) {
     ApplicationId appId = ApplicationId.newInstance(9999, 72);
-    TezDAGID dagId = TezDAGID.getInstance(appId, 1);
-    TezVertexID vId = TezVertexID.getInstance(dagId, 35);
+    TezDAGID dag = TezDAGID.getInstance(appId, 1);
+    TezVertexID vId = TezVertexID.getInstance(dag, dagId);
     return SubmitWorkRequestProto
         .newBuilder()
         .setAttemptNumber(0)
@@ -167,7 +181,7 @@ public class TaskExecutorTestHelpers {
                     QueryIdentifierProto.newBuilder()
                         .setApplicationIdString(appId.toString())
                         .setAppAttemptNumber(0)
-                        .setDagIndex(dagId.getId())
+                        .setDagIndex(dag.getId())
                         .build())
                 .setVertexIndex(vId.getId())
                 .setVertexName("MockVertex")

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestTaskExecutorService.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/TestTaskExecutorService.java
@@ -103,25 +103,29 @@ public class TestTaskExecutorService {
   org.slf4j.Logger LOG = org.slf4j.LoggerFactory.getLogger(TestTaskExecutorService.class);
   @Test(timeout = 20000)
   public void testFinishablePreemptsNonFinishable() throws InterruptedException {
-    MockRequest r1 = createMockRequest(1, 1, 100, 200, false, 50000000l, false);
-    MockRequest r2 = createMockRequest(2, 1, 100, 200, true, 10000000l, false);
+    MockRequest r1 = createMockRequest(1, 1, 100, 200, false, 50000000l, false, 10);
+    MockRequest r2 = createMockRequest(2, 1, 100, 200, true, 10000000l, false, 11);
     testPreemptionHelper(r1, r2, true);
-    r1 = createMockRequest(1, 1, 100, 200, false, 5000l, true);
-    r2 = createMockRequest(2, 1, 100, 200, true, 1000l, true);
+    r1 = createMockRequest(1, 1, 100, 200, false, 5000l, true, 12);
+    r2 = createMockRequest(2, 1, 100, 200, true, 1000l, true, 13);
     testPreemptionHelper(r1, r2, true);
     // No preemption with ducks reversed.
-    r1 = createMockRequest(1, 1, 100, 200, false, 500l, true);
-    r2 = createMockRequest(2, 1, 100, 200, true, 1000l, false);
+    r1 = createMockRequest(1, 1, 100, 200, false, 500l, true, 14);
+    r2 = createMockRequest(2, 1, 100, 200, true, 1000l, false, 15);
+    testPreemptionHelper(r1, r2, false);
+    // Same DAG/Vertex tasks should NOT preempt each-other!
+    r1 = createMockRequest(1, 1, 100, 200, false, 500l, false, 15);
+    r2 = createMockRequest(2, 1, 100, 200, true, 1000l, false, 15);
     testPreemptionHelper(r1, r2, false);
   }
 
   @Test//(timeout = 10000)
   public void testDuckPreemptsNonDuck() throws InterruptedException {
-    MockRequest r1 = createMockRequest(1, 1, 100, 200, true, 5000l, false);
-    MockRequest r2 = createMockRequest(2, 1, 100, 200, false, 1000l, true);
+    MockRequest r1 = createMockRequest(1, 1, 100, 200, true, 5000l, false, 1);
+    MockRequest r2 = createMockRequest(2, 1, 100, 200, false, 1000l, true, 2);
     testPreemptionHelper(r1, r2, true);
-    r1 = createMockRequest(1, 1, 100, 200, false, 5000l, false);
-    r2 = createMockRequest(2, 1, 100, 200, false, 1000l, true);
+    r1 = createMockRequest(1, 1, 100, 200, false, 5000l, false, 2);
+    r2 = createMockRequest(2, 1, 100, 200, false, 1000l, true, 3);
     testPreemptionHelper(r1, r2, true);
   }
 
@@ -518,16 +522,16 @@ public class TestTaskExecutorService {
 
   @Test(timeout = 10000)
   public void testDontKillMultiple() throws InterruptedException {
-    MockRequest victim1 = createMockRequest(1, 1, 100, 100, false, 20000l, false);
-    MockRequest victim2 = createMockRequest(2, 1, 100, 100, false, 20000l, false);
+    MockRequest victim1 = createMockRequest(1, 1, 100, 100, false, 20000l, false, 1);
+    MockRequest victim2 = createMockRequest(2, 1, 100, 100, false, 20000l, false, 2);
     runPreemptionGraceTest(victim1, victim2, 200);
     assertNotEquals(victim1.wasPreempted(), victim2.wasPreempted()); // One and only one.
   }
 
   @Test(timeout = 10000)
   public void testDoKillMultiple() throws InterruptedException {
-    MockRequest victim1 = createMockRequest(1, 1, 100, 100, false, 20000l, false);
-    MockRequest victim2 = createMockRequest(2, 1, 100, 100, false, 20000l, false);
+    MockRequest victim1 = createMockRequest(1, 1, 100, 100, false, 20000l, false, 1);
+    MockRequest victim2 = createMockRequest(2, 1, 100, 100, false, 20000l, false, 2);
     runPreemptionGraceTest(victim1, victim2, 1000);
     assertTrue(victim1.wasPreempted());
     assertTrue(victim2.wasPreempted());

--- a/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
+++ b/llap-server/src/test/org/apache/hadoop/hive/llap/daemon/impl/comparator/TestShortestJobFirstComparator.java
@@ -233,9 +233,9 @@ public class TestShortestJobFirstComparator {
 
   @Test(timeout = 60000)
   public void testWaitQueueComparatorParallelism() throws InterruptedException {
-    TaskWrapper r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 10, 3, 10, 100, 1, "q1", false), false, 100000); // 7 pending
-    TaskWrapper r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 10, 7, 10, 100, 1, "q2", false), false, 100000); // 3 pending
-    TaskWrapper r3 = createTaskWrapper(createSubmitWorkRequestProto(3, 10, 5, 10, 100, 1, "q3", false), false, 100000); // 5 pending
+    TaskWrapper r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 10, 3, 10, 100, 1, "q1", 35, false), false, 100000); // 7 pending
+    TaskWrapper r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 10, 7, 10, 100, 1, "q2", 35, false), false, 100000); // 3 pending
+    TaskWrapper r3 = createTaskWrapper(createSubmitWorkRequestProto(3, 10, 5, 10, 100, 1, "q3", 35, false), false, 100000); // 5 pending
 
     EvictingPriorityBlockingQueue<TaskWrapper> queue = new EvictingPriorityBlockingQueue<>(
         new ShortestJobFirstComparator(), 4);
@@ -324,7 +324,7 @@ public class TestShortestJobFirstComparator {
     // Single task DAG with same start and attempt time (wait-time zero)
     TaskWrapper r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 1, 1000, 1000, "q11", true), true, 1000);
     // Multi task DAG with 11 out of 12 task completed
-    TaskWrapper r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 11, 1000, 1500,1, "q12", true), true, 1000);
+    TaskWrapper r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 11, 1000, 1500, 1, "q12", 35, true), true, 1000);
     assertNull(queue.offer(r1, 0));
     assertEquals(r1, queue.peek());
     assertNull(queue.offer(r2, 0));
@@ -349,7 +349,7 @@ public class TestShortestJobFirstComparator {
     // Single task DAG with different start and attempt time
     r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 1, 1000, 1000, "q11", true), true, 1000);
     // Multi-task DAG with 5 out of 12
-    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 5, 1000, 1000, 1, "q12", true), true, 1000);
+    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 5, 1000, 1000, 1, "q12", 35, true), true, 1000);
 
     // pending/wait-time -> r2 has lower priority because it has more pending tasks
     assertNull(queue.offer(r1, 0));
@@ -365,7 +365,7 @@ public class TestShortestJobFirstComparator {
     // Single task DAG with different start and attempt time
     r1 = createTaskWrapper(createSubmitWorkRequestProto(1, 5, 800, 1000, "q11", true), true, 1000);
     // Multi-task DAG with 5 out of 12
-    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 7, 700, 900, 1, "q12", true), true, 1000);
+    r2 = createTaskWrapper(createSubmitWorkRequestProto(2, 12, 7, 700, 900, 1, "q12", 35, true), true, 1000);
 
     // r2 started earlier it should thus receive priority
     assertNull(queue.offer(r1, 0));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Victim Task (A) should be preempted in favor of a candidate Task (B) when:
    1. A is NOT on the same DAG and Vertex as B  AND
     1.1. B is a Guaranteed Task while A is not OR
      1.2. Both are guaranteed but A is not finishable and B is
To make sure that Victim task is not behind some upstream updates (asynchronous),  we check its sources' state (by QueryFragmentInfo.canFinish method)


### Why are the changes needed?
Non-useful Task preemptions can increase query latency


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Updated TestTaskExecutorService.testFinishablePreemptsNonFinishable()
