### PR TITLE
HIVE-25034: Implement unpartitioned CTAS for Iceberg

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -52,6 +52,8 @@ public class InputFormatConfig {
   public static final String CATALOG = "iceberg.mr.catalog";
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
+  public static final String IS_CTAS_QUERY_TEMPLATE = "%s.iceberg.mr.is.ctas";
+  public static final String CTAS_TABLE_NAME_TEMPLATE = "%s.iceberg.mr.ctas.table.name";
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergCTASHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergCTASHook.java
@@ -18,6 +18,7 @@
 
 package org.apache.iceberg.mr.hive;
 
+import java.util.Properties;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHook;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHookContext;
@@ -25,8 +26,6 @@ import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Properties;
 
 public class HiveIcebergCTASHook implements QueryLifeTimeHook {
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergCTASHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergCTASHook.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.iceberg.mr.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHook;
+import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHookContext;
+import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Properties;
+
+public class HiveIcebergCTASHook implements QueryLifeTimeHook {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergCTASHook.class);
+
+  @Override
+  public void beforeCompile(QueryLifeTimeHookContext ctx) {
+
+  }
+
+  @Override
+  public void afterCompile(QueryLifeTimeHookContext ctx, boolean hasError) {
+    if (hasError) {
+      checkAndRollbackIcebergCTAS(ctx);
+    }
+  }
+
+  @Override
+  public void beforeExecution(QueryLifeTimeHookContext ctx) {
+
+  }
+
+  @Override
+  public void afterExecution(QueryLifeTimeHookContext ctx, boolean hasError) {
+    if (hasError) {
+      checkAndRollbackIcebergCTAS(ctx);
+    }
+  }
+
+  private void checkAndRollbackIcebergCTAS(QueryLifeTimeHookContext ctx) {
+    HiveConf conf = ctx.getHiveConf();
+    String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
+    if (conf.getBoolean(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId), false)) {
+      try {
+        String tableName = conf.get(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId));
+        LOG.info("Dropping the following CTAS target table as part of rollback: {}", tableName);
+        Properties props = new Properties();
+        props.put(Catalogs.NAME, tableName);
+        Catalogs.dropTable(conf, props);
+      } finally {
+        conf.unset(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId));
+        conf.unset(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId));
+      }
+    }
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
@@ -27,9 +27,9 @@ import org.apache.iceberg.mr.InputFormatConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HiveIcebergCTASHook implements QueryLifeTimeHook {
+public class HiveIcebergQueryLifeTimeHook implements QueryLifeTimeHook {
 
-  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergCTASHook.class);
+  private static final Logger LOG = LoggerFactory.getLogger(HiveIcebergQueryLifeTimeHook.class);
 
   @Override
   public void beforeCompile(QueryLifeTimeHookContext ctx) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
@@ -112,7 +113,8 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         // This is only for table creation, it is ok to have an empty partition column list
         this.partitionColumns = ImmutableList.of();
         // create table for CTAS
-        if (Boolean.parseBoolean(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
+        if (e instanceof NoSuchTableException &&
+            Boolean.parseBoolean(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
           LOG.info("Creating table {} for CTAS with schema: {}", serDeProperties.get(Catalogs.NAME), tableSchema);
           createTableForCTAS(configuration, serDeProperties);
         }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
@@ -149,6 +150,11 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     serDeProperties.setProperty(TableProperties.ENGINE_HIVE_ENABLED, "true");
     serDeProperties.setProperty(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(tableSchema));
     Catalogs.createTable(configuration, serDeProperties);
+    // set these in the global conf so that we can rollback the table in the lifecycle hook in case of failures
+    String queryId = configuration.get(HiveConf.ConfVars.HIVEQUERYID.varname);
+    configuration.set(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId), "true");
+    configuration.set(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId),
+        serDeProperties.getProperty(Catalogs.NAME));
   }
 
   private void assertNotVectorizedTez(Configuration configuration) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -30,6 +30,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
@@ -46,6 +47,7 @@ import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.mr.Catalogs;
@@ -108,6 +110,11 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         this.tableSchema = hiveSchemaOrThrow(serDeProperties, e, autoConversion);
         // This is only for table creation, it is ok to have an empty partition column list
         this.partitionColumns = ImmutableList.of();
+        // create table for CTAS
+        if (Boolean.parseBoolean(serDeProperties.getProperty(hive_metastoreConstants.TABLE_IS_CTAS))) {
+          LOG.info("Creating table {} for CTAS with schema: {}", serDeProperties.get(Catalogs.NAME), tableSchema);
+          createTableForCTAS(configuration, serDeProperties);
+        }
       }
     }
 
@@ -136,6 +143,12 @@ public class HiveIcebergSerDe extends AbstractSerDe {
     } catch (Exception e) {
       throw new SerDeException(e);
     }
+  }
+
+  private void createTableForCTAS(Configuration configuration, Properties serDeProperties) {
+    serDeProperties.setProperty(TableProperties.ENGINE_HIVE_ENABLED, "true");
+    serDeProperties.setProperty(InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(tableSchema));
+    Catalogs.createTable(configuration, serDeProperties);
   }
 
   private void assertNotVectorizedTez(Configuration configuration) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -161,6 +161,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   }
 
   @Override
