### PR TITLE
HIVE-21200: Vectorization: date column throwing java.lang.UnsupportedOperationException for parquet

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedPrimitiveColumnReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedPrimitiveColumnReader.java
@@ -168,9 +168,9 @@ public class VectorizedPrimitiveColumnReader implements VectorizedColumnReader {
     case INT:
     case BYTE:
     case SHORT:
+    case DATE:
       readIntegers(num, (LongColumnVector) column, rowId);
       break;
-    case DATE:
     case INTERVAL_YEAR_MONTH:
     case LONG:
       readLongs(num, (LongColumnVector) column, rowId);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestVectorizedColumnReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestVectorizedColumnReader.java
@@ -57,6 +57,11 @@ public class TestVectorizedColumnReader extends VectorizedColumnReaderTestBase {
   }
 
   @Test
+  public void testDateRead() throws Exception {
+    dateRead(isDictionaryEncoding);
+  }
+
+  @Test
   public void testDoubleRead() throws Exception {
     doubleRead(isDictionaryEncoding);
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
@@ -389,7 +389,7 @@ public class VectorizedColumnReaderTestBase {
         LongColumnVector vector = (LongColumnVector) previous.cols[0];
         assertTrue(vector.noNulls);
         for (int i = 0; i < vector.vector.length; i++) {
-          if(c == nElements){
+          if (c == nElements){
             break;
           }
           assertEquals("Failed at " + c, getIntValue(isDictionaryEncoding, c), vector.vector[i]);

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
@@ -79,6 +79,7 @@ public class VectorizedColumnReaderTestBase {
       + "required int32 int32_field; "
       + "required int64 int64_field; "
       + "required int96 int96_field; "
+      + "required int32 date_field; "
       + "required double double_field; "
       + "required float float_field; "
       + "required boolean boolean_field; "
@@ -246,7 +247,8 @@ public class VectorizedColumnReaderTestBase {
         .append("double_field", doubleVal)
         .append("float_field", floatVal)
         .append("boolean_field", booleanVal)
-        .append("flba_field", "abc");
+        .append("flba_field", "abc")
+        .append("date_field", intVal);
 
       if (!isNull) {
         group.append("some_null_field", "x");
@@ -362,6 +364,35 @@ public class VectorizedColumnReaderTestBase {
             break;
           }
           assertEquals("Failed at " + c, getLongValue(isDictionaryEncoding, c), vector.vector[i]);
+          assertFalse(vector.isNull[i]);
+          c++;
+        }
+      }
+      assertEquals(nElements, c);
+    } finally {
+      reader.close();
+    }
+  }
+
+  protected void dateRead(boolean isDictionaryEncoding) throws InterruptedException, HiveException, IOException {
+    Configuration conf = new Configuration();
+    conf.set(IOConstants.COLUMNS,"date_field");
+    conf.set(IOConstants.COLUMNS_TYPES,"date");
+    conf.setBoolean(ColumnProjectionUtils.READ_ALL_COLUMNS, false);
+    conf.set(ColumnProjectionUtils.READ_COLUMN_IDS_CONF_STR, "0");
+    VectorizedParquetRecordReader reader =
+            createParquetReader("message test { required int date_field;}", conf);
+    VectorizedRowBatch previous = reader.createValue();
+    try {
+      int c = 0;
+      while (reader.next(NullWritable.get(), previous)) {
+        LongColumnVector vector = (LongColumnVector) previous.cols[0];
+        assertTrue(vector.noNulls);
+        for (int i = 0; i < vector.vector.length; i++) {
+          if(c == nElements){
+            break;
+          }
+          assertEquals("Failed at " + c, getIntValue(isDictionaryEncoding, c), vector.vector[i]);
           assertFalse(vector.isNull[i]);
           c++;
         }


### PR DESCRIPTION
### What changes were proposed in this pull request?
The date type should be treated as int instead of long.


### Why are the changes needed?
otherwise exception will be thrown when read parquet files with date column when vectorization is enabled.


### Does this PR introduce _any_ user-facing change?
no.


### How was this patch tested?
add a unit test for date.
