### PR TITLE
HIVE-25109: CBO fails when updating table has constraints defined

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3485,11 +3485,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
       RelNode constraintRel = genFilterRelNode(constraintUDF, selPair.left, outerNameToPosMap, outerRR);
 
       List<RexNode> originalInputRefs = toRexNodeList(selPair.left);
-      List<RexNode> selectedRefs = Lists.newArrayList();
-      for (int index = 0; index < selPair.right.getColumnInfos().size(); index++) {
-        selectedRefs.add(originalInputRefs.get(index));
-      }
-
+      List<RexNode> selectedRefs = originalInputRefs.subList(0, selPair.right.getColumnInfos().size());
       return new Pair<>(genSelectRelNode(selectedRefs, selPair.right, constraintRel), selPair.right);
     }
 
@@ -4090,10 +4086,8 @@ public class CalcitePlanner extends SemanticAnalyzer {
 
       if (obLogicalPlanGenState.getSelectOutputRR() != null) {
         List<RexNode> originalInputRefs = toRexNodeList(obLogicalPlanGenState.getSrcRel());
-        List<RexNode> selectedRefs = Lists.newArrayList();
-        for (int index = 0; index < obLogicalPlanGenState.getSelectOutputRR().getColumnInfos().size(); index++) {
-          selectedRefs.add(originalInputRefs.get(index));
-        }
+        List<RexNode> selectedRefs = originalInputRefs.subList(
+                0, obLogicalPlanGenState.getSelectOutputRR().getColumnInfos().size());
         // We need to add select since order by schema may have more columns than result schema.
         return genSelectRelNode(selectedRefs, obLogicalPlanGenState.getSelectOutputRR(), sortRel);
       } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7133,6 +7133,11 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       return input;
     }
 
+    if (updating(dest) && isCBOExecuted()) {
+      // for UPDATE statements CBO already added and pushed down the constraints
+      return input;
+    }
+
     //MERGE statements could have inserted a cardinality violation branch, we need to avoid that
     if (mergeCardinalityViolationBranch(input)) {
       return input;

--- a/ql/src/test/queries/clientpositive/check_constraint.q
+++ b/ql/src/test/queries/clientpositive/check_constraint.q
@@ -123,6 +123,7 @@ drop table src_multi2_n0;
 
 -- update
 select * from acid_uami_n0 order by de desc limit 15;
+explain cbo update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00;
 explain update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00;
 update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00;
 select * from acid_uami_n0 order by de desc limit 15;

--- a/ql/src/test/results/clientnegative/merge_constraint_notnull.q.out
+++ b/ql/src/test/results/clientnegative/merge_constraint_notnull.q.out
@@ -66,8 +66,7 @@ Caused by: org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: E
 [Masked Vertex killed due to OTHER_VERTEX_FAILURE]
 [Masked Vertex killed due to OTHER_VERTEX_FAILURE]
 [Masked Vertex killed due to OTHER_VERTEX_FAILURE]
-[Masked Vertex killed due to OTHER_VERTEX_FAILURE]
-DAG did not succeed due to VERTEX_FAILURE. failedVertices:1 killedVertices:6
+DAG did not succeed due to VERTEX_FAILURE. failedVertices:1 killedVertices:5
 FAILED: Execution Error, return code 2 from org.apache.hadoop.hive.ql.exec.tez.TezTask. Vertex failed, vertexName=Reducer 2, vertexId=vertex_#ID#, diagnostics=[Task failed, taskId=task_#ID#, diagnostics=[TaskAttempt 0 failed, info=[Error: Error while running task ( failure ) : attempt_#ID#:java.lang.RuntimeException: org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: Either CHECK or NOT NULL constraint violated!
 #### A masked pattern was here ####
 Caused by: org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: Either CHECK or NOT NULL constraint violated!
@@ -76,4 +75,4 @@ Caused by: org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: E
 #### A masked pattern was here ####
 Caused by: org.apache.hadoop.hive.ql.exec.errors.DataConstraintViolationError: Either CHECK or NOT NULL constraint violated!
 #### A masked pattern was here ####
-]], Vertex did not succeed due to OWN_TASK_FAILURE, failedTasks:1 killedTasks:0, Vertex vertex_#ID# [Reducer 2] killed/failed due to:OWN_TASK_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE]DAG did not succeed due to VERTEX_FAILURE. failedVertices:1 killedVertices:6
+]], Vertex did not succeed due to OWN_TASK_FAILURE, failedTasks:1 killedTasks:0, Vertex vertex_#ID# [Reducer 2] killed/failed due to:OWN_TASK_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE][Masked Vertex killed due to OTHER_VERTEX_FAILURE]DAG did not succeed due to VERTEX_FAILURE. failedVertices:1 killedVertices:5

