### PR TITLE
HIVE-24945: Support vectorization for lead/lag functions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/BufferedVectorizedRowBatch.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/BufferedVectorizedRowBatch.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
  */
 public class BufferedVectorizedRowBatch extends VectorizedRowBatch {
   boolean isLastGroupBatch;
+  boolean isInputExpressionEvaluated;
 
   public BufferedVectorizedRowBatch(int numCols) {
     super(numCols);

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorAbstractLeadLag.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorAbstractLeadLag.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import java.util.stream.IntStream;
+
+import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatch;
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector.Type;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.ConstantVectorExpression;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.IdentityExpression;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.exec.vector.ptf.VectorPTFEvaluatorBase;
+import org.apache.hadoop.hive.ql.exec.vector.ptf.VectorPTFGroupBatches;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+import org.apache.hadoop.hive.ql.udf.ptf.Range;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+
+public abstract class VectorPTFEvaluatorAbstractLeadLag extends VectorPTFEvaluatorBase {
+
+  protected int amt;
+  protected Object defaultValue;
+  protected int defaultValueColumn = -1;
+  protected Type type;
+
+  public VectorPTFEvaluatorAbstractLeadLag(WindowFrameDef windowFrameDef,
+      VectorExpression inputVecExpr, int outputColumnNum, Type type, int amt,
+      VectorExpression defaultValueExpression) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum);
+    this.type = type;
+    this.amt = amt;
+    initDefaultValue(defaultValueExpression);
+  }
+
+  private void initDefaultValue(VectorExpression defaultValueExpression) {
+    if (defaultValueExpression == null) {
+      defaultValue = null;
+      return;
+    } else if (defaultValueExpression instanceof ConstantVectorExpression) {
+      // FIXME: always getLongValue()? check if other type is given in 3rd argument
+      long longValue = ((ConstantVectorExpression) defaultValueExpression).getLongValue();
+      switch (type) {
+      case LONG:
+        defaultValue = longValue;
+        break;
+      case DOUBLE:
+        defaultValue = Double.valueOf(longValue);
+        break;
+      case DECIMAL:
+        defaultValue = new HiveDecimalWritable(longValue);
+        break;
+      default:
+        throw new RuntimeException("Unexpected column vector type " + type + " for lag function");
+      }
+    } else if (defaultValueExpression instanceof IdentityExpression) {
+      defaultValueColumn = ((IdentityExpression) defaultValueExpression).getOutputColumnNum();
+    } else {
+      throw new RuntimeException(
+          "Unexpected vector expression type for default value in lag function: "
+              + defaultValueExpression.getClass().getName());
+    }
+  }
+
+  @Override
+  public boolean canRunOptimizedCalculation(int rowNum, Range range) {
+    return true;
+  }
+
+  protected Object getDefaultValue(int rowNum, VectorPTFGroupBatches batches) throws HiveException {
+    if (defaultValueColumn > -1) {
+      return batches.getValue(rowNum, defaultValueColumn);
+    } else {
+      return defaultValue;
+    }
+  }
+
+  @Override
+  public void evaluateGroupBatch(VectorizedRowBatch batch) throws HiveException {
+  }
+
+  // TODO: HIVE-25123: Implement vectorized streaming lead/lag
+  @Override
+  public boolean streamsResult() {
+    return false;
+  }
+
+  @Override
+  public Type getResultColumnVectorType() {
+    return type;
+  }
+
+  @Override
+  public void resetEvaluator() {
+  }
+
+  @Override
+  public boolean isCacheableForRange() {
+    return false;
+  }
+
+  @Override
+  public void mapCustomColumns(int[] bufferedColumnMap) {
+    if (defaultValueColumn > -1) {
+      defaultValueColumn = IntStream.range(0, bufferedColumnMap.length)
+          .filter(j -> bufferedColumnMap[j] == defaultValueColumn).findFirst()
+          .orElseGet(() -> defaultValueColumn);
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorBase.java
@@ -186,4 +186,12 @@ public abstract class VectorPTFEvaluatorBase {
   public boolean isCacheableForRange() {
     return true;
   }
+
+  /**
+   * VectorPTFGroupBatches class works on a subset of columns, which are mapped by an array of
+   * changed indices. Some evaluators might refer to column indices, so they can adapt to the
+   * changed column layout by this call.
+   */
+  public void mapCustomColumns(int[] bufferedColumnMap) {
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLag.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLag.java
@@ -38,7 +38,7 @@ public class VectorPTFEvaluatorLag extends VectorPTFEvaluatorAbstractLeadLag {
     if (lagRow < 0 || lagRow >= batches.size()) {
       return getDefaultValue(rowNum, batches);
     } else {
-      return batches.getValue(lagRow, inputColumnNum);
+      return batches.getValueAndEvaluateInputExpression(this, lagRow, inputColumnNum);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLag.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLag.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector.Type;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+import org.apache.hadoop.hive.ql.udf.ptf.Range;
+
+public class VectorPTFEvaluatorLag extends VectorPTFEvaluatorAbstractLeadLag {
+
+  public VectorPTFEvaluatorLag(WindowFrameDef windowFrameDef, VectorExpression inputVecExpr,
+      int outputColumnNum, Type type, int amt, VectorExpression defaultValueExpression) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum, type, amt, defaultValueExpression);
+  }
+
+  @Override
+  public Object runOnRange(int rowNum, Range range, VectorPTFGroupBatches batches)
+      throws HiveException {
+    int lagRow = rowNum - amt;
+    if (lagRow < 0 || lagRow >= batches.size()) {
+      return getDefaultValue(rowNum, batches);
+    } else {
+      return batches.getValue(lagRow, inputColumnNum);
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLead.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLead.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec.vector.ptf;
+
+import org.apache.hadoop.hive.ql.exec.vector.ColumnVector.Type;
+import org.apache.hadoop.hive.ql.exec.vector.expressions.VectorExpression;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.plan.ptf.WindowFrameDef;
+import org.apache.hadoop.hive.ql.udf.ptf.Range;
+
+public class VectorPTFEvaluatorLead extends VectorPTFEvaluatorAbstractLeadLag {
+
+  public VectorPTFEvaluatorLead(WindowFrameDef windowFrameDef, VectorExpression inputVecExpr,
+      int outputColumnNum, Type type, int amt, VectorExpression defaultValueExpression) {
+    super(windowFrameDef, inputVecExpr, outputColumnNum, type, amt, defaultValueExpression);
+  }
+
+  @Override
+  public Object runOnRange(int rowNum, Range range, VectorPTFGroupBatches batches)
+      throws HiveException {
+    int leadRow = rowNum + amt;
+    if (leadRow < 0 || leadRow >= batches.size()) {
+      return getDefaultValue(rowNum, batches);
+    } else {
+      return batches.getValue(leadRow, inputColumnNum);
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLead.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFEvaluatorLead.java
@@ -38,7 +38,7 @@ public class VectorPTFEvaluatorLead extends VectorPTFEvaluatorAbstractLeadLag {
     if (leadRow < 0 || leadRow >= batches.size()) {
       return getDefaultValue(rowNum, batches);
     } else {
-      return batches.getValue(leadRow, inputColumnNum);
+      return batches.getValueAndEvaluateInputExpression(this, leadRow, inputColumnNum);
     }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFGroupBatches.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFGroupBatches.java
@@ -858,6 +858,15 @@ public class VectorPTFGroupBatches extends PTFPartition {
 
     Object result = null;
     if (evaluator.canRunOptimizedCalculation(rowNum, range)) {
+      /*
+       * A classic evaluator (which doesn't take advantage of optimized calculation) usually
+       * evaluates its input expression in evaluateGroupBatch. The optimized calculation doesn't
+       * necessarily work on batches, but input expressions still have to be evaluated, so we take
+       * care of them here.
+       */
+      RowPositionInBatch rp = getPosition(rowNum);
+      evaluator.evaluateInputExpr(bufferedBatches.get(rp.batchIndex));
+
       result = copyResultIfNeeded(evaluator, evaluator.runOnRange(rowNum, range, this));
       partitionMetrics.evaluationOptimized += 1;
     } else { // fallback to batch-by-batch manner over the whole range

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorPTFOperator.java
@@ -505,6 +505,7 @@ public class VectorPTFOperator extends Operator<PTFDesc>
               .filter(j -> bufferedColumnMap[j] == evaluator.inputVecExpr.outputColumnNum)
               .findFirst().orElseGet(() -> evaluator.inputVecExpr.outputColumnNum);
         }
+        evaluator.mapCustomColumns(bufferedColumnMap);
       }
     }
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorSpillBlockContainer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/ptf/VectorSpillBlockContainer.java
@@ -140,6 +140,10 @@ class VectorSpillBlockContainer {
     boolean[] isLastGroupBatch;
 
     /**
+     * Stores the isInputExpressionEvaluated property for buffered/spilled batches.
+     */
+    boolean[] isInputExpressionEvaluated;
+    /**
      * <pre>
       * Deserializer needs to know which columns to put the deserialized values into. Basically,
       * deserialization can happen in 2 cases:
@@ -161,6 +165,7 @@ class VectorSpillBlockContainer {
       startBatchIndex = blockIndex * blockSize;
       startRowIndex = new int[blockSize];
       isLastGroupBatch = new boolean[blockSize];
+      isInputExpressionEvaluated = new boolean[blockSize];
     }
 
     void releaseRowBytesContainer() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/PTFDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/PTFDesc.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizationContext;
@@ -153,7 +154,8 @@ public class PTFDesc extends AbstractOperatorDesc {
 
     @Explain(vectorization = Vectorization.EXPRESSION, displayName = "functionInputExpressions", explainLevels = { Level.DEFAULT, Level.EXTENDED })
     public String getFunctionInputExpressions() {
-      return Arrays.toString(vectorPTFInfo.getEvaluatorInputExpressions());
+      return Arrays.asList(vectorPTFInfo.getEvaluatorInputExpressions()).stream().map(i -> i[0])
+          .collect(Collectors.toList()).toString();
     }
 
     @Explain(vectorization = Vectorization.EXPRESSION, displayName = "partitionExpressions", explainLevels = { Level.DEFAULT, Level.EXTENDED })

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFDesc.java
@@ -179,8 +179,8 @@ public class VectorPTFDesc extends AbstractVectorDesc  {
 
   // We provide this public method to help EXPLAIN VECTORIZATION show the evaluator classes.
   public static VectorPTFEvaluatorBase getEvaluator(SupportedFunctionType functionType,
-      List<ExprNodeDesc> evaluatorParameters, boolean isDistinct, WindowFrameDef windowFrameDef,
-      Type[] columnVectorTypes, VectorExpression[] inputVectorExpressions, int outputColumnNum) {
+      boolean isDistinct, WindowFrameDef windowFrameDef, Type[] columnVectorTypes,
+      VectorExpression[] inputVectorExpressions, int outputColumnNum) {
 
     final boolean isRowEndCurrent = (windowFrameDef.getWindowType() == WindowType.ROWS
         && windowFrameDef.getEnd().isCurrentRow());
@@ -431,7 +431,6 @@ public class VectorPTFDesc extends AbstractVectorDesc  {
   public static VectorPTFEvaluatorBase[] getEvaluators(VectorPTFDesc vectorPTFDesc, VectorPTFInfo vectorPTFInfo) {
     String[] evaluatorFunctionNames = vectorPTFDesc.getEvaluatorFunctionNames();
     boolean[] evaluatorsAreDistinct = vectorPTFDesc.getEvaluatorsAreDistinct();
-    List<ExprNodeDesc>[] evaluatorInputExprNodeDescLists = vectorPTFDesc.getEvaluatorInputExprNodeDescLists();
     int evaluatorCount = evaluatorFunctionNames.length;
     WindowFrameDef[] evaluatorWindowFrameDefs = vectorPTFDesc.getEvaluatorWindowFrameDefs();
     VectorExpression[][] evaluatorInputExpressions = vectorPTFInfo.getEvaluatorInputExpressions();
@@ -452,7 +451,7 @@ public class VectorPTFDesc extends AbstractVectorDesc  {
       final int outputColumnNum = outputColumnMap[i];
 
       VectorPTFEvaluatorBase evaluator =
-          VectorPTFDesc.getEvaluator(functionType, evaluatorInputExprNodeDescLists[i], isDistinct,
+          VectorPTFDesc.getEvaluator(functionType, isDistinct,
               windowFrameDef, columnVectorTypes, inputVectorExpressions, outputColumnNum);
 
       evaluators[i] = evaluator;

--- a/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFInfo.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/plan/VectorPTFInfo.java
@@ -42,8 +42,16 @@ public class VectorPTFInfo {
   private Type[] partitionColumnVectorTypes;
   private VectorExpression[] partitionExpressions;
 
-  private VectorExpression[] evaluatorInputExpressions;
-  private Type[] evaluatorInputColumnVectorTypes;
+  /**
+   * Two dimensional array for storing input vector expressions for all evaluators, so this will
+   * typically look like: evaluatorInputColumnVectorTypes[evaluatorCount][inputExpressionCount]
+   */
+  private VectorExpression[][] evaluatorInputExpressions;
+  /**
+   * Two dimensional array for storing input column vector types for all evaluators, so this will
+   * typically look like: evaluatorInputColumnVectorTypes[evaluatorCount][inputExpressionCount]
+   */
+  private Type[][] evaluatorInputColumnVectorTypes;
 
   private int[] keyInputColumnMap;
   private int[] nonKeyInputColumnMap;
@@ -123,19 +131,19 @@ public class VectorPTFInfo {
     this.partitionExpressions = partitionExpressions;
   }
 
-  public VectorExpression[] getEvaluatorInputExpressions() {
+  public VectorExpression[][] getEvaluatorInputExpressions() {
     return evaluatorInputExpressions;
   }
 
-  public void setEvaluatorInputExpressions(VectorExpression[] evaluatorInputExpressions) {
+  public void setEvaluatorInputExpressions(VectorExpression[][] evaluatorInputExpressions) {
     this.evaluatorInputExpressions = evaluatorInputExpressions;
   }
 
-  public Type[] getEvaluatorInputColumnVectorTypes() {
+  public Type[][] getEvaluatorInputColumnVectorTypes() {
     return evaluatorInputColumnVectorTypes;
   }
 
-  public void setEvaluatorInputColumnVectorTypes(Type[] evaluatorInputColumnVectorTypes) {
+  public void setEvaluatorInputColumnVectorTypes(Type[][] evaluatorInputColumnVectorTypes) {
     this.evaluatorInputColumnVectorTypes = evaluatorInputColumnVectorTypes;
   }
 

--- a/ql/src/test/queries/clientpositive/vector_ptf_bounded_start.q
+++ b/ql/src/test/queries/clientpositive/vector_ptf_bounded_start.q
@@ -44,7 +44,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -71,7 +73,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -98,7 +102,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -125,7 +131,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -152,7 +160,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -179,7 +189,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -207,7 +219,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -234,7 +248,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -262,7 +278,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 
@@ -289,7 +307,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 select "************ FOLLOWING ROWS ************";
@@ -317,7 +337,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 select p_mfgr, p_name, rowindex, p_date, p_retailprice,
@@ -340,7 +362,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc;
 
 

--- a/ql/src/test/queries/clientpositive/vector_ptf_lead_lag.q
+++ b/ql/src/test/queries/clientpositive/vector_ptf_lead_lag.q
@@ -1,0 +1,175 @@
+set hive.vectorized.testing.reducer.batch.size=2;
+
+CREATE TABLE vector_ptf_lead_lag_int(name string, rowindex int, mynumber int) stored as orc;
+
+INSERT INTO vector_ptf_lead_lag_int values
+-- a partition
+('first', 1, 1),
+('first', 2, 2),
+('first', 3, 2),
+('first', 4, NULL),
+('first', 5, 3),
+('first', 6, 3),
+('first', 7, 4),
+('first', 8, NULL),
+('first', 9, 4),
+('first', 10, 4),
+('first', 11, 5),
+('first', 12, 5),
+('first', 13, NULL),
+('first', 14, 5),
+('first', 15, 5),
+('first', 16, 6),
+('first', 17, 6),
+('first', 18, 6),
+('first', 19, NULL),
+('first', 20, 6),
+('first', 21, 6),
+-- another partition
+('second', 22, 1),
+('second', 23, 2),
+('second', 24, 2),
+('second', 25, NULL),
+('second', 26, 3),
+('second', 27, 3),
+('second', 28, 4),
+('second', 29, NULL),
+('second', 30, 4),
+('second', 31, 4),
+('second', 32, 5),
+('second', 33, 5),
+('second', 34, NULL),
+('second', 35, 5),
+('second', 36, 5),
+('second', 37, 6),
+('second', 38, 6),
+('second', 39, 6),
+('second', 40, NULL),
+('second', 41, 6),
+('second', 42, 6),
+-- null partition
+(NULL, 43, 7),
+(NULL, 44, 7);
+
+select "************ INT, NON-VECTORIZED ************";
+set hive.vectorized.execution.ptf.enabled=false;
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int;
+
+set hive.vectorized.execution.ptf.enabled=true;
+explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int;
+
+select "************ INT, VECTORIZED ************";
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int;
+
+
+
+
+CREATE TABLE vector_ptf_lead_lag_double(name string, rowindex int, mynumber double) stored as orc;
+INSERT INTO vector_ptf_lead_lag_double SELECT * from vector_ptf_lead_lag_int;
+
+select "************ DOUBLE, NON-VECTORIZED ************";
+set hive.vectorized.execution.ptf.enabled=false;
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double;
+
+set hive.vectorized.execution.ptf.enabled=true;
+explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double;
+
+select "************ DOUBLE, VECTORIZED ************";
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double;
+
+
+
+
+CREATE TABLE vector_ptf_lead_lag_decimal(name string, rowindex int, mynumber decimal) stored as orc;
+INSERT INTO vector_ptf_lead_lag_decimal SELECT * from vector_ptf_lead_lag_int;
+
+select "************ DECIMAL, NON-VECTORIZED ************";
+set hive.vectorized.execution.ptf.enabled=false;
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal;
+
+set hive.vectorized.execution.ptf.enabled=true;
+explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal;
+
+select "************ DECIMAL, VECTORIZED ************";
+select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal;

--- a/ql/src/test/results/clientpositive/llap/pcs.q.out
+++ b/ql/src/test/results/clientpositive/llap/pcs.q.out
@@ -973,7 +973,7 @@ STAGE PLANS:
             Execution mode: vectorized, llap
             LLAP IO: all inputs
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int)

--- a/ql/src/test/results/clientpositive/llap/ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/ptf.q.out
@@ -298,7 +298,7 @@ STAGE PLANS:
                     Statistics: Num rows: 27 Data size: 6021 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col5 (type: int)
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int)
@@ -774,7 +774,7 @@ STAGE PLANS:
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col5 (type: int)
         Reducer 3 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int)
@@ -2504,7 +2504,7 @@ STAGE PLANS:
                   Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col5 (type: int), _col7 (type: double)
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)

--- a/ql/src/test/results/clientpositive/llap/vector_ptf_bounded_start.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_ptf_bounded_start.q.out
@@ -91,7 +91,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -116,52 +118,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: EXPLAIN VECTORIZATION DETAIL
 select p_mfgr, p_name, rowindex, p_date, p_retailprice,
 count(*) over(partition by p_mfgr order by p_date range between 1 preceding and current row) as cs1,
@@ -183,7 +187,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -209,7 +215,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
@@ -451,7 +459,7 @@ STAGE PLANS:
                     dataColumnCount: 20
                     dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col1:bigint, VALUE._col2:bigint, VALUE._col3:bigint, VALUE._col4:bigint, VALUE._col5:double, VALUE._col6:double, VALUE._col7:double, VALUE._col8:double, VALUE._col9:double, VALUE._col10:double, VALUE._col11:double, VALUE._col12:double, VALUE._col13:int, VALUE._col14:int, VALUE._col15:string, VALUE._col16:date, VALUE._col19:double, VALUE._col21:int
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint, bigint, bigint, double]
+                    scratchColumnTypeNames: [bigint, bigint, bigint, double, double, double]
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: bigint), VALUE._col5 (type: double), VALUE._col6 (type: double), VALUE._col7 (type: double), VALUE._col8 (type: double), VALUE._col9 (type: double), VALUE._col10 (type: double), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: int), VALUE._col14 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col15 (type: string), VALUE._col16 (type: date), VALUE._col19 (type: double), VALUE._col21 (type: int)
@@ -500,28 +508,42 @@ STAGE PLANS:
                               name: first_value
                               window function: GenericUDAFFirstValueEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                            window function definition
+                              alias: lead_window_20
+                              arguments: _col20
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_21
+                              arguments: _col20
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
                   PTF Vectorization:
-                      allEvaluatorsAreStreaming: true
+                      allEvaluatorsAreStreaming: false
                       className: VectorPTFOperator
-                      evaluatorClasses: [VectorPTFEvaluatorRowNumber, VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorDoubleFirstValue]
-                      functionInputExpressions: [null, col 0:string, col 0:string, col 18:double]
-                      functionNames: [row_number, rank, dense_rank, first_value]
+                      evaluatorClasses: [VectorPTFEvaluatorRowNumber, VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorDoubleFirstValue, VectorPTFEvaluatorLead, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [null, col 0:string, col 0:string, col 18:double, col 18:double, col 18:double]
+                      functionNames: [row_number, rank, dense_rank, first_value, lead, lag]
                       keyInputColumns: [0]
                       native: true
                       nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
                       orderExpressions: [col 0:string]
-                      outputColumns: [20, 21, 22, 23, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
-                      outputTypes: [int, int, int, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
+                      outputColumns: [20, 21, 22, 23, 24, 25, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
+                      outputTypes: [int, int, int, double, double, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
                       partitionExpressions: [col 0:string]
                       streamingColumns: [20, 21, 22, 23]
                   Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col15 (type: string), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
-                    outputColumnNames: row_number_window_13, rank_window_14, dense_rank_window_15, first_value_window_18, _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col20, _col22
+                    expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), lead_window_20 (type: double), lag_window_21 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col15 (type: string), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
+                    outputColumnNames: row_number_window_13, rank_window_14, dense_rank_window_15, first_value_window_18, lead_window_20, lag_window_21, _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col20, _col22
                     Select Vectorization:
                         className: VectorSelectOperator
                         native: true
-                        projectedOutputColumnNums: [20, 21, 22, 23, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
+                        projectedOutputColumnNums: [20, 21, 22, 23, 24, 25, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
                     Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col15 (type: string)
@@ -533,9 +555,9 @@ STAGE PLANS:
                           keyColumns: 0:string
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                          valueColumns: 20:int, 21:int, 22:int, 23:double, 1:bigint, 2:bigint, 3:bigint, 4:bigint, 5:bigint, 6:double, 7:double, 8:double, 9:double, 10:double, 11:double, 12:double, 13:double, 14:int, 15:int, 16:string, 17:date, 18:double, 19:int
+                          valueColumns: 20:int, 21:int, 22:int, 23:double, 24:double, 25:double, 1:bigint, 2:bigint, 3:bigint, 4:bigint, 5:bigint, 6:double, 7:double, 8:double, 9:double, 10:double, 11:double, 12:double, 13:double, 14:int, 15:int, 16:string, 17:date, 18:double, 19:int
                       Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
+                      value expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), lead_window_20 (type: double), lag_window_21 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -547,35 +569,35 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
-                    dataColumnCount: 24
-                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:double, VALUE._col4:bigint, VALUE._col5:bigint, VALUE._col6:bigint, VALUE._col7:bigint, VALUE._col8:bigint, VALUE._col9:double, VALUE._col10:double, VALUE._col11:double, VALUE._col12:double, VALUE._col13:double, VALUE._col14:double, VALUE._col15:double, VALUE._col16:double, VALUE._col17:int, VALUE._col18:int, VALUE._col19:string, VALUE._col20:date, VALUE._col23:double, VALUE._col25:int
+                    dataColumnCount: 26
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:double, VALUE._col4:double, VALUE._col5:double, VALUE._col6:bigint, VALUE._col7:bigint, VALUE._col8:bigint, VALUE._col9:bigint, VALUE._col10:bigint, VALUE._col11:double, VALUE._col12:double, VALUE._col13:double, VALUE._col14:double, VALUE._col15:double, VALUE._col16:double, VALUE._col17:double, VALUE._col18:double, VALUE._col19:int, VALUE._col20:int, VALUE._col21:string, VALUE._col22:date, VALUE._col25:double, VALUE._col27:int
                     partitionColumnCount: 0
                     scratchColumnTypeNames: [double]
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: double), VALUE._col4 (type: bigint), VALUE._col5 (type: bigint), VALUE._col6 (type: bigint), VALUE._col7 (type: bigint), VALUE._col8 (type: bigint), VALUE._col9 (type: double), VALUE._col10 (type: double), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: double), VALUE._col14 (type: double), VALUE._col15 (type: double), VALUE._col16 (type: double), VALUE._col17 (type: int), VALUE._col18 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col19 (type: string), VALUE._col20 (type: date), VALUE._col23 (type: double), VALUE._col25 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col24, _col26
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: double), VALUE._col4 (type: double), VALUE._col5 (type: double), VALUE._col6 (type: bigint), VALUE._col7 (type: bigint), VALUE._col8 (type: bigint), VALUE._col9 (type: bigint), VALUE._col10 (type: bigint), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: double), VALUE._col14 (type: double), VALUE._col15 (type: double), VALUE._col16 (type: double), VALUE._col17 (type: double), VALUE._col18 (type: double), VALUE._col19 (type: int), VALUE._col20 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col21 (type: string), VALUE._col22 (type: date), VALUE._col25 (type: double), VALUE._col27 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col26, _col28
                 Select Vectorization:
                     className: VectorSelectOperator
                     native: true
-                    projectedOutputColumnNums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 20, 21, 22, 23]
-                Statistics: Num rows: 40 Data size: 14916 Basic stats: COMPLETE Column stats: COMPLETE
+                    projectedOutputColumnNums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 0, 22, 23, 24, 25]
+                Statistics: Num rows: 40 Data size: 15556 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
                         input alias: ptf_0
-                        output shape: _col0: int, _col1: int, _col2: int, _col3: double, _col4: bigint, _col5: bigint, _col6: bigint, _col7: bigint, _col8: bigint, _col9: double, _col10: double, _col11: double, _col12: double, _col13: double, _col14: double, _col15: double, _col16: double, _col17: int, _col18: int, _col19: string, _col20: string, _col21: date, _col24: double, _col26: int
+                        output shape: _col0: int, _col1: int, _col2: int, _col3: double, _col4: double, _col5: double, _col6: bigint, _col7: bigint, _col8: bigint, _col9: bigint, _col10: bigint, _col11: double, _col12: double, _col13: double, _col14: double, _col15: double, _col16: double, _col17: double, _col18: double, _col19: int, _col20: int, _col21: string, _col22: string, _col23: date, _col26: double, _col28: int
                         type: WINDOWING
                       Windowing table definition
                         input alias: ptf_1
                         name: windowingtablefunction
-                        order by: _col19 DESC NULLS LAST
-                        partition by: _col19
+                        order by: _col21 DESC NULLS LAST
+                        partition by: _col21
                         raw input shape:
                         window functions:
                             window function definition
                               alias: first_value_window_19
-                              arguments: _col24
+                              arguments: _col26
                               name: first_value
                               window function: GenericUDAFFirstValueEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
@@ -583,31 +605,31 @@ STAGE PLANS:
                       allEvaluatorsAreStreaming: true
                       className: VectorPTFOperator
                       evaluatorClasses: [VectorPTFEvaluatorDoubleFirstValue]
-                      functionInputExpressions: [col 22:double]
+                      functionInputExpressions: [col 24:double]
                       functionNames: [first_value]
                       keyInputColumns: [0]
                       native: true
-                      nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+                      nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
                       orderExpressions: [col 0:string]
-                      outputColumns: [24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 20, 21, 22, 23]
-                      outputTypes: [double, int, int, int, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
+                      outputColumns: [26, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 0, 22, 23, 24, 25]
+                      outputTypes: [double, int, int, int, double, double, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
                       partitionExpressions: [col 0:string]
-                      streamingColumns: [24]
-                  Statistics: Num rows: 40 Data size: 14916 Basic stats: COMPLETE Column stats: COMPLETE
+                      streamingColumns: [26]
+                  Statistics: Num rows: 40 Data size: 15556 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col19 (type: string), _col20 (type: string), _col26 (type: int), _col21 (type: date), _col24 (type: double), _col4 (type: bigint), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: double), _col14 (type: double), _col15 (type: double), _col16 (type: double), _col0 (type: int), _col1 (type: int), _col2 (type: int), _col17 (type: int), _col18 (type: int), _col3 (type: double), first_value_window_19 (type: double)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24
+                    expressions: _col21 (type: string), _col22 (type: string), _col28 (type: int), _col23 (type: date), _col26 (type: double), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: bigint), _col10 (type: bigint), _col11 (type: double), _col12 (type: double), _col13 (type: double), _col14 (type: double), _col15 (type: double), _col16 (type: double), _col17 (type: double), _col18 (type: double), _col0 (type: int), _col1 (type: int), _col2 (type: int), _col19 (type: int), _col20 (type: int), _col3 (type: double), first_value_window_19 (type: double), _col4 (type: double), _col5 (type: double)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26
                     Select Vectorization:
                         className: VectorSelectOperator
                         native: true
-                        projectedOutputColumnNums: [0, 20, 23, 21, 22, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 1, 2, 3, 18, 19, 4, 24]
-                    Statistics: Num rows: 40 Data size: 13284 Basic stats: COMPLETE Column stats: COMPLETE
+                        projectedOutputColumnNums: [0, 22, 25, 23, 24, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 1, 2, 3, 20, 21, 4, 26, 5, 6]
+                    Statistics: Num rows: 40 Data size: 13924 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
                       File Sink Vectorization:
                           className: VectorFileSinkOperator
                           native: false
-                      Statistics: Num rows: 40 Data size: 13284 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 40 Data size: 13924 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -649,7 +671,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -674,52 +698,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=2, BUFFERED BATCHES: 3 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -750,7 +776,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -775,52 +803,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=2, BUFFERED BATCHES: 4 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -851,7 +881,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -876,52 +908,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=1, BUFFERED BATCHES: 2 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -952,7 +986,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -977,52 +1013,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=2, BUFFERED BATCHES: 3 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1053,7 +1091,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1078,52 +1118,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=2, BUFFERED BATCHES: 5 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1154,7 +1196,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1179,52 +1223,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ BATCH SIZE=2, BUFFERED BATCHES: 10 ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1255,7 +1301,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1280,52 +1328,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	2	3	2	3	3	2527.56	4450.54	1190.27	1190.27	1337.29	1922.98	1263.78	1483.5133333333333	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	1	1	1	1	1	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	4	5	4	5	5	2627.24	4550.22	99.68	99.68	1337.29	1922.98	875.7466666666666	1137.555	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.95	3817.51	99.68	99.68	1190.27	1337.29	644.975	954.3775	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	5	5	4	4	5	6194.2300000000005	6194.2300000000005	2.0	2.0	1753.76	1753.76	1238.846	1238.846	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	3	3	2	2	3	3388.42	3388.42	2.0	2.0	1753.76	1753.76	1129.4733333333334	1129.4733333333334	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.16	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666666	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	5	8	4	6	8	5615.620000000001	9004.04	4.0	2.0	1632.66	1753.76	1123.1240000000003	1125.505	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.1400000000003	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0700000000002	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	2	2	1	1	2	1024.1	1024.1	6.0	6.0	1018.1	1018.1	512.05	512.05	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	3	3	2	2	3	2812.83	2812.83	6.0	6.0	1788.73	1788.73	937.61	937.61	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	2	4	2	3	4	3253.21	4277.3099999999995	1464.48	6.0	1788.73	1788.73	1626.605	1069.3274999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	2	2	2	2	2	3220.34	3220.34	1375.42	1375.42	1844.92	1844.92	1610.17	1610.17	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.66	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.33	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	2	3	2	3	3	3499.36	5300.06	1698.66	1698.66	1800.7	1800.7	1749.68	1766.6866666666667	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	2	2	2	2	2	3601.4	3601.4	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	1	1	1	1	1	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	2	4	2	4	4	3730.6400000000003	7332.040000000001	1698.66	1698.66	2031.98	2031.98	1865.3200000000002	1833.0100000000002	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ FOLLOWING ROWS NON-VECTORIZED REFERENCE ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1356,7 +1406,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1381,52 +1433,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	5	1	5	1	1	4550.22	1922.98	99.68	1922.98	1922.98	1922.98	1137.555	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.9500000000003	3817.5099999999998	99.68	99.68	1190.27	1337.29	644.9750000000001	954.3774999999999	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.139999999999	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0699999999995	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	5	4	4	3	4	5888.969999999999	4277.3099999999995	6.0	6.0	1788.73	1788.73	1177.7939999999999	1069.3274999999999	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	3	5	3	4	5	4864.869999999999	5888.969999999999	1464.48	6.0	1788.73	1788.73	1621.623333333333	1177.7939999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	5	3	5	3	3	5716.950000000001	4510.6900000000005	1206.26	1290.35	1844.92	1844.92	1429.2375000000002	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.6600000000017	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.3300000000008	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	4	4	4	4	4	7222.020000000001	7332.040000000001	1690.68	1698.66	2031.98	2031.98	1805.5050000000003	1833.0100000000002	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	5	3	5	3	3	9022.720000000001	5300.06	1690.68	1698.66	2031.98	1800.7	1804.5440000000003	1766.6866666666667	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	4	2	4	2	2	7332.040000000001	3601.4	1698.66	1800.7	2031.98	1800.7	1833.0100000000002	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	3	5	3	5	5	5421.3200000000015	9022.720000000001	1690.68	1690.68	2031.98	2031.98	1807.1066666666673	1804.5440000000003	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	5	1	5	1	1	4550.22	1922.98	99.68	1922.98	1922.98	1922.98	1137.555	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.9500000000003	3817.5099999999998	99.68	99.68	1190.27	1337.29	644.9750000000001	954.3774999999999	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.139999999999	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0699999999995	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	5	4	4	3	4	5888.969999999999	4277.3099999999995	6.0	6.0	1788.73	1788.73	1177.7939999999999	1069.3274999999999	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	3	5	3	4	5	4864.869999999999	5888.969999999999	1464.48	6.0	1788.73	1788.73	1621.623333333333	1177.7939999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	5	3	5	3	3	5716.950000000001	4510.6900000000005	1206.26	1290.35	1844.92	1844.92	1429.2375000000002	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.6600000000017	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.3300000000008	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	4	4	4	4	4	7222.020000000001	7332.040000000001	1690.68	1698.66	2031.98	2031.98	1805.5050000000003	1833.0100000000002	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	5	3	5	3	3	9022.720000000001	5300.06	1690.68	1698.66	2031.98	1800.7	1804.5440000000003	1766.6866666666667	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	4	2	4	2	2	7332.040000000001	3601.4	1698.66	1800.7	2031.98	1800.7	1833.0100000000002	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	3	5	3	5	5	5421.3200000000015	9022.720000000001	1690.68	1690.68	2031.98	2031.98	1807.1066666666673	1804.5440000000003	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ FOLLOWING ROWS ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -1457,7 +1511,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1482,7 +1538,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1688,7 +1746,7 @@ STAGE PLANS:
                     dataColumnCount: 20
                     dataColumns: KEY.reducesinkkey0:string, VALUE._col0:bigint, VALUE._col1:bigint, VALUE._col2:bigint, VALUE._col3:bigint, VALUE._col4:bigint, VALUE._col5:double, VALUE._col6:double, VALUE._col7:double, VALUE._col8:double, VALUE._col9:double, VALUE._col10:double, VALUE._col11:double, VALUE._col12:double, VALUE._col13:int, VALUE._col14:int, VALUE._col15:string, VALUE._col16:date, VALUE._col19:double, VALUE._col21:int
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint, bigint, bigint, double]
+                    scratchColumnTypeNames: [bigint, bigint, bigint, double, double, double]
             Reduce Operator Tree:
               Select Operator
                 expressions: VALUE._col0 (type: bigint), VALUE._col1 (type: bigint), VALUE._col2 (type: bigint), VALUE._col3 (type: bigint), VALUE._col4 (type: bigint), VALUE._col5 (type: double), VALUE._col6 (type: double), VALUE._col7 (type: double), VALUE._col8 (type: double), VALUE._col9 (type: double), VALUE._col10 (type: double), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: int), VALUE._col14 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col15 (type: string), VALUE._col16 (type: date), VALUE._col19 (type: double), VALUE._col21 (type: int)
@@ -1737,28 +1795,42 @@ STAGE PLANS:
                               name: first_value
                               window function: GenericUDAFFirstValueEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                            window function definition
+                              alias: lead_window_20
+                              arguments: _col20
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_21
+                              arguments: _col20
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
                   PTF Vectorization:
-                      allEvaluatorsAreStreaming: true
+                      allEvaluatorsAreStreaming: false
                       className: VectorPTFOperator
-                      evaluatorClasses: [VectorPTFEvaluatorRowNumber, VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorDoubleFirstValue]
-                      functionInputExpressions: [null, col 0:string, col 0:string, col 18:double]
-                      functionNames: [row_number, rank, dense_rank, first_value]
+                      evaluatorClasses: [VectorPTFEvaluatorRowNumber, VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorDoubleFirstValue, VectorPTFEvaluatorLead, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [null, col 0:string, col 0:string, col 18:double, col 18:double, col 18:double]
+                      functionNames: [row_number, rank, dense_rank, first_value, lead, lag]
                       keyInputColumns: [0]
                       native: true
                       nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19]
                       orderExpressions: [col 0:string]
-                      outputColumns: [20, 21, 22, 23, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
-                      outputTypes: [int, int, int, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
+                      outputColumns: [20, 21, 22, 23, 24, 25, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
+                      outputTypes: [int, int, int, double, double, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
                       partitionExpressions: [col 0:string]
                       streamingColumns: [20, 21, 22, 23]
                   Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col15 (type: string), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
-                    outputColumnNames: row_number_window_13, rank_window_14, dense_rank_window_15, first_value_window_18, _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col20, _col22
+                    expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), lead_window_20 (type: double), lag_window_21 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col15 (type: string), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
+                    outputColumnNames: row_number_window_13, rank_window_14, dense_rank_window_15, first_value_window_18, lead_window_20, lag_window_21, _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col20, _col22
                     Select Vectorization:
                         className: VectorSelectOperator
                         native: true
-                        projectedOutputColumnNums: [20, 21, 22, 23, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
+                        projectedOutputColumnNums: [20, 21, 22, 23, 24, 25, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 16, 17, 18, 19]
                     Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col15 (type: string)
@@ -1770,9 +1842,9 @@ STAGE PLANS:
                           keyColumns: 0:string
                           native: true
                           nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
-                          valueColumns: 20:int, 21:int, 22:int, 23:double, 1:bigint, 2:bigint, 3:bigint, 4:bigint, 5:bigint, 6:double, 7:double, 8:double, 9:double, 10:double, 11:double, 12:double, 13:double, 14:int, 15:int, 16:string, 17:date, 18:double, 19:int
+                          valueColumns: 20:int, 21:int, 22:int, 23:double, 24:double, 25:double, 1:bigint, 2:bigint, 3:bigint, 4:bigint, 5:bigint, 6:double, 7:double, 8:double, 9:double, 10:double, 11:double, 12:double, 13:double, 14:int, 15:int, 16:string, 17:date, 18:double, 19:int
                       Statistics: Num rows: 40 Data size: 15092 Basic stats: COMPLETE Column stats: COMPLETE
-                      value expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
+                      value expressions: row_number_window_13 (type: int), rank_window_14 (type: int), dense_rank_window_15 (type: int), first_value_window_18 (type: double), lead_window_20 (type: double), lag_window_21 (type: double), _col0 (type: bigint), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: double), _col6 (type: double), _col7 (type: double), _col8 (type: double), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: int), _col14 (type: int), _col16 (type: string), _col17 (type: date), _col20 (type: double), _col22 (type: int)
         Reducer 4 
             Execution mode: vectorized, llap
             Reduce Vectorization:
@@ -1784,35 +1856,35 @@ STAGE PLANS:
                 usesVectorUDFAdaptor: false
                 vectorized: true
                 rowBatchContext:
-                    dataColumnCount: 24
-                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:double, VALUE._col4:bigint, VALUE._col5:bigint, VALUE._col6:bigint, VALUE._col7:bigint, VALUE._col8:bigint, VALUE._col9:double, VALUE._col10:double, VALUE._col11:double, VALUE._col12:double, VALUE._col13:double, VALUE._col14:double, VALUE._col15:double, VALUE._col16:double, VALUE._col17:int, VALUE._col18:int, VALUE._col19:string, VALUE._col20:date, VALUE._col23:double, VALUE._col25:int
+                    dataColumnCount: 26
+                    dataColumns: KEY.reducesinkkey0:string, VALUE._col0:int, VALUE._col1:int, VALUE._col2:int, VALUE._col3:double, VALUE._col4:double, VALUE._col5:double, VALUE._col6:bigint, VALUE._col7:bigint, VALUE._col8:bigint, VALUE._col9:bigint, VALUE._col10:bigint, VALUE._col11:double, VALUE._col12:double, VALUE._col13:double, VALUE._col14:double, VALUE._col15:double, VALUE._col16:double, VALUE._col17:double, VALUE._col18:double, VALUE._col19:int, VALUE._col20:int, VALUE._col21:string, VALUE._col22:date, VALUE._col25:double, VALUE._col27:int
                     partitionColumnCount: 0
                     scratchColumnTypeNames: [double]
             Reduce Operator Tree:
               Select Operator
-                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: double), VALUE._col4 (type: bigint), VALUE._col5 (type: bigint), VALUE._col6 (type: bigint), VALUE._col7 (type: bigint), VALUE._col8 (type: bigint), VALUE._col9 (type: double), VALUE._col10 (type: double), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: double), VALUE._col14 (type: double), VALUE._col15 (type: double), VALUE._col16 (type: double), VALUE._col17 (type: int), VALUE._col18 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col19 (type: string), VALUE._col20 (type: date), VALUE._col23 (type: double), VALUE._col25 (type: int)
-                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col24, _col26
+                expressions: VALUE._col0 (type: int), VALUE._col1 (type: int), VALUE._col2 (type: int), VALUE._col3 (type: double), VALUE._col4 (type: double), VALUE._col5 (type: double), VALUE._col6 (type: bigint), VALUE._col7 (type: bigint), VALUE._col8 (type: bigint), VALUE._col9 (type: bigint), VALUE._col10 (type: bigint), VALUE._col11 (type: double), VALUE._col12 (type: double), VALUE._col13 (type: double), VALUE._col14 (type: double), VALUE._col15 (type: double), VALUE._col16 (type: double), VALUE._col17 (type: double), VALUE._col18 (type: double), VALUE._col19 (type: int), VALUE._col20 (type: int), KEY.reducesinkkey0 (type: string), VALUE._col21 (type: string), VALUE._col22 (type: date), VALUE._col25 (type: double), VALUE._col27 (type: int)
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col26, _col28
                 Select Vectorization:
                     className: VectorSelectOperator
                     native: true
-                    projectedOutputColumnNums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 20, 21, 22, 23]
-                Statistics: Num rows: 40 Data size: 14916 Basic stats: COMPLETE Column stats: COMPLETE
+                    projectedOutputColumnNums: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 0, 22, 23, 24, 25]
+                Statistics: Num rows: 40 Data size: 15556 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
                       Input definition
                         input alias: ptf_0
-                        output shape: _col0: int, _col1: int, _col2: int, _col3: double, _col4: bigint, _col5: bigint, _col6: bigint, _col7: bigint, _col8: bigint, _col9: double, _col10: double, _col11: double, _col12: double, _col13: double, _col14: double, _col15: double, _col16: double, _col17: int, _col18: int, _col19: string, _col20: string, _col21: date, _col24: double, _col26: int
+                        output shape: _col0: int, _col1: int, _col2: int, _col3: double, _col4: double, _col5: double, _col6: bigint, _col7: bigint, _col8: bigint, _col9: bigint, _col10: bigint, _col11: double, _col12: double, _col13: double, _col14: double, _col15: double, _col16: double, _col17: double, _col18: double, _col19: int, _col20: int, _col21: string, _col22: string, _col23: date, _col26: double, _col28: int
                         type: WINDOWING
                       Windowing table definition
                         input alias: ptf_1
                         name: windowingtablefunction
-                        order by: _col19 DESC NULLS LAST
-                        partition by: _col19
+                        order by: _col21 DESC NULLS LAST
+                        partition by: _col21
                         raw input shape:
                         window functions:
                             window function definition
                               alias: first_value_window_19
-                              arguments: _col24
+                              arguments: _col26
                               name: first_value
                               window function: GenericUDAFFirstValueEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
@@ -1820,31 +1892,31 @@ STAGE PLANS:
                       allEvaluatorsAreStreaming: true
                       className: VectorPTFOperator
                       evaluatorClasses: [VectorPTFEvaluatorDoubleFirstValue]
-                      functionInputExpressions: [col 22:double]
+                      functionInputExpressions: [col 24:double]
                       functionNames: [first_value]
                       keyInputColumns: [0]
                       native: true
-                      nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23]
+                      nonKeyInputColumns: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25]
                       orderExpressions: [col 0:string]
-                      outputColumns: [24, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 20, 21, 22, 23]
-                      outputTypes: [double, int, int, int, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
+                      outputColumns: [26, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 0, 22, 23, 24, 25]
+                      outputTypes: [double, int, int, int, double, double, double, bigint, bigint, bigint, bigint, bigint, double, double, double, double, double, double, double, double, int, int, string, string, date, double, int]
                       partitionExpressions: [col 0:string]
-                      streamingColumns: [24]
-                  Statistics: Num rows: 40 Data size: 14916 Basic stats: COMPLETE Column stats: COMPLETE
+                      streamingColumns: [26]
+                  Statistics: Num rows: 40 Data size: 15556 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
-                    expressions: _col19 (type: string), _col20 (type: string), _col26 (type: int), _col21 (type: date), _col24 (type: double), _col4 (type: bigint), _col5 (type: bigint), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: double), _col10 (type: double), _col11 (type: double), _col12 (type: double), _col13 (type: double), _col14 (type: double), _col15 (type: double), _col16 (type: double), _col0 (type: int), _col1 (type: int), _col2 (type: int), _col17 (type: int), _col18 (type: int), _col3 (type: double), first_value_window_19 (type: double)
-                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24
+                    expressions: _col21 (type: string), _col22 (type: string), _col28 (type: int), _col23 (type: date), _col26 (type: double), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: bigint), _col10 (type: bigint), _col11 (type: double), _col12 (type: double), _col13 (type: double), _col14 (type: double), _col15 (type: double), _col16 (type: double), _col17 (type: double), _col18 (type: double), _col0 (type: int), _col1 (type: int), _col2 (type: int), _col19 (type: int), _col20 (type: int), _col3 (type: double), first_value_window_19 (type: double), _col4 (type: double), _col5 (type: double)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18, _col19, _col20, _col21, _col22, _col23, _col24, _col25, _col26
                     Select Vectorization:
                         className: VectorSelectOperator
                         native: true
-                        projectedOutputColumnNums: [0, 20, 23, 21, 22, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 1, 2, 3, 18, 19, 4, 24]
-                    Statistics: Num rows: 40 Data size: 13284 Basic stats: COMPLETE Column stats: COMPLETE
+                        projectedOutputColumnNums: [0, 22, 25, 23, 24, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 1, 2, 3, 20, 21, 4, 26, 5, 6]
+                    Statistics: Num rows: 40 Data size: 13924 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
                       File Sink Vectorization:
                           className: VectorFileSinkOperator
                           native: false
-                      Statistics: Num rows: 40 Data size: 13284 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 40 Data size: 13924 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
                           output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
@@ -1876,7 +1948,9 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 PREHOOK: type: QUERY
 PREHOOK: Input: default@vector_ptf_part_simple_orc
@@ -1901,52 +1975,54 @@ dense_rank() over(partition by p_mfgr) as dr,
 rank() over(partition by p_mfgr order by p_date) as r_date,
 dense_rank() over(partition by p_mfgr order by p_date) as dr_date,
 first_value(p_retailprice) over(partition by p_mfgr) as fv,
-last_value(p_retailprice) over(partition by p_mfgr) as lv
+last_value(p_retailprice) over(partition by p_mfgr) as lv,
+lead(p_retailprice) over(partition by p_mfgr) as lead1,
+lag(p_retailprice) over(partition by p_mfgr) as lag1
 from vector_ptf_part_simple_orc
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@vector_ptf_part_simple_orc
 #### A masked pattern was here ####
-p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv
-Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	1	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	8	1	1	2	2	1190.27	1190.27
-Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	5	1	5	1	1	4550.22	1922.98	99.68	1922.98	1922.98	1922.98	1137.555	1922.98	7	1	1	1	1	1190.27	1190.27
-Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	6	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	5	1	1	4	3	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.9500000000003	3817.5099999999998	99.68	99.68	1190.27	1337.29	644.9750000000001	954.3774999999999	4	1	1	6	4	1190.27	1190.27
-Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27
-Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27
-Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	1	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	2	1	1	6	3	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	3	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	4	1	1	4	2	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	5	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	6	1	1	1	1	4.0	4.0
-Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	7	1	1	1	1	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	9	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	10	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	11	1	1	9	4	4.0	4.0
-Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	12	1	1	6	3	4.0	4.0
-Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.139999999999	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0699999999995	1177.7939999999999	6	1	1	5	4	1789.69	1611.66
-Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66
-Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	2	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	3	1	1	1	1	1789.69	1611.66
-Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	5	4	4	3	4	5888.969999999999	4277.3099999999995	6.0	6.0	1788.73	1788.73	1177.7939999999999	1069.3274999999999	4	1	1	3	2	1789.69	1611.66
-Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	3	5	3	4	5	4864.869999999999	5888.969999999999	1464.48	6.0	1788.73	1788.73	1621.623333333333	1177.7939999999999	5	1	1	4	3	1789.69	1611.66
-Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	5	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	6	1	1	1	1	1290.35	1375.42
-Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	5	3	5	3	3	5716.950000000001	4510.6900000000005	1206.26	1290.35	1844.92	1844.92	1429.2375000000002	1503.5633333333335	1	1	1	3	2	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42
-Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42
-Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.6600000000017	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.3300000000008	1805.5050000000003	3	1	1	5	5	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68
-Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	4	4	4	4	4	7222.020000000001	7332.040000000001	1690.68	1698.66	2031.98	2031.98	1805.5050000000003	1833.0100000000002	7	1	1	3	3	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	5	3	5	3	3	9022.720000000001	5300.06	1690.68	1698.66	2031.98	1800.7	1804.5440000000003	1766.6866666666667	6	1	1	2	2	1800.7	1690.68
-Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	4	2	4	2	2	7332.040000000001	3601.4	1698.66	1800.7	2031.98	1800.7	1833.0100000000002	1800.7	5	1	1	1	1	1800.7	1690.68
-Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	3	5	3	5	5	5421.3200000000015	9022.720000000001	1690.68	1690.68	2031.98	2031.98	1807.1066666666673	1804.5440000000003	4	1	1	4	4	1800.7	1690.68
+p_mfgr	p_name	rowindex	p_date	p_retailprice	cs1	cs2	c1	c2	c_order	s1	s2	min1	min2	max1	max2	avg1	avg2	rn	r	dr	r_date	dr_date	fv	lv	lead1	lag1
+Manufacturer#3	almond antique forest lavender goldenrod	33	1970-01-03	1190.27	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	1	1	1	2	2	1190.27	1190.27	55.39	NULL
+Manufacturer#3	almond antique olive coral navajo	28	1970-01-03	1337.29	5	5	5	5	5	3817.51	4550.219999999999	99.68	99.68	1337.29	1922.98	954.3775	1137.5549999999998	8	1	1	2	2	1190.27	1190.27	NULL	1922.98
+Manufacturer#3	almond antique misty red olive	31	1970-01-01	1922.98	5	1	5	1	1	4550.22	1922.98	99.68	1922.98	1922.98	1922.98	1137.555	1922.98	7	1	1	1	1	1190.27	1190.27	1337.29	99.68
+Manufacturer#3	almond antique chartreuse khaki white	24	1970-01-04	99.68	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	6	1	1	4	3	1190.27	1190.27	1922.98	NULL
+Manufacturer#3	almond antique forest lavender goldenrod	14	1970-01-04	NULL	5	6	5	6	6	3817.51	5740.49	99.68	99.68	1337.29	1922.98	954.3775	1148.098	5	1	1	4	3	1190.27	1190.27	99.68	1190.27
+Manufacturer#3	almond antique forest lavender goldenrod	10	1970-01-05	1190.27	3	5	3	5	5	1289.9500000000003	3817.5099999999998	99.68	99.68	1190.27	1337.29	644.9750000000001	954.3774999999999	4	1	1	6	4	1190.27	1190.27	NULL	590.27
+Manufacturer#3	almond antique forest lavender goldenrod	19	NULL	590.27	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	3	1	1	7	5	1190.27	1190.27	1190.27	55.39
+Manufacturer#3	almond antique metallic orange dim	38	NULL	55.39	2	2	2	2	0	645.66	645.66	55.39	55.39	590.27	590.27	322.83	322.83	2	1	1	7	5	1190.27	1190.27	590.27	1190.27
+Manufacturer#1	almond aquamarine pink moccasin thistle	NULL	1970-01-04	4.0	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	1	1	1	6	3	4.0	4.0	1632.66	NULL
+Manufacturer#1	almond aquamarine pink moccasin thistle	9	1970-01-04	1632.66	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	2	1	1	6	3	4.0	4.0	1632.66	4.0
+Manufacturer#1	almond aquamarine pink moccasin thistle	23	1970-01-03	1632.66	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	3	1	1	4	2	4.0	4.0	1173.15	1632.66
+Manufacturer#1	almond antique burnished rose metallic	8	1970-01-03	1173.15	11	8	8	6	8	12365.39	9004.04	2.0	2.0	1753.76	1753.76	1124.1263636363635	1125.505	4	1	1	4	2	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	12	1970-01-02	1753.76	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	5	1	1	1	1	4.0	4.0	1632.66	1173.15
+Manufacturer#1	almond aquamarine pink moccasin thistle	17	1970-01-02	1632.66	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	6	1	1	1	1	4.0	4.0	2.0	1753.76
+Manufacturer#1	almond aquamarine burnished black steel	NULL	1970-01-02	2.0	11	5	8	4	5	12365.39	6194.23	2.0	2.0	1753.76	1753.76	1124.1263636363635	1238.846	7	1	1	1	1	4.0	4.0	1753.76	1632.66
+Manufacturer#1	almond antique chartreuse lavender yellow	26	NULL	1753.76	1	1	1	1	0	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	1753.76	8	1	1	12	5	4.0	4.0	1753.76	2.0
+Manufacturer#1	almond antique chartreuse lavender yellow	20	1970-01-05	1753.76	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	9	1	1	9	4	4.0	4.0	5.0	1753.76
+Manufacturer#1	almond antique chartreuse lavender yellow	NULL	1970-01-05	5.0	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	10	1	1	9	4	4.0	4.0	1602.59	1753.76
+Manufacturer#1	almond antique salmon chartreuse burlywood	30	1970-01-05	1602.59	6	11	4	8	11	6171.159999999999	12365.390000000001	4.0	2.0	1753.76	1753.76	1028.5266666666664	1124.1263636363637	11	1	1	9	4	4.0	4.0	1173.15	5.0
+Manufacturer#1	almond antique burnished rose metallic	39	1970-01-04	1173.15	8	11	6	8	11	8976.97	12365.390000000001	4.0	2.0	1753.76	1753.76	1122.12125	1124.1263636363637	12	1	1	6	3	4.0	4.0	NULL	1602.59
+Manufacturer#5	almond antique medium spring khaki	29	1970-01-04	1611.66	2	5	2	4	5	3076.139999999999	5888.969999999999	1464.48	6.0	1611.66	1788.73	1538.0699999999995	1177.7939999999999	6	1	1	5	4	1789.69	1611.66	NULL	1464.48
+Manufacturer#5	almond antique blue firebrick mint	7	NULL	1789.69	1	1	1	1	0	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1789.69	1	1	1	6	5	1789.69	1611.66	1018.1	NULL
+Manufacturer#5	almond aquamarine dodger light gainsboro	36	1970-01-01	1018.1	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	2	1	1	1	1	1789.69	1611.66	6.0	1789.69
+Manufacturer#5	almond antique medium spring khaki	NULL	1970-01-01	6.0	5	3	4	2	3	5888.969999999999	2812.83	6.0	6.0	1788.73	1788.73	1177.7939999999999	937.61	3	1	1	1	1	1789.69	1611.66	1788.73	1018.1
+Manufacturer#5	almond antique sky peru orange	22	1970-01-02	1788.73	5	4	4	3	4	5888.969999999999	4277.3099999999995	6.0	6.0	1788.73	1788.73	1177.7939999999999	1069.3274999999999	4	1	1	3	2	1789.69	1611.66	1464.48	6.0
+Manufacturer#5	almond azure blanched chiffon midnight	18	1970-01-03	1464.48	3	5	3	4	5	4864.869999999999	5888.969999999999	1464.48	6.0	1788.73	1788.73	1621.623333333333	1177.7939999999999	5	1	1	4	3	1789.69	1611.66	1611.66	1788.73
+Manufacturer#4	almond antique violet mint lemon	16	1970-01-01	1375.42	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	5	1	1	1	1	1290.35	1375.42	1844.92	NULL
+Manufacturer#4	almond aquamarine yellow dodger mint	11	1970-01-01	1844.92	3	3	3	3	3	4510.6900000000005	4510.6900000000005	1290.35	1290.35	1844.92	1844.92	1503.5633333333335	1503.5633333333335	6	1	1	1	1	1290.35	1375.42	NULL	1375.42
+Manufacturer#4	almond azure aquamarine papaya violet	37	1970-01-02	1290.35	5	3	5	3	3	5716.950000000001	4510.6900000000005	1206.26	1290.35	1844.92	1844.92	1429.2375000000002	1503.5633333333335	1	1	1	3	2	1290.35	1375.42	1206.26	NULL
+Manufacturer#4	almond aquamarine floral ivory bisque	40	1970-01-05	1206.26	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	2	1	1	4	3	1290.35	1375.42	NULL	1290.35
+Manufacturer#4	almond aquamarine floral ivory bisque	35	1970-01-05	NULL	2	3	2	3	3	1206.26	2496.6099999999997	1206.26	1206.26	1206.26	1290.35	1206.26	1248.3049999999998	3	1	1	4	3	1290.35	1375.42	NULL	1206.26
+Manufacturer#4	almond antique gainsboro frosted violet	25	NULL	NULL	1	1	1	1	0	NULL	NULL	NULL	NULL	NULL	NULL	NULL	NULL	4	1	1	6	4	1290.35	1375.42	1375.42	NULL
+Manufacturer#2	almond antique violet chocolate turquoise	15	1970-01-05	1690.68	2	4	2	4	4	3722.6600000000017	7222.020000000001	1690.68	1690.68	2031.98	2031.98	1861.3300000000008	1805.5050000000003	3	1	1	5	5	1800.7	1690.68	2031.98	900.66
+Manufacturer#2	almond aquamarine rose maroon antique	1	NULL	900.66	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	2	1	1	6	6	1800.7	1690.68	1690.68	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	13	NULL	1800.7	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	1	1	1	6	6	1800.7	1690.68	900.66	NULL
+Manufacturer#2	almond aquamarine sandy cyan gainsboro	32	NULL	1000.6	3	3	3	3	0	3701.96	3701.96	900.66	900.66	1800.7	1800.7	1233.9866666666667	1233.9866666666667	8	1	1	6	6	1800.7	1690.68	NULL	1698.66
+Manufacturer#2	almond aquamarine rose maroon antique	3	1970-01-03	1698.66	4	4	4	4	4	7222.020000000001	7332.040000000001	1690.68	1698.66	2031.98	2031.98	1805.5050000000003	1833.0100000000002	7	1	1	3	3	1800.7	1690.68	1000.6	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	27	1970-01-02	1800.7	5	3	5	3	3	9022.720000000001	5300.06	1690.68	1698.66	2031.98	1800.7	1804.5440000000003	1766.6866666666667	6	1	1	2	2	1800.7	1690.68	1698.66	1800.7
+Manufacturer#2	almond antique violet turquoise frosted	21	1970-01-01	1800.7	4	2	4	2	2	7332.040000000001	3601.4	1698.66	1800.7	2031.98	1800.7	1833.0100000000002	1800.7	5	1	1	1	1	1800.7	1690.68	1800.7	2031.98
+Manufacturer#2	almond aquamarine midnight light salmon	34	1970-01-04	2031.98	3	5	3	5	5	5421.3200000000015	9022.720000000001	1690.68	1690.68	2031.98	2031.98	1807.1066666666673	1804.5440000000003	4	1	1	4	4	1800.7	1690.68	1800.7	1690.68
 PREHOOK: query: select "************ STRING WINDOW RANGE TYPE ************"
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table

--- a/ql/src/test/results/clientpositive/llap/vector_ptf_lead_lag.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_ptf_lead_lag.q.out
@@ -1,0 +1,1267 @@
+PREHOOK: query: CREATE TABLE vector_ptf_lead_lag_int(name string, rowindex int, mynumber int) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@vector_ptf_lead_lag_int
+POSTHOOK: query: CREATE TABLE vector_ptf_lead_lag_int(name string, rowindex int, mynumber int) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@vector_ptf_lead_lag_int
+PREHOOK: query: INSERT INTO vector_ptf_lead_lag_int values
+
+('first', 1, 1),
+('first', 2, 2),
+('first', 3, 2),
+('first', 4, NULL),
+('first', 5, 3),
+('first', 6, 3),
+('first', 7, 4),
+('first', 8, NULL),
+('first', 9, 4),
+('first', 10, 4),
+('first', 11, 5),
+('first', 12, 5),
+('first', 13, NULL),
+('first', 14, 5),
+('first', 15, 5),
+('first', 16, 6),
+('first', 17, 6),
+('first', 18, 6),
+('first', 19, NULL),
+('first', 20, 6),
+('first', 21, 6),
+
+('second', 22, 1),
+('second', 23, 2),
+('second', 24, 2),
+('second', 25, NULL),
+('second', 26, 3),
+('second', 27, 3),
+('second', 28, 4),
+('second', 29, NULL),
+('second', 30, 4),
+('second', 31, 4),
+('second', 32, 5),
+('second', 33, 5),
+('second', 34, NULL),
+('second', 35, 5),
+('second', 36, 5),
+('second', 37, 6),
+('second', 38, 6),
+('second', 39, 6),
+('second', 40, NULL),
+('second', 41, 6),
+('second', 42, 6),
+
+(NULL, 43, 7),
+(NULL, 44, 7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@vector_ptf_lead_lag_int
+POSTHOOK: query: INSERT INTO vector_ptf_lead_lag_int values
+
+('first', 1, 1),
+('first', 2, 2),
+('first', 3, 2),
+('first', 4, NULL),
+('first', 5, 3),
+('first', 6, 3),
+('first', 7, 4),
+('first', 8, NULL),
+('first', 9, 4),
+('first', 10, 4),
+('first', 11, 5),
+('first', 12, 5),
+('first', 13, NULL),
+('first', 14, 5),
+('first', 15, 5),
+('first', 16, 6),
+('first', 17, 6),
+('first', 18, 6),
+('first', 19, NULL),
+('first', 20, 6),
+('first', 21, 6),
+
+('second', 22, 1),
+('second', 23, 2),
+('second', 24, 2),
+('second', 25, NULL),
+('second', 26, 3),
+('second', 27, 3),
+('second', 28, 4),
+('second', 29, NULL),
+('second', 30, 4),
+('second', 31, 4),
+('second', 32, 5),
+('second', 33, 5),
+('second', 34, NULL),
+('second', 35, 5),
+('second', 36, 5),
+('second', 37, 6),
+('second', 38, 6),
+('second', 39, 6),
+('second', 40, NULL),
+('second', 41, 6),
+('second', 42, 6),
+
+(NULL, 43, 7),
+(NULL, 44, 7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@vector_ptf_lead_lag_int
+POSTHOOK: Lineage: vector_ptf_lead_lag_int.mynumber SCRIPT []
+POSTHOOK: Lineage: vector_ptf_lead_lag_int.name SCRIPT []
+POSTHOOK: Lineage: vector_ptf_lead_lag_int.rowindex SCRIPT []
+PREHOOK: query: select "************ INT, NON-VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ INT, NON-VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ INT, NON-VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+NULL	44	7	NULL	NULL	100	7	7	NULL	100	7
+NULL	43	7	7	NULL	100	7	NULL	NULL	100	7
+first	1	1	NULL	NULL	100	1	2	2	3	3
+first	2	2	1	NULL	100	2	2	3	3	4
+first	3	2	2	1	100	2	3	3	4	4
+first	5	3	2	2	1	3	3	4	4	4
+first	6	3	3	2	2	1	4	4	4	5
+first	7	4	3	3	2	2	4	4	5	5
+first	9	4	4	3	3	2	4	5	5	5
+first	10	4	4	4	3	3	5	5	5	5
+first	14	5	4	4	4	3	5	5	5	6
+first	11	5	5	4	4	4	5	5	6	6
+first	12	5	5	5	4	4	5	6	6	6
+first	15	5	5	5	5	4	6	6	6	6
+first	16	6	5	5	5	5	6	6	6	6
+first	17	6	6	5	5	5	6	6	6	NULL
+first	18	6	6	6	5	5	6	6	NULL	NULL
+first	20	6	6	6	6	5	6	NULL	NULL	NULL
+first	21	6	6	6	6	6	NULL	NULL	NULL	NULL
+first	4	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+first	8	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+first	13	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+second	22	1	NULL	NULL	100	1	2	2	3	3
+second	24	2	1	NULL	100	2	2	3	3	4
+second	23	2	2	1	100	2	3	3	4	4
+second	26	3	2	2	1	3	3	4	4	4
+second	27	3	3	2	2	1	4	4	4	5
+second	30	4	3	3	2	2	4	4	5	5
+second	31	4	4	3	3	2	4	5	5	5
+second	28	4	4	4	3	3	5	5	5	5
+second	36	5	4	4	4	3	5	5	5	6
+second	32	5	5	4	4	4	5	5	6	6
+second	33	5	5	5	4	4	5	6	6	6
+second	35	5	5	5	5	4	6	6	6	6
+second	37	6	5	5	5	5	6	6	6	6
+second	38	6	6	5	5	5	6	6	6	NULL
+second	39	6	6	6	5	5	6	6	NULL	NULL
+second	41	6	6	6	6	5	6	NULL	NULL	NULL
+second	42	6	6	6	6	6	NULL	NULL	NULL	NULL
+second	34	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+second	29	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+second	40	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+PREHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: vector_ptf_lead_lag_int
+                  Statistics: Num rows: 44 Data size: 4151 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:name:string, 1:rowindex:int, 2:mynumber:int, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>, 4:ROW__IS__DELETED:boolean]
+                  Reduce Output Operator
+                    key expressions: name (type: string), mynumber (type: int)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: name (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkObjectHashOperator
+                        keyColumns: 0:string, 2:int
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        partitionColumns: 0:string
+                        valueColumns: 1:int
+                    Statistics: Num rows: 44 Data size: 4151 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: rowindex (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [0, 1, 2]
+                    dataColumns: name:string, rowindex:int, mynumber:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:int, VALUE._col0:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), KEY.reducesinkkey1 (type: int)
+                outputColumnNames: _col0, _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 2, 1]
+                Statistics: Num rows: 44 Data size: 4151 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string, _col1: int, _col2: int
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS LAST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: lag_window_0
+                              arguments: _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_1
+                              arguments: _col2, 2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_2
+                              arguments: _col2, 3, 100
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_3
+                              arguments: _col2, 4, _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_4
+                              arguments: _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_5
+                              arguments: _col2, 2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_6
+                              arguments: _col2, 3, 100
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_7
+                              arguments: _col2, 4, _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead]
+                      functionInputExpressions: [col 1:int, col 1:int, col 1:int, col 1:int, col 1:int, col 1:int, col 1:int, col 1:int]
+                      functionNames: [lag, lag, lag, lag, lead, lead, lead, lead]
+                      keyInputColumns: [0, 1]
+                      native: true
+                      nonKeyInputColumns: [2]
+                      orderExpressions: [col 1:int]
+                      outputColumns: [3, 4, 5, 6, 7, 8, 9, 10, 0, 2, 1]
+                      outputTypes: [int, int, int, int, int, int, int, int, string, int, int]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: []
+                  Statistics: Num rows: 44 Data size: 4151 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: int), _col2 (type: int), lag_window_0 (type: int), lag_window_1 (type: int), lag_window_2 (type: int), lag_window_3 (type: int), lead_window_4 (type: int), lead_window_5 (type: int), lead_window_6 (type: int), lead_window_7 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3, 4, 5, 6, 7, 8, 9, 10]
+                    Statistics: Num rows: 44 Data size: 5349 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
+                      Statistics: Num rows: 44 Data size: 5349 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select "************ INT, VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ INT, VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ INT, VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_int
+#### A masked pattern was here ####
+NULL	44	7	NULL	NULL	100	7	7	NULL	100	7
+NULL	43	7	7	NULL	100	7	NULL	NULL	100	7
+first	1	1	NULL	NULL	100	1	2	2	3	3
+first	2	2	1	NULL	100	2	2	3	3	4
+first	3	2	2	1	100	2	3	3	4	4
+first	5	3	2	2	1	3	3	4	4	4
+first	6	3	3	2	2	1	4	4	4	5
+first	7	4	3	3	2	2	4	4	5	5
+first	9	4	4	3	3	2	4	5	5	5
+first	10	4	4	4	3	3	5	5	5	5
+first	14	5	4	4	4	3	5	5	5	6
+first	11	5	5	4	4	4	5	5	6	6
+first	12	5	5	5	4	4	5	6	6	6
+first	15	5	5	5	5	4	6	6	6	6
+first	16	6	5	5	5	5	6	6	6	6
+first	17	6	6	5	5	5	6	6	6	NULL
+first	18	6	6	6	5	5	6	6	NULL	NULL
+first	20	6	6	6	6	5	6	NULL	NULL	NULL
+first	21	6	6	6	6	6	NULL	NULL	NULL	NULL
+first	4	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+first	8	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+first	13	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+second	22	1	NULL	NULL	100	1	2	2	3	3
+second	24	2	1	NULL	100	2	2	3	3	4
+second	23	2	2	1	100	2	3	3	4	4
+second	26	3	2	2	1	3	3	4	4	4
+second	27	3	3	2	2	1	4	4	4	5
+second	30	4	3	3	2	2	4	4	5	5
+second	31	4	4	3	3	2	4	5	5	5
+second	28	4	4	4	3	3	5	5	5	5
+second	36	5	4	4	4	3	5	5	5	6
+second	32	5	5	4	4	4	5	5	6	6
+second	33	5	5	5	4	4	5	6	6	6
+second	35	5	5	5	5	4	6	6	6	6
+second	37	6	5	5	5	5	6	6	6	6
+second	38	6	6	5	5	5	6	6	6	NULL
+second	39	6	6	6	5	5	6	6	NULL	NULL
+second	41	6	6	6	6	5	6	NULL	NULL	NULL
+second	42	6	6	6	6	6	NULL	NULL	NULL	NULL
+second	34	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+second	29	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+second	40	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+PREHOOK: query: CREATE TABLE vector_ptf_lead_lag_double(name string, rowindex int, mynumber double) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@vector_ptf_lead_lag_double
+POSTHOOK: query: CREATE TABLE vector_ptf_lead_lag_double(name string, rowindex int, mynumber double) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@vector_ptf_lead_lag_double
+PREHOOK: query: INSERT INTO vector_ptf_lead_lag_double SELECT * from vector_ptf_lead_lag_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_int
+PREHOOK: Output: default@vector_ptf_lead_lag_double
+POSTHOOK: query: INSERT INTO vector_ptf_lead_lag_double SELECT * from vector_ptf_lead_lag_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_int
+POSTHOOK: Output: default@vector_ptf_lead_lag_double
+POSTHOOK: Lineage: vector_ptf_lead_lag_double.mynumber EXPRESSION [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:mynumber, type:int, comment:null), ]
+POSTHOOK: Lineage: vector_ptf_lead_lag_double.name SIMPLE [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:name, type:string, comment:null), ]
+POSTHOOK: Lineage: vector_ptf_lead_lag_double.rowindex SIMPLE [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:rowindex, type:int, comment:null), ]
+PREHOOK: query: select "************ DOUBLE, NON-VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ DOUBLE, NON-VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ DOUBLE, NON-VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+NULL	44	7.0	NULL	NULL	100.0	7.0	7.0	NULL	100.0	7.0
+NULL	43	7.0	7.0	NULL	100.0	7.0	NULL	NULL	100.0	7.0
+first	1	1.0	NULL	NULL	100.0	1.0	2.0	2.0	3.0	3.0
+first	2	2.0	1.0	NULL	100.0	2.0	2.0	3.0	3.0	4.0
+first	3	2.0	2.0	1.0	100.0	2.0	3.0	3.0	4.0	4.0
+first	5	3.0	2.0	2.0	1.0	3.0	3.0	4.0	4.0	4.0
+first	6	3.0	3.0	2.0	2.0	1.0	4.0	4.0	4.0	5.0
+first	7	4.0	3.0	3.0	2.0	2.0	4.0	4.0	5.0	5.0
+first	9	4.0	4.0	3.0	3.0	2.0	4.0	5.0	5.0	5.0
+first	10	4.0	4.0	4.0	3.0	3.0	5.0	5.0	5.0	5.0
+first	14	5.0	4.0	4.0	4.0	3.0	5.0	5.0	5.0	6.0
+first	11	5.0	5.0	4.0	4.0	4.0	5.0	5.0	6.0	6.0
+first	12	5.0	5.0	5.0	4.0	4.0	5.0	6.0	6.0	6.0
+first	15	5.0	5.0	5.0	5.0	4.0	6.0	6.0	6.0	6.0
+first	16	6.0	5.0	5.0	5.0	5.0	6.0	6.0	6.0	6.0
+first	17	6.0	6.0	5.0	5.0	5.0	6.0	6.0	6.0	NULL
+first	18	6.0	6.0	6.0	5.0	5.0	6.0	6.0	NULL	NULL
+first	20	6.0	6.0	6.0	6.0	5.0	6.0	NULL	NULL	NULL
+first	21	6.0	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+first	4	NULL	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6.0	6.0	6.0	NULL	NULL	100.0	NULL
+first	8	NULL	NULL	NULL	6.0	6.0	NULL	NULL	100.0	NULL
+first	13	NULL	NULL	NULL	NULL	6.0	NULL	NULL	100.0	NULL
+second	22	1.0	NULL	NULL	100.0	1.0	2.0	2.0	3.0	3.0
+second	24	2.0	1.0	NULL	100.0	2.0	2.0	3.0	3.0	4.0
+second	23	2.0	2.0	1.0	100.0	2.0	3.0	3.0	4.0	4.0
+second	26	3.0	2.0	2.0	1.0	3.0	3.0	4.0	4.0	4.0
+second	27	3.0	3.0	2.0	2.0	1.0	4.0	4.0	4.0	5.0
+second	30	4.0	3.0	3.0	2.0	2.0	4.0	4.0	5.0	5.0
+second	31	4.0	4.0	3.0	3.0	2.0	4.0	5.0	5.0	5.0
+second	28	4.0	4.0	4.0	3.0	3.0	5.0	5.0	5.0	5.0
+second	36	5.0	4.0	4.0	4.0	3.0	5.0	5.0	5.0	6.0
+second	32	5.0	5.0	4.0	4.0	4.0	5.0	5.0	6.0	6.0
+second	33	5.0	5.0	5.0	4.0	4.0	5.0	6.0	6.0	6.0
+second	35	5.0	5.0	5.0	5.0	4.0	6.0	6.0	6.0	6.0
+second	37	6.0	5.0	5.0	5.0	5.0	6.0	6.0	6.0	6.0
+second	38	6.0	6.0	5.0	5.0	5.0	6.0	6.0	6.0	NULL
+second	39	6.0	6.0	6.0	5.0	5.0	6.0	6.0	NULL	NULL
+second	41	6.0	6.0	6.0	6.0	5.0	6.0	NULL	NULL	NULL
+second	42	6.0	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+second	34	NULL	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6.0	6.0	6.0	NULL	NULL	100.0	NULL
+second	29	NULL	NULL	NULL	6.0	6.0	NULL	NULL	100.0	NULL
+second	40	NULL	NULL	NULL	NULL	6.0	NULL	NULL	100.0	NULL
+PREHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: vector_ptf_lead_lag_double
+                  Statistics: Num rows: 44 Data size: 4299 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:name:string, 1:rowindex:int, 2:mynumber:double, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>, 4:ROW__IS__DELETED:boolean]
+                  Reduce Output Operator
+                    key expressions: name (type: string), mynumber (type: double)
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: name (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkObjectHashOperator
+                        keyColumns: 0:string, 2:double
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        partitionColumns: 0:string
+                        valueColumns: 1:int
+                    Statistics: Num rows: 44 Data size: 4299 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: rowindex (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [0, 1, 2]
+                    dataColumns: name:string, rowindex:int, mynumber:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:double, VALUE._col0:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [double, double, double, double, double, double, double, double, bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), KEY.reducesinkkey1 (type: double)
+                outputColumnNames: _col0, _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 2, 1]
+                Statistics: Num rows: 44 Data size: 4299 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string, _col1: int, _col2: double
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS LAST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: lag_window_0
+                              arguments: _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_1
+                              arguments: _col2, 2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_2
+                              arguments: _col2, 3, 100
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_3
+                              arguments: _col2, 4, _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_4
+                              arguments: _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_5
+                              arguments: _col2, 2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_6
+                              arguments: _col2, 3, 100
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_7
+                              arguments: _col2, 4, _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead]
+                      functionInputExpressions: [col 1:double, col 1:double, col 1:double, col 1:double, col 1:double, col 1:double, col 1:double, col 1:double]
+                      functionNames: [lag, lag, lag, lag, lead, lead, lead, lead]
+                      keyInputColumns: [0, 1]
+                      native: true
+                      nonKeyInputColumns: [2]
+                      orderExpressions: [col 1:double]
+                      outputColumns: [3, 4, 5, 6, 7, 8, 9, 10, 0, 2, 1]
+                      outputTypes: [double, double, double, double, double, double, double, double, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: []
+                  Statistics: Num rows: 44 Data size: 4299 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: int), _col2 (type: double), lag_window_0 (type: double), lag_window_1 (type: double), lag_window_2 (type: double), lag_window_3 (type: double), lead_window_4 (type: double), lead_window_5 (type: double), lead_window_6 (type: double), lead_window_7 (type: double)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3, 4, 5, 6, 7, 8, 9, 10]
+                    Statistics: Num rows: 44 Data size: 6873 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
+                      Statistics: Num rows: 44 Data size: 6873 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select "************ DOUBLE, VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ DOUBLE, VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ DOUBLE, VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_double
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_double
+#### A masked pattern was here ####
+NULL	44	7.0	NULL	NULL	100.0	7.0	7.0	NULL	100.0	7.0
+NULL	43	7.0	7.0	NULL	100.0	7.0	NULL	NULL	100.0	7.0
+first	1	1.0	NULL	NULL	100.0	1.0	2.0	2.0	3.0	3.0
+first	2	2.0	1.0	NULL	100.0	2.0	2.0	3.0	3.0	4.0
+first	3	2.0	2.0	1.0	100.0	2.0	3.0	3.0	4.0	4.0
+first	5	3.0	2.0	2.0	1.0	3.0	3.0	4.0	4.0	4.0
+first	6	3.0	3.0	2.0	2.0	1.0	4.0	4.0	4.0	5.0
+first	7	4.0	3.0	3.0	2.0	2.0	4.0	4.0	5.0	5.0
+first	9	4.0	4.0	3.0	3.0	2.0	4.0	5.0	5.0	5.0
+first	10	4.0	4.0	4.0	3.0	3.0	5.0	5.0	5.0	5.0
+first	14	5.0	4.0	4.0	4.0	3.0	5.0	5.0	5.0	6.0
+first	11	5.0	5.0	4.0	4.0	4.0	5.0	5.0	6.0	6.0
+first	12	5.0	5.0	5.0	4.0	4.0	5.0	6.0	6.0	6.0
+first	15	5.0	5.0	5.0	5.0	4.0	6.0	6.0	6.0	6.0
+first	16	6.0	5.0	5.0	5.0	5.0	6.0	6.0	6.0	6.0
+first	17	6.0	6.0	5.0	5.0	5.0	6.0	6.0	6.0	NULL
+first	18	6.0	6.0	6.0	5.0	5.0	6.0	6.0	NULL	NULL
+first	20	6.0	6.0	6.0	6.0	5.0	6.0	NULL	NULL	NULL
+first	21	6.0	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+first	4	NULL	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6.0	6.0	6.0	NULL	NULL	100.0	NULL
+first	8	NULL	NULL	NULL	6.0	6.0	NULL	NULL	100.0	NULL
+first	13	NULL	NULL	NULL	NULL	6.0	NULL	NULL	100.0	NULL
+second	22	1.0	NULL	NULL	100.0	1.0	2.0	2.0	3.0	3.0
+second	24	2.0	1.0	NULL	100.0	2.0	2.0	3.0	3.0	4.0
+second	23	2.0	2.0	1.0	100.0	2.0	3.0	3.0	4.0	4.0
+second	26	3.0	2.0	2.0	1.0	3.0	3.0	4.0	4.0	4.0
+second	27	3.0	3.0	2.0	2.0	1.0	4.0	4.0	4.0	5.0
+second	30	4.0	3.0	3.0	2.0	2.0	4.0	4.0	5.0	5.0
+second	31	4.0	4.0	3.0	3.0	2.0	4.0	5.0	5.0	5.0
+second	28	4.0	4.0	4.0	3.0	3.0	5.0	5.0	5.0	5.0
+second	36	5.0	4.0	4.0	4.0	3.0	5.0	5.0	5.0	6.0
+second	32	5.0	5.0	4.0	4.0	4.0	5.0	5.0	6.0	6.0
+second	33	5.0	5.0	5.0	4.0	4.0	5.0	6.0	6.0	6.0
+second	35	5.0	5.0	5.0	5.0	4.0	6.0	6.0	6.0	6.0
+second	37	6.0	5.0	5.0	5.0	5.0	6.0	6.0	6.0	6.0
+second	38	6.0	6.0	5.0	5.0	5.0	6.0	6.0	6.0	NULL
+second	39	6.0	6.0	6.0	5.0	5.0	6.0	6.0	NULL	NULL
+second	41	6.0	6.0	6.0	6.0	5.0	6.0	NULL	NULL	NULL
+second	42	6.0	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+second	34	NULL	6.0	6.0	6.0	6.0	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6.0	6.0	6.0	NULL	NULL	100.0	NULL
+second	29	NULL	NULL	NULL	6.0	6.0	NULL	NULL	100.0	NULL
+second	40	NULL	NULL	NULL	NULL	6.0	NULL	NULL	100.0	NULL
+PREHOOK: query: CREATE TABLE vector_ptf_lead_lag_decimal(name string, rowindex int, mynumber decimal) stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@vector_ptf_lead_lag_decimal
+POSTHOOK: query: CREATE TABLE vector_ptf_lead_lag_decimal(name string, rowindex int, mynumber decimal) stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@vector_ptf_lead_lag_decimal
+PREHOOK: query: INSERT INTO vector_ptf_lead_lag_decimal SELECT * from vector_ptf_lead_lag_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_int
+PREHOOK: Output: default@vector_ptf_lead_lag_decimal
+POSTHOOK: query: INSERT INTO vector_ptf_lead_lag_decimal SELECT * from vector_ptf_lead_lag_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_int
+POSTHOOK: Output: default@vector_ptf_lead_lag_decimal
+POSTHOOK: Lineage: vector_ptf_lead_lag_decimal.mynumber EXPRESSION [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:mynumber, type:int, comment:null), ]
+POSTHOOK: Lineage: vector_ptf_lead_lag_decimal.name SIMPLE [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:name, type:string, comment:null), ]
+POSTHOOK: Lineage: vector_ptf_lead_lag_decimal.rowindex SIMPLE [(vector_ptf_lead_lag_int)vector_ptf_lead_lag_int.FieldSchema(name:rowindex, type:int, comment:null), ]
+PREHOOK: query: select "************ DECIMAL, NON-VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ DECIMAL, NON-VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ DECIMAL, NON-VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+NULL	44	7	NULL	NULL	100	7	7	NULL	100	7
+NULL	43	7	7	NULL	100	7	NULL	NULL	100	7
+first	1	1	NULL	NULL	100	1	2	2	3	3
+first	2	2	1	NULL	100	2	2	3	3	4
+first	3	2	2	1	100	2	3	3	4	4
+first	5	3	2	2	1	3	3	4	4	4
+first	6	3	3	2	2	1	4	4	4	5
+first	7	4	3	3	2	2	4	4	5	5
+first	9	4	4	3	3	2	4	5	5	5
+first	10	4	4	4	3	3	5	5	5	5
+first	14	5	4	4	4	3	5	5	5	6
+first	11	5	5	4	4	4	5	5	6	6
+first	12	5	5	5	4	4	5	6	6	6
+first	15	5	5	5	5	4	6	6	6	6
+first	16	6	5	5	5	5	6	6	6	6
+first	17	6	6	5	5	5	6	6	6	NULL
+first	18	6	6	6	5	5	6	6	NULL	NULL
+first	20	6	6	6	6	5	6	NULL	NULL	NULL
+first	21	6	6	6	6	6	NULL	NULL	NULL	NULL
+first	4	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+first	8	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+first	13	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+second	22	1	NULL	NULL	100	1	2	2	3	3
+second	24	2	1	NULL	100	2	2	3	3	4
+second	23	2	2	1	100	2	3	3	4	4
+second	26	3	2	2	1	3	3	4	4	4
+second	27	3	3	2	2	1	4	4	4	5
+second	30	4	3	3	2	2	4	4	5	5
+second	31	4	4	3	3	2	4	5	5	5
+second	28	4	4	4	3	3	5	5	5	5
+second	36	5	4	4	4	3	5	5	5	6
+second	32	5	5	4	4	4	5	5	6	6
+second	33	5	5	5	4	4	5	6	6	6
+second	35	5	5	5	5	4	6	6	6	6
+second	37	6	5	5	5	5	6	6	6	6
+second	38	6	6	5	5	5	6	6	6	NULL
+second	39	6	6	6	5	5	6	6	NULL	NULL
+second	41	6	6	6	6	5	6	NULL	NULL	NULL
+second	42	6	6	6	6	6	NULL	NULL	NULL	NULL
+second	34	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+second	29	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+second	40	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+PREHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: explain vectorization detail select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: vector_ptf_lead_lag_decimal
+                  Statistics: Num rows: 44 Data size: 8147 Basic stats: COMPLETE Column stats: COMPLETE
+                  TableScan Vectorization:
+                      native: true
+                      vectorizationSchemaColumns: [0:name:string, 1:rowindex:int, 2:mynumber:decimal(10,0)/DECIMAL_64, 3:ROW__ID:struct<writeid:bigint,bucketid:int,rowid:bigint>, 4:ROW__IS__DELETED:boolean]
+                  Reduce Output Operator
+                    key expressions: name (type: string), mynumber (type: decimal(10,0))
+                    null sort order: az
+                    sort order: ++
+                    Map-reduce partition columns: name (type: string)
+                    Reduce Sink Vectorization:
+                        className: VectorReduceSinkObjectHashOperator
+                        keyColumns: 0:string, 2:decimal(10,0)
+                        native: true
+                        nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                        partitionColumns: 0:string
+                        valueColumns: 1:int
+                    Statistics: Num rows: 44 Data size: 8147 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: rowindex (type: int)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vectorized.input.format IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                allNative: true
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    includeColumns: [0, 1, 2]
+                    dataColumns: name:string, rowindex:int, mynumber:decimal(10,0)/DECIMAL_64
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: []
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:decimal(10,0), VALUE._col0:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), bigint, bigint, bigint, bigint, bigint, bigint, bigint, bigint]
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), KEY.reducesinkkey1 (type: decimal(10,0))
+                outputColumnNames: _col0, _col1, _col2
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 2, 1]
+                Statistics: Num rows: 44 Data size: 8147 Basic stats: COMPLETE Column stats: COMPLETE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: string, _col1: int, _col2: decimal(10,0)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col2 ASC NULLS LAST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: lag_window_0
+                              arguments: _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_1
+                              arguments: _col2, 2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_2
+                              arguments: _col2, 3, 100
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lag_window_3
+                              arguments: _col2, 4, _col2
+                              name: lag
+                              window function: GenericUDAFLagEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_4
+                              arguments: _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_5
+                              arguments: _col2, 2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_6
+                              arguments: _col2, 3, 100
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                            window function definition
+                              alias: lead_window_7
+                              arguments: _col2, 4, _col2
+                              name: lead
+                              window function: GenericUDAFLeadEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLag, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead, VectorPTFEvaluatorLead]
+                      functionInputExpressions: [col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0), col 1:decimal(10,0)]
+                      functionNames: [lag, lag, lag, lag, lead, lead, lead, lead]
+                      keyInputColumns: [0, 1]
+                      native: true
+                      nonKeyInputColumns: [2]
+                      orderExpressions: [col 1:decimal(10,0)]
+                      outputColumns: [3, 4, 5, 6, 7, 8, 9, 10, 0, 2, 1]
+                      outputTypes: [decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), decimal(10,0), string, int, decimal(10,0)]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: []
+                  Statistics: Num rows: 44 Data size: 8147 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: string), _col1 (type: int), _col2 (type: decimal(10,0)), lag_window_0 (type: decimal(10,0)), lag_window_1 (type: decimal(10,0)), lag_window_2 (type: decimal(10,0)), lag_window_3 (type: decimal(10,0)), lead_window_4 (type: decimal(10,0)), lead_window_5 (type: decimal(10,0)), lead_window_6 (type: decimal(10,0)), lead_window_7 (type: decimal(10,0))
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 2, 1, 3, 4, 5, 6, 7, 8, 9, 10]
+                    Statistics: Num rows: 44 Data size: 46497 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
+                      Statistics: Num rows: 44 Data size: 46497 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                          serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: select "************ DECIMAL, VECTORIZED ************"
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select "************ DECIMAL, VECTORIZED ************"
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+************ DECIMAL, VECTORIZED ************
+PREHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: select name, rowindex, mynumber,
+lag(mynumber) over (partition by name order by mynumber) as lag1,
+lag(mynumber, 2) over (partition by name order by mynumber) as lag2,
+lag(mynumber, 3, 100) over (partition by name order by mynumber) as lag3_default100,
+lag(mynumber, 4, mynumber) over (partition by name order by mynumber) as lag4_default_col,
+lead(mynumber) over (partition by name order by mynumber) as lead1,
+lead(mynumber, 2) over (partition by name order by mynumber) as lead2,
+lead(mynumber, 3, 100) over (partition by name order by mynumber) as lead3_default100,
+lead(mynumber, 4, mynumber) over (partition by name order by mynumber) as lead4_default_col
+from vector_ptf_lead_lag_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@vector_ptf_lead_lag_decimal
+#### A masked pattern was here ####
+NULL	44	7	NULL	NULL	100	7	7	NULL	100	7
+NULL	43	7	7	NULL	100	7	NULL	NULL	100	7
+first	1	1	NULL	NULL	100	1	2	2	3	3
+first	2	2	1	NULL	100	2	2	3	3	4
+first	3	2	2	1	100	2	3	3	4	4
+first	5	3	2	2	1	3	3	4	4	4
+first	6	3	3	2	2	1	4	4	4	5
+first	7	4	3	3	2	2	4	4	5	5
+first	9	4	4	3	3	2	4	5	5	5
+first	10	4	4	4	3	3	5	5	5	5
+first	14	5	4	4	4	3	5	5	5	6
+first	11	5	5	4	4	4	5	5	6	6
+first	12	5	5	5	4	4	5	6	6	6
+first	15	5	5	5	5	4	6	6	6	6
+first	16	6	5	5	5	5	6	6	6	6
+first	17	6	6	5	5	5	6	6	6	NULL
+first	18	6	6	6	5	5	6	6	NULL	NULL
+first	20	6	6	6	6	5	6	NULL	NULL	NULL
+first	21	6	6	6	6	6	NULL	NULL	NULL	NULL
+first	4	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+first	19	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+first	8	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+first	13	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL
+second	22	1	NULL	NULL	100	1	2	2	3	3
+second	24	2	1	NULL	100	2	2	3	3	4
+second	23	2	2	1	100	2	3	3	4	4
+second	26	3	2	2	1	3	3	4	4	4
+second	27	3	3	2	2	1	4	4	4	5
+second	30	4	3	3	2	2	4	4	5	5
+second	31	4	4	3	3	2	4	5	5	5
+second	28	4	4	4	3	3	5	5	5	5
+second	36	5	4	4	4	3	5	5	5	6
+second	32	5	5	4	4	4	5	5	6	6
+second	33	5	5	5	4	4	5	6	6	6
+second	35	5	5	5	5	4	6	6	6	6
+second	37	6	5	5	5	5	6	6	6	6
+second	38	6	6	5	5	5	6	6	6	NULL
+second	39	6	6	6	5	5	6	6	NULL	NULL
+second	41	6	6	6	6	5	6	NULL	NULL	NULL
+second	42	6	6	6	6	6	NULL	NULL	NULL	NULL
+second	34	NULL	6	6	6	6	NULL	NULL	NULL	NULL
+second	25	NULL	NULL	6	6	6	NULL	NULL	100	NULL
+second	29	NULL	NULL	NULL	6	6	NULL	NULL	100	NULL
+second	40	NULL	NULL	NULL	NULL	6	NULL	NULL	100	NULL

