### PR TITLE
HIVE-25063: Enforce hive.default.nulls.last when enforce bucketing

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/CommonMergeJoinOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/CommonMergeJoinOperator.java
@@ -167,7 +167,7 @@ public class CommonMergeJoinOperator extends AbstractMapJoinOperator<CommonMerge
     sources = ((TezContext) MapredContext.get()).getRecordSources();
     interruptChecker = new InterruptibleProcessing();
 
-    nullOrdering = NullOrdering.NULLS_FIRST;
+    nullOrdering = NullOrdering.defaultNullOrder(hconf);
     if (sources[0] instanceof ReduceRecordSource) {
       ReduceRecordSource reduceRecordSource = (ReduceRecordSource) sources[0];
       if (reduceRecordSource.getKeyTableDesc() != null &&
@@ -178,7 +178,6 @@ public class CommonMergeJoinOperator extends AbstractMapJoinOperator<CommonMerge
           nullOrdering = NullOrdering.fromSign(nullSortOrder.charAt(0));
         }
       }
-      nullOrdering = NullOrdering.defaultNullOrder(hconf);
       if (parentOperators != null && !parentOperators.isEmpty()) {
         // Tell ReduceRecordSource to flush last record as this is a reduce
         // side SMB

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -6933,7 +6933,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       StringBuilder nullOrder = new StringBuilder();
       for (int sortOrder : sortOrders) {
         order.append(DirectionUtils.codeToSign(sortOrder));
-        nullOrder.append(sortOrder == DirectionUtils.ASCENDING_CODE ? 'a' : 'z');
+        nullOrder.append(NullOrdering.map(sortOrder, conf).getSign());
       }
       input = genReduceSinkPlan(input, partnCols, sortCols, order.toString(), nullOrder.toString(),
           maxReducers, acidOp, isCompaction);

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/NullOrdering.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/NullOrdering.java
@@ -22,6 +22,8 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.parse.HiveParser;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspectorUtils.NullValueOption;
 
+import static org.apache.hadoop.hive.ql.util.DirectionUtils.ASCENDING_CODE;
+
 /**
  * Enum for converting different Null ordering description types.
  */
@@ -71,6 +73,13 @@ public enum NullOrdering {
   public static NullOrdering defaultNullOrder(Configuration hiveConf) {
     return HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_DEFAULT_NULLS_LAST) ?
             NullOrdering.NULLS_LAST : NullOrdering.NULLS_FIRST;
+  }
+
+  public static NullOrdering map(int orderCode, Configuration hiveConf) {
+    if (HiveConf.getBoolVar(hiveConf, HiveConf.ConfVars.HIVE_DEFAULT_NULLS_LAST)) {
+      return orderCode == ASCENDING_CODE ? NullOrdering.NULLS_LAST : NullOrdering.NULLS_FIRST;
+    }
+    return orderCode == ASCENDING_CODE ? NullOrdering.NULLS_FIRST : NullOrdering.NULLS_LAST;
   }
 
   public int getCode() {

--- a/ql/src/test/results/clientpositive/beeline/smb_mapjoin_11.q.out
+++ b/ql/src/test/results/clientpositive/beeline/smb_mapjoin_11.q.out
@@ -92,7 +92,7 @@ STAGE PLANS:
                   Reduce Output Operator
                     bucketingVersion: 2
                     key expressions: _col0 (type: int)
-                    null sort order: a
+                    null sort order: z
                     numBuckets: -1
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/beeline/smb_mapjoin_12.q.out
+++ b/ql/src/test/results/clientpositive/beeline/smb_mapjoin_12.q.out
@@ -310,7 +310,7 @@ STAGE PLANS:
                   Reduce Output Operator
                     bucketingVersion: 2
                     key expressions: _col0 (type: int)
-                    null sort order: a
+                    null sort order: z
                     numBuckets: -1
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/autoColumnStats_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/autoColumnStats_4.q.out
@@ -104,7 +104,7 @@ STAGE PLANS:
                   Statistics: Num rows: 10 Data size: 1296 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int)
-                    null sort order: a
+                    null sort order: z
                     sort order: +
                     Map-reduce partition columns: _col0 (type: int)
                     Statistics: Num rows: 10 Data size: 1296 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucket1.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket1.q.out
@@ -48,7 +48,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket2.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket2.q.out
@@ -47,7 +47,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket3.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket3.q.out
@@ -48,7 +48,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket4.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket4.q.out
@@ -47,7 +47,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket5.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket5.q.out
@@ -67,7 +67,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket6.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket6.q.out
@@ -50,7 +50,7 @@ STAGE PLANS:
                     Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 2000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucket_many.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_many.q.out
@@ -48,7 +48,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket_num_reducers.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_num_reducers.q.out
@@ -45,7 +45,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucket_num_reducers2.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucket_num_reducers2.q.out
@@ -45,7 +45,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_1.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_1.q.out
@@ -404,7 +404,7 @@ STAGE PLANS:
                     Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_2.q.out
@@ -153,7 +153,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
@@ -379,7 +379,7 @@ STAGE PLANS:
                           Statistics: Num rows: 29 Data size: 5452 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 29 Data size: 5452 Basic stats: COMPLETE Column stats: COMPLETE
@@ -629,7 +629,7 @@ STAGE PLANS:
                           Statistics: Num rows: 29 Data size: 5452 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 29 Data size: 5452 Basic stats: COMPLETE Column stats: COMPLETE
@@ -883,7 +883,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1119,7 +1119,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1355,7 +1355,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_3.q.out
@@ -201,7 +201,7 @@ STAGE PLANS:
                     Statistics: Num rows: 500 Data size: 94000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
                       Statistics: Num rows: 500 Data size: 94000 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_4.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_4.q.out
@@ -142,7 +142,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col1 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
@@ -395,7 +395,7 @@ STAGE PLANS:
                         Statistics: Num rows: 14 Data size: 1302 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: string)
                           Statistics: Num rows: 14 Data size: 1302 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_5.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_5.q.out
