### PR TITLE
HIVE-25160: Automatically pass on iceberg-handler jar as job dependency

### DIFF
--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandler.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandler.java
@@ -85,6 +85,7 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
+import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.hooks.WriteEntity;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
@@ -770,7 +771,7 @@ import static org.apache.hadoop.hive.druid.DruidStorageHandlerUtils.JSON_MAPPER;
       jobConf.set(HiveConf.ConfVars.HIVE_AM_SPLIT_GENERATION.toString(), Boolean.FALSE.toString());
     }
     try {
-      DruidStorageHandlerUtils.addDependencyJars(jobConf, DruidRecordWriter.class);
+      Utilities.addDependencyJars(jobConf, DruidRecordWriter.class);
     } catch (IOException e) {
       Throwables.propagate(e);
     }

--- a/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandlerUtils.java
+++ b/druid-handler/src/java/org/apache/hadoop/hive/druid/DruidStorageHandlerUtils.java
@@ -124,7 +124,6 @@ import org.apache.hadoop.hive.ql.exec.ExprNodeEvaluator;
 import org.apache.hadoop.hive.ql.exec.ExprNodeEvaluatorFactory;
 import org.apache.hadoop.hive.ql.exec.FunctionRegistry;
 import org.apache.hadoop.hive.ql.exec.UDF;
-import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.ExprNodeColumnDesc;
 import org.apache.hadoop.hive.ql.plan.ExprNodeDesc;
@@ -145,7 +144,6 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoFactory;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.retry.RetryPolicies;
 import org.apache.hadoop.io.retry.RetryProxy;
-import org.apache.hadoop.util.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpMethod;
 import org.jboss.netty.handler.codec.http.HttpResponseStatus;
@@ -178,7 +176,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -724,31 +721,6 @@ public final class DruidStorageHandlerUtils {
    */
   public interface DataPusher {
     void push() throws IOException;
-  }
-
-  // Thanks, HBase Storage handler
-  @SuppressWarnings("SameParameterValue") static void addDependencyJars(Configuration conf, Class<?>... classes)
-      throws IOException {
-    FileSystem localFs = FileSystem.getLocal(conf);
-    Set<String> jars = new HashSet<>(conf.getStringCollection("tmpjars"));
-    for (Class<?> clazz : classes) {
-      if (clazz == null) {
-        continue;
-      }
-      final String path = Utilities.jarFinderGetJar(clazz);
-      if (path == null) {
-        throw new RuntimeException("Could not find jar for class " + clazz + " in order to ship it to the cluster.");
-      }
-      if (!localFs.exists(new Path(path))) {
-        throw new RuntimeException("Could not validate jar file " + path + " for class " + clazz);
-      }
-      jars.add(path);
-    }
-    if (jars.isEmpty()) {
-      return;
-    }
-    //noinspection ToArrayCallWithZeroLengthArrayArgument
-    conf.set("tmpjars", StringUtils.arrayToString(jars.toArray(new String[jars.size()])));
   }
 
   private static VersionedIntervalTimeline<String, DataSegment> getTimelineForIntervalWithHandle(final Handle handle,

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -23,15 +23,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.Timestamp;
@@ -56,7 +52,6 @@ import org.apache.hadoop.mapred.InputFormat;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.JobContext;
 import org.apache.hadoop.mapred.OutputFormat;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotSummary;
@@ -165,36 +160,10 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       }
     }
     try {
-      addDependencyJars(jobConf, HiveIcebergStorageHandler.class);
+      Utilities.addDependencyJars(jobConf, HiveIcebergStorageHandler.class);
     } catch (IOException e) {
       Throwables.propagate(e);
     }
-  }
-
-  // Copied from the KuduStorageHandler :)
-  private static void addDependencyJars(Configuration conf, Class<?>... classes)
-      throws IOException {
-    FileSystem localFs = FileSystem.getLocal(conf);
-    Set<String> jars = new HashSet<>(conf.getStringCollection("tmpjars"));
-    for (Class<?> clazz : classes) {
-      if (clazz == null) {
-        continue;
-      }
-      final String path = Utilities.jarFinderGetJar(clazz);
-      if (path == null) {
-        throw new RuntimeException("Could not find jar for class " + clazz +
-            " in order to ship it to the cluster.");
-      }
-      if (!localFs.exists(new Path(path))) {
-        throw new RuntimeException("Could not validate jar file " + path + " for class " + clazz);
-      }
-      jars.add(path);
-    }
-    if (jars.isEmpty()) {
-      return;
-    }
-    // noinspection ToArrayCallWithZeroLengthArrayArgument
-    conf.set("tmpjars", StringUtils.arrayToString(jars.toArray(new String[jars.size()])));
   }
 
   @Override

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.common.type.Date;
 import org.apache.hadoop.hive.common.type.Timestamp;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
@@ -160,7 +161,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
       }
     }
     try {
-      Utilities.addDependencyJars(jobConf, HiveIcebergStorageHandler.class);
+      if (!jobConf.getBoolean(HiveConf.ConfVars.HIVE_IN_TEST_IDE.varname, false)) {
+        // For running unit test this won't work as maven surefire CP is different than what we have on a cluster:
+        // it places the current projects' classes and test-classes to top instead of jars made from these...
+        Utilities.addDependencyJars(jobConf, HiveIcebergStorageHandler.class);
+      }
     } catch (IOException e) {
       Throwables.propagate(e);
     }


### PR DESCRIPTION
Currently users are required to run the ADD JAR command in their session if they want to use Iceberg tables in Hive jobs.

This should be done in an automatic way similarly to how hbase-, kudu-, .. etc handlers are doing it.

Options