--- a/ql/src/test/results/clientpositive/llap/vector_ptf_part_simple.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_ptf_part_simple.q.out
@@ -6101,7 +6101,7 @@ STAGE PLANS:
                     dataColumnCount: 4
                     dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:timestamp, VALUE._col0:string, VALUE._col1:double
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint, bigint, timestamp, timestamp, bigint, timestamp, timestamp]
+                    scratchColumnTypeNames: [bigint, bigint, timestamp, timestamp, bigint, timestamp, timestamp, bigint, timestamp, timestamp]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: double)
@@ -7267,7 +7267,7 @@ STAGE PLANS:
                     dataColumnCount: 4
                     dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:timestamp, VALUE._col0:string, VALUE._col1:double
                     partitionColumnCount: 0
-                    scratchColumnTypeNames: [bigint, bigint, timestamp, timestamp, bigint, timestamp, timestamp]
+                    scratchColumnTypeNames: [bigint, bigint, timestamp, timestamp, bigint, timestamp, timestamp, bigint, timestamp, timestamp]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: string), VALUE._col0 (type: string), VALUE._col1 (type: double)

--- a/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing.q.out
@@ -360,16 +360,28 @@ STAGE PLANS:
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: int), _col3 (type: double)
         Reducer 3 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col0:int, VALUE._col1:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: double)
                 outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -405,13 +417,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int]