@@ -142,7 +142,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: z
+                            null sort order: a
                             sort order: -
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
@@ -386,7 +386,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: z
+                            null sort order: a
                             sort order: -
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2632 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_6.q.out
@@ -143,7 +143,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -387,7 +387,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -631,7 +631,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -810,7 +810,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -995,7 +995,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1257,7 +1257,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: az
+                            null sort order: za
                             sort order: +-
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1529,7 +1529,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int), _col1 (type: int)
-                            null sort order: zz
+                            null sort order: aa
                             sort order: --
                             Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_7.q.out
@@ -131,7 +131,7 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
@@ -359,7 +359,7 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
@@ -593,7 +593,7 @@ STAGE PLANS:
                           Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 3 Data size: 564 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/bucketsortoptimize_insert_8.q.out
@@ -142,7 +142,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
@@ -381,7 +381,7 @@ STAGE PLANS:
                           Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col0 (type: int)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col0 (type: int)
                             Statistics: Num rows: 14 Data size: 2688 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -122,7 +122,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: int)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: int)
                               Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1381,7 +1381,7 @@ STAGE PLANS:
                         Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1496,7 +1496,7 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 1640 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 5 Data size: 1640 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1660,7 +1660,7 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 1528 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 5 Data size: 1528 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1837,7 +1837,7 @@ STAGE PLANS:
                       Statistics: Num rows: 5 Data size: 1640 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 5 Data size: 1640 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1962,7 +1962,7 @@ STAGE PLANS:
                       Statistics: Num rows: 83 Data size: 27224 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 83 Data size: 27224 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2429,7 +2429,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2661,7 +2661,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2942,7 +2942,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -3214,7 +3214,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: bigint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: bigint)
                           Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3374,7 +3374,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: bigint)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: bigint)
                               Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3459,7 +3459,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: bigint)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: bigint)
                               Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/cp_sel.q.out
+++ b/ql/src/test/results/clientpositive/llap/cp_sel.q.out
@@ -138,7 +138,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 1000 Data size: 356000 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/default_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/default_constraint.q.out
@@ -107,7 +107,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: tinyint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -208,7 +208,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: tinyint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: tinyint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -623,7 +623,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -723,7 +723,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: string)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -883,7 +883,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: boolean)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: boolean)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -980,7 +980,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: boolean)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: boolean)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -1460,7 +1460,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: smallint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: smallint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -1628,7 +1628,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: smallint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: smallint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -1896,7 +1896,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: smallint)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: smallint)
                               Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -2236,7 +2236,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col1 (type: smallint)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col1 (type: smallint)
                               Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -2648,7 +2648,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: smallint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: smallint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