--- a/ql/src/test/results/clientpositive/llap/check_constraint.q.out
+++ b/ql/src/test/results/clientpositive/llap/check_constraint.q.out
@@ -2041,6 +2041,20 @@ POSTHOOK: query: select * from acid_uami_n0 order by de desc limit 15
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@acid_uami_n0
 #### A masked pattern was here ####
+PREHOOK: query: explain cbo update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00
+PREHOOK: type: QUERY
+PREHOOK: Input: default@acid_uami_n0
+PREHOOK: Output: default@acid_uami_n0
+POSTHOOK: query: explain cbo update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@acid_uami_n0
+POSTHOOK: Output: default@acid_uami_n0
+CBO PLAN:
+HiveSortExchange(distribution=[any], collation=[[0]])
+  HiveProject(row__id=[$5], i=[$0], _o__c2=[893.14:DECIMAL(5, 2)], vc=[$2])
+    HiveFilter(condition=[AND(IN($1, 103:DECIMAL(5, 2), 119:DECIMAL(5, 2)), enforce_constraint(IS NOT FALSE(>=(893.14, CAST($0):DECIMAL(5, 2)))))])
+      HiveTableScan(table=[[default, acid_uami_n0]], table:alias=[acid_uami_n0])
+
 PREHOOK: query: explain update acid_uami_n0 set de = 893.14 where de = 103.00 or de = 119.00
 PREHOOK: type: QUERY
 PREHOOK: Input: default@acid_uami_n0
@@ -2066,10 +2080,10 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: acid_uami_n0
-                  filterExpr: ((de) IN (103, 119) and enforce_constraint((893.14 >= CAST( i AS decimal(5,2))) is not false)) (type: boolean)
+                  filterExpr: ((de) IN (103, 119) and enforce_constraint((CAST( i AS decimal(5,2)) <= 893.14) is not false)) (type: boolean)
                   Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
                   Filter Operator
-                    predicate: ((de) IN (103, 119) and enforce_constraint((893.14 >= CAST( i AS decimal(5,2))) is not false)) (type: boolean)
+                    predicate: ((de) IN (103, 119) and enforce_constraint((CAST( i AS decimal(5,2)) <= 893.14) is not false)) (type: boolean)
                     Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), i (type: int), vc (type: varchar(128))
