### PR TITLE
HIVE-25106: Do not exclude avatica and protobuf for Iceberg

### DIFF
--- a/iceberg/pom.xml
+++ b/iceberg/pom.xml
@@ -117,16 +117,8 @@
                         <artifactId>*</artifactId>
                     </exclusion>
                     <exclusion>
-                        <groupId>com.google.protobuf</groupId>
-                        <artifactId>protobuf-java</artifactId>
-                    </exclusion>
-                    <exclusion>
                         <groupId>org.apache.avro</groupId>
                         <artifactId>avro</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.apache.calcite.avatica</groupId>
-                        <artifactId>*</artifactId>
                     </exclusion>
                     <exclusion>
                         <groupId>org.apache.hive</groupId>


### PR DESCRIPTION
IDE test runs can otherwise result in:
```
Caused by: java.lang.ClassNotFoundException: com.google.protobuf.GeneratedMessageV3
	at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 62 more
```
and
```
sed by: java.lang.NoClassDefFoundError: Could not initialize class org.apache.calcite.avatica.ConnectionPropertiesImpl
	at org.apache.calcite.avatica.MetaImpl.<init>(MetaImpl.java:72)
	at org.apache.calcite.jdbc.CalciteMetaImpl.<init>(CalciteMetaImpl.java:85)
	at org.apache.calcite.jdbc.Driver.createMeta(Driver.java:169)
	at org.apache.calcite.avatica.AvaticaConnection.<init>(AvaticaConnection.java:121)
```
when running `testCBOWithSelectedColumnsOverlapJoin` and `testCBOWithSelectedColumnsNonOverlapJoin`