### PR TITLE
HIVE-25162: Add support for CREATE TABLE ... STORED BY ICEBERG statements

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -311,6 +311,7 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
    * <li>The base of the properties is the properties stored at the Hive Metastore for the given table
    * <li>We add the {@link Catalogs#LOCATION} as the table location
    * <li>We add the {@link Catalogs#NAME} as TableIdentifier defined by the database name and table name
+   * <li>We add the serdeProperties of the HMS table
    * <li>We remove some parameters that we don't want to push down to the Iceberg table props
    * </ul>
    * @param hmsTable Table for which we are calculating the properties
@@ -333,6 +334,12 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
     if (properties.get(Catalogs.NAME) == null) {
       properties.put(Catalogs.NAME, TableIdentifier.of(hmsTable.getDbName(), hmsTable.getTableName()).toString());
     }
+
+    hmsTable.getSd().getSerdeInfo().getParameters().entrySet().stream()
+        .filter(e -> e.getKey() != null && e.getValue() != null).forEach(e -> {
+          String icebergKey = HiveTableOperations.translateToIcebergProp(e.getKey());
+          properties.put(icebergKey, e.getValue());
+        });
 
     // Remove HMS table parameters we don't want to propagate to Iceberg
     PROPERTIES_TO_REMOVE.forEach(properties::remove);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -335,11 +335,14 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
       properties.put(Catalogs.NAME, TableIdentifier.of(hmsTable.getDbName(), hmsTable.getTableName()).toString());
     }
 
-    hmsTable.getSd().getSerdeInfo().getParameters().entrySet().stream()
-        .filter(e -> e.getKey() != null && e.getValue() != null).forEach(e -> {
-          String icebergKey = HiveTableOperations.translateToIcebergProp(e.getKey());
-          properties.put(icebergKey, e.getValue());
-        });
+    SerDeInfo serdeInfo = hmsTable.getSd().getSerdeInfo();
+    if (serdeInfo != null) {
+      serdeInfo.getParameters().entrySet().stream()
+          .filter(e -> e.getKey() != null && e.getValue() != null).forEach(e -> {
+            String icebergKey = HiveTableOperations.translateToIcebergProp(e.getKey());
+            properties.put(icebergKey, e.getValue());
+          });
+    }
 
     // Remove HMS table parameters we don't want to propagate to Iceberg
     PROPERTIES_TO_REMOVE.forEach(properties::remove);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerLocalScan.java
@@ -193,7 +193,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
     String createSql = "CREATE EXTERNAL TABLE " + identifier +
         " (customer_id BIGINT, first_name STRING COMMENT 'This is first name', " +
         "last_name STRING COMMENT 'This is last name')" +
-        " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        " STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of());
     runCreateAndReadTest(identifier, createSql, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
@@ -212,7 +212,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
     String createSql = "CREATE EXTERNAL TABLE " + identifier +
         " (customer_id BIGINT, first_name STRING COMMENT 'This is first name') " +
         "PARTITIONED BY (last_name STRING COMMENT 'This is last name') STORED BY " +
-         "'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+         "ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of());
     runCreateAndReadTest(identifier, createSql, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, data);
@@ -228,7 +228,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
         Row.of("Green"), Collections.singletonList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(1)),
         Row.of("Pink"), Collections.singletonList(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2)));
     String createSql = "CREATE EXTERNAL TABLE " + identifier +
-        " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        " STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.PARTITION_SPEC + "'='" + PartitionSpecParser.toJson(spec) + "', " +
         "'" + InputFormatConfig.TABLE_SCHEMA + "'='" +
@@ -249,7 +249,7 @@ public class TestHiveIcebergStorageHandlerLocalScan {
     String createSql = "CREATE EXTERNAL TABLE " + identifier + " (customer_id BIGINT) " +
         "PARTITIONED BY (first_name STRING COMMENT 'This is first name', " +
         "last_name STRING COMMENT 'This is last name') " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of());
     runCreateAndReadTest(identifier, createSql, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, data);

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -160,7 +160,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
@@ -222,7 +222,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     String createSql = "CREATE EXTERNAL TABLE " + identifier +
         " (customer_id BIGINT, first_name STRING COMMENT 'This is first name'," +
         " last_name STRING COMMENT 'This is last name')" +
