### PR TITLE
HIVE-25166: Query with multiple count(distinct constant) fails

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/HiveRelFieldTrimmer.java
@@ -581,7 +581,7 @@ public class HiveRelFieldTrimmer extends RelFieldTrimmer {
       relBuilder.push(input);
       relBuilder.project(newProjects);
       Aggregate newAggregate = new HiveAggregate(aggregate.getCluster(), aggregate.getTraitSet(), relBuilder.build(),
-          aggregate.getGroupSet(), null, aggregate.getAggCallList());
+          aggregate.getGroupSet(), aggregate.getGroupSets(), aggregate.getAggCallList());
       return newAggregate;
     }
     return aggregate;

--- a/ql/src/test/queries/clientpositive/multi_count_distinct_null.q
+++ b/ql/src/test/queries/clientpositive/multi_count_distinct_null.q
@@ -3,8 +3,15 @@ set hive.mapred.mode=nonstrict;
 drop table employee;
 
 create table employee (department_id int, gender varchar(10), education_level int);
- 
+
+explain cbo
+select count(distinct 0), count(distinct null) from employee;
+
+select count(distinct 0), count(distinct null) from employee;
+
 insert into employee values (1, 'M', 1),(1, 'M', 1),(2, 'F', 1),(1, 'F', 3),(1, 'M', 2),(4, 'M', 1),(2, 'F', 1),(2, 'F', 3),(3, 'M', 2),(null, 'M', 1),(null, null, 1),(null, null, null);
+
+select count(distinct 0), count(distinct null) from employee;
 
 explain select count(distinct department_id), count(distinct gender), count(distinct education_level) from employee;
 

--- a/ql/src/test/results/clientpositive/llap/multi_count_distinct_null.q.out
+++ b/ql/src/test/results/clientpositive/llap/multi_count_distinct_null.q.out
@@ -10,6 +10,32 @@ POSTHOOK: query: create table employee (department_id int, gender varchar(10), e
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@employee
+PREHOOK: query: explain cbo
+select count(distinct 0), count(distinct null) from employee
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain cbo
+select count(distinct 0), count(distinct null) from employee
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+CBO PLAN:
+HiveAggregate(group=[{}], agg#0=[count($0)], agg#1=[count($1)])
+  HiveProject($f0=[CASE(=($2, 1), 1, null:INTEGER)], $f1=[null:INTEGER])
+    HiveAggregate(group=[{0, 1}], groups=[[{0}, {1}]], GROUPING__ID=[GROUPING__ID()])
+      HiveProject($f0=[true], $f1=[true])
+        HiveTableScan(table=[[default, employee]], table:alias=[employee])
+
+PREHOOK: query: select count(distinct 0), count(distinct null) from employee
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(distinct 0), count(distinct null) from employee
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0	0
 PREHOOK: query: insert into employee values (1, 'M', 1),(1, 'M', 1),(2, 'F', 1),(1, 'F', 3),(1, 'M', 2),(4, 'M', 1),(2, 'F', 1),(2, 'F', 3),(3, 'M', 2),(null, 'M', 1),(null, null, 1),(null, null, null)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
@@ -21,6 +47,15 @@ POSTHOOK: Output: default@employee
 POSTHOOK: Lineage: employee.department_id SCRIPT []
 POSTHOOK: Lineage: employee.education_level SCRIPT []
 POSTHOOK: Lineage: employee.gender SCRIPT []
+PREHOOK: query: select count(distinct 0), count(distinct null) from employee
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(distinct 0), count(distinct null) from employee
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	0
 PREHOOK: query: explain select count(distinct department_id), count(distinct gender), count(distinct education_level) from employee
 PREHOOK: type: QUERY
 PREHOOK: Input: default@employee


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
Copy grouping sets when rewriting gby constant keys in `HiveRelFieldTrimmer`

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
`HiveExpandDistinctAggregatesRule` introduce an Aggregate with grouping sets even if query projects only count distinct constant expressions.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
Yes. Queries projects only count distinct constant expressions won't fail.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapCliDriver -Dqfile=multi_count_distinct_null.q -pl itests/qtest -Pitests
```