+  public boolean directInsertCTAS() {
+    return true;
+  }
+
+  @Override
   public Configuration getConf() {
     return conf;
   }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -525,9 +525,10 @@ public class TestHiveIcebergStorageHandlerWithEngine {
         testTableType == TestTables.TestTableType.HIVE_CATALOG);
 
     // get source data from a different catalog
-    shell.executeStatement(String.format("CREATE TABLE source STORED BY '%s' LOCATION '%s' TBLPROPERTIES ('%s'='%s', '%s'='%s')",
+    shell.executeStatement(String.format(
+        "CREATE TABLE source STORED BY '%s' LOCATION '%s' TBLPROPERTIES ('%s'='%s', '%s'='%s')",
         HiveIcebergStorageHandler.class.getName(),
-        temp.getRoot().getPath() + "/source/",
+        temp.getRoot().getPath() + "/default/source/",
         InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_HADOOP_TABLE_NAME,
         InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)));
     shell.executeStatement("INSERT INTO source VALUES (1, 'Mike', 'Roger'), (2, 'Linda', 'Albright')");

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -217,7 +217,7 @@ public class TestHiveShell {
     hiveConf.set("tez.mrreader.config.update.properties", "hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids");
 
     // set lifecycle hooks
-    hiveConf.setVar(HiveConf.ConfVars.HIVE_QUERY_LIFETIME_HOOKS, HiveIcebergCTASHook.class.getName());
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_QUERY_LIFETIME_HOOKS, HiveIcebergQueryLifeTimeHook.class.getName());
 
     return hiveConf;
   }

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveShell.java
@@ -216,6 +216,9 @@ public class TestHiveShell {
     // enables vectorization on Tez
     hiveConf.set("tez.mrreader.config.update.properties", "hive.io.file.readcolumn.names,hive.io.file.readcolumn.ids");
 
+    // set lifecycle hooks
+    hiveConf.setVar(HiveConf.ConfVars.HIVE_QUERY_LIFETIME_HOOKS, HiveIcebergCTASHook.class.getName());
+
     return hiveConf;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -361,7 +361,7 @@ public class TezTask extends Task<TezWork> {
           .filter(name -> name.endsWith("HiveIcebergNoJobCommitter")).isPresent();
       // we should only consider jobs with Iceberg output committer and a data sink
       if (hasIcebergCommitter && !vertex.getDataSinks().isEmpty()) {
-        String tableLocationRoot = jobConf.get("location");
+        String tableLocationRoot = jobConf.get("iceberg.mr.table.location");
         if (tableLocationRoot != null) {
           VertexStatus status = dagClient.getVertexStatus(vertex.getName(), EnumSet.of(StatusGetOpts.GET_COUNTERS));
           Path path = new Path(tableLocationRoot + "/temp");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -106,7 +106,7 @@ public class TezTask extends Task<TezWork> {
 
   private static final String CLASS_NAME = TezTask.class.getName();
   private static final String JOB_ID_TEMPLATE = "job_%s%d_%s";
-  private static final String ICEBERG_MR_TABLE_LOCATION = "iceberg.mr.table.location";
+  private static final String ICEBERG_TABLE_LOCATION = "iceberg.mr.table.location";
   private static transient Logger LOG = LoggerFactory.getLogger(CLASS_NAME);
   private final PerfLogger perfLogger = SessionState.getPerfLogger();
   private static final String TEZ_MEMORY_RESERVE_FRACTION = "tez.task.scale.memory.reserve-fraction";
@@ -362,7 +362,7 @@ public class TezTask extends Task<TezWork> {
           .filter(name -> name.endsWith("HiveIcebergNoJobCommitter")).isPresent();
       // we should only consider jobs with Iceberg output committer and a data sink
       if (hasIcebergCommitter && !vertex.getDataSinks().isEmpty()) {
-        String tableLocationRoot = jobConf.get(ICEBERG_MR_TABLE_LOCATION);
+        String tableLocationRoot = jobConf.get(ICEBERG_TABLE_LOCATION);
         if (tableLocationRoot != null) {
           VertexStatus status = dagClient.getVertexStatus(vertex.getName(), EnumSet.of(StatusGetOpts.GET_COUNTERS));
           Path path = new Path(tableLocationRoot + "/temp");

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -106,6 +106,7 @@ public class TezTask extends Task<TezWork> {
 
   private static final String CLASS_NAME = TezTask.class.getName();
   private static final String JOB_ID_TEMPLATE = "job_%s%d_%s";
+  private static final String ICEBERG_MR_TABLE_LOCATION = "iceberg.mr.table.location";
   private static transient Logger LOG = LoggerFactory.getLogger(CLASS_NAME);
   private final PerfLogger perfLogger = SessionState.getPerfLogger();
   private static final String TEZ_MEMORY_RESERVE_FRACTION = "tez.task.scale.memory.reserve-fraction";
@@ -361,7 +362,7 @@ public class TezTask extends Task<TezWork> {
           .filter(name -> name.endsWith("HiveIcebergNoJobCommitter")).isPresent();
       // we should only consider jobs with Iceberg output committer and a data sink
       if (hasIcebergCommitter && !vertex.getDataSinks().isEmpty()) {
-        String tableLocationRoot = jobConf.get("iceberg.mr.table.location");
+        String tableLocationRoot = jobConf.get(ICEBERG_MR_TABLE_LOCATION);
         if (tableLocationRoot != null) {
           VertexStatus status = dagClient.getVertexStatus(vertex.getName(), EnumSet.of(StatusGetOpts.GET_COUNTERS));
           Path path = new Path(tableLocationRoot + "/temp");

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -218,4 +218,19 @@ public interface HiveStorageHandler extends Configurable {
   default boolean canProvideBasicStatistics() {
     return false;
   }
+
+  /**
+   * Check if CTAS operations should behave in a direct-insert manner (i.e. no move task).
+   *
+   * If true, the compiler will not include the table creation task and move task into the execution plan.
+   * Instead, it's the responsibility of storage handler/serde to create the table during the compilation phase.
+   * Please note that the atomicity of the operation will suffer in this case, i.e. the created table might become
+   * exposed, depending on the implementation, before the CTAS operations finishes.
+   * Rollback (e.g. dropping the table) is also the responsibility of the storage handler in case of failures.
+   *
+   * @return whether direct insert CTAS is required
+   */
+  default boolean directInsertCTAS() {
+    return false;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7859,8 +7859,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
 
     LOG.debug("Created FileSink Plan for clause: {}dest_path: {} row schema: {}", dest, destinationPath, inputRR);
 
-//    createPreInsertDesc(getTable(tableDesc.getTableName().getDbTable()), false);
-
     FileSinkOperator fso = (FileSinkOperator) output;
     fso.getConf().setTable(destinationTable);
     // the following code is used to collect column stats when
@@ -11809,11 +11807,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     if (qb.getAlias() != null) {
       rewriteRRForSubQ(qb.getAlias(), bodyOpInfo, skipAmbiguityCheck);
     }
-
-//    // handle direct insert CTAS
-//    if (qb.isCTAS()) {
-//      createPreInsertDesc(getTable(tableDesc.getTableName().getDbTable()), false);
-//    }
 
     setQB(qb);
     return bodyOpInfo;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.optimizer.GenMapRedUtils;
@@ -133,6 +134,16 @@ public abstract class TaskCompiler {
 
     boolean isCStats = pCtx.getQueryProperties().isAnalyzeRewrite();
     int outerQueryLimit = pCtx.getQueryProperties().getOuterQueryLimit();
+
+    boolean directInsertCtas = false;
+    if (pCtx.getCreateTable() != null && pCtx.getCreateTable().getStorageHandler() != null) {
+      try {
+        directInsertCtas =
+            HiveUtils.getStorageHandler(conf, pCtx.getCreateTable().getStorageHandler()).directInsertCTAS();
+      } catch (HiveException e) {
+        // do nothing
+      }
+    }
 
     if (pCtx.getFetchTask() != null) {
       if (pCtx.getFetchTask().getTblDesc() == null) {
@@ -271,8 +282,11 @@ public abstract class TaskCompiler {
           setLoadFileLocation(pCtx, lfd);
           oneLoadFileForCtas = false;
         }
-        mvTask.add(TaskFactory
-            .get(new MoveWork(null, null, null, lfd, false)));
+        // for direct insert CTAS, we don't need this MoveTask since the data will be inserted into its final location
+        if (!directInsertCtas) {
+          mvTask.add(TaskFactory
+              .get(new MoveWork(null, null, null, lfd, false)));
+        }
       }
     }
 
@@ -357,7 +371,9 @@ public abstract class TaskCompiler {
 
     decideExecMode(rootTasks, ctx, globalLimitCtx);
 
-    if (pCtx.getQueryProperties().isCTAS() && !pCtx.getCreateTable().isMaterialization()) {
+    // for direct insert CTAS, we don't need this table creation DDL task, since the table will be created
+    // ahead of time by the non-native table
+    if (pCtx.getQueryProperties().isCTAS() && !pCtx.getCreateTable().isMaterialization() && !directInsertCtas) {
       // generate a DDL task and make it a dependent task of the leaf
       CreateTableDesc crtTblDesc = pCtx.getCreateTable();
       crtTblDesc.validate(conf);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -141,7 +141,7 @@ public abstract class TaskCompiler {
         directInsertCtas =
             HiveUtils.getStorageHandler(conf, pCtx.getCreateTable().getStorageHandler()).directInsertCTAS();
       } catch (HiveException e) {
-        // do nothing
+        throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
       }
     }
 


### PR DESCRIPTION
- CTAS table is created inside the `HiveIcebergSerDe`
- StorageHandler API is extended with `isDirectInsertCTAS`
- In the execution plan, table creation task and move task are skipped if storageHandler.isDirectInsertCtas == true
- Also, a PreInsert hook is attached, so that the commitInsertTable hook will be called
- Rollback is implemented using a lifecycle hook