### PR TITLE
HIVE-25101: Remove HBase libraries from Hive distribution

### DIFF
--- a/bin/hive
+++ b/bin/hive
@@ -212,7 +212,12 @@ if [ "$SKIP_HBASECP" = false ]; then
 
   # perhaps we've located the HBase config. if so, include it on classpath.
   if [[ -d $HBASE_CONF_DIR ]] ; then
-    HBASE_MR_CLASSPATH="${HBASE_CONF_DIR}"
+    if [ "$HBASE_MR_CLASSPATH" != "" ]; then
+      HBASE_MR_CLASSPATH="${HBASE_MR_CLASSPATH},${HBASE_CONF_DIR}"
+    else
+      HBASE_MR_CLASSPATH="${HBASE_CONF_DIR}"
+    fi
+    CLASSPATH="${CLASSPATH}:${HBASE_CONF_DIR}"
   fi
 
   # look for the hbase script. First check HBASE_HOME and then ask PATH.

--- a/bin/hive
+++ b/bin/hive
@@ -97,7 +97,7 @@ if [[ "$SERVICE" == "beeline" && ! -z "$BEELINE_URL_LEGACY" ]] ; then
   SERVICE_ARGS=("${SERVICE_ARGS[@]}" "-c" "${BEELINE_URL_LEGACY}")
 fi
 
-if [[ "$SERVICE" =~ ^(help|version|orcfiledump|rcfilecat|schemaTool|cleardanglingscratchdir|metastore|beeline|llapstatus|llap)$ ]] ; then
+if [[ "$SERVICE" =~ ^(help|version|orcfiledump|rcfilecat|schemaTool|cleardanglingscratchdir|metastore|beeline|llapstatus)$ ]] ; then
   SKIP_HBASECP=true
 fi
 
@@ -200,6 +200,49 @@ else
     CLASSPATH=${CLASSPATH}:${AUX_CLASSPATH}
 fi
 
+if [ "$SKIP_HBASECP" = false ]; then
+  # HBase detection. Need bin/hbase and a conf dir for building classpath entries.
+  # Start with BigTop defaults for HBASE_HOME and HBASE_CONF_DIR.
+  HBASE_HOME=${HBASE_HOME:-"/usr/lib/hbase"}
+  HBASE_CONF_DIR=${HBASE_CONF_DIR:-"/etc/hbase/conf"}
+  if [[ ! -d $HBASE_CONF_DIR ]] ; then
+    # not explicitly set, nor in BigTop location. Try looking in HBASE_HOME.
+    HBASE_CONF_DIR="$HBASE_HOME/conf"
+  fi
+
+  # perhaps we've located the HBase config. if so, include it on classpath.
+  if [[ -d $HBASE_CONF_DIR ]] ; then
+    HBASE_MR_CLASSPATH="${HBASE_CONF_DIR}"
+  fi
+
+  # look for the hbase script. First check HBASE_HOME and then ask PATH.
+  if [[ -e $HBASE_HOME/bin/hbase ]] ; then
+    HBASE_BIN="$HBASE_HOME/bin/hbase"
+  fi
+  HBASE_BIN=${HBASE_BIN:-"$(which hbase)"}
+
+  # perhaps we've located HBase. If so, include its details on the classpath
+  if [[ -n $HBASE_BIN ]] ; then
+    # exclude ZK, PB, and Guava (See HIVE-2055)
+    # depends on HBASE-8438 (hbase-0.94.14+, hbase-0.96.1+) for `hbase mapredcp` command
+    for x in $($HBASE_BIN mapredcp 2>&2 | tr ':' '\n') ; do
+      if [[ $x == *zookeeper* || $x == *protobuf-java* || $x == *guava* || $x == *slf4j* || $x == *log4j* ]] ; then
+        continue
+      fi
+      if [ "$HBASE_MR_CLASSPATH" != "" ]; then
+        HBASE_MR_CLASSPATH="${HBASE_MR_CLASSPATH},${x}"
+      else
+        HBASE_MR_CLASSPATH="${x}"
+      fi
+      CLASSPATH="${CLASSPATH}:${x}"
+    done
+  fi
+fi
+
+if [[ "$SERVICE" == "llap" && ! -z "$HBASE_MR_CLASSPATH" ]] ; then
+  SERVICE_ARGS=("${SERVICE_ARGS[@]}" "-k" "${HBASE_MR_CLASSPATH}")
+fi
+
 # supress the HADOOP_HOME warnings in 1.x.x
 export HADOOP_HOME_WARN_SUPPRESS=true 
 
@@ -289,41 +332,6 @@ if [ "$EXECUTE_WITH_JAVA" == "false" ]; then
       echo `$HADOOP version`
       exit 6
     fi