@@ -2816,7 +2816,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col1 (type: smallint)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col1 (type: smallint)
                           Statistics: Num rows: 1 Data size: ###Masked### Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/disable_merge_for_bucketing.q.out
+++ b/ql/src/test/results/clientpositive/llap/disable_merge_for_bucketing.q.out
@@ -47,7 +47,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynamic_semijoin_reduction_3.q.out
@@ -155,7 +155,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -485,7 +485,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
@@ -736,7 +736,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_opt_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_opt_vectorization.q.out
@@ -2728,7 +2728,7 @@ STAGE PLANS:
                       Statistics: Num rows: 11 Data size: 264 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col3 (type: float)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: smallint)
                         Statistics: Num rows: 11 Data size: 264 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization.q.out
+++ b/ql/src/test/results/clientpositive/llap/dynpart_sort_optimization.q.out
@@ -2657,7 +2657,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col3 (type: float)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: smallint)
                         Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -2593,7 +2593,7 @@ STAGE PLANS:
                             Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: COMPLETE
                             Reduce Output Operator
                               key expressions: _col0 (type: int)
-                              null sort order: a
+                              null sort order: z
                               sort order: +
                               Map-reduce partition columns: _col0 (type: int)
                               Statistics: Num rows: 1 Data size: 212 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2741,7 +2741,7 @@ STAGE PLANS:
                         Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2895,7 +2895,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3041,7 +3041,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3212,7 +3212,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3333,7 +3333,7 @@ STAGE PLANS:
                         Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 250 Data size: 82000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3658,7 +3658,7 @@ STAGE PLANS:
                       Statistics: Num rows: 83 Data size: 27224 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 83 Data size: 27224 Basic stats: COMPLETE Column stats: COMPLETE
@@ -4504,7 +4504,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -4787,7 +4787,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5122,7 +5122,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5393,7 +5393,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
@@ -54,7 +54,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
@@ -201,7 +201,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -348,7 +348,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -496,7 +496,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 88 Basic stats: COMPLETE Column stats: COMPLETE
@@ -643,7 +643,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -808,7 +808,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -965,7 +965,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1112,7 +1112,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1259,7 +1259,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1407,7 +1407,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1554,7 +1554,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1701,7 +1701,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 184 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1848,7 +1848,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 84 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2762,7 +2762,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col2 (type: string)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col2 (type: string)
                           Statistics: Num rows: 1 Data size: 174 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3009,7 +3009,7 @@ STAGE PLANS:
                           Statistics: Num rows: 1 Data size: 175 Basic stats: COMPLETE Column stats: COMPLETE
                           Reduce Output Operator
                             key expressions: _col2 (type: string)
-                            null sort order: a
+                            null sort order: z
                             sort order: +
                             Map-reduce partition columns: _col2 (type: string)
                             Statistics: Num rows: 1 Data size: 175 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3365,7 +3365,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/insert_only_empty_query.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_only_empty_query.q.out
@@ -72,7 +72,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col1 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col1 (type: int)
                         Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/insert_values_orig_table_use_metadata.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_values_orig_table_use_metadata.q.out
@@ -171,7 +171,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	12288               
 	rawDataSize         	0                   
-	totalSize           	309566              
+	totalSize           	310048              
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####
@@ -528,7 +528,7 @@ Table Parameters:
 	numFiles            	3                   
 	numRows             	12292               
 	rawDataSize         	0                   
-	totalSize           	312904              
+	totalSize           	313385              
 	transactional       	true                
 	transactional_properties	default             
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/insertoverwrite_bucket.q.out
+++ b/ql/src/test/results/clientpositive/llap/insertoverwrite_bucket.q.out
@@ -132,7 +132,7 @@ STAGE PLANS:
                     Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: string)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col1 (type: string)
                       Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
