### PR TITLE
HIVE-25104: Backward incompatible timestamp serialization in Parquet for certain timezones

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2214,13 +2214,6 @@ public class HiveConf extends Configuration {
     HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT("hive.parquet.date.proleptic.gregorian.default", false,
       "This value controls whether date type in Parquet files was written using the hybrid or proleptic\n" +
       "calendar. Hybrid is the default."),
-    /**
-     * @deprecated Use {@link #HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED} instead.
-     */
-    @Deprecated
-    HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.legacy.conversion.enabled", true,
-      "This value controls whether we use former Java time API to convert between timezones on files where timezone\n" +
-      "is not encoded in the metadata. This is for debugging."),
     HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.write.legacy.conversion.enabled", false,
         "Whether to use former Java date/time APIs to convert between timezones when writing timestamps in " +
         "Parquet files. Once data are written to the file the effect is permanent (also reflected in the metadata)." +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2214,9 +2214,21 @@ public class HiveConf extends Configuration {
     HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT("hive.parquet.date.proleptic.gregorian.default", false,
       "This value controls whether date type in Parquet files was written using the hybrid or proleptic\n" +
       "calendar. Hybrid is the default."),
+    /**
+     * @deprecated Use {@link #HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED} instead.
+     */
+    @Deprecated
     HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.legacy.conversion.enabled", true,
       "This value controls whether we use former Java time API to convert between timezones on files where timezone\n" +
       "is not encoded in the metadata. This is for debugging."),
+    HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.write.legacy.conversion.enabled", false,
+        "Whether to use former Java date/time APIs to convert between timezones when writing timestamps in " +
+        "Parquet files. Once data are written to the file the effect is permanent (also reflected in the metadata)." +
+        "Changing the value of this property affects only new data written to the file."),
+    HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.read.legacy.conversion.enabled", true,
+        "Whether to use former Java date/time APIs to convert between timezones when reading timestamps from " +
+        "Parquet files. The property has no effect when the file contains explicit metadata about the conversion " +
+        "used to write the data; in this case reading conversion is chosen based on the metadata."),
     HIVE_AVRO_TIMESTAMP_SKIP_CONVERSION("hive.avro.timestamp.skip.conversion", false,
         "Some older Hive implementations (pre-3.1) wrote Avro timestamps in a UTC-normalized" +
         "manner, while from version 3.1 until now Hive wrote time zone agnostic timestamps. " +

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2214,14 +2214,14 @@ public class HiveConf extends Configuration {
     HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT("hive.parquet.date.proleptic.gregorian.default", false,
       "This value controls whether date type in Parquet files was written using the hybrid or proleptic\n" +
       "calendar. Hybrid is the default."),
+    HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.legacy.conversion.enabled", true,
+    "Whether to use former Java date/time APIs to convert between timezones when reading timestamps from " +
+        "Parquet files. The property has no effect when the file contains explicit metadata about the conversion " +
+        "used to write the data; in this case reading conversion is chosen based on the metadata."),
     HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.write.legacy.conversion.enabled", false,
         "Whether to use former Java date/time APIs to convert between timezones when writing timestamps in " +
         "Parquet files. Once data are written to the file the effect is permanent (also reflected in the metadata)." +
         "Changing the value of this property affects only new data written to the file."),