-        " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        " STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of());
     shell.executeStatement(createSql);
@@ -245,7 +245,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
     String query = String.format("CREATE EXTERNAL TABLE customers (customer_id BIGINT, first_name STRING, last_name " +
         "STRING) STORED BY %s %s TBLPROPERTIES ('%s'='%s')",
-        "ICEBERG",
+        "iceBeRg",
         testTables.locationForCreateTableSQL(identifier),
         InputFormatConfig.CATALOG_NAME,
         Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
@@ -258,7 +258,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
     String query = String.format("CREATE EXTERNAL TABLE customers (customer_id BIGINT, first_name STRING, last_name " +
             "STRING) STORED BY %s WITH SERDEPROPERTIES('%s'='%s') %s TBLPROPERTIES ('%s'='%s')",
-        "ICEBERG",
+        "iceberg",
         TableProperties.DEFAULT_FILE_FORMAT,
         "orc",
         testTables.locationForCreateTableSQL(identifier),
@@ -275,7 +275,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "','" +
@@ -291,7 +291,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
     // We need the location for HadoopTable based tests only
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
@@ -309,7 +309,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
         SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "', " +
@@ -355,7 +355,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
         "Unrecognized token 'WrongSchema'", () -> {
           shell.executeStatement("CREATE EXTERNAL TABLE withShell2 " +
-              "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+              "STORED BY ICEBERG " +
               testTables.locationForCreateTableSQL(identifier) +
               "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='WrongSchema'" +
               ",'" + InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
@@ -366,7 +366,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
         "Please provide ", () -> {
           shell.executeStatement("CREATE EXTERNAL TABLE withShell2 " +
-              "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+              "STORED BY ICEBERG " +
               testTables.locationForCreateTableSQL(identifier) +
               testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
         }
@@ -377,7 +377,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "Table location not set", () -> {
             shell.executeStatement("CREATE EXTERNAL TABLE withShell2 " +
-                "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+                "STORED BY ICEBERG " +
                 "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
                 SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "','" +
                 InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
@@ -397,7 +397,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
       AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
           "customers already exists", () -> {
             shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-                "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+                "STORED BY ICEBERG " +
                 "TBLPROPERTIES ('" + InputFormatConfig.TABLE_SCHEMA + "'='" +
                 SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA) + "',' " +
                 InputFormatConfig.CATALOG_NAME + "'='" + Catalogs.ICEBERG_DEFAULT_CATALOG_NAME + "')");
@@ -406,7 +406,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     } else {
       // With other catalogs, table creation should succeed
       shell.executeStatement("CREATE EXTERNAL TABLE customers " +
-          "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+          "STORED BY ICEBERG " +
           testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")) +
           testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
     }
@@ -421,7 +421,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         "Provide only one of the following", () -> {
           shell.executeStatement("CREATE EXTERNAL TABLE customers (customer_id BIGINT) " +
               "PARTITIONED BY (first_name STRING) " +
-              "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+              "STORED BY ICEBERG " +
               testTables.locationForCreateTableSQL(TableIdentifier.of("default", "customers")) +
               " TBLPROPERTIES ('" + InputFormatConfig.PARTITION_SPEC + "'='" +
               PartitionSpecParser.toJson(spec) + "')");
@@ -440,7 +440,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         "memorable_moments MAP < STRING, STRUCT < year: INT, place: STRING, details: STRING >>, " +
         "current_address STRUCT < street_address: STRUCT " +
         "<street_number: INT, street_name: STRING, street_type: STRING>, country: STRING, postal_code: STRING >) " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
 
@@ -469,7 +469,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     shell.executeStatement("CREATE EXTERNAL TABLE all_types (" +
         "t_Float FLOaT, t_dOuble DOUBLE, t_boolean BOOLEAN, t_int INT, t_bigint BIGINT, t_binary BINARY, " +
         "t_string STRING, t_timestamp TIMESTAMP, t_date DATE, t_decimal DECIMAL(3,2)) " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
 
@@ -493,7 +493,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
           "Unsupported Hive type", () -> {
             shell.executeStatement("CREATE EXTERNAL TABLE not_supported_types " +
                 "(not_supported " + notSupportedType + ") " +
-                "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+                "STORED BY ICEBERG " +
                 testTables.locationForCreateTableSQL(identifier) +
                 testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
           }
@@ -515,7 +515,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     for (String notSupportedType : notSupportedTypes.keySet()) {
       shell.executeStatement("CREATE EXTERNAL TABLE not_supported_types (not_supported " + notSupportedType + ") " +
-              "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+              "STORED BY ICEBERG " +
               testTables.locationForCreateTableSQL(identifier) +
               testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
 
@@ -531,7 +531,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     shell.executeStatement("CREATE EXTERNAL TABLE comment_table (" +
         "t_int INT COMMENT 'int column',  " +
         "t_string STRING COMMENT 'string column') " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
@@ -551,7 +551,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     shell.executeStatement("CREATE EXTERNAL TABLE without_comment_table (" +
             "t_int INT,  " +
             "t_string STRING) " +
-            "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+            "STORED BY ICEBERG " +
             testTables.locationForCreateTableSQL(identifier) +
             testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
@@ -572,7 +572,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     shell.executeStatement("CREATE EXTERNAL TABLE customers (" +
         "t_int INT,  " +
         "t_string STRING) " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' " +
+        "STORED BY ICEBERG " +
         testTables.locationForCreateTableSQL(identifier) +
         testTables.propertiesForCreateTableSQL(ImmutableMap.of()));
     String propKey = "dummy";
@@ -602,7 +602,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
 
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' %s" +
+        "STORED BY ICEBERG %s" +
         "TBLPROPERTIES ('%s'='%s', '%s'='%s', '%s'='%s', '%s'='%s')",
         testTables.locationForCreateTableSQL(identifier), // we need the location for HadoopTable based tests only
         InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA),
@@ -723,7 +723,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     // Create HMS table with with a property to be translated
     shell.executeStatement(String.format("CREATE EXTERNAL TABLE default.customers " +
-        "STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'" +
+        "STORED BY ICEBERG " +
         "TBLPROPERTIES ('%s'='%s', '%s'='%s', '%s'='%s')",
         InputFormatConfig.TABLE_SCHEMA, SchemaParser.toJson(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA),
         InputFormatConfig.PARTITION_SPEC, PartitionSpecParser.toJson(SPEC),

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -244,8 +244,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableStoredByIceberg() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
     String query = String.format("CREATE EXTERNAL TABLE customers (customer_id BIGINT, first_name STRING, last_name " +
-        "STRING) STORED BY %s %s TBLPROPERTIES ('%s'='%s')",
-        "iceBeRg",
+        "STRING) STORED BY iceBerg %s TBLPROPERTIES ('%s'='%s')",
         testTables.locationForCreateTableSQL(identifier),
         InputFormatConfig.CATALOG_NAME,
         Catalogs.ICEBERG_DEFAULT_CATALOG_NAME);
@@ -257,8 +256,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
   public void testCreateTableStoredByIcebergWithSerdeProperties() {
     TableIdentifier identifier = TableIdentifier.of("default", "customers");
     String query = String.format("CREATE EXTERNAL TABLE customers (customer_id BIGINT, first_name STRING, last_name " +
-            "STRING) STORED BY %s WITH SERDEPROPERTIES('%s'='%s') %s TBLPROPERTIES ('%s'='%s')",
-        "iceberg",
+            "STRING) STORED BY iceberg WITH SERDEPROPERTIES('%s'='%s') %s TBLPROPERTIES ('%s'='%s')",
         TableProperties.DEFAULT_FILE_FORMAT,
         "orc",
         testTables.locationForCreateTableSQL(identifier),

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithMultipleCatalogs.java
@@ -173,7 +173,7 @@ public class TestHiveIcebergStorageHandlerWithMultipleCatalogs {
                                    String catalogName, List<Record> records) throws IOException {
     String createSql = String.format(
         "CREATE EXTERNAL TABLE %s (customer_id BIGINT, first_name STRING, last_name STRING)" +
-        " STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' %s " +
+        " STORED BY ICEBERG %s " +
         " TBLPROPERTIES ('%s'='%s', '%s'='%s')",
         identifier,
         testTables.locationForCreateTableSQL(identifier),

--- a/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_failure.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_failure.q
@@ -1,2 +1,2 @@
 set hive.vectorized.execution.enabled=true;
-CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler';
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG;

--- a/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table.q
@@ -1,4 +1,4 @@
 set hive.vectorized.execution.enabled=false;
-CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler';
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG;
 DESCRIBE FORMATTED ice_t;
 DROP TABLE ice_t;

--- a/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_by_iceberg.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_by_iceberg.q
@@ -1,0 +1,4 @@
+set hive.vectorized.execution.enabled=false;
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG;
+DESCRIBE FORMATTED ice_t;
+DROP TABLE ice_t;

--- a/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_by_iceberg_with_serdeproperties.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_by_iceberg_with_serdeproperties.q
@@ -1,0 +1,4 @@
+set hive.vectorized.execution.enabled=false;
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('write.format.default'='orc');
+DESCRIBE FORMATTED ice_t;
+DROP TABLE ice_t;

--- a/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_failure.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_failure.q.out
@@ -1,4 +1,4 @@
-PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@ice_t

--- a/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table.q.out
@@ -1,8 +1,8 @@
-PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@ice_t
-POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice_t

--- a/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_by_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_by_iceberg.q.out
@@ -1,8 +1,8 @@
-PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@ice_t
-POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice_t

--- a/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_by_iceberg_with_serdeproperties.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_by_iceberg_with_serdeproperties.q.out
@@ -1,8 +1,8 @@
-PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('write.format.default'='orc')
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
 PREHOOK: Output: default@ice_t
-POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('write.format.default'='orc')
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@ice_t
@@ -39,6 +39,7 @@ Table Parameters:
 	table_type          	ICEBERG             
 	totalSize           	0                   
 #### A masked pattern was here ####
+	write.format.default	orc                 
 	 	 
 # Storage Information	 	 
 SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -1972,6 +1972,9 @@ tableFileFormat
       | KW_STORED KW_BY storageHandler=StringLiteral
          (KW_WITH KW_SERDEPROPERTIES serdeprops=tableProperties)?
       -> ^(TOK_STORAGEHANDLER $storageHandler $serdeprops?)
+      | KW_STORED KW_BY genericSpec=identifier
+         (KW_WITH KW_SERDEPROPERTIES serdeprops=tableProperties)?
+      -> ^(TOK_STORAGEHANDLER $genericSpec $serdeprops?)
       | KW_STORED KW_AS genericSpec=identifier
       -> ^(TOK_FILEFORMAT_GENERIC $genericSpec)
     ;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hive.ql.parse;
 
 import static org.apache.hadoop.hive.ql.parse.ParseUtils.ensureClassExists;
+
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -107,8 +109,11 @@ public class StorageFormat {
   }
 
   private String processStorageHandler(String name) throws SemanticException {
-    if (StorageHandlerTypes.ICEBERG.name().equalsIgnoreCase(name)) {
-      name = StorageHandlerTypes.ICEBERG.className();
+    for (StorageHandlerTypes type : StorageHandlerTypes.values()) {
+      if (type.name().equalsIgnoreCase(name)) {
+        name = type.className();
+        break;
+      }
     }
 
     return ensureClassExists(BaseSemanticAnalyzer.unescapeSQLString(name));


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
This PR introduces syntactic shortcut to allow the creation of Iceberg tables  without providing the handler class
`CREATE TABLE ice_t (a int) STORED BY ICEBERG [WITH SERDEPROPERTIES (...)]`


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
At the moment, when we want to create an Iceberg table, we have to provide the fully qualified iceberg storage handler class name.
`CREATE TABLE ice_t (a int) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' [WITH SERDEPROPERTIES (...)]`

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Unit test, q test