### PR TITLE
HIVE-25296: Replace parquet-hadoop-bundle dependency with the actual parquet modules

### DIFF
--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -181,12 +181,6 @@
                       </includes>
                     </filter>
                     <filter>
-                      <artifact>org.apache.parquet:parquet-hadoop-bundle</artifact>
-                      <excludes>
-                        <exclude>shaded/parquet/org/codehaus/jackson/**</exclude>
-                      </excludes>
-                    </filter>
-                    <filter>
                       <artifact>org.apache.hadoop:hadoop-common</artifact>
                       <includes>
                         <include>org/apache/hadoop/security/*</include>

--- a/pom.xml
+++ b/pom.xml
@@ -315,18 +315,17 @@
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet</artifactId>
+        <artifactId>parquet-common</artifactId>
         <version>${parquet.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
         <artifactId>parquet-column</artifactId>
         <version>${parquet.version}</version>
-        <classifier>tests</classifier>
       </dependency>
       <dependency>
         <groupId>org.apache.parquet</groupId>
-        <artifactId>parquet-hadoop-bundle</artifactId>
+        <artifactId>parquet-hadoop</artifactId>
         <version>${parquet.version}</version>
       </dependency>
       <dependency>

--- a/ql/pom.xml
+++ b/ql/pom.xml
@@ -183,7 +183,15 @@
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop-bundle</artifactId>
+      <artifactId>parquet-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-column</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -549,12 +557,6 @@
       <scope>test</scope>
     </dependency>
     <!-- test inter-project -->
-    <dependency>
-      <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-column</artifactId>
-      <classifier>tests</classifier>
-      <scope>test</scope>
-    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -1092,7 +1094,9 @@
                   <include>com.esotericsoftware:reflectasm</include>
                   <include>com.esotericsoftware:minlog</include>
                   <include>org.objenesis:objenesis</include>
-                  <include>org.apache.parquet:parquet-hadoop-bundle</include>
+                  <include>org.apache.parquet:common</include>
+                  <include>org.apache.parquet:column</include>
+                  <include>org.apache.parquet:hadoop</include>
                   <include>org.apache.thrift:libthrift</include>
                   <include>org.apache.thrift:libfb303</include>
                   <include>org.datanucleus:javax.jdo</include>

--- a/serde/pom.xml
+++ b/serde/pom.xml
@@ -111,7 +111,15 @@
     </dependency>
     <dependency>
       <groupId>org.apache.parquet</groupId>
-      <artifactId>parquet-hadoop-bundle</artifactId>
+      <artifactId>parquet-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-column</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.parquet</groupId>
+      <artifactId>parquet-hadoop</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request and why?
The parquet-hadoop-bundle is not a real dependency but a mere packaging
of three parquet modules to create an uber jar. The Parquet community
created this artificial module on demand by HIVE-5783 but the
benefits if any are unclear.

On the contrary using the uber dependency has some drawbacks:
-Parquet souce code cannot be attached easily in IDEs which makes
debugging sessions cumbersome.
-Finding concrete dependencies with Parquet is not possible
just by inspecting the pom files.
-Extra maintenance cost for the Parquet community adding
additional verification steps during a release.

For the reasons above the uber dependency is replaced with concrete
dependencies to the respective modules:
* parquet-common
* parquet-column
* parquet-hadoop

No need to exclude ord.codehaus.jackson from parquet in the shaded
hive-jdbc jar cause its not a compile dependency in the afforementioned
Parquet modules (at the current version).

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Existing tests