+                      functionNames: [rank, dense_rank, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 1, 0, 2, 3]
+                      outputTypes: [int, int, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5]
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: string), _col0 (type: string), _col2 (type: int), _col3 (type: double), rank_window_0 (type: int), dense_rank_window_1 (type: int), _col2 (type: int), (_col2 - lag_window_2) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 2, 8]
+                        selectExpressions: LongColSubtractLongColumn(col 2:int, col 6:int) -> 8:int
                     Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -617,16 +651,28 @@ STAGE PLANS:
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: int), _col3 (type: double)
         Reducer 3 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col0:int, VALUE._col1:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: double)
                 outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -662,13 +708,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int]
+                      functionNames: [rank, dense_rank, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 1, 0, 2, 3]
+                      outputTypes: [int, int, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5]
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: string), _col0 (type: string), _col2 (type: int), _col3 (type: double), rank_window_0 (type: int), dense_rank_window_1 (type: int), _col2 (type: int), (_col2 - lag_window_2) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 2, 8]
+                        selectExpressions: LongColSubtractLongColumn(col 2:int, col 6:int) -> 8:int
                     Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -998,16 +1066,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int, VALUE._col5:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, double, bigint, bigint, double, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
                 outputColumnNames: _col1, _col2, _col5, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 26 Data size: 6006 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -1055,13 +1135,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorCount, VectorPTFEvaluatorStreamingDoubleSum, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int, col 3:double, col 2:int]