-  fi
-fi
-
-if [ "$SKIP_HBASECP" = false ]; then
-  # HBase detection. Need bin/hbase and a conf dir for building classpath entries.
-  # Start with BigTop defaults for HBASE_HOME and HBASE_CONF_DIR.
-  HBASE_HOME=${HBASE_HOME:-"/usr/lib/hbase"}
-  HBASE_CONF_DIR=${HBASE_CONF_DIR:-"/etc/hbase/conf"}
-  if [[ ! -d $HBASE_CONF_DIR ]] ; then
-    # not explicitly set, nor in BigTop location. Try looking in HBASE_HOME.
-    HBASE_CONF_DIR="$HBASE_HOME/conf"
-  fi
-  
-  # perhaps we've located the HBase config. if so, include it on classpath.
-  if [[ -d $HBASE_CONF_DIR ]] ; then
-    export HADOOP_CLASSPATH="${HADOOP_CLASSPATH}:${HBASE_CONF_DIR}"
-  fi
-  
-  # look for the hbase script. First check HBASE_HOME and then ask PATH.
-  if [[ -e $HBASE_HOME/bin/hbase ]] ; then
-    HBASE_BIN="$HBASE_HOME/bin/hbase"
-  fi
-  HBASE_BIN=${HBASE_BIN:-"$(which hbase)"}
-  
-  # perhaps we've located HBase. If so, include its details on the classpath
-  if [[ -n $HBASE_BIN ]] ; then
-    # exclude ZK, PB, and Guava (See HIVE-2055)
-    # depends on HBASE-8438 (hbase-0.94.14+, hbase-0.96.1+) for `hbase mapredcp` command
-    for x in $($HBASE_BIN mapredcp 2>&2 | tr ':' '\n') ; do
-      if [[ $x == *zookeeper* || $x == *protobuf-java* || $x == *guava* ]] ; then
-        continue
-      fi
-      # TODO: should these should be added to AUX_PARAM as well?
-      export HADOOP_CLASSPATH="${HADOOP_CLASSPATH}:${x}"
-    done
   fi
 fi
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -68,6 +68,10 @@
        <version>${commons-lang3.version}</version>
     </dependency>
     <dependency>
+       <groupId>org.apache.commons</groupId>
+       <artifactId>commons-math3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-core</artifactId>
     </dependency>