@@ -269,7 +269,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col2 (type: string)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 1 Data size: 368 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/load_data_using_job.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_data_using_job.q.out
@@ -1041,7 +1041,7 @@ STAGE PLANS:
                     Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/load_dyn_part2.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_dyn_part2.q.out
@@ -71,7 +71,7 @@ STAGE PLANS:
                     Statistics: Num rows: 2000 Data size: 724000 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: string)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)
                       Statistics: Num rows: 2000 Data size: 724000 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/load_static_ptn_into_bucketed_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/load_static_ptn_into_bucketed_table.q.out
@@ -39,7 +39,7 @@ STAGE PLANS:
                     Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE
@@ -726,7 +726,7 @@ STAGE PLANS:
                     Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 46 Data size: 8460 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/murmur_hash_migration.q.out
+++ b/ql/src/test/results/clientpositive/llap/murmur_hash_migration.q.out
@@ -187,7 +187,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
@@ -382,7 +382,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/reduce_deduplicate.q.out
+++ b/ql/src/test/results/clientpositive/llap/reduce_deduplicate.q.out
@@ -45,7 +45,7 @@ STAGE PLANS:
                     Reduce Output Operator
                       bucketingVersion: 2
                       key expressions: _col0 (type: string)
-                      null sort order: a
+                      null sort order: z
                       numBuckets: -1
                       sort order: +
                       Map-reduce partition columns: _col0 (type: string)

--- a/ql/src/test/results/clientpositive/llap/semijoin_hint.q.out
+++ b/ql/src/test/results/clientpositive/llap/semijoin_hint.q.out
@@ -3485,7 +3485,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
@@ -3840,7 +3840,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/smb_mapjoin_18.q.out
+++ b/ql/src/test/results/clientpositive/llap/smb_mapjoin_18.q.out
@@ -263,7 +263,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 190 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge.q.out
@@ -138,7 +138,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: NONE
@@ -438,7 +438,7 @@ STAGE PLANS:
                     Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: NONE

--- a/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/sqlmerge_stats.q.out
@@ -208,7 +208,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -758,7 +758,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1066,7 +1066,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1374,7 +1374,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1682,7 +1682,7 @@ STAGE PLANS:
                       Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 2 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2055,7 +2055,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -2394,7 +2394,7 @@ STAGE PLANS:
                       Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: int)
-                        null sort order: a
+                        null sort order: z
                         sort order: +
                         Map-reduce partition columns: _col0 (type: int)
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/stats10.q.out
+++ b/ql/src/test/results/clientpositive/llap/stats10.q.out
@@ -44,7 +44,7 @@ STAGE PLANS:
                     Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col0 (type: int)
-                      null sort order: a
+                      null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col0 (type: int)
                       Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/vector_bucket.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_bucket.q.out
@@ -53,7 +53,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/llap/vectorized_insert_into_bucketed_table.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_insert_into_bucketed_table.q.out
@@ -51,7 +51,7 @@ STAGE PLANS:
                         Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
                         Reduce Output Operator
                           key expressions: _col0 (type: int)
-                          null sort order: a
+                          null sort order: z
                           sort order: +
                           Map-reduce partition columns: _col0 (type: int)
                           Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
@@ -67,7 +67,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                reduceColumnNullOrder: a
+                reduceColumnNullOrder: z
                 reduceColumnSortOrder: +
                 allNative: false
                 usesVectorUDFAdaptor: false

--- a/ql/src/test/results/clientpositive/smb_mapjoin_20.q.out
+++ b/ql/src/test/results/clientpositive/smb_mapjoin_20.q.out
@@ -64,7 +64,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 183000 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: string)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col0 (type: string)
                 Statistics: Num rows: 500 Data size: 183000 Basic stats: COMPLETE Column stats: COMPLETE
@@ -242,7 +242,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col1 (type: int)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col1 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -1467,7 +1467,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 183000 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: string)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col0 (type: string)
                 Statistics: Num rows: 500 Data size: 183000 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/smb_mapjoin_21.q.out
+++ b/ql/src/test/results/clientpositive/smb_mapjoin_21.q.out
@@ -143,7 +143,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: int)
-                null sort order: z
+                null sort order: a
                 sort order: -
                 Map-reduce partition columns: _col0 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -283,7 +283,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: int), _col1 (type: string)