+                      functionNames: [rank, dense_rank, count, sum, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 7, 8, 1, 0, 2, 3]
+                      outputTypes: [int, int, bigint, double, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5, 7]
                   Statistics: Num rows: 26 Data size: 6006 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: string), _col1 (type: string), rank_window_0 (type: int), dense_rank_window_1 (type: int), count_window_2 (type: bigint), _col7 (type: double), round(sum_window_3, 2) (type: double), _col5 (type: int), (_col5 - lag_window_4) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 4, 5, 6, 3, 10, 2, 11]
+                        selectExpressions: RoundWithNumDigitsDoubleToDouble(col 7, decimalPlaces 2) -> 10:double, LongColSubtractLongColumn(col 2:int, col 8:int) -> 11:int
                     Statistics: Num rows: 26 Data size: 6734 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 26 Data size: 6734 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1204,16 +1306,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int, VALUE._col5:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, double, bigint, bigint, double, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
                 outputColumnNames: _col1, _col2, _col5, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 26 Data size: 6006 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -1261,13 +1375,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorCount, VectorPTFEvaluatorStreamingDoubleSum, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int, col 3:double, col 2:int]
+                      functionNames: [rank, dense_rank, count, sum, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 7, 8, 1, 0, 2, 3]
+                      outputTypes: [int, int, bigint, double, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5, 7]
                   Statistics: Num rows: 26 Data size: 6006 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: rank_window_0 (type: int), dense_rank_window_1 (type: int), count_window_2 (type: bigint), round(sum_window_3, 2) (type: double), (_col5 - lag_window_4) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [4, 5, 6, 10, 11]
