### PR TITLE
HIVE-24806: Compactor: Initiator should lazy evaluate findUserToRunAs()

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Initiator.java
@@ -246,8 +246,12 @@ public class Initiator extends MetaStoreCompactorThread {
     String fullTableName = TxnUtils.getFullTableName(t.getDbName(), t.getTableName());
     StorageDescriptor sd = resolveStorageDescriptor(t, p);
 
-    cache.putIfAbsent(fullTableName, findUserToRunAs(sd.getLocation(), t));
-    return cache.get(fullTableName);
+    String user = cache.get(fullTableName);
+    if (user == null) {
+      user = findUserToRunAs(sd.getLocation(), t);
+      cache.put(fullTableName, user);
+    }
+    return user;
   }
 
   @Override


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-24806

### What changes were proposed in this pull request?
Compute findUserToRunAs on need basis to avoid FS lookup calls. https://issues.apache.org/jira/browse/HIVE-24806 has more details.

### Why are the changes needed?
To reduce lookup calls in initiator.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Test on small internal cluster.