-    HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED("hive.parquet.timestamp.read.legacy.conversion.enabled", true,
-        "Whether to use former Java date/time APIs to convert between timezones when reading timestamps from " +
-        "Parquet files. The property has no effect when the file contains explicit metadata about the conversion " +
-        "used to write the data; in this case reading conversion is chosen based on the metadata."),
     HIVE_AVRO_TIMESTAMP_SKIP_CONVERSION("hive.avro.timestamp.skip.conversion", false,
         "Some older Hive implementations (pre-3.1) wrote Avro timestamps in a UTC-normalized" +
         "manner, while from version 3.1 until now Hive wrote time zone agnostic timestamps. " +

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
@@ -421,7 +421,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	2626                
+	totalSize           	2899                
 #### A masked pattern was here ####
 	write.format.default	parquet             
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
@@ -333,7 +333,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1503                
+	totalSize           	1659                
 #### A masked pattern was here ####
 	write.format.default	parquet             
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
@@ -249,7 +249,7 @@ Table Parameters:
 	rawDataSize         	116                 
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	568                 
+	totalSize           	607                 
 #### A masked pattern was here ####
 	write.format.default	parquet             
 	 	 

--- a/pom.xml
+++ b/pom.xml
@@ -433,6 +433,11 @@
         <version>${junit.jupiter.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter-params</artifactId>
+        <version>${junit.jupiter.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.junit.vintage</groupId>
         <artifactId>junit-vintage-engine</artifactId>
         <version>${junit.vintage.version}</version>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -561,6 +561,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.junit.vintage</groupId>
       <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
@@ -145,7 +145,7 @@ public class ParquetRecordReaderBase {
       legacyConversionEnabled = DataWritableReadSupport.getWriterLegacyConversion(fileMetaData.getKeyValueMetaData());
       if (legacyConversionEnabled == null) {
         legacyConversionEnabled =
-            HiveConf.getBoolVar(conf, ConfVars.HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED);
+            HiveConf.getBoolVar(conf, ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED);
       }
 
       split = new ParquetInputSplit(finalPath,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
@@ -20,6 +20,7 @@ import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.parquet.read.DataWritableReadSupport;
 import org.apache.hadoop.hive.ql.io.parquet.read.ParquetFilterPredicateConverter;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
 import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
 import org.apache.hadoop.hive.serde2.SerDeStats;
@@ -142,10 +143,10 @@ public class ParquetRecordReaderBase {
         skipProlepticConversion = HiveConf.getBoolVar(
             conf, HiveConf.ConfVars.HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT);
       }
-      legacyConversionEnabled = DataWritableReadSupport.getWriterLegacyConversion(fileMetaData.getKeyValueMetaData());
-      if (legacyConversionEnabled == null) {
-        legacyConversionEnabled =
-            HiveConf.getBoolVar(conf, ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED);
+      legacyConversionEnabled = HiveConf.getBoolVar(conf, ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED);
+      if (fileMetaData.getKeyValueMetaData().containsKey(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY)) {
+        legacyConversionEnabled = Boolean.parseBoolean(
+            fileMetaData.getKeyValueMetaData().get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY));
       }
 
       split = new ParquetInputSplit(finalPath,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/ParquetRecordReaderBase.java
@@ -142,8 +142,11 @@ public class ParquetRecordReaderBase {
         skipProlepticConversion = HiveConf.getBoolVar(
             conf, HiveConf.ConfVars.HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT);
       }
-      legacyConversionEnabled = HiveConf.getBoolVar(
-          conf, ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED);
+      legacyConversionEnabled = DataWritableReadSupport.getWriterLegacyConversion(fileMetaData.getKeyValueMetaData());
+      if (legacyConversionEnabled == null) {
+        legacyConversionEnabled =
+            HiveConf.getBoolVar(conf, ConfVars.HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED);
+      }
 
       split = new ParquetInputSplit(finalPath,
         splitStart,

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
@@ -703,8 +703,8 @@ public enum ETypeConverter {
           // time zone in order to emulate time zone agnostic behavior.
           boolean skipConversion = Boolean.parseBoolean(
               metadata.get(HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION.varname));
-          boolean legacyConversion = Boolean.parseBoolean(
-              metadata.get(ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED.varname));
+          Boolean legacyConversion = DataWritableReadSupport.getWriterLegacyConversion(metadata);
+          assert legacyConversion != null;
           ZoneId targetZone = skipConversion ? ZoneOffset.UTC : MoreObjects
               .firstNonNull(DataWritableReadSupport.getWriterTimeZoneId(metadata), TimeZone.getDefault().toZoneId());
           Timestamp ts = NanoTimeUtils.getTimestamp(nt, targetZone, legacyConversion);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
@@ -27,12 +27,12 @@ import com.google.common.base.MoreObjects;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
 import org.apache.hadoop.hive.ql.io.parquet.read.DataWritableReadSupport;
 import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTime;
 import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils;
 import org.apache.hadoop.hive.ql.io.parquet.timestamp.ParquetTimestampUtils;
 import org.apache.hadoop.hive.common.type.CalendarUtils;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.io.DateWritableV2;
 import org.apache.hadoop.hive.serde2.io.DoubleWritable;
@@ -703,11 +703,11 @@ public enum ETypeConverter {
           // time zone in order to emulate time zone agnostic behavior.
           boolean skipConversion = Boolean.parseBoolean(
               metadata.get(HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION.varname));
-          Boolean legacyConversion = DataWritableReadSupport.getWriterLegacyConversion(metadata);
+          String legacyConversion = metadata.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
           assert legacyConversion != null;
           ZoneId targetZone = skipConversion ? ZoneOffset.UTC : MoreObjects
               .firstNonNull(DataWritableReadSupport.getWriterTimeZoneId(metadata), TimeZone.getDefault().toZoneId());
-          Timestamp ts = NanoTimeUtils.getTimestamp(nt, targetZone, legacyConversion);
+          Timestamp ts = NanoTimeUtils.getTimestamp(nt, targetZone, Boolean.parseBoolean(legacyConversion));
           return new TimestampWritableV2(ts);
         }
       };

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/convert/ETypeConverter.java
@@ -16,10 +16,14 @@ package org.apache.hadoop.hive.ql.io.parquet.convert;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TimeZone;
 
+import com.google.common.base.MoreObjects;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -701,8 +705,9 @@ public enum ETypeConverter {
               metadata.get(HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION.varname));
           boolean legacyConversion = Boolean.parseBoolean(
               metadata.get(ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED.varname));
-          Timestamp ts = NanoTimeUtils.getTimestamp(nt, skipConversion,
-              DataWritableReadSupport.getWriterTimeZoneId(metadata), legacyConversion);
+          ZoneId targetZone = skipConversion ? ZoneOffset.UTC : MoreObjects
+              .firstNonNull(DataWritableReadSupport.getWriterTimeZoneId(metadata), TimeZone.getDefault().toZoneId());
+          Timestamp ts = NanoTimeUtils.getTimestamp(nt, targetZone, legacyConversion);
           return new TimestampWritableV2(ts);
         }
       };

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
@@ -304,6 +305,14 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
     return null;
   }
 
+  public static Boolean getWriterLegacyConversion(Map<String, String> metadata) {
+    if (metadata == null) {
+      return null;
+    }
+    String value = metadata.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
+    return value != null ? Boolean.valueOf(value) : null;
+  }
+  
   /**
    * Return the columns which contains required nested attribute level
    * E.g., given struct a:<x:int, y:int> while 'x' is required and 'y' is not, the method will return
@@ -523,10 +532,30 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
           configuration, HiveConf.ConfVars.HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN_DEFAULT)));
     }
 
-    String legacyConversion = ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED.varname;
-    if (!metadata.containsKey(legacyConversion)) {
-      metadata.put(legacyConversion, String.valueOf(HiveConf.getBoolVar(
-          configuration, HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED)));
+    if (!metadata.containsKey(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY)) {
+      final String legacyConversion;
+      if(keyValueMetaData.containsKey(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY)) {
+        // If there is meta about the legacy conversion then the file should be read in the same way it was written. 
+        legacyConversion = keyValueMetaData.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
+      } else if(keyValueMetaData.containsKey(DataWritableWriteSupport.WRITER_TIMEZONE)) {
+        // If there is no meta about the legacy conversion but there is meta about the timezone then we can infer the
+        // file was written with the new rules.
+        legacyConversion = "false";
+      } else {
+        // If there is no meta at all then it is not possible to determine which rules were used to write the file.
+        // Choose between old/new rules using the respective configuration property.
+        legacyConversion = String.valueOf(
+            HiveConf.getBoolVar(configuration, ConfVars.HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED));
+      }
+      metadata.put(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY, legacyConversion);
+    } else {
+      String ctxMeta = metadata.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
+      String fileMeta = keyValueMetaData.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
+      if (!Objects.equals(ctxMeta, fileMeta)) {
+        throw new IllegalStateException(
+            "Different values for " + DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY + " metadata: context ["
+                + ctxMeta + "], file [" + fileMeta + "].");
+      }
     }
 
     return new DataWritableRecordConverter(readContext.getRequestedSchema(), metadata, hiveTypeInfo);

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -545,7 +545,7 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
         // If there is no meta at all then it is not possible to determine which rules were used to write the file.
         // Choose between old/new rules using the respective configuration property.
         legacyConversion = String.valueOf(
-            HiveConf.getBoolVar(configuration, ConfVars.HIVE_PARQUET_TIMESTAMP_READ_LEGACY_CONVERSION_ENABLED));
+            HiveConf.getBoolVar(configuration, ConfVars.HIVE_PARQUET_TIMESTAMP_LEGACY_CONVERSION_ENABLED));
       }
       metadata.put(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY, legacyConversion);
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/read/DataWritableReadSupport.java
@@ -304,14 +304,6 @@ public class DataWritableReadSupport extends ReadSupport<ArrayWritable> {
 
     return null;
   }
-
-  public static Boolean getWriterLegacyConversion(Map<String, String> metadata) {
-    if (metadata == null) {
-      return null;
-    }
-    String value = metadata.get(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY);
-    return value != null ? Boolean.valueOf(value) : null;
-  }
   
   /**
    * Return the columns which contains required nested attribute level

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
@@ -78,32 +78,17 @@ public class NanoTimeUtils {
     return new NanoTime(days, nanosOfDay);
   }
 
-  public static Timestamp getTimestamp(NanoTime nt, boolean skipConversion) {
-    return getTimestamp(nt, skipConversion, null, false);
+  public static Timestamp getTimestamp(NanoTime nt, ZoneId targetZone) {
+    return getTimestamp(nt, targetZone, false);
   }
 
   /**
-   * Gets a Timestamp object from a NanoTime object, which represents timestamps as nanoseconds
-   * since epoch. Parquet stores these as int96.
+   * Converts a nanotime representation in UTC, to a timestamp in the specified timezone.
    *
-   * Before converting to NanoTime, we may convert the timestamp to a desired time zone
-   * (timeZoneId). This will only happen if skipConversion flag is off.
-   * If skipConversion is off and timeZoneId is not found, then convert the timestamp to system
-   * time zone.
-   *
-   * For skipConversion to be true it must be set in conf AND the parquet file must NOT be written
-   * by parquet's java library (parquet-mr). This is enforced in ParquetRecordReaderBase#getSplit.
+   * @param legacyConversion when true the conversion to the target timezone is done with legacy (backwards compatible)
+   * method.
    */
-  public static Timestamp getTimestamp(NanoTime nt, boolean skipConversion, ZoneId timeZoneId,
-      boolean legacyConversionEnabled) {
-    boolean legacyConversion = false;
-    if (skipConversion) {
-      timeZoneId = ZoneOffset.UTC;
-    } else if (timeZoneId == null) {
-      legacyConversion = legacyConversionEnabled;
-      timeZoneId = TimeZone.getDefault().toZoneId();
-    }
-
+  public static Timestamp getTimestamp(NanoTime nt, ZoneId targetZone, boolean legacyConversion) {
     int julianDay = nt.getJulianDay();
     long nanosOfDay = nt.getTimeOfDayNanos();
 
@@ -134,7 +119,7 @@ public class NanoTimeUtils {
     calendar.set(Calendar.SECOND, seconds);
 
     Timestamp ts = Timestamp.ofEpochMilli(calendar.getTimeInMillis(), (int) nanos);
-    ts = TimestampTZUtil.convertTimestampToZone(ts, ZoneOffset.UTC, timeZoneId, legacyConversion);
+    ts = TimestampTZUtil.convertTimestampToZone(ts, ZoneOffset.UTC, targetZone, legacyConversion);
     return ts;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
@@ -50,28 +50,11 @@ public class NanoTimeUtils {
     return parquetGMTCalendar.get();
   }
 
-  public static NanoTime getNanoTime(Timestamp ts, boolean skipConversion) {
-    return getNanoTime(ts, skipConversion, null);
-  }
-
   /**
-   * Gets a NanoTime object, which represents timestamps as nanoseconds since epoch, from a
-   * Timestamp object. Parquet will store this NanoTime object as int96.
-   *
-   * If skipConversion flag is on, the timestamp will be converted to NanoTime as-is, i.e.
-   * timeZoneId argument will be ignored.
-   * If skipConversion is off, timestamp can be converted from a given time zone (timeZoneId) to UTC
-   * if timeZoneId is present, and if not present: from system time zone to UTC, before being
-   * converted to NanoTime.
-   * (See TimestampDataWriter#write for current Hive writing procedure.)
+   * Converts a timestamp from the specified timezone to UTC and returns its representation in NanoTime.
    */
-  public static NanoTime getNanoTime(Timestamp ts, boolean skipConversion, ZoneId timeZoneId) {
-    if (skipConversion) {
-      timeZoneId = ZoneOffset.UTC;
-    } else if (timeZoneId == null) {
-      timeZoneId = TimeZone.getDefault().toZoneId();
-    }
-    ts = TimestampTZUtil.convertTimestampToZone(ts, timeZoneId, ZoneOffset.UTC);
+  public static NanoTime getNanoTime(Timestamp ts, ZoneId sourceZone) {
+    ts = TimestampTZUtil.convertTimestampToZone(ts, sourceZone, ZoneOffset.UTC);
 
     Calendar calendar = getGMTCalendar();
     calendar.setTimeInMillis(ts.toEpochMilli());

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/timestamp/NanoTimeUtils.java
@@ -53,8 +53,8 @@ public class NanoTimeUtils {
   /**
    * Converts a timestamp from the specified timezone to UTC and returns its representation in NanoTime.
    */
-  public static NanoTime getNanoTime(Timestamp ts, ZoneId sourceZone) {
-    ts = TimestampTZUtil.convertTimestampToZone(ts, sourceZone, ZoneOffset.UTC);
+  public static NanoTime getNanoTime(Timestamp ts, ZoneId sourceZone, boolean legacyConversion) {
+    ts = TimestampTZUtil.convertTimestampToZone(ts, sourceZone, ZoneOffset.UTC, legacyConversion);
 
     Calendar calendar = getGMTCalendar();
     calendar.setTimeInMillis(ts.toEpochMilli());

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriteSupport.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriteSupport.java
@@ -37,6 +37,7 @@ public class DataWritableWriteSupport extends WriteSupport<ParquetHiveRecord> {
   public static final String PARQUET_HIVE_SCHEMA = "parquet.hive.schema";
   public static final String WRITER_TIMEZONE = "writer.time.zone";
   public static final String WRITER_DATE_PROLEPTIC = "writer.date.proleptic";
+  public static final String WRITER_ZONE_CONVERSION_LEGACY = "writer.zone.conversion.legacy";
 
   private DataWritableWriter writer;
   private MessageType schema;
@@ -60,6 +61,8 @@ public class DataWritableWriteSupport extends WriteSupport<ParquetHiveRecord> {
     defaultDateProleptic = HiveConf.getBoolVar(
         configuration, HiveConf.ConfVars.HIVE_PARQUET_DATE_PROLEPTIC_GREGORIAN);
     metaData.put(WRITER_DATE_PROLEPTIC, String.valueOf(defaultDateProleptic));
+    metaData.put(WRITER_ZONE_CONVERSION_LEGACY, String
+        .valueOf(HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED)));
     return new WriteContext(schema, metaData);
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  *
@@ -536,7 +537,7 @@ public class DataWritableWriter {
         Long int64value = ParquetTimestampUtils.getInt64(ts, timeUnit);
         recordConsumer.addLong(int64value);
       } else {
-        recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, false).toBinary());
+        recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId()).toBinary());
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/write/DataWritableWriter.java
@@ -70,6 +70,7 @@ public class DataWritableWriter {
   protected final RecordConsumer recordConsumer;
   private final GroupType schema;
   private final boolean defaultDateProleptic;
+  private final boolean isLegacyZoneConversion;
   private Configuration conf;
 
   /* This writer will be created when writing the first row in order to get
@@ -81,6 +82,8 @@ public class DataWritableWriter {
     this.recordConsumer = recordConsumer;
     this.schema = schema;
     this.defaultDateProleptic = defaultDateProleptic;
+    this.isLegacyZoneConversion =
+        HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED.defaultBoolVal;
   }
 
 	public DataWritableWriter(final RecordConsumer recordConsumer, final GroupType schema,
@@ -89,6 +92,8 @@ public class DataWritableWriter {
     this.schema = schema;
     this.defaultDateProleptic = defaultDateProleptic;
     this.conf = conf;
+    this.isLegacyZoneConversion =
+        HiveConf.getBoolVar(this.conf, HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED);
   }
 
   /**
@@ -537,7 +542,8 @@ public class DataWritableWriter {
         Long int64value = ParquetTimestampUtils.getInt64(ts, timeUnit);
         recordConsumer.addLong(int64value);
       } else {
-        recordConsumer.addBinary(NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId()).toBinary());
+        recordConsumer.addBinary(
+            NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId(), isLegacyZoneConversion).toBinary());
       }
     }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
@@ -212,7 +212,7 @@ public class VectorizedColumnReaderTestBase {
   protected static NanoTime getNanoTime(int index) {
     Timestamp ts = new Timestamp();
     ts.setTimeInMillis(index);
-    return NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId());
+    return NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId(), false);
   }
 
   protected static HiveDecimal getDecimal(

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/VectorizedColumnReaderTestBase.java
@@ -65,6 +65,7 @@ import org.apache.parquet.schema.MessageType;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.TimeZone;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.TestCase.assertFalse;
@@ -211,7 +212,7 @@ public class VectorizedColumnReaderTestBase {
   protected static NanoTime getNanoTime(int index) {
     Timestamp ts = new Timestamp();
     ts.setTimeInMillis(index);
-    return NanoTimeUtils.getNanoTime(ts, false);
+    return NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId());
   }
 
   protected static HiveDecimal getDecimal(

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/MyConverterParent.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/MyConverterParent.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.ql.io.parquet.write.DataWritableWriteSupport;
 import org.apache.hadoop.io.Writable;
 
 /**
@@ -44,6 +45,7 @@ public class MyConverterParent implements ConverterParent {
   public Map<String, String> getMetadata() {
     Map<String, String> metadata = new HashMap<>();
     metadata.put(HiveConf.ConfVars.HIVE_PARQUET_TIMESTAMP_SKIP_CONVERSION.varname, "false");
+    metadata.put(DataWritableWriteSupport.WRITER_ZONE_CONVERSION_LEGACY, "false");
     return metadata;
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/TestETypeConverter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/TestETypeConverter.java
@@ -130,7 +130,7 @@ public class TestETypeConverter {
   @Test
   public void testGetBigIntConverter() {
     Timestamp timestamp = Timestamp.valueOf("1998-10-03 09:58:31.231");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC, false);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(createHiveTypeInfo("bigint"), primitiveType, nanoTime.toBinary());
     // Retrieve as BigInt
@@ -141,7 +141,7 @@ public class TestETypeConverter {
   @Test
   public void testGetTimestampConverter() throws Exception {
     Timestamp timestamp = Timestamp.valueOf("2018-06-15 15:12:20.0");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC, false);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(null, primitiveType, nanoTime.toBinary());
     TimestampWritableV2 timestampWritable = (TimestampWritableV2) writable;
@@ -151,7 +151,7 @@ public class TestETypeConverter {
   @Test
   public void testGetTimestampProlepticConverter() throws Exception {
     Timestamp timestamp = Timestamp.valueOf("1572-06-15 15:12:20.0");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC, false);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(null, primitiveType, nanoTime.toBinary());
     TimestampWritableV2 timestampWritable = (TimestampWritableV2) writable;

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/TestETypeConverter.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/convert/TestETypeConverter.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 
 import org.apache.hadoop.hive.common.type.Timestamp;
 import org.apache.hadoop.hive.ql.io.parquet.convert.ETypeConverter.BinaryConverter;
@@ -129,7 +130,7 @@ public class TestETypeConverter {
   @Test
   public void testGetBigIntConverter() {
     Timestamp timestamp = Timestamp.valueOf("1998-10-03 09:58:31.231");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, true);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(createHiveTypeInfo("bigint"), primitiveType, nanoTime.toBinary());
     // Retrieve as BigInt
@@ -140,7 +141,7 @@ public class TestETypeConverter {
   @Test
   public void testGetTimestampConverter() throws Exception {
     Timestamp timestamp = Timestamp.valueOf("2018-06-15 15:12:20.0");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, true);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(null, primitiveType, nanoTime.toBinary());
     TimestampWritableV2 timestampWritable = (TimestampWritableV2) writable;
@@ -150,7 +151,7 @@ public class TestETypeConverter {
   @Test
   public void testGetTimestampProlepticConverter() throws Exception {
     Timestamp timestamp = Timestamp.valueOf("1572-06-15 15:12:20.0");
-    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, true);
+    NanoTime nanoTime = NanoTimeUtils.getNanoTime(timestamp, ZoneOffset.UTC);
     PrimitiveType primitiveType = Types.optional(PrimitiveTypeName.INT96).named("value");
     Writable writable = getWritableFromBinaryConverter(null, primitiveType, nanoTime.toBinary());
     TimestampWritableV2 timestampWritable = (TimestampWritableV2) writable;

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
@@ -54,7 +54,7 @@ public class TestParquetTimestampUtils {
     cal.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts = Timestamp.ofEpochMilli(cal.getTimeInMillis());
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId());
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId() ,false);
     Assert.assertEquals(nt.getJulianDay(), 2440000);
 
     Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, TimeZone.getDefault().toZoneId());
@@ -70,7 +70,7 @@ public class TestParquetTimestampUtils {
     cal1.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
-    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
+    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId() ,false);
 
     Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts1Fetched, ts1);
@@ -84,7 +84,7 @@ public class TestParquetTimestampUtils {
     cal2.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
-    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
+    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId(), false);
 
     Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts2Fetched, ts2);
@@ -102,7 +102,7 @@ public class TestParquetTimestampUtils {
     cal1.set(Calendar.HOUR_OF_DAY, 0);
 
     ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
-    nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
+    nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId(), false);
 
     ts1Fetched = NanoTimeUtils.getTimestamp(nt1, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts1Fetched, ts1);
@@ -116,7 +116,7 @@ public class TestParquetTimestampUtils {
     cal2.set(Calendar.HOUR_OF_DAY, 0);
 
     ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
-    nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
+    nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId(), false);
 
     ts2Fetched = NanoTimeUtils.getTimestamp(nt2, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts2Fetched, ts2);
@@ -143,7 +143,7 @@ public class TestParquetTimestampUtils {
     Timestamp ts = Timestamp.ofEpochMilli(cal.getTimeInMillis(), 1);
 
     //(1*60*60 + 1*60 + 1) * 10e9 + 1
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, GMT);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, GMT, false);
     Assert.assertEquals(nt.getTimeOfDayNanos(), 3661000000001L);
 
     //case 2: 23:59:59.999999999
@@ -158,7 +158,7 @@ public class TestParquetTimestampUtils {
     ts = Timestamp.ofEpochMilli(cal.getTimeInMillis(), 999999999);
 
     //(23*60*60 + 59*60 + 59)*10e9 + 999999999
-    nt = NanoTimeUtils.getNanoTime(ts, GMT);
+    nt = NanoTimeUtils.getNanoTime(ts, GMT, false);
     Assert.assertEquals(nt.getTimeOfDayNanos(), 86399999999999L);
 
     //case 3: verify the difference.
@@ -182,8 +182,8 @@ public class TestParquetTimestampUtils {
     cal1.setTimeZone(TimeZone.getTimeZone("GMT"));
     Timestamp ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis(), 1);
 
-    NanoTime n2 = NanoTimeUtils.getNanoTime(ts2, GMT);
-    NanoTime n1 = NanoTimeUtils.getNanoTime(ts1, GMT);
+    NanoTime n2 = NanoTimeUtils.getNanoTime(ts2, GMT, false);
+    NanoTime n1 = NanoTimeUtils.getNanoTime(ts1, GMT, false);
 
     Assert.assertEquals(n2.getTimeOfDayNanos() - n1.getTimeOfDayNanos(), 600000000009L);
 
@@ -213,7 +213,7 @@ public class TestParquetTimestampUtils {
      * 17:00 PST = 01:00 GMT (if not daylight savings)
      * (1*60*60 + 1*60 + 1)*10e9 + 1 = 3661000000001
      */
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, US_PACIFIC);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, US_PACIFIC, false);
     long timeOfDayNanos = nt.getTimeOfDayNanos();
     Assert.assertTrue(timeOfDayNanos == 61000000001L || timeOfDayNanos == 3661000000001L);
 
@@ -234,14 +234,14 @@ public class TestParquetTimestampUtils {
   @Test
   public void testTimezoneless() {
     Timestamp ts1 = Timestamp.valueOf("2011-01-01 00:30:30.111111111");
-    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, ZoneOffset.UTC);
+    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, ZoneOffset.UTC, false);
     Assert.assertEquals(nt1.getJulianDay(), 2455563);
     Assert.assertEquals(nt1.getTimeOfDayNanos(), 1830111111111L);
     Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, ZoneOffset.UTC);
     Assert.assertEquals(ts1Fetched.toString(), ts1.toString());
 
     Timestamp ts2 = Timestamp.valueOf("2011-02-02 08:30:30.222222222");
-    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, ZoneOffset.UTC);
+    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, ZoneOffset.UTC, false);
     Assert.assertEquals(nt2.getJulianDay(), 2455595);
     Assert.assertEquals(nt2.getTimeOfDayNanos(), 30630222222222L);
     Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, ZoneOffset.UTC);
@@ -280,7 +280,7 @@ public class TestParquetTimestampUtils {
   private void verifyTsString(String tsString, boolean local) {
     Timestamp ts = Timestamp.valueOf(tsString);
     ZoneId sourceZone = local ? ZoneOffset.UTC : TimeZone.getDefault().toZoneId(); 
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, sourceZone);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, sourceZone, false);
     ZoneId targetZone = local ? ZoneOffset.UTC : TimeZone.getDefault().toZoneId();
     Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, targetZone);
     Assert.assertEquals(tsString, tsFetched.toString());

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
@@ -14,6 +14,7 @@
 package org.apache.hadoop.hive.ql.io.parquet.serde;
 
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
@@ -53,7 +54,7 @@ public class TestParquetTimestampUtils {
     cal.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts = Timestamp.ofEpochMilli(cal.getTimeInMillis());
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, false);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(nt.getJulianDay(), 2440000);
 
     Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, false);
@@ -69,7 +70,7 @@ public class TestParquetTimestampUtils {
     cal1.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
-    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, false);
+    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
 
     Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, false);
     Assert.assertEquals(ts1Fetched, ts1);
@@ -83,7 +84,7 @@ public class TestParquetTimestampUtils {
     cal2.set(Calendar.HOUR_OF_DAY, 0);
 
     Timestamp ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
-    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, false);
+    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
 
     Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, false);
     Assert.assertEquals(ts2Fetched, ts2);
@@ -101,7 +102,7 @@ public class TestParquetTimestampUtils {
     cal1.set(Calendar.HOUR_OF_DAY, 0);
 
     ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
-    nt1 = NanoTimeUtils.getNanoTime(ts1, false);
+    nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
 
     ts1Fetched = NanoTimeUtils.getTimestamp(nt1, false);
     Assert.assertEquals(ts1Fetched, ts1);
@@ -115,7 +116,7 @@ public class TestParquetTimestampUtils {
     cal2.set(Calendar.HOUR_OF_DAY, 0);
 
     ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
-    nt2 = NanoTimeUtils.getNanoTime(ts2, false);
+    nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
 
     ts2Fetched = NanoTimeUtils.getTimestamp(nt2, false);
     Assert.assertEquals(ts2Fetched, ts2);
@@ -142,7 +143,7 @@ public class TestParquetTimestampUtils {
     Timestamp ts = Timestamp.ofEpochMilli(cal.getTimeInMillis(), 1);
 
     //(1*60*60 + 1*60 + 1) * 10e9 + 1
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, false, GMT);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, GMT);
     Assert.assertEquals(nt.getTimeOfDayNanos(), 3661000000001L);
 
     //case 2: 23:59:59.999999999
@@ -157,7 +158,7 @@ public class TestParquetTimestampUtils {
     ts = Timestamp.ofEpochMilli(cal.getTimeInMillis(), 999999999);
 
     //(23*60*60 + 59*60 + 59)*10e9 + 999999999
-    nt = NanoTimeUtils.getNanoTime(ts, false, GMT);
+    nt = NanoTimeUtils.getNanoTime(ts, GMT);
     Assert.assertEquals(nt.getTimeOfDayNanos(), 86399999999999L);
 
     //case 3: verify the difference.
@@ -181,8 +182,8 @@ public class TestParquetTimestampUtils {
     cal1.setTimeZone(TimeZone.getTimeZone("GMT"));
     Timestamp ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis(), 1);
 
-    NanoTime n2 = NanoTimeUtils.getNanoTime(ts2, false, GMT);
-    NanoTime n1 = NanoTimeUtils.getNanoTime(ts1, false, GMT);
+    NanoTime n2 = NanoTimeUtils.getNanoTime(ts2, GMT);
+    NanoTime n1 = NanoTimeUtils.getNanoTime(ts1, GMT);
 
     Assert.assertEquals(n2.getTimeOfDayNanos() - n1.getTimeOfDayNanos(), 600000000009L);
 
@@ -212,7 +213,7 @@ public class TestParquetTimestampUtils {
      * 17:00 PST = 01:00 GMT (if not daylight savings)
      * (1*60*60 + 1*60 + 1)*10e9 + 1 = 3661000000001
      */
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, false, US_PACIFIC);
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, US_PACIFIC);
     long timeOfDayNanos = nt.getTimeOfDayNanos();
     Assert.assertTrue(timeOfDayNanos == 61000000001L || timeOfDayNanos == 3661000000001L);
 
@@ -233,14 +234,14 @@ public class TestParquetTimestampUtils {
   @Test
   public void testTimezoneless() {
     Timestamp ts1 = Timestamp.valueOf("2011-01-01 00:30:30.111111111");
-    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, true);
+    NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, ZoneOffset.UTC);
     Assert.assertEquals(nt1.getJulianDay(), 2455563);
     Assert.assertEquals(nt1.getTimeOfDayNanos(), 1830111111111L);
     Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, true);
     Assert.assertEquals(ts1Fetched.toString(), ts1.toString());
 
     Timestamp ts2 = Timestamp.valueOf("2011-02-02 08:30:30.222222222");
-    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, true);
+    NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, ZoneOffset.UTC);
     Assert.assertEquals(nt2.getJulianDay(), 2455595);
     Assert.assertEquals(nt2.getTimeOfDayNanos(), 30630222222222L);
     Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, true);
