### PR TITLE
HIVE-25163 UnsupportedTemporalTypeException when starting llap

### DIFF
--- a/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceDriver.java
+++ b/llap-server/src/java/org/apache/hadoop/hive/llap/cli/service/LlapServiceDriver.java
@@ -44,7 +44,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Paths;
-import java.time.Instant;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -298,7 +298,7 @@ public class LlapServiceDriver {
     int rc;
     String version = System.getenv("HIVE_VERSION");
     if (StringUtils.isEmpty(version)) {
-      version = DateTimeFormatter.BASIC_ISO_DATE.format(Instant.now());
+      version = DateTimeFormatter.BASIC_ISO_DATE.format(LocalDateTime.now());
     }
 
     String outputDir = cl.getOutput();


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use LocalDateTime instead of Instant to generate an llap version string when HIVE_VERSION is not set.


### Why are the changes needed?
The current code throws a  java.time.temporal.UnsupportedTemporalTypeException,
making it impossible to start the llap jobs when HIVE_VERSION  is not set.


### Does this PR introduce _any_ user-facing change?
No. 

### How was this patch tested?
Built Hive and started llap successfully 
(well, at least it got past the point where the exception was thrown).