@@ -2081,14 +2095,14 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: varchar(128))
+                        value expressions: _col1 (type: int), 893.14 (type: decimal(5,2)), _col3 (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 893.14 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 328 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -2188,14 +2202,14 @@ STAGE PLANS:
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int)
+                        value expressions: _col1 (type: int), 893.14 (type: decimal(5,2)), 'apache_hive' (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 893.14 (type: decimal(5,2)), 'apache_hive' (type: varchar(128))
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
                 File Output Operator
@@ -2343,11 +2357,236 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 6 (SIMPLE_EDGE)
+        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: s
+                  Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
+                  Select Operator
+                    expressions: key (type: int), a1 (type: string), value (type: string)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
+                      value expressions: _col1 (type: string), _col2 (type: string)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: t
+                  filterExpr: key is not null (type: boolean)
+                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: key is not null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: key (type: int), value (type: string), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Outer Join 0 to 1
+                keys:
+                  0 _col0 (type: int)
+                  1 _col0 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                Select Operator
+                  expressions: _col1 (type: string), _col0 (type: int), _col4 (type: string), _col5 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
+                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: _col5 is null (type: boolean)
+                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
+                      outputColumnNames: _col0, _col1, _col2
+                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Filter Operator
+                        predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
+                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          key expressions: _col2 (type: string)
+                          null sort order: a
+                          sort order: +
+                          Map-reduce partition columns: _col2 (type: string)
+                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                          value expressions: _col0 (type: int), _col1 (type: string)
+                  Filter Operator
+                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col5 (type: int), _col2 (type: string)
+                      outputColumnNames: _col0, _col1, _col3
+                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                        value expressions: _col1 (type: int), '1' (type: string), _col3 (type: string)
+        Reducer 3 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.tmerge
+                  Write Type: DELETE
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.tmerge
+                  Write Type: INSERT
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                      name: default.tmerge
+                  Write Type: UPDATE
+
+  Stage: Stage-4
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.tmerge
+          Write Type: DELETE
+
+  Stage: Stage-1
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.tmerge
+          Write Type: INSERT
+
+  Stage: Stage-2
+    Move Operator
+      tables:
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.tmerge
+          Write Type: UPDATE
+
+PREHOOK: query: explain MERGE INTO tmerge as t using nonacid as s ON t.key = s.key
+WHEN MATCHED AND s.key < 5 THEN DELETE
+WHEN MATCHED AND s.key < 3 THEN UPDATE set a1 = '1'
+WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.a1, s.value)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@nonacid
+PREHOOK: Input: default@tmerge
+PREHOOK: Output: default@merge_tmp_table
+PREHOOK: Output: default@tmerge
+PREHOOK: Output: default@tmerge
+PREHOOK: Output: default@tmerge
+POSTHOOK: query: explain MERGE INTO tmerge as t using nonacid as s ON t.key = s.key
+WHEN MATCHED AND s.key < 5 THEN DELETE
+WHEN MATCHED AND s.key < 3 THEN UPDATE set a1 = '1'
+WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.a1, s.value)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@nonacid
+POSTHOOK: Input: default@tmerge
+POSTHOOK: Output: default@merge_tmp_table
+POSTHOOK: Output: default@tmerge
+POSTHOOK: Output: default@tmerge
+POSTHOOK: Output: default@tmerge
+STAGE DEPENDENCIES:
+  Stage-4 is a root stage
+  Stage-5 depends on stages: Stage-4
+  Stage-0 depends on stages: Stage-5
+  Stage-1 depends on stages: Stage-5
+  Stage-2 depends on stages: Stage-5
+  Stage-3 depends on stages: Stage-5
+
+STAGE PLANS:
+  Stage: Stage-4
+    Tez
+#### A masked pattern was here ####
+      Edges:
         Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2446,251 +2685,9 @@ STAGE PLANS:
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: string)
-        Reducer 3 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                outputColumnNames: _col0
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.tmerge
-                  Write Type: DELETE
-        Reducer 4 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: string), KEY.reducesinkkey0 (type: string)
-                outputColumnNames: _col0, _col1, _col2
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.tmerge
-                  Write Type: INSERT
-        Reducer 5 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), '1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: enforce_constraint((_col2 is not null and ((_col1 > 0) and ((_col1 < 100) or (_col1 = 5))) is not false)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                File Output Operator
-                  compressed: false
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  table:
-                      input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-                      output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-                      serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-                      name: default.tmerge
-                  Write Type: UPDATE
-
-  Stage: Stage-4
-    Dependency Collection
-
-  Stage: Stage-0
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-              name: default.tmerge
-          Write Type: DELETE
-
-  Stage: Stage-1
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-              name: default.tmerge
-          Write Type: INSERT
-
-  Stage: Stage-2
-    Move Operator
-      tables:
-          replace: false
-          table:
-              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
-              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
-              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
-              name: default.tmerge
-          Write Type: UPDATE
-
-PREHOOK: query: explain MERGE INTO tmerge as t using nonacid as s ON t.key = s.key
-WHEN MATCHED AND s.key < 5 THEN DELETE
-WHEN MATCHED AND s.key < 3 THEN UPDATE set a1 = '1'
-WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.a1, s.value)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@nonacid
-PREHOOK: Input: default@tmerge
-PREHOOK: Output: default@merge_tmp_table
-PREHOOK: Output: default@tmerge
-PREHOOK: Output: default@tmerge
-PREHOOK: Output: default@tmerge
-POSTHOOK: query: explain MERGE INTO tmerge as t using nonacid as s ON t.key = s.key
-WHEN MATCHED AND s.key < 5 THEN DELETE
-WHEN MATCHED AND s.key < 3 THEN UPDATE set a1 = '1'
-WHEN NOT MATCHED THEN INSERT VALUES (s.key, s.a1, s.value)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@nonacid
-POSTHOOK: Input: default@tmerge
-POSTHOOK: Output: default@merge_tmp_table
-POSTHOOK: Output: default@tmerge
-POSTHOOK: Output: default@tmerge
-POSTHOOK: Output: default@tmerge
-STAGE DEPENDENCIES:
-  Stage-4 is a root stage
-  Stage-5 depends on stages: Stage-4
-  Stage-0 depends on stages: Stage-5
-  Stage-1 depends on stages: Stage-5
-  Stage-2 depends on stages: Stage-5
-  Stage-3 depends on stages: Stage-5
-
-STAGE PLANS:
-  Stage: Stage-4
-    Tez
-#### A masked pattern was here ####
-      Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
-        Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 2 (SIMPLE_EDGE)
-#### A masked pattern was here ####
-      Vertices:
-        Map 1 
-            Map Operator Tree:
-                TableScan
-                  alias: s
-                  Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
-                  Select Operator
-                    expressions: key (type: int), a1 (type: string), value (type: string)
-                    outputColumnNames: _col0, _col1, _col2
-                    Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
-                    Reduce Output Operator
-                      key expressions: _col0 (type: int)
-                      null sort order: z
-                      sort order: +
-                      Map-reduce partition columns: _col0 (type: int)
-                      Statistics: Num rows: 1 Data size: 372 Basic stats: COMPLETE Column stats: NONE
-                      value expressions: _col1 (type: string), _col2 (type: string)
-            Execution mode: vectorized, llap
-            LLAP IO: all inputs
-        Map 8 
-            Map Operator Tree:
-                TableScan
-                  alias: t
-                  filterExpr: key is not null (type: boolean)
-                  Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: key is not null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: key (type: int), value (type: string), ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: int)
-                        null sort order: z
-                        sort order: +
-                        Map-reduce partition columns: _col0 (type: int)
-                        Statistics: Num rows: 1 Data size: 188 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: string), _col2 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-            Execution mode: vectorized, llap
-            LLAP IO: may be used (ACID table)
-        Reducer 2 
-            Execution mode: llap
-            Reduce Operator Tree:
-              Merge Join Operator
-                condition map:
-                     Left Outer Join 0 to 1
-                keys:
-                  0 _col0 (type: int)
-                  1 _col0 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Select Operator
-                  expressions: _col1 (type: string), _col0 (type: int), _col4 (type: string), _col5 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col2 (type: string), _col3 (type: int)
-                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                      outputColumnNames: _col0
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                        null sort order: z
-                        sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Filter Operator
-                    predicate: _col5 is null (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: _col1 (type: int), _col0 (type: string), _col4 (type: string)
-                      outputColumnNames: _col0, _col1, _col2
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                      Filter Operator
-                        predicate: enforce_constraint((_col1 is not null and ((_col0 > 0) and ((_col0 < 100) or (_col0 = 5))) is not false)) (type: boolean)
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        Reduce Output Operator
-                          key expressions: _col2 (type: string)
-                          null sort order: a
-                          sort order: +
-                          Map-reduce partition columns: _col2 (type: string)
-                          Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                          value expressions: _col0 (type: int), _col1 (type: string)
-                  Filter Operator
-                    predicate: ((_col5 = _col1) and (_col1 < 3) and (_col1 >= 5)) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    Select Operator
-                      expressions: _col3 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), _col5 (type: int), _col2 (type: string)
-                      outputColumnNames: _col0, _col1, _col3
-                      Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                      Reduce Output Operator
-                        key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                        null sort order: z
-                        sort order: +
-                        Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: string)
+                        value expressions: _col1 (type: int), '1' (type: string), _col3 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2748,23 +2745,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), '1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: enforce_constraint((_col2 is not null and ((_col1 > 0) and ((_col1 < 100) or (_col1 = 5))) is not false)) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -2777,7 +2757,7 @@ STAGE PLANS:
                       serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
                       name: default.tmerge
                   Write Type: UPDATE
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
+++ b/ql/src/test/results/clientpositive/llap/enforce_constraint_notnull.q.out
@@ -3450,34 +3450,34 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: acid_uami_n1
-                  filterExpr: ((de) IN (109.23, 119.23) and enforce_constraint(vc is not null)) (type: boolean)
+                  filterExpr: (de) IN (109.23, 119.23) (type: boolean)
                   Statistics: Num rows: 1002 Data size: 225450 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((de) IN (109.23, 119.23) and enforce_constraint(vc is not null)) (type: boolean)