@@ -278,7 +279,8 @@ public class TestParquetTimestampUtils {
 
   private void verifyTsString(String tsString, boolean local) {
     Timestamp ts = Timestamp.valueOf(tsString);
-    NanoTime nt = NanoTimeUtils.getNanoTime(ts, local);
+    ZoneId sourceZone = local ? ZoneOffset.UTC : TimeZone.getDefault().toZoneId(); 
+    NanoTime nt = NanoTimeUtils.getNanoTime(ts, sourceZone);
     Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, local);
     Assert.assertEquals(tsString, tsFetched.toString());
   }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampUtils.java
@@ -57,7 +57,7 @@ public class TestParquetTimestampUtils {
     NanoTime nt = NanoTimeUtils.getNanoTime(ts, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(nt.getJulianDay(), 2440000);
 
-    Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, false);
+    Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(tsFetched, ts);
 
     //check if 30 Julian Days between Jan 1, 2005 and Jan 31, 2005.
@@ -72,7 +72,7 @@ public class TestParquetTimestampUtils {
     Timestamp ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
     NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
 
-    Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, false);
+    Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts1Fetched, ts1);
 
     GregorianCalendar cal2 = new GregorianCalendar();
@@ -86,7 +86,7 @@ public class TestParquetTimestampUtils {
     Timestamp ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
     NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
 
-    Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, false);
+    Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts2Fetched, ts2);
     Assert.assertEquals(nt2.getJulianDay() - nt1.getJulianDay(), 30);
 