+                        selectExpressions: RoundWithNumDigitsDoubleToDouble(col 7, decimalPlaces 2) -> 10:double, LongColSubtractLongColumn(col 2:int, col 8:int) -> 11:int
                     Statistics: Num rows: 26 Data size: 728 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 26 Data size: 728 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1492,16 +1628,28 @@ STAGE PLANS:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int, VALUE._col5:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, double, bigint, bigint, double, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
                 outputColumnNames: _col1, _col2, _col5, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -1543,13 +1691,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorStreamingDoubleSum, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 3:double, col 2:int]
+                      functionNames: [rank, dense_rank, sum, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 7, 1, 0, 2, 3]
+                      outputTypes: [int, int, double, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5, 6]
                   Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: string), _col1 (type: string), rank_window_0 (type: int), dense_rank_window_1 (type: int), _col7 (type: double), round(sum_window_2, 2) (type: double), _col5 (type: int), (_col5 - lag_window_3) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 4, 5, 3, 9, 2, 10]
+                        selectExpressions: RoundWithNumDigitsDoubleToDouble(col 6, decimalPlaces 2) -> 9:double, LongColSubtractLongColumn(col 2:int, col 7:int) -> 10:int
                     Statistics: Num rows: 27 Data size: 6777 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 27 Data size: 6777 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -3080,7 +3250,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator
@@ -3377,7 +3547,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator
@@ -6000,7 +6170,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator
@@ -6765,16 +6935,28 @@ STAGE PLANS:
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   value expressions: _col2 (type: int), _col3 (type: double)
         Reducer 3 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col0:int, VALUE._col1:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col0 (type: int), VALUE._col1 (type: double)
                 outputColumnNames: _col0, _col1, _col2, _col3
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -6810,13 +6992,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int]
+                      functionNames: [rank, dense_rank, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 1, 0, 2, 3]
+                      outputTypes: [int, int, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5]
                   Statistics: Num rows: 25 Data size: 5775 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col1 (type: string), _col0 (type: string), _col2 (type: int), _col3 (type: double), rank_window_0 (type: int), dense_rank_window_1 (type: int), _col2 (type: int), (_col2 - lag_window_2) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 2, 3, 4, 5, 2, 8]
+                        selectExpressions: LongColSubtractLongColumn(col 2:int, col 6:int) -> 8:int
                     Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 25 Data size: 6175 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_expressions.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_expressions.q.out
@@ -515,16 +515,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lead not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: azzza
+                reduceColumnSortOrder: ++++-
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 5
+                    dataColumns: KEY.reducesinkkey0:tinyint, KEY.reducesinkkey1:boolean, KEY.reducesinkkey2:string, KEY.reducesinkkey3:smallint, KEY.reducesinkkey4:float
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [double, bigint, double, double]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: tinyint), KEY.reducesinkkey3 (type: smallint), KEY.reducesinkkey4 (type: float), KEY.reducesinkkey1 (type: boolean), KEY.reducesinkkey2 (type: string)
                 outputColumnNames: _col0, _col1, _col4, _col6, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 3, 4, 1, 2]
                 Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                 PTF Operator
                   Function definitions:
