### PR TITLE
HIVE-25076: Get number of write tasks from jobConf for Iceberg commits

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -413,8 +413,6 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
   private JobContext getJobContextForCommitOrAbort(String tableName, boolean overwrite) {
     JobConf jobConf = new JobConf(conf);
     JobID jobID = JobID.forName(jobConf.get(TezTask.HIVE_TEZ_COMMIT_JOB_ID_PREFIX + tableName));
-    int numTasks = conf.getInt(TezTask.HIVE_TEZ_COMMIT_TASK_COUNT_PREFIX + tableName, -1);
-    jobConf.setNumReduceTasks(numTasks);
     jobConf.setBoolean(InputFormatConfig.IS_OVERWRITE, overwrite);
 
     // we should only commit this current table because

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -152,7 +152,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public TemporaryFolder temp = new TemporaryFolder();
 
   @Rule
-  public Timeout timeout = new Timeout(200_000, TimeUnit.MILLISECONDS);
+  public Timeout timeout = new Timeout(400_000, TimeUnit.MILLISECONDS);
 
   @BeforeClass
   public static void beforeClass() {


### PR DESCRIPTION
- Get task num from job conf under a key, instead of hacking the numReduceTasks function
- We can still use numReduceTasks/numMapTasks as a fall back
- Increasing test timeout due to recent failure with 200 secs

This should fix cases when the num succeeded task count is 0, and therefore we mistakenly take the task count from the numMapTasks.