### PR TITLE
HIVE-25058: PTF: TimestampValueBoundaryScanner can be optimised during range computation pt2 - isDistanceGreater

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/ValueBoundaryScanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/ptf/ValueBoundaryScanner.java
@@ -1010,11 +1010,17 @@ class TimestampValueBoundaryScanner extends SingleValueBoundaryScanner {
   @Override
   public boolean isDistanceGreater(Object v1, Object v2, int amt) {
     if (v1 != null && v2 != null) {
-      long l1 = PrimitiveObjectInspectorUtils.getTimestamp(v1,
-          (PrimitiveObjectInspector) expressionDef.getOI()).toEpochMilli();
-      long l2 = PrimitiveObjectInspectorUtils.getTimestamp(v2,
-          (PrimitiveObjectInspector) expressionDef.getOI()).toEpochMilli();
-      return (double)(l1-l2)/1000 > amt; // TODO: lossy conversion, distance is considered in seconds
+      if (v1 instanceof TimestampWritableV2 && v2 instanceof TimestampWritableV2) {
+        TimestampWritableV2 w1 = (TimestampWritableV2) v1;
+        TimestampWritableV2 w2 = (TimestampWritableV2) v2;
+        return w1.getSeconds() - w2.getSeconds() > amt;
+      } else {
+        long l1 = PrimitiveObjectInspectorUtils.getTimestamp(v1,
+            (PrimitiveObjectInspector) expressionDef.getOI()).toEpochMilli();
+        long l2 = PrimitiveObjectInspectorUtils.getTimestamp(v2,
+            (PrimitiveObjectInspector) expressionDef.getOI()).toEpochMilli();
+        return (double)(l1-l2)/1000 > amt; // TODO: lossy conversion, distance is considered in seconds
+      }
     }
     return v1 != null || v2 != null; // True if only one value is null
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/ptf/TestValueBoundaryScanner.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/ptf/TestValueBoundaryScanner.java
@@ -184,4 +184,33 @@ public class TestValueBoundaryScanner {
 
     Assert.assertTrue(scanner.isEqual(null, null));
   }
+
+  @Test
+  public void testTimestampIsDistanceGreater() {
+    PTFExpressionDef argDef = new PTFExpressionDef();
+    argDef.setOI(PrimitiveObjectInspectorFactory.writableTimestampObjectInspector);
+
+    TimestampValueBoundaryScanner scanner =
+        new TimestampValueBoundaryScanner(null, null, new OrderExpressionDef(argDef), false);
+    Timestamp ts = new Timestamp();
+    ts.setTimeInMillis(1000000); // 1000s
+
+    TimestampWritableV2 w1 = new TimestampWritableV2(ts); // 1000s
+    TimestampWritableV2 w2 = new TimestampWritableV2(ts); // 1000s
+    TimestampWritableV2 w3 = new TimestampWritableV2(); // empty == epoch == 0s
+
+    // equal timestamps, distance is not greater than 0
+    Assert.assertFalse(scanner.isDistanceGreater(w1, w2, 0));
+    Assert.assertFalse(scanner.isDistanceGreater(w2, w1, 0));
+
+    // null comparison, true only if one value is null
+    Assert.assertTrue(scanner.isDistanceGreater(w1, null, 100));
+    Assert.assertTrue(scanner.isDistanceGreater(w2, null, 100));
+    Assert.assertFalse(scanner.isDistanceGreater(null, null, 100));
+
+    // 1000s distance
+    Assert.assertTrue(scanner.isDistanceGreater(w1, w3, 999)); // 1000 > 999
+    Assert.assertFalse(scanner.isDistanceGreater(w1, w3, 1000));
+    Assert.assertFalse(scanner.isDistanceGreater(w1, w3, 1001));
+  }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Introduced faster TimestampWritableV2 handling into isDistanceGreater method.

### Why are the changes needed?
Performance improvement.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Unit test included, behavior is the same before/after the patch. Tested on cluster.