-                    Statistics: Num rows: 3 Data size: 675 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (de) IN (109.23, 119.23) (type: boolean)
+                    Statistics: Num rows: 6 Data size: 1350 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), i (type: int), vc (type: varchar(128))
                       outputColumnNames: _col0, _col1, _col3
-                      Statistics: Num rows: 3 Data size: 567 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 6 Data size: 1134 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 3 Data size: 567 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col3 (type: varchar(128))
+                        Statistics: Num rows: 6 Data size: 1806 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), 3.14 (type: decimal(5,2)), _col3 (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 3.14 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 3 Data size: 903 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 6 Data size: 1806 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 3 Data size: 903 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 1806 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -3549,34 +3549,34 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: acid_uami_n1
-                  filterExpr: ((de = 3.14) and enforce_constraint((i is not null and vc is not null))) (type: boolean)
+                  filterExpr: (de = 3.14) (type: boolean)
                   Statistics: Num rows: 1002 Data size: 225450 Basic stats: COMPLETE Column stats: COMPLETE
                   Filter Operator
-                    predicate: ((de = 3.14) and enforce_constraint((i is not null and vc is not null))) (type: boolean)
-                    Statistics: Num rows: 1 Data size: 225 Basic stats: COMPLETE Column stats: COMPLETE
+                    predicate: (de = 3.14) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 675 Basic stats: COMPLETE Column stats: COMPLETE
                     Select Operator
                       expressions: ROW__ID (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), i (type: int), vc (type: varchar(128))
                       outputColumnNames: _col0, _col1, _col3
-                      Statistics: Num rows: 1 Data size: 189 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 3 Data size: 567 Basic stats: COMPLETE Column stats: COMPLETE
                       Reduce Output Operator
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
                         Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                        Statistics: Num rows: 1 Data size: 189 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col3 (type: varchar(128))
+                        Statistics: Num rows: 3 Data size: 903 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), 3.14 (type: decimal(5,2)), _col3 (type: varchar(128))
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
         Reducer 2 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 3.14 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