@@ -104,7 +104,7 @@ public class TestParquetTimestampUtils {
     ts1 = Timestamp.ofEpochMilli(cal1.getTimeInMillis());
     nt1 = NanoTimeUtils.getNanoTime(ts1, TimeZone.getDefault().toZoneId());
 
-    ts1Fetched = NanoTimeUtils.getTimestamp(nt1, false);
+    ts1Fetched = NanoTimeUtils.getTimestamp(nt1, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts1Fetched, ts1);
 
     cal2 = new GregorianCalendar();
@@ -118,7 +118,7 @@ public class TestParquetTimestampUtils {
     ts2 = Timestamp.ofEpochMilli(cal2.getTimeInMillis());
     nt2 = NanoTimeUtils.getNanoTime(ts2, TimeZone.getDefault().toZoneId());
 
-    ts2Fetched = NanoTimeUtils.getTimestamp(nt2, false);
+    ts2Fetched = NanoTimeUtils.getTimestamp(nt2, TimeZone.getDefault().toZoneId());
     Assert.assertEquals(ts2Fetched, ts2);
     Assert.assertEquals(730517, nt2.getJulianDay() - nt1.getJulianDay());
 
@@ -188,9 +188,9 @@ public class TestParquetTimestampUtils {
     Assert.assertEquals(n2.getTimeOfDayNanos() - n1.getTimeOfDayNanos(), 600000000009L);
 
     NanoTime n3 = new NanoTime(n1.getJulianDay() - 1, n1.getTimeOfDayNanos() + TimeUnit.DAYS.toNanos(1));
-    Assert.assertEquals(ts1, NanoTimeUtils.getTimestamp(n3, false, GMT, false));
+    Assert.assertEquals(ts1, NanoTimeUtils.getTimestamp(n3, GMT, false));
     n3 = new NanoTime(n1.getJulianDay() + 3, n1.getTimeOfDayNanos() - TimeUnit.DAYS.toNanos(3));
-    Assert.assertEquals(ts1, NanoTimeUtils.getTimestamp(n3, false, GMT, false));
+    Assert.assertEquals(ts1, NanoTimeUtils.getTimestamp(n3, GMT, false));
   }
 
   @Test
@@ -237,14 +237,14 @@ public class TestParquetTimestampUtils {
     NanoTime nt1 = NanoTimeUtils.getNanoTime(ts1, ZoneOffset.UTC);
     Assert.assertEquals(nt1.getJulianDay(), 2455563);
     Assert.assertEquals(nt1.getTimeOfDayNanos(), 1830111111111L);
-    Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, true);
+    Timestamp ts1Fetched = NanoTimeUtils.getTimestamp(nt1, ZoneOffset.UTC);
     Assert.assertEquals(ts1Fetched.toString(), ts1.toString());
 
     Timestamp ts2 = Timestamp.valueOf("2011-02-02 08:30:30.222222222");
     NanoTime nt2 = NanoTimeUtils.getNanoTime(ts2, ZoneOffset.UTC);
     Assert.assertEquals(nt2.getJulianDay(), 2455595);
     Assert.assertEquals(nt2.getTimeOfDayNanos(), 30630222222222L);
-    Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, true);
+    Timestamp ts2Fetched = NanoTimeUtils.getTimestamp(nt2, ZoneOffset.UTC);
     Assert.assertEquals(ts2Fetched.toString(), ts2.toString());
   }
 
