### PR TITLE
HIVE-21563: Improve Table#getEmptyTable performance by disabling registerAllFunctionsOnce

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -392,6 +392,13 @@ public class Hive {
     return getInternal(c, false, true, doRegisterAllFns);
   }
 
+  /**
+   * Same as {@link #get(HiveConf)}, except that it does not register all functions.
+   */
+  public static Hive getWithoutRegisterFns(HiveConf c) throws HiveException {
+    return getInternal(c, false, false, false);
+  }
+
   private static Hive getInternal(HiveConf c, boolean needsRefresh, boolean isFastCheck,
       boolean doRegisterAllFns) throws HiveException {
     Hive db = hiveDB.get();

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1025,7 +1025,7 @@ public class SessionState implements ISessionAuthState{
     authorizerV2.applyAuthorizationConfigPolicy(sessionConf);
     // update config in Hive thread local as well and init the metastore client
     try {
-      Hive.get(sessionConf).getMSC();
+      Hive.getWithoutRegisterFns(sessionConf).getMSC();
     } catch (Exception e) {
       // catch-all due to some exec time dependencies on session state
       // that would cause ClassNoFoundException otherwise


### PR DESCRIPTION
### What changes were proposed in this pull request?

Improve `Table#getEmptyTable` performance by disabling `registerAllFunctionsOnce`.

### Why are the changes needed?

`Table#getEmptyTable` do not need `registerAllFunctionsOnce` . The stack trace:
```java
  at org.apache.hadoop.hive.ql.exec.Registry.registerGenericUDF(Registry.java:177)
  at org.apache.hadoop.hive.ql.exec.Registry.registerGenericUDF(Registry.java:170)
  at org.apache.hadoop.hive.ql.exec.FunctionRegistry.<clinit>(FunctionRegistry.java:209)
  at org.apache.hadoop.hive.ql.metadata.Hive.reloadFunctions(Hive.java:247)
  at org.apache.hadoop.hive.ql.metadata.Hive.registerAllFunctionsOnce(Hive.java:231)
  at org.apache.hadoop.hive.ql.metadata.Hive.<init>(Hive.java:388)
  at org.apache.hadoop.hive.ql.metadata.Hive.create(Hive.java:332)
  at org.apache.hadoop.hive.ql.metadata.Hive.getInternal(Hive.java:312)
  at org.apache.hadoop.hive.ql.metadata.Hive.get(Hive.java:288)
  at org.apache.hadoop.hive.ql.session.SessionState.setAuthorizerV2Config(SessionState.java:913)
  at org.apache.hadoop.hive.ql.session.SessionState.setupAuth(SessionState.java:877)
  at org.apache.hadoop.hive.ql.session.SessionState.getAuthenticator(SessionState.java:1479)
  at org.apache.hadoop.hive.ql.session.SessionState.getUserFromAuthenticator(SessionState.java:1150)
  at org.apache.hadoop.hive.ql.metadata.Table.getEmptyTable(Table.java:180)
```

### Does this PR introduce _any_ user-facing change?

No.


### How was this patch tested?

Existing test.
