### PR TITLE
HIVE-25173. Fix build failure of hive-pre-upgrade due to missing dependency on pentaho-aggdesigner-algorithm.

### DIFF
--- a/upgrade-acid/pre-upgrade/pom.xml
+++ b/upgrade-acid/pre-upgrade/pom.xml
@@ -99,6 +99,10 @@
                 <groupId>org.apache.curator</groupId>
                 <artifactId>curator-framework</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>org.pentaho</groupId>
+                <artifactId>pentaho-aggdesigner-algorithm</artifactId>
+              </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HIVE-25173

```
[ERROR] Failed to execute goal on project hive-pre-upgrade: Could not resolve dependencies for project org.apache.hive:hive-pre-upgrade:jar:4.0.0-SNAPSHOT: Failure to find org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
```

The dependency on org.pentaho:pentaho-aggdesigner-algorithm is pulled from hive-exec-2.3.3 via calcite-core-1.10.0. I think we can safely exclude it from transitive dependencies. 
