### PR TITLE
HIVE:25054 Upgrade `jodd-core` dependency to get rid of CVE-2018-21234

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
     <jline.version>2.14.6</jline.version>
     <jms.version>2.0.2</jms.version>
     <joda.version>2.9.9</joda.version>
-    <jodd.version>3.5.2</jodd.version>
+    <jodd.version>6.0.0</jodd.version>
     <json.version>1.8</json.version>
     <junit.version>4.13</junit.version>
     <junit.jupiter.version>5.6.2</junit.jupiter.version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -387,7 +387,7 @@
     </dependency>
     <dependency>
       <groupId>org.jodd</groupId>
-      <artifactId>jodd-core</artifactId>
+      <artifactId>jodd-util</artifactId>
       <version>${jodd.version}</version>
     </dependency>
     <dependency>
@@ -1088,7 +1088,7 @@
                   <include>org.datanucleus:javax.jdo</include>
                   <include>commons-lang:commons-lang</include>
                   <include>org.apache.commons:commons-lang3</include>
-                  <include>org.jodd:jodd-core</include>
+                  <include>org.jodd:jodd-util</include>
                   <include>com.tdunning:json</include>
                   <include>org.apache.avro:avro</include>
                   <include>org.apache.avro:avro-mapred</include>

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
@@ -21,9 +21,9 @@ import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.hadoop.hive.common.type.Timestamp;
+import jodd.time.JulianDate;
 