@@ -281,7 +281,8 @@ public class TestParquetTimestampUtils {
     Timestamp ts = Timestamp.valueOf(tsString);
     ZoneId sourceZone = local ? ZoneOffset.UTC : TimeZone.getDefault().toZoneId(); 
     NanoTime nt = NanoTimeUtils.getNanoTime(ts, sourceZone);
-    Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, local);
+    ZoneId targetZone = local ? ZoneOffset.UTC : TimeZone.getDefault().toZoneId();
+    Timestamp tsFetched = NanoTimeUtils.getTimestamp(nt, targetZone);
     Assert.assertEquals(tsString, tsFetched.toString());
   }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/serde/TestParquetTimestampsHive2Compatibility.java
@@ -1,0 +1,276 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.io.parquet.serde;
+
+import jodd.datetime.JDateTime;
+import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTime;
+import org.apache.hadoop.hive.ql.io.parquet.timestamp.NanoTimeUtils;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.ZoneId;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Compatibility tests for timestamp serialization/deserialization in Parquet files.
+ * <p>
+ * The main goal of the suite is to test that writing parquet files in Hive2 and reading them in Hive4 produces the
+ * expected results and vice-versa. 
+ * </p>
+ * <p>
+ * It is difficult to come up with an end-to-end test between Hive2 and Hive4 in both directions so we are limiting
+ * the test to few APIs that are responsible for the conversion assuming that the main code path still relies on these
+ * APIs. In order to test compatibility with Hive2 some pieces of code were copy-pasted from branch-2.3 inside this
+ * class. 
+ * </p>
+ */
+class TestParquetTimestampsHive2Compatibility {
+  private static final long NANOS_PER_HOUR = TimeUnit.HOURS.toNanos(1);
+  private static final long NANOS_PER_MINUTE = TimeUnit.MINUTES.toNanos(1);
+  private static final long NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
+  private static final long NANOS_PER_DAY = TimeUnit.DAYS.toNanos(1);
+
+  /**
+   * Tests that timestamps written using Hive2 APIs are read correctly by Hive2 APIs.
+   *
+   * This is test is here just for sanity reasons in case somebody changes something in the code and breaks
+   * the Hive2 APIs.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive2ReadHive2(String timestampString) {
+    NanoTime nt = writeHive2(timestampString);
+    java.sql.Timestamp ts = readHive2(nt);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  /**
+   * Tests that timestamps written using Hive2 APIs are read correctly by Hive4 APIs when legacy conversion is on.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive2ReadHive4UsingLegacyConversion(String timestampString) {
+    NanoTime nt = writeHive2(timestampString);
+    Timestamp ts = readHive4(nt, TimeZone.getDefault().getID(), true);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  /**
+   * Tests that timestamps written using Hive4 APIs are read correctly by Hive4 APIs when legacy conversion is on. 
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive4ReadHive4UsingLegacyConversion(String timestampString) {
+    String zoneId = "US/Pacific";
+    NanoTime nt = writeHive4(timestampString, zoneId, true);
+    Timestamp ts = readHive4(nt, zoneId, true);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  /**
+   * Tests that timestamps written using Hive4 APIs are read correctly by Hive4 APIs when legacy conversion is off.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive4ReadHive4UsingNewConversion(String timestampString) {
+    String zoneId = "US/Pacific";
+    NanoTime nt = writeHive4(timestampString, zoneId, false);
+    Timestamp ts = readHive4(nt, zoneId, false);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  /**
+   * Tests that timestamps written using Hive4 APIs are read correctly by Hive2 APIs when legacy conversion is on when
+   * writing.
+   */
+  @ParameterizedTest(name = "{0}")
+  @MethodSource("generateTimestamps")
+  void testWriteHive4UsingLegacyConversionReadHive2(String timestampString) {
+    NanoTime nt = writeHive4(timestampString, TimeZone.getDefault().getID(), true);
+    java.sql.Timestamp ts = readHive2(nt);
+    assertEquals(timestampString, ts.toString());
+  }
+
+  private static Stream<String> generateTimestamps() {
+    return Stream.generate(new Supplier<String>() {
+      int i = 0;
+
+      @Override
+      public String get() {
+        StringBuilder sb = new StringBuilder(29);
+        int year = (i % 9999) + 1;
+        sb.append(zeros(4 - digits(year)));
+        sb.append(year);
+        sb.append('-');
+        int month = (i % 12) + 1;
+        sb.append(zeros(2 - digits(month)));
+        sb.append(month);
+        sb.append('-');
+        int day = (i % 28) + 1;
+        sb.append(zeros(2 - digits(day)));
+        sb.append(day);
+        sb.append(' ');
+        int hour = i % 24;
+        sb.append(zeros(2 - digits(hour)));
+        sb.append(hour);
+        sb.append(':');
+        int minute = i % 60;
+        sb.append(zeros(2 - digits(minute)));
+        sb.append(minute);
+        sb.append(':');
+        int second = i % 60;
+        sb.append(zeros(2 - digits(second)));
+        sb.append(second);
+        sb.append('.');
+        // Bitwise OR with one to avoid times with trailing zeros
+        int nano = (i % 1000000000) | 1;
+        sb.append(zeros(9 - digits(nano)));
+        sb.append(nano);
+        i++;
+        return sb.toString();
+      }
+    })
+    // Exclude dates falling in the default Gregorian change date since legacy code does not handle that interval
+    // gracefully. It is expected that these do not work well when legacy APIs are in use. 
+    .filter(s -> !s.startsWith("1582-10"))
+    .limit(3000);
+  }
+
+  private static int digits(int number) {
+    int digits = 0;
+    do {
+      digits++;
+      number = number / 10;
+    } while (number != 0);
+    return digits;
+  }
+
+  private static char[] zeros(int len) {
+    char[] array = new char[len];
+    for (int i = 0; i < len; i++) {
+      array[i] = '0';
+    }
+    return array;
+  }
+
+  private static java.sql.Timestamp toTimestampHive2(String s) {
+    java.sql.Timestamp result;
+    s = s.trim();
+
+    // Throw away extra if more than 9 decimal places
+    int periodIdx = s.indexOf(".");
+    if (periodIdx != -1) {
+      if (s.length() - periodIdx > 9) {
+        s = s.substring(0, periodIdx + 10);
+      }
+    }
+    if (s.indexOf(' ') < 0) {
+      s = s.concat(" 00:00:00");
+    }
+    try {
+      result = java.sql.Timestamp.valueOf(s);
+    } catch (IllegalArgumentException e) {
+      result = null;
+    }
+    return result;
+  }
+
+  /**
+   * Converts the specified timestamp to nano time using Hive2 legacy code.
+   *
+   * In Hive2, the input string is considered to be in the default system timezone and it is converted to GMT before
+   * it is transformed to nano time.
+   */
+  private static NanoTime writeHive2(String str) {
+    java.sql.Timestamp ts = toTimestampHive2(str);
+    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("GMT")));
+    calendar.setTime(ts);
+    int year = calendar.get(Calendar.YEAR);
+    if (calendar.get(Calendar.ERA) == GregorianCalendar.BC) {
+      year = 1 - year;
+    }
+    JDateTime jDateTime = new JDateTime(year, calendar.get(Calendar.MONTH) + 1,  //java calendar index starting at 1.
+        calendar.get(Calendar.DAY_OF_MONTH));
+    int days = jDateTime.getJulianDayNumber();
+
+    long hour = calendar.get(Calendar.HOUR_OF_DAY);
+    long minute = calendar.get(Calendar.MINUTE);
+    long second = calendar.get(Calendar.SECOND);
+    long nanos = ts.getNanos();
+    long nanosOfDay = nanos + NANOS_PER_SECOND * second + NANOS_PER_MINUTE * minute + NANOS_PER_HOUR * hour;
+
+    return new NanoTime(days, nanosOfDay);
+  }
+
+  /**
+   * Converts the specified nano time to a java.sql.Timestamp using Hive2 legacy code.
+   */
+  private static java.sql.Timestamp readHive2(NanoTime nt) {
+    //Current Hive parquet timestamp implementation stores it in UTC, but other components do not do that.
+    //If this file written by current Hive implementation itself, we need to do the reverse conversion, else skip the conversion.
+    int julianDay = nt.getJulianDay();
+    long nanosOfDay = nt.getTimeOfDayNanos();
+
+    long remainder = nanosOfDay;
+    julianDay += remainder / NANOS_PER_DAY;
+    remainder %= NANOS_PER_DAY;
+    if (remainder < 0) {
+      remainder += NANOS_PER_DAY;
+      julianDay--;
+    }
+
+    JDateTime jDateTime = new JDateTime((double) julianDay);
+    Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone(ZoneId.of("GMT")));
+    calendar.set(Calendar.YEAR, jDateTime.getYear());
+    calendar.set(Calendar.MONTH, jDateTime.getMonth() - 1); //java calendar index starting at 1.
+    calendar.set(Calendar.DAY_OF_MONTH, jDateTime.getDay());
+
+    int hour = (int) (remainder / (NANOS_PER_HOUR));
+    remainder = remainder % (NANOS_PER_HOUR);
+    int minutes = (int) (remainder / (NANOS_PER_MINUTE));
+    remainder = remainder % (NANOS_PER_MINUTE);
+    int seconds = (int) (remainder / (NANOS_PER_SECOND));
+    long nanos = remainder % NANOS_PER_SECOND;
+
+    calendar.set(Calendar.HOUR_OF_DAY, hour);
+    calendar.set(Calendar.MINUTE, minutes);
+    calendar.set(Calendar.SECOND, seconds);
+    java.sql.Timestamp ts = new java.sql.Timestamp(calendar.getTimeInMillis());
+    ts.setNanos((int) nanos);
+    return ts;
+  }
+
+  private static NanoTime writeHive4(String str, String sourceZone, boolean legacyConversion) {
+    Timestamp newTs = PrimitiveObjectInspectorUtils.getTimestampFromString(str);
+    return NanoTimeUtils.getNanoTime(newTs, ZoneId.of(sourceZone), legacyConversion);
+  }
+
+  private static Timestamp readHive4(NanoTime nt, String targetZone, boolean legacyConversion) {
+    return NanoTimeUtils.getTimestamp(nt, ZoneId.of(targetZone), legacyConversion);
+  }
+
+}

