### PR TITLE
HIVE-25159: Remove support for ordered results in llap external client library

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -5158,11 +5158,6 @@ public class HiveConf extends Configuration {
     LLAP_EXTERNAL_SPLITS_TEMP_TABLE_STORAGE_FORMAT("hive.llap.external.splits.temp.table.storage.format",
         "orc", new StringSet("default", "text", "orc"),
         "Storage format for temp tables created using LLAP external client"),
-    LLAP_EXTERNAL_SPLITS_ORDER_BY_FORCE_SINGLE_SPLIT("hive.llap.external.splits.order.by.force.single.split",
-      true,
-      "If LLAP external clients submits ORDER BY queries, force return a single split to guarantee reading\n" +
-        "data out in ordered way. Setting this to false will let external clients read data out in parallel\n" +
-        "losing the ordering (external clients are responsible for guaranteeing the ordering)"),
     LLAP_EXTERNAL_CLIENT_USE_HYBRID_CALENDAR("hive.llap.external.client.use.hybrid.calendar",
         false,
         "Whether to use hybrid calendar for parsing of data/timestamps."),

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractTestJdbcGenericUDTFGetSplits.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/AbstractTestJdbcGenericUDTFGetSplits.java
@@ -201,13 +201,13 @@ public abstract class AbstractTestJdbcGenericUDTFGetSplits {
     runQuery(query, getConfigs(), expectedCounts[1]);
 
     query = "select " + udtfName + "(" + "'select id from " + partitionedTableName + " limit 2', 5)";
-    runQuery(query, getConfigs(), expectedCounts[1]);
+    runQuery(query, getConfigs(), expectedCounts[2]);
 
     query = "select " + udtfName + "(" + "'select id from " + partitionedTableName + " where id != 0 limit 2', 5)";
-    runQuery(query, getConfigs(), expectedCounts[1]);
+    runQuery(query, getConfigs(), expectedCounts[3]);
 
     query = "select " + udtfName + "(" + "'select id from " + partitionedTableName + " group by id limit 2', 5)";
-    runQuery(query, getConfigs(), expectedCounts[1]);
+    runQuery(query, getConfigs(), expectedCounts[4]);
 
   }
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits.java
@@ -45,7 +45,7 @@ public class TestJdbcGenericUDTFGetSplits extends AbstractTestJdbcGenericUDTFGet
 
   @Test(timeout = 200000)
   public void testGenericUDTFOrderBySplitCount1OnPartitionedTable() throws Exception {
-    super.testGenericUDTFOrderBySplitCount1OnPartitionedTable("get_splits", new int[]{5, 1, 2, 2, 2});
+    super.testGenericUDTFOrderBySplitCount1OnPartitionedTable("get_splits", new int[]{5, 5, 1, 1, 1});
   }
 
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcGenericUDTFGetSplits2.java
@@ -32,7 +32,7 @@ public class TestJdbcGenericUDTFGetSplits2 extends AbstractTestJdbcGenericUDTFGe
 
   @Test(timeout = 200000)
   public void testGenericUDTFOrderBySplitCount1OnPartitionedTable() throws Exception {
-    super.testGenericUDTFOrderBySplitCount1OnPartitionedTable("get_llap_splits", new int[]{7, 3, 4, 4, 4});
+    super.testGenericUDTFOrderBySplitCount1OnPartitionedTable("get_llap_splits", new int[]{7, 7, 3, 3, 3});
   }
 
 }


### PR DESCRIPTION
The issue with order by in llap external client is described in https://issues.apache.org/jira/browse/HIVE-25159

### What changes were proposed in this pull request?
To resolve the above issue, we propose removing of order by handling in the llap external client library and let the clients do it at their end.

### Why are the changes needed?
1. These changes are needed to make llap external client queries more performant, earlier they used to generate only a single split for order by queries.
2. Removing order by support also helps us to get rid of exception arising to due false detection of order by clause (it was specific to spark-llap and was done for that only).


### Does this PR introduce _any_ user-facing change?
It removes a config - hive.llap.external.splits.order.by.force.single.split


### How was this patch tested?
Through existing unit tests 
- org.apache.hive.jdbc.TestJdbcGenericUDTFGetSplits
- org.apache.hive.jdbc.TestJdbcGenericUDTFGetSplits2