@@ -546,16 +558,41 @@ STAGE PLANS:
                               window function: GenericUDAFLeadEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLead]
+                      functionInputExpressions: [col 4:float]
+                      functionNames: [lead]
+                      keyInputColumns: [0, 3, 4, 1, 2]
+                      native: true
+                      nonKeyInputColumns: []
+                      orderExpressions: [col 1:boolean, col 2:string, col 3:smallint, col 4:float]
+                      outputColumns: [5, 0, 3, 4, 1, 2]
+                      outputTypes: [float, tinyint, smallint, float, boolean, string]
+                      partitionExpressions: [col 0:tinyint]
+                      streamingColumns: []
                   Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                   Limit
                     Number of rows: 100
+                    Limit Vectorization:
+                        className: VectorLimitOperator
+                        native: true
                     Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col7 (type: string), _col1 (type: smallint), _col4 (type: float), (UDFToFloat(_col1) - lead_window_0) (type: float)
                       outputColumnNames: _col0, _col1, _col2, _col3
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [2, 3, 4, 8]
+                          selectExpressions: DoubleColSubtractDoubleColumn(col 7:float, col 5:float)(children: CastLongToFloatViaLongToDouble(col 3:smallint) -> 7:float) -> 8:float
                       Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
+                        File Sink Vectorization:
+                            className: VectorFileSinkOperator
+                            native: false
                         Statistics: Num rows: 1 Data size: 200 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -742,16 +779,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lead not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: azz