-import jodd.datetime.JDateTime;
+import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.common.type.TimestampTZUtil;
 
 /**
@@ -79,9 +79,10 @@ public class NanoTimeUtils {
     if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
       year = 1 - year;
     }
-    JDateTime jDateTime = new JDateTime(year,
+    JulianDate jDateTime;
+    jDateTime = JulianDate.of(year,
         calendar.get(Calendar.MONTH) + 1,  //java calendar index starting at 1.
-        calendar.get(Calendar.DAY_OF_MONTH));
+        calendar.get(Calendar.DAY_OF_MONTH), 0, 0, 0, 0);
     int days = jDateTime.getJulianDayNumber();
 
     long hour = calendar.get(Calendar.HOUR_OF_DAY);
@@ -131,11 +132,12 @@ public class NanoTimeUtils {
       julianDay--;
     }
 
-    JDateTime jDateTime = new JDateTime((double) julianDay);
+    JulianDate jDateTime;
+    jDateTime = JulianDate.of((double) julianDay);
     Calendar calendar = getGMTCalendar();
-    calendar.set(Calendar.YEAR, jDateTime.getYear());
-    calendar.set(Calendar.MONTH, jDateTime.getMonth() - 1); //java calendar index starting at 1.
-    calendar.set(Calendar.DAY_OF_MONTH, jDateTime.getDay());
+    calendar.set(Calendar.YEAR, jDateTime.toLocalDateTime().getYear());
+    calendar.set(Calendar.MONTH, jDateTime.toLocalDateTime().getMonth().getValue() - 1); //java calendar index starting at 1.
+    calendar.set(Calendar.DAY_OF_MONTH, jDateTime.toLocalDateTime().getDayOfMonth());
 
     int hour = (int) (remainder / (NANOS_PER_HOUR));
     remainder = remainder % (NANOS_PER_HOUR);

--- a/service/src/resources/hive-webapps/hiveserver2/hiveserver2.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/hiveserver2.jsp
@@ -32,7 +32,7 @@
   import="java.util.Collection"
   import="java.util.Date"
   import="java.util.List"
-  import="jodd.util.HtmlEncoder"
+  import="jodd.net.HtmlEncoder"
 %>
 
 <%
@@ -159,7 +159,7 @@ for (HiveSession hiveSession: hiveSessions) {
     %>
     <tr>
         <td><%= operation.getUserName() %></td>
-        <td><%= HtmlEncoder.strict(operation.getQueryDisplay() == null ? "Unknown" : operation.getQueryDisplay().getQueryString()) %></td>
+        <td><%= HtmlEncoder.text(operation.getQueryDisplay() == null ? "Unknown" : operation.getQueryDisplay().getQueryString()) %></td>
         <td><%= operation.getExecutionEngine() %>
         <td><%= operation.getState() %></td>
         <td><%= new Date(operation.getBeginTime()) %></td>
@@ -203,7 +203,7 @@ for (HiveSession hiveSession: hiveSessions) {
     %>
     <tr>
         <td><%= operation.getUserName() %></td>
-        <td><%= HtmlEncoder.strict(operation.getQueryDisplay() == null ? "Unknown" : operation.getQueryDisplay().getQueryString()) %></td>
+        <td><%= HtmlEncoder.text(operation.getQueryDisplay() == null ? "Unknown" : operation.getQueryDisplay().getQueryString()) %></td>
         <td><%= operation.getExecutionEngine() %>
         <td><%= operation.getState() %></td>
         <td><%= operation.getElapsedTime()/1000 %></td>

--- a/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
+++ b/service/src/resources/hive-webapps/hiveserver2/logconf.jsp
@@ -32,7 +32,7 @@
          import="java.util.Collection"
          import="java.util.Date"
          import="java.util.List"
-         import="jodd.util.HtmlEncoder"
+         import="jodd.net.HtmlEncoder"
 %>
 
 <%


### PR DESCRIPTION
All of the util classes that were used in Hive as part of `jodd-core` dependency have moved to jodd-util.
Upgrading to 6.0.0 version of the jodd-util package.


### What changes were proposed in this pull request?
Hive uses a version of `jodd-core` dependency directly that is susceptible to CVE-2018-21234. We need to upgrade this library to a more recent version but the higher versions don't exactly have the same classes and methods that Hive needs. There is a breaking change introduced in the library  https://github.com/oblac/jodd/blob/master/CHANGELOG_v4.md#breaking-changes-1. 
Currently, we use the JDateTime class(https://github.com/apache/hive/blob/7b3ecf617a6d46f48a3b6f77e0339fd4ad95a420/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java#L26) and HtmlEncoder class (https://github.com/apache/hive/blob/7b3ecf617a6d46f48a3b6f77e0339fd4ad95a420/service/src/resources/hive-webapps/hiveserver2/hiveserver2.jsp#L35) from this library.

The equivalent classes are JulianDate( https://github.com/oblac/jodd-util/blob/master/src/main/java/jodd/time/JulianDate.java) and HtmlEncoder(https://github.com/oblac/jodd-util/blob/03b045739cae2ddb4954c679739ef1c694d7f1e5/src/main/java/jodd/net/HtmlEncoder.java). The above two classes have been modified to use the below ones. 

Note: The HTML Encoder class hasn't changed much in functionality except that one of the methods strict() has been renamed to text(). It pretty much does the same thing. The JulianDate class has changed a bit and this piece of code needs to be reviewed carefully.


### Why are the changes needed?
We need this change to get rid of CVE https://nvd.nist.gov/vuln/detail/CVE-2018-21234
Below is a brief description of it
CVE-2018-21234  suppress

Jodd before 5.0.4 performs Deserialization of Untrusted JSON Data when setClassMetadataName is set.
CWE-502 Deserialization of Untrusted Data

CVSSv2:
Base Score: HIGH (7.5)
Vector: /AV:N/AC:L/Au:N/C:P/I:P/A:P
CVSSv3:
Base Score: CRITICAL (9.8)
Vector: CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H

References:
MISC - https://github.com/oblac/jodd/commit/9bffc3913aeb8472c11bb543243004b4b4376f16
MISC - https://github.com/oblac/jodd/compare/v5.0.3...v5.0.4
MISC - https://github.com/oblac/jodd/issues/628
Vulnerable Software & Versions:
cpe:2.3:a:jodd:jodd:*:*:*:*:*:*:*:* versions up to (excluding) 5.0.4

Although, we don't make use of the vulnerable method in Hive, it's a good practice to keep the libraries up-to-date.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Ran Pre-commit tests. Any suggestions to locally test this patch would be helpful.
Specifically the `TestParquetTimestampUtils` . This test class has the method `testJulianDay()` which specifically tests the JulianDay number is correct or not.
