### PR TITLE
HIVE-25082: Make updateTimezone a default method on SettableTreeReader

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/OrcEncodedDataConsumer.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/io/decode/OrcEncodedDataConsumer.java
@@ -327,9 +327,8 @@ public class OrcEncodedDataConsumer
       ((SettableTreeReader) reader).setBuffers(batch, sameStripe);
       // TODO: When hive moves to java8, make updateTimezone() as default method in
       // SettableTreeReader so that we can avoid this check.
-      if (reader instanceof EncodedTreeReaderFactory.TimestampStreamReader && !sameStripe) {
-        ((EncodedTreeReaderFactory.TimestampStreamReader) reader)
-                .updateTimezone(stripeMetadata.getWriterTimezone());
+      if (!sameStripe) {
+        ((SettableTreeReader) reader).updateTimezone(stripeMetadata.getWriterTimezone());
       }
       reader.seek(pps);
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedTreeReaderFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/encoded/EncodedTreeReaderFactory.java
@@ -48,6 +48,8 @@ public class EncodedTreeReaderFactory extends TreeReaderFactory {
    */
   public interface SettableTreeReader {
     void setBuffers(EncodedColumnBatch<OrcBatchKey> batch, boolean sameStripe) throws IOException;
+
+    default void updateTimezone(String writerTimezoneId) throws IOException { }
   }
 
   public static class TimestampStreamReader extends TimestampTreeReader


### PR DESCRIPTION
Change-Id: I1585469ac7f6ec032fc666d467cb0725bff19633

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Avoid useless TimestampStreamReader instance checks by making updateTimezone() a default method in SettableTreeReader


### Why are the changes needed?
Cleaner code, less instance of checks


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Existing tests