+                reduceColumnSortOrder: +++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:smallint, KEY.reducesinkkey1:int, KEY.reducesinkkey2:string
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: smallint), KEY.reducesinkkey1 (type: int), KEY.reducesinkkey2 (type: string)
                 outputColumnNames: _col1, _col2, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2]
                 Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
                 PTF Operator
                   Function definitions:
@@ -773,16 +822,41 @@ STAGE PLANS:
                               window function: GenericUDAFLeadEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLead]
+                      functionInputExpressions: [col 1:int]
+                      functionNames: [lead]
+                      keyInputColumns: [0, 1, 2]
+                      native: true
+                      nonKeyInputColumns: []
+                      orderExpressions: [col 1:int, col 2:string]
+                      outputColumns: [3, 0, 1, 2]
+                      outputTypes: [int, smallint, int, string]
+                      partitionExpressions: [col 0:smallint]
+                      streamingColumns: []
                   Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
                   Limit
                     Number of rows: 100
+                    Limit Vectorization:
+                        className: VectorLimitOperator
+                        native: true
                     Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col7 (type: string), _col2 (type: int), (_col2 - lead_window_0) (type: int)
                       outputColumnNames: _col0, _col1, _col2
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [2, 1, 6]
+                          selectExpressions: LongColSubtractLongColumn(col 1:int, col 3:int) -> 6:int
                       Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
+                        File Sink Vectorization:
+                            className: VectorFileSinkOperator
+                            native: false
                         Statistics: Num rows: 1 Data size: 192 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -969,16 +1043,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: azzz
+                reduceColumnSortOrder: ++++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:bigint, KEY.reducesinkkey1:smallint, KEY.reducesinkkey2:string, KEY.reducesinkkey3:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [double, bigint, double, double]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: smallint), KEY.reducesinkkey0 (type: bigint), KEY.reducesinkkey3 (type: double), KEY.reducesinkkey2 (type: string)
                 outputColumnNames: _col1, _col3, _col5, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 3, 2]
                 Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: NONE
                 PTF Operator
                   Function definitions:
@@ -1000,16 +1086,41 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 3:double]
+                      functionNames: [lag]
+                      keyInputColumns: [1, 0, 3, 2]
+                      native: true
+                      nonKeyInputColumns: []
+                      orderExpressions: [col 1:smallint, col 2:string, col 3:double]
+                      outputColumns: [4, 1, 0, 3, 2]
+                      outputTypes: [double, smallint, bigint, double, string]
+                      partitionExpressions: [col 0:bigint]
+                      streamingColumns: []
                   Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: NONE
                   Limit
                     Number of rows: 100
+                    Limit Vectorization:
+                        className: VectorLimitOperator
+                        native: true
                     Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col7 (type: string), _col1 (type: smallint), _col5 (type: double), (UDFToDouble(_col1) - lag_window_0) (type: double)
                       outputColumnNames: _col0, _col1, _col2, _col3
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [2, 1, 3, 7]
+                          selectExpressions: DoubleColSubtractDoubleColumn(col 6:double, col 4:double)(children: CastLongToDouble(col 1:smallint) -> 6:double) -> 7:double
                       Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
+                        File Sink Vectorization:
+                            className: VectorFileSinkOperator
+                            native: false
                         Statistics: Num rows: 1 Data size: 204 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1202,7 +1313,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: string data type not supported in argument expression of aggregation function lag
                 vectorized: false
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_gby2.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_gby2.q.out
@@ -796,7 +796,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: percent_rank not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: percent_rank not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_navfn.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_navfn.q.out
@@ -539,7 +539,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lead not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: string data type not supported in argument expression of aggregation function lead
                 vectorized: false
             Reduce Operator Tree:
               Select Operator
@@ -762,16 +762,28 @@ STAGE PLANS:
                     partitionColumnCount: 0
                     scratchColumnTypeNames: []
         Reducer 2 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: zzz
+                reduceColumnSortOrder: +++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:int, KEY.reducesinkkey1:string, KEY.reducesinkkey2:decimal(4,2)
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [decimal(4,2)]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: string), KEY.reducesinkkey2 (type: decimal(4,2))
                 outputColumnNames: _col2, _col7, _col9
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [0, 1, 2]
                 Statistics: Num rows: 1 Data size: 300 Basic stats: COMPLETE Column stats: NONE
                 PTF Operator
                   Function definitions:
@@ -793,16 +805,40 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 2:decimal(4,2)]
+                      functionNames: [lag]
+                      keyInputColumns: [0, 1, 2]
+                      native: true
+                      nonKeyInputColumns: []
+                      orderExpressions: [col 1:string, col 0:int, col 2:decimal(4,2)]
+                      outputColumns: [3, 0, 1, 2]
+                      outputTypes: [decimal(4,2), int, string, decimal(4,2)]
+                      partitionExpressions: [col 0:int]
+                      streamingColumns: []
                   Statistics: Num rows: 1 Data size: 300 Basic stats: COMPLETE Column stats: NONE
                   Limit
                     Number of rows: 100
+                    Limit Vectorization:
+                        className: VectorLimitOperator
+                        native: true
                     Statistics: Num rows: 1 Data size: 300 Basic stats: COMPLETE Column stats: NONE
                     Select Operator
                       expressions: _col2 (type: int), lag_window_0 (type: decimal(4,2))
                       outputColumnNames: _col0, _col1
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: [0, 3]
                       Statistics: Num rows: 1 Data size: 300 Basic stats: COMPLETE Column stats: NONE
                       File Output Operator
                         compressed: false
+                        File Sink Vectorization:
+                            className: VectorFileSinkOperator
+                            native: false
                         Statistics: Num rows: 1 Data size: 300 Basic stats: COMPLETE Column stats: NONE
                         table:
                             input format: org.apache.hadoop.mapred.SequenceFileInputFormat

--- a/ql/src/test/results/clientpositive/llap/vector_windowing_rank.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_windowing_rank.q.out
@@ -641,7 +641,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator
@@ -870,7 +870,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: percent_rank not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: percent_rank not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator

--- a/ql/src/test/results/clientpositive/llap/vectorized_ptf.q.out
+++ b/ql/src/test/results/clientpositive/llap/vectorized_ptf.q.out
@@ -544,16 +544,28 @@ STAGE PLANS:
                     Statistics: Num rows: 27 Data size: 6021 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col5 (type: int)
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int)
                 outputColumnNames: _col1, _col2, _col5
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
                 Statistics: Num rows: 27 Data size: 6021 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -575,13 +587,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 2:int]
+                      functionNames: [lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [3, 1, 0, 2]
+                      outputTypes: [int, string, string, int]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: []
                   Statistics: Num rows: 27 Data size: 6021 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: string), _col1 (type: string), _col5 (type: int), (_col5 - lag_window_0) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 2, 5]
+                        selectExpressions: LongColSubtractLongColumn(col 2:int, col 3:int) -> 5:int
                     Statistics: Num rows: 27 Data size: 6129 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 27 Data size: 6129 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -1166,16 +1200,28 @@ STAGE PLANS:
                     Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col5 (type: int)
         Reducer 3 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 3
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, bigint, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int)
                 outputColumnNames: _col1, _col2, _col5
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2]
                 Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -1211,13 +1257,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 2:int]
+                      functionNames: [rank, dense_rank, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [3, 4, 5, 1, 0, 2]
+                      outputTypes: [int, int, int, string, string, int]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [3, 4]
                   Statistics: Num rows: 26 Data size: 5798 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: string), _col1 (type: string), _col5 (type: int), rank_window_0 (type: int), dense_rank_window_1 (type: int), _col5 (type: int), (_col5 - lag_window_2) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 2, 3, 4, 2, 7]
+                        selectExpressions: LongColSubtractLongColumn(col 2:int, col 5:int) -> 7:int
                     Statistics: Num rows: 26 Data size: 6214 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 26 Data size: 6214 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -3375,16 +3443,28 @@ STAGE PLANS:
                 enabled: false
                 enableConditionsNotMet: Vectorizing MergeJoin Supported IS false
         Reducer 4 
-            Execution mode: llap
+            Execution mode: vectorized, llap
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: lag not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
-                vectorized: false
+                reduceColumnNullOrder: az
+                reduceColumnSortOrder: ++
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+                rowBatchContext:
+                    dataColumnCount: 4
+                    dataColumns: KEY.reducesinkkey0:string, KEY.reducesinkkey1:string, VALUE._col3:int, VALUE._col5:double
+                    partitionColumnCount: 0
+                    scratchColumnTypeNames: [bigint, bigint, bigint, double, bigint, bigint, double, bigint]
             Reduce Operator Tree:
               Select Operator
                 expressions: KEY.reducesinkkey1 (type: string), KEY.reducesinkkey0 (type: string), VALUE._col3 (type: int), VALUE._col5 (type: double)
                 outputColumnNames: _col1, _col2, _col5, _col7
+                Select Vectorization:
+                    className: VectorSelectOperator
+                    native: true
+                    projectedOutputColumnNums: [1, 0, 2, 3]
                 Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                 PTF Operator
                   Function definitions:
@@ -3432,13 +3512,35 @@ STAGE PLANS:
                               window function: GenericUDAFLagEvaluator
                               window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
                               isPivotResult: true
+                  PTF Vectorization:
+                      allEvaluatorsAreStreaming: false
+                      className: VectorPTFOperator
+                      evaluatorClasses: [VectorPTFEvaluatorRank, VectorPTFEvaluatorDenseRank, VectorPTFEvaluatorCount, VectorPTFEvaluatorStreamingDoubleSum, VectorPTFEvaluatorLag]
+                      functionInputExpressions: [col 1:string, col 1:string, col 1:string, col 3:double, col 2:int]
+                      functionNames: [rank, dense_rank, count, sum, lag]
+                      keyInputColumns: [1, 0]
+                      native: true
+                      nonKeyInputColumns: [2, 3]
+                      orderExpressions: [col 1:string]
+                      outputColumns: [4, 5, 6, 7, 8, 1, 0, 2, 3]
+                      outputTypes: [int, int, bigint, double, int, string, string, int, double]
+                      partitionExpressions: [col 0:string]
+                      streamingColumns: [4, 5, 7]
                   Statistics: Num rows: 27 Data size: 6237 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: _col2 (type: string), _col1 (type: string), rank_window_0 (type: int), dense_rank_window_1 (type: int), count_window_2 (type: bigint), _col7 (type: double), round(sum_window_3, 2) (type: double), _col5 (type: int), (_col5 - lag_window_4) (type: int)
                     outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8
+                    Select Vectorization:
+                        className: VectorSelectOperator
+                        native: true
+                        projectedOutputColumnNums: [0, 1, 4, 5, 6, 3, 10, 2, 11]
+                        selectExpressions: RoundWithNumDigitsDoubleToDouble(col 7, decimalPlaces 2) -> 10:double, LongColSubtractLongColumn(col 2:int, col 8:int) -> 11:int
                     Statistics: Num rows: 27 Data size: 6993 Basic stats: COMPLETE Column stats: COMPLETE
                     File Output Operator
                       compressed: false
+                      File Sink Vectorization:
+                          className: VectorFileSinkOperator
+                          native: false
                       Statistics: Num rows: 27 Data size: 6993 Basic stats: COMPLETE Column stats: COMPLETE
                       table:
                           input format: org.apache.hadoop.mapred.SequenceFileInputFormat
@@ -4425,7 +4527,7 @@ STAGE PLANS:
             Reduce Vectorization:
                 enabled: true
                 enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
-                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, last_value, max, min, rank, row_number, sum]
+                notVectorizedReason: PTF operator: cume_dist not in supported functions [avg, count, dense_rank, first_value, lag, last_value, lead, max, min, rank, row_number, sum]
                 vectorized: false
             Reduce Operator Tree:
               Select Operator


### PR DESCRIPTION
### What changes were proposed in this pull request?
Implement vectorized evaluators for lead and lag functions.


### Why are the changes needed?
For better vectorization coverage (performance).


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Performance tested on cluster, added new qtests + old qtests got vectorized without query result change.