--- a/ql/src/test/queries/clientpositive/parquet_int96_legacy_compatibility_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_int96_legacy_compatibility_timestamp.q
@@ -1,0 +1,28 @@
+-- HIVE-25104: Backward incompatible timestamp serialization in Parquet for certain timezones
+-- Test writing timestamps in Parquet tables using old and new date/time APIs
+-- using the appropriate configuration properties. 
+CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS PARQUET;
+-- Rows written using legacy conversion enabled (1 to 4) are backwards compatible and
+-- can be read correctly by older versions of Hive (e.g., Hive 2).
+SET hive.parquet.timestamp.write.legacy.conversion.enabled=true;
+INSERT INTO employee VALUES (1, '1220-01-01 00:00:00');
+INSERT INTO employee VALUES (2, '1880-01-01 00:00:00');
+INSERT INTO employee VALUES (3, '1884-01-01 00:00:00');
+INSERT INTO employee VALUES (4, '1990-01-01 00:00:00');
+-- Rows written using legacy conversion disabled (5 to 8) are not backwards compatible.
+-- Reading those rows in older versions of Hive (or other applications) might show
+-- the timestamps (5, 6) shifted for some timezones (e.g., US/Pacific).
+SET hive.parquet.timestamp.write.legacy.conversion.enabled=false;
+INSERT INTO employee VALUES (5, '1220-01-01 00:00:00');
+INSERT INTO employee VALUES (6, '1880-01-01 00:00:00');
+INSERT INTO employee VALUES (7, '1884-01-01 00:00:00');
+INSERT INTO employee VALUES (8, '1990-01-01 00:00:00');
+-- No matter how timestamps are written they are always read correctly by the current
+-- version of Hive by exploiting the metadata in the file
+SELECT eid, birth FROM employee ORDER BY eid;
+-- Changing the read property does not have any effect in the current version of Hive
+-- since the file metadata contains the appropriate information to read them correctly 
+SET hive.parquet.timestamp.read.legacy.conversion.enabled=false;
+SELECT eid, birth FROM employee ORDER BY eid;
+SET hive.parquet.timestamp.read.legacy.conversion.enabled=true;
+SELECT eid, birth FROM employee ORDER BY eid;