-                null sort order: aa
+                null sort order: zz
                 sort order: ++
                 Map-reduce partition columns: _col0 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -422,7 +422,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col1 (type: string)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col0 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -562,7 +562,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: int)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col0 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
@@ -702,7 +702,7 @@ STAGE PLANS:
               Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE
               Reduce Output Operator
                 key expressions: _col0 (type: int)
-                null sort order: a
+                null sort order: z
                 sort order: +
                 Map-reduce partition columns: _col0 (type: int)
                 Statistics: Num rows: 500 Data size: 47500 Basic stats: COMPLETE Column stats: COMPLETE

--- a/ql/src/test/results/clientpositive/smb_mapjoin_46.q.out
+++ b/ql/src/test/results/clientpositive/smb_mapjoin_46.q.out
@@ -149,12 +149,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
 100	1	Bob	NULL	NULL	NULL
 PREHOOK: query: EXPLAIN
@@ -239,10 +239,10 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
 101	2	Car	102	2	Del
 99	2	Mat	NULL	NULL	NULL
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
 100	1	Bob	NULL	NULL	NULL
 Warning: Map Join MAPJOIN[11][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
@@ -356,10 +356,10 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
 101	2	Car	102	2	Del
 99	2	Mat	NULL	NULL	NULL
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
 100	1	Bob	102	2	Del
 PREHOOK: query: EXPLAIN
@@ -429,12 +429,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-NULL	NULL	NULL	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
 NULL	NULL	NULL	104	3	Fli
+NULL	NULL	NULL	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -538,18 +538,18 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
-101	2	Car	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	104	3	Fli
+101	2	Car	105	NULL	None
 99	2	Mat	NULL	NULL	NULL
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
-100	1	Bob	105	NULL	None
 100	1	Bob	103	2	Ema
 100	1	Bob	102	2	Del
 100	1	Bob	104	3	Fli
+100	1	Bob	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -655,19 +655,19 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	102	2	Del
-NULL	NULL	None	102	2	Del
-101	2	Car	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	104	3	Fli
+101	2	Car	105	NULL	None
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
+98	NULL	None	102	2	Del
+NULL	NULL	None	102	2	Del
 99	0	Alice	102	2	Del
-100	1	Bob	105	NULL	None
 100	1	Bob	103	2	Ema
 100	1	Bob	102	2	Del
 100	1	Bob	104	3	Fli
+100	1	Bob	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -769,19 +769,19 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
-101	2	Car	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	104	3	Fli
+101	2	Car	105	NULL	None
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
-100	1	Bob	105	NULL	None
 100	1	Bob	103	2	Ema
 100	1	Bob	102	2	Del
 100	1	Bob	104	3	Fli
+100	1	Bob	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -879,12 +879,12 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	102	2	Del
-NULL	NULL	None	102	2	Del
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
+98	NULL	None	102	2	Del
+NULL	NULL	None	102	2	Del
 99	0	Alice	102	2	Del
 100	1	Bob	102	2	Del
 PREHOOK: query: EXPLAIN
@@ -967,11 +967,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-98	NULL	None	NULL	NULL	NULL
-NULL	NULL	None	NULL	NULL	NULL
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 99	2	Mat	102	2	Del
+98	NULL	None	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
 99	0	Alice	NULL	NULL	NULL
 100	1	Bob	NULL	NULL	NULL
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
@@ -1079,19 +1079,19 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-101	2	Car	105	NULL	None
-100	1	Bob	105	NULL	None
 101	2	Car	103	2	Ema
 99	2	Mat	103	2	Ema
 100	1	Bob	103	2	Ema
-98	NULL	None	102	2	Del
-NULL	NULL	None	102	2	Del
 101	2	Car	102	2	Del
 99	2	Mat	102	2	Del
+98	NULL	None	102	2	Del
+NULL	NULL	None	102	2	Del
 99	0	Alice	102	2	Del
 100	1	Bob	102	2	Del
 101	2	Car	104	3	Fli
 100	1	Bob	104	3	Fli
+101	2	Car	105	NULL	None
+100	1	Bob	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1189,8 +1189,6 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-101	2	Car	105	NULL	None
-100	1	Bob	105	NULL	None
 101	2	Car	103	2	Ema
 99	2	Mat	103	2	Ema
 100	1	Bob	103	2	Ema
@@ -1199,6 +1197,8 @@ POSTHOOK: Input: default@test2_n3
 100	1	Bob	102	2	Del
 101	2	Car	104	3	Fli
 100	1	Bob	104	3	Fli
+101	2	Car	105	NULL	None
+100	1	Bob	105	NULL	None
 Warning: Map Join MAPJOIN[9][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1300,16 +1300,16 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-NULL	NULL	NULL	105	NULL	None
 101	2	Car	103	2	Ema
 99	2	Mat	103	2	Ema
-98	NULL	None	102	2	Del
-NULL	NULL	None	102	2	Del
 101	2	Car	102	2	Del
 99	2	Mat	102	2	Del
+98	NULL	None	102	2	Del
+NULL	NULL	None	102	2	Del
 99	0	Alice	102	2	Del
 100	1	Bob	102	2	Del
 NULL	NULL	NULL	104	3	Fli
+NULL	NULL	NULL	105	NULL	None
 PREHOOK: query: EXPLAIN
 SELECT *
 FROM test1_n5 RIGHT OUTER JOIN test2_n3
@@ -1390,11 +1390,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
-NULL	NULL	NULL	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 99	2	Mat	102	2	Del
 NULL	NULL	NULL	104	3	Fli
+NULL	NULL	NULL	105	NULL	None
 Warning: Shuffle Join JOIN[6][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1491,19 +1491,19 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
+100	1	Bob	105	NULL	None
 100	1	Bob	104	3	Fli
 100	1	Bob	102	2	Del
 100	1	Bob	103	2	Ema
-100	1	Bob	105	NULL	None
 99	0	Alice	102	2	Del
+NULL	NULL	None	102	2	Del
+98	NULL	None	102	2	Del
 99	2	Mat	102	2	Del
 99	2	Mat	103	2	Ema
+101	2	Car	105	NULL	None
 101	2	Car	104	3	Fli
 101	2	Car	102	2	Del
 101	2	Car	103	2	Ema
-101	2	Car	105	NULL	None
-NULL	NULL	None	102	2	Del
-98	NULL	None	102	2	Del
 Warning: Shuffle Join JOIN[6][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1596,19 +1596,19 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n5
 POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
+100	1	Bob	105	NULL	None
 100	1	Bob	104	3	Fli
 100	1	Bob	102	2	Del
 100	1	Bob	103	2	Ema
-100	1	Bob	105	NULL	None
 99	0	Alice	NULL	NULL	NULL
+NULL	NULL	None	NULL	NULL	NULL
+98	NULL	None	NULL	NULL	NULL
 99	2	Mat	102	2	Del
 99	2	Mat	103	2	Ema
+101	2	Car	105	NULL	None
 101	2	Car	104	3	Fli
 101	2	Car	102	2	Del
 101	2	Car	103	2	Ema
-101	2	Car	105	NULL	None
-NULL	NULL	None	NULL	NULL	NULL
-98	NULL	None	NULL	NULL	NULL
 Warning: Shuffle Join JOIN[6][tables = [$hdt$_0, $hdt$_1]] in Stage 'Stage-1:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1703,14 +1703,14 @@ POSTHOOK: Input: default@test2_n3
 #### A masked pattern was here ####
 100	1	Bob	102	2	Del
 99	0	Alice	102	2	Del
+NULL	NULL	None	102	2	Del
+98	NULL	None	102	2	Del
 99	2	Mat	102	2	Del
 99	2	Mat	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	103	2	Ema
-NULL	NULL	None	102	2	Del
-98	NULL	None	102	2	Del
-NULL	NULL	NULL	104	3	Fli
 NULL	NULL	NULL	105	NULL	None
+NULL	NULL	NULL	104	3	Fli
 PREHOOK: query: EXPLAIN
 SELECT *
 FROM test1_n5 FULL OUTER JOIN test2_n3

--- a/ql/src/test/results/clientpositive/smb_mapjoin_47.q.out
+++ b/ql/src/test/results/clientpositive/smb_mapjoin_47.q.out
@@ -481,16 +481,16 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n8
 POSTHOOK: Input: default@test2_n5
 #### A masked pattern was here ####
-98	NULL	None	102	2	Del
-NULL	NULL	None	102	2	Del
-101	2	Car	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	104	3	Fli
+101	2	Car	105	NULL	None
 99	2	Mat	103	2	Ema
 99	2	Mat	102	2	Del
+98	NULL	None	102	2	Del
+NULL	NULL	None	102	2	Del
 99	0	Alice	102	2	Del
-100	1	Bob	105	NULL	None
+100	1	Bob	103	2	Ema
 Warning: Map Join MAPJOIN[10][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -699,16 +699,16 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n8
 POSTHOOK: Input: default@test2_n5
 #### A masked pattern was here ####
-98	NULL	None	105	NULL	None
-98	NULL	None	103	2	Ema
-98	NULL	None	102	2	Del
-98	NULL	None	104	3	Fli
-101	2	Car	105	NULL	None
 101	2	Car	103	2	Ema
 101	2	Car	102	2	Del
 101	2	Car	104	3	Fli
-99	2	Mat	105	NULL	None
+101	2	Car	105	NULL	None
 99	2	Mat	103	2	Ema
+99	2	Mat	102	2	Del
+99	2	Mat	104	3	Fli
+99	2	Mat	105	NULL	None
+98	NULL	None	103	2	Ema
+98	NULL	None	102	2	Del
 Warning: Map Join MAPJOIN[10][bigTable=?] in task 'Stage-3:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -920,6 +920,8 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n8
 POSTHOOK: Input: default@test2_n5
 #### A masked pattern was here ####
+105	NULL	None	100	1	Bob	NULL	NULL	NULL
+105	NULL	None	99	0	Alice	NULL	NULL	NULL
 104	3	Fli	100	1	Bob	NULL	NULL	NULL
 104	3	Fli	99	0	Alice	NULL	NULL	NULL
 102	2	Del	100	1	Bob	99	2	Mat
@@ -928,8 +930,6 @@ POSTHOOK: Input: default@test2_n5
 102	2	Del	99	0	Alice	101	2	Car
 103	2	Ema	100	1	Bob	99	2	Mat
 103	2	Ema	99	0	Alice	99	2	Mat
-103	2	Ema	100	1	Bob	101	2	Car
-103	2	Ema	99	0	Alice	101	2	Car
 Warning: Shuffle Join JOIN[12][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Stage-1:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1239,16 +1239,16 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test1_n8
 POSTHOOK: Input: default@test2_n5
 #### A masked pattern was here ####
-NULL	NULL	NULL	NULL	NULL	NULL	98	NULL	None
-NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	None
-103	2	Ema	98	NULL	None	101	2	Car
-102	2	Del	98	NULL	None	101	2	Car
 103	2	Ema	101	2	Car	101	2	Car
 102	2	Del	101	2	Car	101	2	Car
 103	2	Ema	99	2	Mat	101	2	Car
 102	2	Del	99	2	Mat	101	2	Car
+103	2	Ema	98	NULL	None	101	2	Car
+102	2	Del	98	NULL	None	101	2	Car
 103	2	Ema	99	0	Alice	101	2	Car
 102	2	Del	99	0	Alice	101	2	Car
+103	2	Ema	100	1	Bob	101	2	Car
+102	2	Del	100	1	Bob	101	2	Car
 Warning: Shuffle Join JOIN[12][tables = [$hdt$_0, $hdt$_1, $hdt$_2]] in Stage 'Stage-1:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *
@@ -1492,14 +1492,14 @@ POSTHOOK: Input: default@test2_n5
 #### A masked pattern was here ####
 NULL	NULL	NULL	NULL	NULL	NULL	99	0	Alice
 NULL	NULL	NULL	NULL	NULL	NULL	100	1	Bob
-102	2	Del	100	1	Bob	99	2	Mat
 102	2	Del	100	1	Bob	101	2	Car
-103	2	Ema	100	1	Bob	99	2	Mat
+102	2	Del	100	1	Bob	99	2	Mat
 103	2	Ema	100	1	Bob	101	2	Car
-102	2	Del	99	0	Alice	99	2	Mat
+103	2	Ema	100	1	Bob	99	2	Mat
 102	2	Del	99	0	Alice	101	2	Car
-103	2	Ema	99	0	Alice	99	2	Mat
+102	2	Del	99	0	Alice	99	2	Mat
 103	2	Ema	99	0	Alice	101	2	Car
+103	2	Ema	99	0	Alice	99	2	Mat
 Warning: Map Join MAPJOIN[17][bigTable=?] in task 'Stage-5:MAPRED' is a cross product
 PREHOOK: query: EXPLAIN
 SELECT *

--- a/ql/src/test/results/clientpositive/tez/acid_vectorization_original_tez.q.out
+++ b/ql/src/test/results/clientpositive/tez/acid_vectorization_original_tez.q.out
@@ -372,8 +372,8 @@ POSTHOOK: Lineage: over10k_orc_bucketed_n0.si SIMPLE [(over10k_n9)over10k_n9.Fie
 POSTHOOK: Lineage: over10k_orc_bucketed_n0.t SIMPLE [(over10k_n9)over10k_n9.FieldSchema(name:t, type:tinyint, comment:null), ]
 POSTHOOK: Lineage: over10k_orc_bucketed_n0.ts SIMPLE [(over10k_n9)over10k_n9.FieldSchema(name:ts, type:timestamp, comment:null), ]
 Found 4 items
--rw-rw-rw-   3 ### USER ### ### GROUP ###       8746 ### HDFS DATE ### hdfs://### HDFS PATH ###
--rw-rw-rw-   3 ### USER ### ### GROUP ###       7525 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       8777 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       7522 ### HDFS DATE ### hdfs://### HDFS PATH ###
 -rw-rw-rw-   3 ### USER ### ### GROUP ###       7167 ### HDFS DATE ### hdfs://### HDFS PATH ###
 -rw-rw-rw-   3 ### USER ### ### GROUP ###       7058 ### HDFS DATE ### hdfs://### HDFS PATH ###
 PREHOOK: query: insert into over10k_orc_bucketed_n0 select * from over10k_n9
@@ -396,10 +396,10 @@ POSTHOOK: Lineage: over10k_orc_bucketed_n0.si SIMPLE [(over10k_n9)over10k_n9.Fie
 POSTHOOK: Lineage: over10k_orc_bucketed_n0.t SIMPLE [(over10k_n9)over10k_n9.FieldSchema(name:t, type:tinyint, comment:null), ]
 POSTHOOK: Lineage: over10k_orc_bucketed_n0.ts SIMPLE [(over10k_n9)over10k_n9.FieldSchema(name:ts, type:timestamp, comment:null), ]
 Found 8 items
--rw-rw-rw-   3 ### USER ### ### GROUP ###       8746 ### HDFS DATE ### hdfs://### HDFS PATH ###
--rw-rw-rw-   3 ### USER ### ### GROUP ###       8746 ### HDFS DATE ### hdfs://### HDFS PATH ###
--rw-rw-rw-   3 ### USER ### ### GROUP ###       7525 ### HDFS DATE ### hdfs://### HDFS PATH ###
--rw-rw-rw-   3 ### USER ### ### GROUP ###       7525 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       8777 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       8777 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       7522 ### HDFS DATE ### hdfs://### HDFS PATH ###
+-rw-rw-rw-   3 ### USER ### ### GROUP ###       7522 ### HDFS DATE ### hdfs://### HDFS PATH ###
 -rw-rw-rw-   3 ### USER ### ### GROUP ###       7167 ### HDFS DATE ### hdfs://### HDFS PATH ###
 -rw-rw-rw-   3 ### USER ### ### GROUP ###       7167 ### HDFS DATE ### hdfs://### HDFS PATH ###
 -rw-rw-rw-   3 ### USER ### ### GROUP ###       7058 ### HDFS DATE ### hdfs://### HDFS PATH ###


### PR DESCRIPTION
### What changes were proposed in this pull request?
Setup null sort order based on the value of the setting `hive.default.nulls.last` and the order direction when creating ReduceSink operator for bucketing.

### Why are the changes needed?
Null sort order was setup based on the order direction only which may lead to unexpected behavior.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Run existing tests.