### PR TITLE
HIVE-25158: Beeline/hive command can't get operation logs when hive.s…

### DIFF
--- a/beeline/pom.xml
+++ b/beeline/pom.xml
@@ -127,6 +127,11 @@
     </dependency>
     <!-- test intra-project -->
     <dependency>
+     <groupId>org.apache.hadoop</groupId>
+     <artifactId>hadoop-hdfs</artifactId>
+     <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hive</groupId>
       <artifactId>hive-exec</artifactId>
       <version>${project.version}</version>

--- a/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
+++ b/beeline/src/test/org/apache/hive/beeline/cli/TestHiveCli.java
@@ -187,6 +187,18 @@ public class TestHiveCli {
   }
 
   @Test
+  public void testSessionId1() {
+    verifyCMD(null, "hive.session.id=xxxx", out,
+        new String[] { "--hiveconf", "hive.session.id=xxxx", "-e", "set hive.session.id" }, ERRNO_OK, true);
+  }
+
+  @Test
+  public void testSessionId2() {
+    verifyCMD(null, "Compiling", err,
+        new String[] { "--hiveconf", "hive.session.id=xxxx", "-e", "select 1" }, ERRNO_OK, true);
+  }
+
+  @Test
   public void testVariables() {
     verifyCMD(
         "set system:xxx=5;\nset system:yyy=${system:xxx};\nset system:yyy;", "", out, null, ERRNO_OK, true);

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveConnection.java
@@ -98,6 +98,7 @@ import org.apache.hive.jdbc.saml.IJdbcBrowserClientFactory;
 import org.apache.hive.service.rpc.thrift.TSetClientInfoResp;
 
 import org.apache.hive.service.rpc.thrift.TSetClientInfoReq;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hive.jdbc.Utils.JdbcConnectionParams;
 import org.apache.hive.service.auth.HiveAuthConstants;
 import org.apache.hive.service.auth.KerberosSaslHelper;
@@ -347,7 +348,11 @@ public class HiveConnection implements java.sql.Connection {
     }
     if (isEmbeddedMode) {
       client = EmbeddedCLIServicePortal.get(connParams.getHiveConfs());
+      String sessionId = connParams.getHiveConfs().get(HiveConf.ConfVars.HIVESESSIONID.varname);
       connParams.getHiveConfs().clear();
+      if (sessionId != null) {
+        connParams.getHiveConfs().put(HiveConf.ConfVars.HIVESESSIONID.varname, sessionId);
+      }
       // open client session
       if (isBrowserAuthMode()) {
         throw new SQLException(new IllegalArgumentException(

--- a/jdbc/src/java/org/apache/hive/jdbc/Utils.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/Utils.java
@@ -437,6 +437,18 @@ public class Utils {
     // Don't parse them, but set embedded mode as true
     if (uri.equalsIgnoreCase(URL_PREFIX)) {
       connParams.setEmbeddedMode(true);
+      for (Map.Entry<Object, Object> kv : info.entrySet()) {
+        if ((kv.getKey() instanceof String)) {
+          String key = (String) kv.getKey();
+          if (key.startsWith(JdbcConnectionParams.HIVE_VAR_PREFIX)) {
+            connParams.getHiveVars().put(key.substring(JdbcConnectionParams.HIVE_VAR_PREFIX.length()),
+                info.getProperty(key));
+          } else if (key.startsWith(JdbcConnectionParams.HIVE_CONF_PREFIX)) {
+            connParams.getHiveConfs().put(
+                key.substring(JdbcConnectionParams.HIVE_CONF_PREFIX.length()), info.getProperty(key));
+          }
+        }
+      }
       return connParams;
     }
 

--- a/service/src/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
+++ b/service/src/java/org/apache/hive/service/cli/session/HiveSessionImpl.java
@@ -319,7 +319,9 @@ public class HiveSessionImpl implements HiveSession {
       LOG.warn("The operation log root directory is not writable: " +
           operationLogRootDir.getAbsolutePath());
     }
-    sessionLogDir = new File(operationLogRootDir, sessionHandle.getHandleIdentifier().toString());
+    // Get session ID from SessionState in case the client overrides it
+    sessionLogDir = new File(operationLogRootDir, SessionState.get()==null?
+        sessionHandle.getHandleIdentifier().toString(): SessionState.get().getSessionId());
     isOperationLogEnabled = true;
     if (!sessionLogDir.exists()) {
       if (!sessionLogDir.mkdir()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Changed one line in service/src/java/org/apache/hive/service/cli/session/HiveSessionImpl.java. The session log directory should be <operationLogRootDir>/<session_id>/ instead of <operationLogRootDir>/<sessionHandle_id>/.


### Why are the changes needed?
If we run beeline/hive command with parameter "--hiveconf hive.session.id=xxx", we can't see the query operation logs. And the operation logs can't be cleaned up by HS2.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
Added testSessionId1() and testSessionId2() in TestHiveCli.java.
Run "mvn test -Dtest=org.apache.hive.beeline.cli.TestHiveCli"