--- a/druid-handler/pom.xml
+++ b/druid-handler/pom.xml
@@ -44,6 +44,11 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>${validation-api.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <version>${project.version}</version>

--- a/hbase-handler/pom.xml
+++ b/hbase-handler/pom.xml
@@ -49,6 +49,7 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <optional>true</optional>
+      <scope>provided</scope>
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -76,14 +77,17 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop2-compat</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
+      <scope>provided</scope>
       <exclusions>
          <exclusion>
             <groupId>org.slf4j</groupId>
@@ -102,6 +106,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-mapreduce</artifactId>
+      <scope>provided</scope>
       <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
@@ -117,10 +122,12 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop-compat</artifactId>
+      <scope>provided</scope>
     </dependency>
 
     <!-- test inter-project -->
@@ -146,6 +153,7 @@
       <artifactId>hbase-hadoop2-compat</artifactId>
       <version>${hbase.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/itests/hive-unit/pom.xml
+++ b/itests/hive-unit/pom.xml
@@ -235,6 +235,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
+      <scope>test</scope>
         <exclusions>
           <exclusion>
             <groupId>org.glassfish.web</groupId>
@@ -245,6 +246,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
+      <scope>test</scope>
       <classifier>tests</classifier>
     </dependency>
     <dependency>

--- a/llap-server/pom.xml
+++ b/llap-server/pom.xml
@@ -79,6 +79,10 @@
       <artifactId>commons-codec</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
     </dependency>
@@ -224,6 +228,11 @@
       <artifactId>jetty-util</artifactId>
       <version>${jetty.version}</version>
     </dependency>
+    <dependency>
+      <groupId>com.lmax</groupId>
+      <artifactId>disruptor</artifactId>
+      <version>${disruptor.version}</version>
+    </dependency>
 
     <!-- test intra-project -->
     <dependency>
@@ -340,10 +349,12 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop2-compat</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-client</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.glassfish.web</groupId>
@@ -354,6 +365,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -372,6 +384,7 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-mapreduce</artifactId>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.slf4j</groupId>
@@ -386,10 +399,12 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-hadoop-compat</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceCommandLine.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceCommandLine.java
@@ -107,6 +107,13 @@ class LlapServiceCommandLine {
       .hasArg()
       .create('h');
 
+  private static final Option HBASEJARS = OptionBuilder
+      .withLongOpt("hbasejars")
+      .withDescription("HBase mapredcp jars to package")
+      .withArgName("hbasejars")
+      .hasArg()
+      .create('k');
+
   private static final Option HIVECONF = OptionBuilder
       .withLongOpt("hiveconf")
       .withDescription("Use value for given property. Overridden by explicit parameters")
@@ -194,6 +201,7 @@ class LlapServiceCommandLine {
     OPTIONS.addOption(XMX);
     OPTIONS.addOption(AUXJARS);
     OPTIONS.addOption(AUXHBASE);
+    OPTIONS.addOption(HBASEJARS);
     OPTIONS.addOption(HIVECONF);
     OPTIONS.addOption(JAVAHOME);
     OPTIONS.addOption(QUEUE);
@@ -311,6 +319,7 @@ class LlapServiceCommandLine {
   private long size;
   private long xmx;
   private String jars;
+  private String hbaseJars;
   private boolean isHbase;
   private Properties conf = new Properties();
   private String javaPath = null;
@@ -370,6 +379,7 @@ class LlapServiceCommandLine {
     size = TraditionalBinaryPrefix.string2long(cl.getOptionValue(SIZE.getOpt(), "-1"));
     xmx = TraditionalBinaryPrefix.string2long(cl.getOptionValue(XMX.getOpt(), "-1"));
     jars = cl.getOptionValue(AUXJARS.getOpt());
+    hbaseJars = cl.getOptionValue(HBASEJARS.getOpt());
     isHbase = Boolean.parseBoolean(cl.getOptionValue(AUXHBASE.getOpt(), "true"));
     if (cl.hasOption(HIVECONF.getLongOpt())) {
       conf = cl.getOptionProperties(HIVECONF.getLongOpt());
@@ -434,6 +444,10 @@ class LlapServiceCommandLine {
 
   String getAuxJars() {
     return jars;
+  }
+
+  String getHBaseJars() {
+    return hbaseJars;
   }
 
   boolean getIsHBase() {

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
     <commons-exec.version>1.1</commons-exec.version>
     <commons-io.version>2.6</commons-io.version>
     <commons-lang3.version>3.9</commons-lang3.version>
+    <commons-math3.version>3.6.1</commons-math3.version>
     <commons-dbcp2.version>2.7.0</commons-dbcp2.version>
     <commons-text.version>1.8</commons-text.version>
     <derby.version>10.14.1.0</derby.version>
@@ -223,6 +224,7 @@
     <janino.version>3.0.11</janino.version>
     <datasketches.version>1.1.0-incubating</datasketches.version>
     <spotbugs.version>4.0.3</spotbugs.version>
+    <validation-api.version>1.1.0.Final</validation-api.version>
   </properties>
 
   <repositories>
@@ -381,6 +383,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-dbcp2</artifactId>
         <version>${commons-dbcp2.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-math3</artifactId>
+        <version>${commons-math3.version}</version>
       </dependency>
       <dependency>
         <groupId>io.jsonwebtoken</groupId>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -89,6 +89,10 @@
       <version>${commons-configuration.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-math3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-vector-code-gen</artifactId>
       <version>${project.version}</version>
@@ -172,10 +176,11 @@
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
     </dependency>
-      <dependency>
-        <groupId>org.apache.hbase</groupId>
-        <artifactId>hbase-common</artifactId>
-      </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
       <artifactId>parquet-hadoop-bundle</artifactId>

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/HiveSparkClientFactory.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/spark/HiveSparkClientFactory.java
@@ -80,7 +80,11 @@ public class HiveSparkClientFactory {
 
   public static Map<String, String> initiateSparkConf(HiveConf hiveConf, String hiveSessionId) {
     Map<String, String> sparkConf = new HashMap<String, String>();
-    HBaseConfiguration.addHbaseResources(hiveConf);
+    try {
+      HBaseConfiguration.addHbaseResources(hiveConf);
+    } catch (Exception e) {
+      LOG.warn("Could not add HBase resources to Configuration", e);
+    }
 
     // set default spark configurations.
     sparkConf.put("spark.master", SPARK_DEFAULT_MASTER);


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Mark all HBase dependencies as provided, so that they are not include in the distribution package
- Add the hbase mapredcp jars to CLASSPATH  in the hive startup script
- remove SKIP_HBASECP option from llap service in hive script
- Add new -k llap option to specify hbase mapredcp libraries
- Change the code that adds the hbase dependencies to LLAP jobs automatically ti use -k  instead
- Let HiveSparkClientFactory work even if it cannot access the HBase libraries

### Why are the changes needed?
Hive currently includes the HBase libraries in its distribution package, and also adds the HBase libraries separately 
vi the 'hbase mapredcp' command in the startup script.

There are multiple problems with this:
- It's redundant
- The included HBase libraries are ancient, and cannot be easily updated 
- The hbase-shaded-mapredcp.jar added by hbase mapredcp is incompatible with the included unshaded libraries on an API level, and the ordering of the classes, and thus the effective api can be different between the local and the MR/Tez classpath

### Does this PR introduce _any_ user-facing change?
With this change, if the HBASE_HOME environment variable is not set, then the HBase libraries will not
be available in Hive. This is change from the current behaviour.
We are also removing some special case code that added the unshaded hbase libraries to the llap tar.gz, and use 
hive.aux.jars.path instead.
Also, with this change there is no need to manually replace the HBase libraries in the Hive distribution.

### How was this patch tested?
I have built a local pseudodistributed cluster, and manually tested that the hbase handler works with these changes.
I successfully tested with both the mr and tez engines.
I did not get llap fully working, but I tested that the generated Yarn service tar.gz includes the shaded hbase libraries and the hbase storage dirver.
AFAIK Hive does not have end-to-end tests that can test the generated package and start-up scripts.
