### PR TITLE
HIVE-25062 Iceberg: Fix date partition transform insert issue

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergRecordWriter.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.InternalRecordWrapper;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.FileIO;
@@ -49,6 +50,7 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
   // The current key is reused at every write to avoid unnecessary object creation
   private final PartitionKey currentKey;
   private final FileIO io;
+  private final InternalRecordWrapper wrapper;
 
   // <TaskAttemptId, <TABLE_NAME, HiveIcebergRecordWriter>> map to store the active writers
   // Stored in concurrent map, since some executor engines can share containers
@@ -68,13 +70,14 @@ class HiveIcebergRecordWriter extends PartitionedFanoutWriter<Record>
     super(spec, format, appenderFactory, fileFactory, io, targetFileSize);
     this.io = io;
     this.currentKey = new PartitionKey(spec, schema);
+    this.wrapper = new InternalRecordWrapper(schema.asStruct());
     writers.putIfAbsent(taskAttemptID, Maps.newConcurrentMap());
     writers.get(taskAttemptID).put(tableName, this);
   }
 
   @Override
   protected PartitionKey partition(Record row) {
-    currentKey.partition(row);
+    currentKey.partition(wrapper.wrap(row));
     return currentKey;
   }
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -110,8 +110,6 @@ public class HiveIcebergTestUtils {
               PrimitiveObjectInspectorFactory.writableStringObjectInspector
           ));
 
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd hh:mm:ss");
-
   private HiveIcebergTestUtils() {
     // Empty constructor for the utility class
   }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergTestUtils.java
@@ -32,7 +32,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
@@ -278,7 +277,7 @@ public class HiveIcebergTestUtils {
    * @param expected The expected list of Records
    * @param sortBy The column name by which we will sort
    */
-  public static void validateData(TestHiveShell shell, String tableName, List<Record> expected, String sortBy) {
+  public static void validateDataWithSQL(TestHiveShell shell, String tableName, List<Record> expected, String sortBy) {
     List<Object[]> rows = shell.executeStatement("SELECT * FROM " + tableName + " ORDER BY " + sortBy);
 
     Assert.assertEquals(expected.size(), rows.size());

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -757,6 +759,120 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
 
     HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testYearTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.DateType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).year("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, LocalDate.of(2020, 1, 21))
+                               .add(2L, LocalDate.of(2020, 1, 22))
+                               .add(3L, LocalDate.of(2019, 1, 21))
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testMonthTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.DateType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).month("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, LocalDate.of(2020, 1, 21))
+                               .add(2L, LocalDate.of(2020, 1, 22))
+                               .add(3L, LocalDate.of(2019, 1, 21))
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testDayTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.TimestampType.withoutZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).day("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+                               .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+                               .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testHourTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.TimestampType.withoutZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).hour("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+                               .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+                               .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testBucketTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).bucket("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, "Part1")
+                               .add(2L, "Part2")
+                               .add(3L, "Art3")
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testTruncateTransform() throws IOException {
+    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
+
+    Schema schemaWithDate = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).truncate("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+                               .add(1L, "Part1")
+                               .add(2L, "Part2")
+                               .add(3L, "Art3")
+                               .build();
+    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
   }
 
   @Test

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -777,7 +777,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test
@@ -794,7 +794,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test
@@ -811,7 +811,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test
@@ -828,7 +828,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test
@@ -845,7 +845,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test
@@ -862,7 +862,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
-    HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
   }
 
   @Test

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -763,17 +765,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testYearTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.DateType.get()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).year("part_field").build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, LocalDate.of(2020, 1, 21))
-                               .add(2L, LocalDate.of(2020, 1, 22))
-                               .add(3L, LocalDate.of(2019, 1, 21))
-                               .build();
+        .add(1L, LocalDate.of(2020, 1, 21))
+        .add(2L, LocalDate.of(2020, 1, 22))
+        .add(3L, LocalDate.of(2019, 1, 21))
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
@@ -782,17 +782,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testMonthTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.DateType.get()));
+        optional(2, "part_field", Types.TimestampType.withZone()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).month("part_field").build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, LocalDate.of(2020, 1, 21))
-                               .add(2L, LocalDate.of(2020, 1, 22))
-                               .add(3L, LocalDate.of(2019, 1, 21))
-                               .build();
+        .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
+        .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
+        .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
@@ -801,17 +799,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testDayTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.TimestampType.withoutZone()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).day("part_field").build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-                               .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-                               .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-                               .build();
+        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
@@ -820,17 +816,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testHourTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.TimestampType.withoutZone()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).hour("part_field").build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-                               .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-                               .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-                               .build();
+        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
@@ -839,17 +833,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testBucketTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.StringType.get()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).bucket("part_field", 2).build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, "Part1")
-                               .add(2L, "Part2")
-                               .add(3L, "Art3")
-                               .build();
+        .add(1L, "Part1")
+        .add(2L, "Part2")
+        .add(3L, "Art3")
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
@@ -858,17 +850,15 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testTruncateTransform() throws IOException {
-    Assume.assumeTrue("Tez write is not implemented yet", executionEngine.equals("mr"));
-
     Schema schemaWithDate = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.StringType.get()));
     PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).truncate("part_field", 2).build();
     List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
-                               .add(1L, "Part1")
-                               .add(2L, "Part2")
-                               .add(3L, "Art3")
-                               .build();
+        .add(1L, "Part1")
+        .add(2L, "Part2")
+        .add(3L, "Art3")
+        .build();
     Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -765,16 +765,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testYearTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.DateType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).year("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).year("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, LocalDate.of(2020, 1, 21))
         .add(2L, LocalDate.of(2020, 1, 22))
         .add(3L, LocalDate.of(2019, 1, 21))
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
@@ -782,16 +782,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testMonthTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.TimestampType.withZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).month("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).month("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
         .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
         .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
@@ -799,16 +799,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testDayTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.TimestampType.withoutZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).day("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).day("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
         .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
         .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
@@ -816,16 +816,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testHourTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.TimestampType.withoutZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).hour("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).hour("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
         .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
         .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
@@ -833,16 +833,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testBucketTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.StringType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).bucket("part_field", 2).build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, "Part1")
         .add(2L, "Part2")
         .add(3L, "Art3")
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");
@@ -850,16 +850,16 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
   @Test
   public void testTruncateTransform() throws IOException {
-    Schema schemaWithDate = new Schema(
+    Schema schema = new Schema(
         optional(1, "id", Types.LongType.get()),
         optional(2, "part_field", Types.StringType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schemaWithDate).truncate("part_field", 2).build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schemaWithDate)
+    PartitionSpec spec = PartitionSpec.builderFor(schema).truncate("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
         .add(1L, "Part1")
         .add(2L, "Part2")
         .add(3L, "Art3")
         .build();
-    Table table = testTables.createTable(shell, "part_test", schemaWithDate, spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
     HiveIcebergTestUtils.validateData(table, records, 0);
 
     HiveIcebergTestUtils.validateData(shell, "part_test", records, "id");


### PR DESCRIPTION
### What changes were proposed in this pull request?
Wrap the Record before calculating partitions

### Why are the changes needed?
Timestamp/Date needs values converted to long/int respectively to calculate partitions

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added new unit tests
