### PR TITLE
HIVE-25130: handle spark inserted files during alter table concat

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -1287,11 +1287,11 @@ public final class Utilities {
     // and part-00004-c6acfdee-0c32-492e-b209-c2f1cf477770.c000, 00004 is the taskId
     Matcher sparkMatcher = FILE_NAME_EMITTED_BY_SPARK_REGEX.matcher(taskId);
     if (sparkMatcher.matches()) {
-      String strings[] = sparkMatcher.group(0).split("-");
       if (extractAttemptId) {
         // return a constant, since Spark doesn't use attemptId
         taskId = "01";
       } else {
+        String strings[] = sparkMatcher.group(0).split("-");
         taskId = strings[1];
       }
     } else {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -1287,7 +1287,7 @@ public final class Utilities {
     // and part-00004-c6acfdee-0c32-492e-b209-c2f1cf477770.c000, 00004 is the taskId
     Matcher sparkMatcher = FILE_NAME_EMITTED_BY_SPARK_REGEX.matcher(taskId);
     if (sparkMatcher.matches()) {
-      String strings[] = taskId.split("-");
+      String strings[] = sparkMatcher.group(0).split("-");
       if (extractAttemptId) {
         // return a constant, since Spark doesn't use attemptId
         taskId = "01";

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -125,7 +125,6 @@ import org.apache.hadoop.hive.ql.exec.util.DAGTraversal;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedInputFormatInterface;
 import org.apache.hadoop.hive.ql.exec.vector.VectorizedRowBatchCtx;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
-import org.apache.hadoop.hive.ql.io.AcidUtils.IdPathFilter;
 import org.apache.hadoop.hive.ql.io.ContentSummaryInputFormat;
 import org.apache.hadoop.hive.ql.io.HiveFileFormatUtils;
 import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
@@ -1278,7 +1277,7 @@ public final class Utilities {
   private static String getIdFromFilename(String filename, Pattern pattern, int group, boolean extractAttemptId) {
     String taskId = filename;
     int dirEnd = filename.lastIndexOf(Path.SEPARATOR);
-    if (dirEnd!=-1) {
+    if (dirEnd != -1) {
       taskId = filename.substring(dirEnd + 1);
     }
 
@@ -1288,7 +1287,7 @@ public final class Utilities {
     // and part-00004-c6acfdee-0c32-492e-b209-c2f1cf477770.c000, 00004 is the taskId
     Matcher sparkMatcher = FILE_NAME_EMITTED_BY_SPARK_REGEX.matcher(taskId);
     if (sparkMatcher.matches()) {
-    String strings[] = taskId.split("-");
+      String strings[] = taskId.split("-");
       if (extractAttemptId) {
         // return a constant, since Spark doesn't use attemptId
         taskId = "01";

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/UtilitiesTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/UtilitiesTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.exec;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilitiesTest {
+
+  String s1 = "/data/network/probes/mumbai/probes_userplane_mu_extp_3march_case1/"
+      + "partition_date=2021-01-13/hour=4/part-00026-23003837-facb-49ec-b1c4-eeda902cacf3.c000.zlib.orc";
+  String s2 = "/data/network/probes/mumbai/probes_userplane_mu_extp_3march_case1/"
+      + "partition_date=2021-01-13/hour=4/part-00003-c6acfdee-0c32-492e-b209-c2f1cf477770.c000";
+
+  @Test
+  public void TestSparkEmittedFileFormat() {
+
+    Assert.assertEquals("00026-23003837", Utilities.getTaskIdFromFilename(s1));
+    Assert.assertEquals("00026-23003837", Utilities.getPrefixedTaskIdFromFilename(s1));
+    Assert.assertEquals(1, Utilities.getAttemptIdFromFilename(s1));
+
+    Assert.assertEquals("00003-c6acfdee", Utilities.getTaskIdFromFilename(s2));
+    Assert.assertEquals("00003-c6acfdee", Utilities.getPrefixedTaskIdFromFilename(s2));
+    Assert.assertEquals(1, Utilities.getAttemptIdFromFilename(s2));
+
+  }
+}

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/UtilitiesTest.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/UtilitiesTest.java
@@ -31,12 +31,12 @@ public class UtilitiesTest {
   @Test
   public void TestSparkEmittedFileFormat() {
 
-    Assert.assertEquals("00026-23003837", Utilities.getTaskIdFromFilename(s1));
-    Assert.assertEquals("00026-23003837", Utilities.getPrefixedTaskIdFromFilename(s1));
+    Assert.assertEquals("00026", Utilities.getTaskIdFromFilename(s1));
+    Assert.assertEquals("00026", Utilities.getPrefixedTaskIdFromFilename(s1));
     Assert.assertEquals(1, Utilities.getAttemptIdFromFilename(s1));
 
-    Assert.assertEquals("00003-c6acfdee", Utilities.getTaskIdFromFilename(s2));
-    Assert.assertEquals("00003-c6acfdee", Utilities.getPrefixedTaskIdFromFilename(s2));
+    Assert.assertEquals("00003", Utilities.getTaskIdFromFilename(s2));
+    Assert.assertEquals("00003", Utilities.getPrefixedTaskIdFromFilename(s2));
     Assert.assertEquals(1, Utilities.getAttemptIdFromFilename(s2));
 
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
Fix NullPointerException during alter table concat, after data is inserted from Spark. 


### Why are the changes needed?
To fix NPE.

2021-03-01 14:50:32,201 ERROR org.apache.hadoop.hive.ql.exec.Task: [HiveServer2-Background-Pool: Thread-76760]: Job Commit failed with exception 'java.lang.NullPointerException(null)'
java.lang.NullPointerException
at org.apache.hadoop.hive.ql.exec.Utilities.getAttemptIdFromFilename(Utilities.java:1333)
at org.apache.hadoop.hive.ql.exec.Utilities.compareTempOrDuplicateFiles(Utilities.java:1966)
at org.apache.hadoop.hive.ql.exec.Utilities.ponderRemovingTempOrDuplicateFile(Utilities.java:1907)
at org.apache.hadoop.hive.ql.exec.Utilities.removeTempOrDuplicateFilesNonMm(Utilities.java:1892)
at org.apache.hadoop.hive.ql.exec.Utilities.removeTempOrDuplicateFiles(Utilities.java:1797)
at org.apache.hadoop.hive.ql.exec.Utilities.removeTempOrDuplicateFiles(Utilities.java:1674)
at org.apache.hadoop.hive.ql.exec.Utilities.mvFileToFinalPath(Utilities.java:1544)
at org.apache.hadoop.hive.ql.exec.AbstractFileMergeOperator.jobCloseOp(AbstractFileMergeOperator.java:304)



### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Added a unit test