+                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: decimal(5,2)), VALUE._col2 (type: varchar(128))
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 301 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 3 Data size: 903 Basic stats: COMPLETE Column stats: COMPLETE
                 File Output Operator
                   compressed: false
-                  Statistics: Num rows: 1 Data size: 301 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 3 Data size: 903 Basic stats: COMPLETE Column stats: COMPLETE
                   table:
                       input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
                       output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
@@ -4421,12 +4421,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4447,7 +4446,7 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: t
@@ -4521,8 +4520,9 @@ STAGE PLANS:
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: string)
+                        value expressions: _col1 (type: int), '1' (type: string), _col3 (type: string)
         Reducer 3 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
@@ -4590,23 +4590,6 @@ STAGE PLANS:
                         output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
                         serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
         Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), '1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: enforce_constraint(_col1 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 7 
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
@@ -4714,13 +4697,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -4741,7 +4723,7 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 9 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: t
@@ -4815,8 +4797,9 @@ STAGE PLANS:
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: string)
+                        value expressions: _col1 (type: int), '1' (type: string), _col3 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -4908,23 +4891,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), '1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: enforce_constraint(_col1 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -4937,7 +4903,7 @@ STAGE PLANS:
                       serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
                       name: default.masking_test_n4
                   Write Type: UPDATE
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator
@@ -5345,12 +5311,11 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 7 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 3 (CUSTOM_SIMPLE_EDGE)
         Reducer 5 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 6 <- Reducer 5 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -5371,7 +5336,7 @@ STAGE PLANS:
                       value expressions: _col1 (type: string), _col2 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 8 
+        Map 7 
             Map Operator Tree:
                 TableScan
                   alias: t