--- a/ql/src/test/queries/clientpositive/parquet_int96_legacy_compatibility_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_int96_legacy_compatibility_timestamp.q
@@ -22,7 +22,7 @@ INSERT INTO employee VALUES (8, '1990-01-01 00:00:00');
 SELECT eid, birth FROM employee ORDER BY eid;
 -- Changing the read property does not have any effect in the current version of Hive
 -- since the file metadata contains the appropriate information to read them correctly 
-SET hive.parquet.timestamp.read.legacy.conversion.enabled=false;
+SET hive.parquet.timestamp.legacy.conversion.enabled=false;
 SELECT eid, birth FROM employee ORDER BY eid;
-SET hive.parquet.timestamp.read.legacy.conversion.enabled=true;
+SET hive.parquet.timestamp.legacy.conversion.enabled=true;
 SELECT eid, birth FROM employee ORDER BY eid;

--- a/ql/src/test/queries/clientpositive/parquet_legacy_mixed_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_legacy_mixed_timestamp.q
@@ -5,7 +5,7 @@ load data local inpath '../../data/files/parquet_legacy_mixed_timestamps.parq' i
 
 select * from legacy_table;
 
-set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.legacy.conversion.enabled=false;
 
 select * from legacy_table;
 

--- a/ql/src/test/queries/clientpositive/parquet_legacy_mixed_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_legacy_mixed_timestamp.q
@@ -5,7 +5,7 @@ load data local inpath '../../data/files/parquet_legacy_mixed_timestamps.parq' i
 
 select * from legacy_table;
 