@@ -5432,8 +5397,9 @@ STAGE PLANS:
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
                         Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                        value expressions: _col1 (type: int), _col3 (type: string)
+                        value expressions: _col1 (type: int), '1' (type: string), _col3 (type: string)
                   Filter Operator
                     predicate: (_col5 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5509,23 +5475,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), '1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                Filter Operator
-                  predicate: enforce_constraint(_col1 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 6 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 409 Basic stats: COMPLETE Column stats: NONE
@@ -5538,7 +5487,7 @@ STAGE PLANS:
                       serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
                       name: default.masking_test_n4
                   Write Type: UPDATE
-        Reducer 7 
+        Reducer 6 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator

--- a/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
+++ b/ql/src/test/results/clientpositive/llap/insert_into_default_keyword.q.out
@@ -2921,13 +2921,12 @@ STAGE PLANS:
     Tez
 #### A masked pattern was here ####
       Edges:
-        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 9 (SIMPLE_EDGE)
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Map 8 (SIMPLE_EDGE)
         Reducer 3 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 4 <- Reducer 2 (SIMPLE_EDGE)
         Reducer 5 <- Reducer 4 (CUSTOM_SIMPLE_EDGE)
         Reducer 6 <- Reducer 2 (SIMPLE_EDGE)
-        Reducer 7 <- Reducer 6 (SIMPLE_EDGE)
-        Reducer 8 <- Reducer 2 (SIMPLE_EDGE)
+        Reducer 7 <- Reducer 2 (SIMPLE_EDGE)
 #### A masked pattern was here ####
       Vertices:
         Map 1 
@@ -2948,7 +2947,7 @@ STAGE PLANS:
                       value expressions: _col1 (type: string)
             Execution mode: vectorized, llap
             LLAP IO: all inputs
-        Map 9 
+        Map 8 
             Map Operator Tree:
                 TableScan
                   alias: t
@@ -3026,8 +3025,9 @@ STAGE PLANS:
                         key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
                         null sort order: z
                         sort order: +
-                        Statistics: Num rows: 1 Data size: 170 Basic stats: COMPLETE Column stats: COMPLETE
-                        value expressions: _col1 (type: int), _col3 (type: string)
+                        Map-reduce partition columns: UDFToInteger(_col0) (type: int)
+                        Statistics: Num rows: 1 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), 'a1' (type: string), _col3 (type: string)
                   Filter Operator
                     predicate: (_col4 = _col1) (type: boolean)
                     Statistics: Num rows: 1 Data size: 261 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3119,23 +3119,6 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
-                expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), 'a1' (type: string), VALUE._col1 (type: string)
-                outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 1 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
-                Filter Operator
-                  predicate: enforce_constraint(_col1 is not null) (type: boolean)
-                  Statistics: Num rows: 1 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
-                  Reduce Output Operator
-                    key expressions: _col0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>)
-                    null sort order: z
-                    sort order: +
-                    Map-reduce partition columns: UDFToInteger(_col0) (type: int)
-                    Statistics: Num rows: 1 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
-                    value expressions: _col1 (type: int), _col2 (type: string), _col3 (type: string)
-        Reducer 7 
-            Execution mode: vectorized, llap
-            Reduce Operator Tree:
-              Select Operator
                 expressions: KEY.reducesinkkey0 (type: struct<writeid:bigint,bucketid:int,rowid:bigint>), VALUE._col0 (type: int), VALUE._col1 (type: string), VALUE._col2 (type: string)
                 outputColumnNames: _col0, _col1, _col2, _col3
                 Statistics: Num rows: 1 Data size: 256 Basic stats: COMPLETE Column stats: COMPLETE
@@ -3148,7 +3131,7 @@ STAGE PLANS:
                       serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
                       name: default.acidtable
                   Write Type: UPDATE
-        Reducer 8 
+        Reducer 7 
             Execution mode: llap
             Reduce Operator Tree:
               Group By Operator


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
1. Add a Project on top of constraint Filter when building CBO plan from AST since Filter schema can have more columns than result schema. 
2. Disable plan generation for constraint for update statements if CBO is enabled.

### Why are the changes needed?
CBO failed because of Result schema and CBO plan schema mismatch. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=check_constraint.q -pl itests/qtest -Pitests
```