-set hive.parquet.timestamp.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
 
 select * from legacy_table;
 

--- a/ql/src/test/queries/clientpositive/parquet_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_timestamp.q
@@ -7,16 +7,16 @@ load data local inpath '../../data/files/tbl_parq1/' into table legacy_table_par
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.legacy.conversion.enabled=true;
+set hive.parquet.timestamp.read.legacy.conversion.enabled=true;
 set hive.vectorized.execution.enabled=false;
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
 
 select * from legacy_table_parq1;
 

--- a/ql/src/test/queries/clientpositive/parquet_timestamp.q
+++ b/ql/src/test/queries/clientpositive/parquet_timestamp.q
@@ -7,16 +7,16 @@ load data local inpath '../../data/files/tbl_parq1/' into table legacy_table_par
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.legacy.conversion.enabled=false;
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.read.legacy.conversion.enabled=true;
+set hive.parquet.timestamp.legacy.conversion.enabled=true;
 set hive.vectorized.execution.enabled=false;
 
 select * from legacy_table_parq1;
 
-set hive.parquet.timestamp.read.legacy.conversion.enabled=false;
+set hive.parquet.timestamp.legacy.conversion.enabled=false;
 
 select * from legacy_table_parq1;
 

--- a/ql/src/test/results/clientpositive/llap/materialized_view_parquet.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_parquet.q.out
@@ -171,7 +171,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	3                   
 	rawDataSize         	279                 
-	totalSize           	1181                
+	totalSize           	1220                
 	transactional       	true                
 	transactional_properties	insert_only         
 #### A masked pattern was here ####

--- a/ql/src/test/results/clientpositive/llap/parquet_int96_legacy_compatibility_timestamp.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_int96_legacy_compatibility_timestamp.q.out
@@ -1,0 +1,136 @@
+PREHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS PARQUET
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@employee
+POSTHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS PARQUET
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@employee
+PREHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (5, '1220-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (5, '1220-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (6, '1880-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (6, '1880-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (7, '1884-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (7, '1884-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (8, '1990-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (8, '1990-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+5	1220-01-01 00:00:00
+6	1880-01-01 00:00:00
+7	1884-01-01 00:00:00
+8	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+5	1220-01-01 00:00:00
+6	1880-01-01 00:00:00
+7	1884-01-01 00:00:00
+8	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+5	1220-01-01 00:00:00
+6	1880-01-01 00:00:00
+7	1884-01-01 00:00:00
+8	1990-01-01 00:00:00

--- a/ql/src/test/results/clientpositive/llap/parquet_stats.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_stats.q.out
@@ -48,7 +48,7 @@ Table Parameters:
 	numFiles            	1                   
 	numRows             	2                   
 	rawDataSize         	98                  
-	totalSize           	587                 
+	totalSize           	626                 
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 


### PR DESCRIPTION
### What changes were proposed in this pull request?
    
1. Add new read/write config properties to control legacy zone conversions in Parquet.
2. Deprecate hive.parquet.timestamp.legacy.conversion.enabled property since it is not clear if it applies on conversion during read or write.
3. Exploit file metadata and property to choose between new/old conversion rules.
4. Update existing tests to remove usages of now deprecated hive.parquet.timestamp.legacy.conversion.enabled property.
5. Simplify NanoTimeUtils#getTimestamp & NanoTimeUtils#getNanoTime by removing 'skipConversion' parameter

### Why are the changes needed?
1. Provide the end-users the possibility to write backward compatible timestamps in Parquet files so that files can be read correctly by older versions.
2. Improve code readability of NanoTimeUtils APIs.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
1. Add timestamp read/write compatibility test with Hive2 Parquet APIs (`TestParquetTimestampsHive2Compatibility`)
2. Add qtest writing timestamps in Parquet using legacy zone conversions (`parquet_int96_legacy_compatibility_timestamp.q`)
```
mvn test -Dtest=*Timestamp*
cd itests/qtest
mvn test -Dtest=TestMiniLlapLocalCliDriver -Dqfile_regex=".*timestamp.*" -Dtest.output.overwrite
```
3. Manual tests
* Write to external Parquet table with current Hive version setting `hive.parquet.timestamp.write.legacy.conversion.enabled=true`
* Read from external Parquet table with Hive 2 (commit 324f9faf12d4b91a9359391810cb3312c004d356)
