### PR TITLE
HIVE-24987: Introduce a exception list to skip incompatible column change check

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestDisallowColChangesExceptionList.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/metastore/TestDisallowColChangesExceptionList.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.HashMap;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.apache.hive.jdbc.miniHS2.MiniHS2;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Test which makes sure that incompatible column changes are allowed if the serde of the
+ * table is defined in the configuration metastore.allow.incompatible.col.type.changes.serdes
+ */
+public class TestDisallowColChangesExceptionList {
+
+  public static MiniHS2 miniHS2 = null;
+
+  @BeforeClass
+  public static void startServices() throws Exception {
+    HiveConf hiveConf = new HiveConf();
+    hiveConf.setIntVar(ConfVars.HIVE_SERVER2_THRIFT_MIN_WORKER_THREADS, 2);
+    hiveConf.setIntVar(ConfVars.HIVE_SERVER2_THRIFT_MAX_WORKER_THREADS, 2);
+    hiveConf.setBoolVar(ConfVars.HIVE_SUPPORT_CONCURRENCY, false);
+    // we configure the HS2 and metastore to allow parquet and orc tables to be allowed
+    // to make incompatible changes.
+    hiveConf.set(MetastoreConf.ConfVars.ALLOW_INCOMPATIBLE_COL_TYPE_CHANGES_TABLE_SERDES
+            .getVarname(), "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe,"
+        + "org.apache.hadoop.hive.ql.io.orc.OrcSerde");
+
+    miniHS2 = new MiniHS2.Builder().withMiniMR().withRemoteMetastore().withConf(hiveConf)
+        .build();
+
+    miniHS2.start(new HashMap<>());
+
+    Connection hs2Conn = DriverManager
+        .getConnection(miniHS2.getJdbcURL(), "hive", "hive");
+    Statement stmt = hs2Conn.createStatement();
+
+    // create test tables
+    stmt.execute("drop table if exists testParquet");
+    stmt.execute("create table testParquet (c1 string, c2 int) stored as parquet");
+    stmt.execute("drop table if exists testOrc");
+    stmt.execute("create table testOrc (c1 string, c2 int) stored as orc");
+    stmt.execute("drop table if exists testText");
+    stmt.execute("create table testText (c1 string, c2 int)");
+
+    stmt.close();
+    hs2Conn.close();
+  }
+
+  @AfterClass
+  public static void stopServices() throws Exception {
+    if (miniHS2 != null && miniHS2.isStarted()) {
+      miniHS2.stop();
+    }
+  }
+
+  @Test
+  public void testDisallowColChangesExceptionList() {
+    assertTrue("Test setup failed. MiniHS2 is not initialized",
+        miniHS2 != null && miniHS2.isStarted());
+
+    try (
+        Connection hs2conn = DriverManager
+            .getConnection(TestDisallowColChangesExceptionList.miniHS2.getJdbcURL(), "hive",
+                "hive");
+        Statement stmt = hs2conn.createStatement();
+    ) {
+      // parquet and orc are allowed to make incompat changes based on the
+      // hiveConf
+      // change c2 from int to smallint
+      stmt.execute("alter table testParquet change column c2 c2 smallint");
+      // drop c1
+      stmt.execute("alter table testParquet replace columns (c2 int)");
+      // change c1 to smallint; orc doesn't support drop columns and query fails
+      // during compilation itself
+      stmt.execute("alter table testOrc change column c2 c2 smallint");
+      // make sure text tables don't allow incompat column changes because
+      // they are not in the exception list
+      try {
+        // change text table column c1 from int to small; this should fail because it is
+        // not in the exception list
+        stmt.execute("alter table testText change column c2 c2 smallint");
+        fail("Exception not thrown");
+      } catch (Exception e1) {
+        assertTrue("Unexpected exception: " + e1.getMessage(), e1.getMessage().contains(
+            "Unable to alter table. The following columns have types incompatible with the existing columns in their respective positions"));
+      }
+      try {
+        // drop c1 column; this should not be allowed since text is not in the exception
+        // list
+        stmt.execute("alter table testText replace columns (c2 int)");
+        fail("Exception not thrown");
+      } catch (Exception e1) {
+        assertTrue("Unexpected exception: " + e1.getMessage(), e1.getMessage().contains(
+            "Unable to alter table. The following columns have types incompatible with the existing columns in their respective positions"));
+      }
+    } catch (Exception e2) {
+      fail("Unexpected Exception: " + e2.getMessage());
+    }
+  }
+
+}

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/conf/MetastoreConf.java
@@ -600,6 +600,11 @@ public class MetastoreConf {
             "not blocked.\n" +
             "\n" +
             "See HIVE-4409 for more details."),
+    ALLOW_INCOMPATIBLE_COL_TYPE_CHANGES_TABLE_SERDES("metastore.allow.incompatible.col.type.changes.serdes",
+        "hive.metastore.allow.incompatible.col.type.changes.serdes", "org.apache.hadoop.hive.kudu.KuduSerDe",
+        "Comma-separated list of table serdes which are allowed to make incompatible column type\n" +
+        "changes. This configuration is only applicable if metastore.disallow.incompatible.col.type.changes\n" +
+        "is true."),
     DUMP_CONFIG_ON_CREATION("metastore.dump.config.on.creation", "metastore.dump.config.on.creation", true,
         "If true, a printout of the config file (minus sensitive values) will be dumped to the " +
             "log whenever newMetastoreConf() is called.  Can produce a lot of logs"),

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DefaultIncompatibleTableChangeHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DefaultIncompatibleTableChangeHandler.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Default incompatible table change handler. This is invoked by the {@link
+ * HiveAlterHandler} when a table is altered to check if the column type changes if any
+ * are allowed or not.
+ */
+public class DefaultIncompatibleTableChangeHandler implements
+    IMetaStoreIncompatibleChangeHandler {
+
+  private static final Logger LOG = LoggerFactory
+      .getLogger(DefaultIncompatibleTableChangeHandler.class);
+  private static final DefaultIncompatibleTableChangeHandler INSTANCE =
+      new DefaultIncompatibleTableChangeHandler();
+
+  private DefaultIncompatibleTableChangeHandler() {
+  }
+
+  public static DefaultIncompatibleTableChangeHandler get() {
+    return INSTANCE;
+  }
+
+  /**
+   * Checks if the column type changes in the oldTable and newTable are allowed or not. In
+   * addition to checking if the incompatible changes are allowed or not, this also checks
+   * if the table serde library belongs to a list of table serdes which support making any
+   * column type changes.
+   *
+   * @param conf     The configuration which if incompatible col type changes are allowed
+   *                 or not.
+   * @param oldTable The instance of the table being altered.
+   * @param newTable The new instance of the table which represents the altered state of
+   *                 the table.
+   * @throws InvalidOperationException
+   */
+  @Override
+  public void allowChange(Configuration conf, Table oldTable, Table newTable)
+      throws InvalidOperationException {
+    if (!MetastoreConf.getBoolVar(conf,
+        MetastoreConf.ConfVars.DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES)) {
+      // incompatible column changes are allowed for all
+      return;
+    }
+    if (oldTable.getTableType().equals(TableType.VIRTUAL_VIEW.toString())) {
+      // Views derive the column type from the base table definition. So the view
+      // definition can be altered to change the column types. The column type
+      // compatibility checks should be done only for non-views.
+      return;
+    }
+    checkColTypeChangeCompatible(conf, oldTable, newTable);
+  }
+
+  private void checkColTypeChangeCompatible(Configuration conf, Table oldTable,
+      Table newTable) throws InvalidOperationException {
+    List<FieldSchema> oldCols = oldTable.getSd().getCols();
+    List<FieldSchema> newCols = newTable.getSd().getCols();
+    List<String> incompatibleCols = new ArrayList<>();
+    int maxCols = Math.min(oldCols.size(), newCols.size());
+    for (int i = 0; i < maxCols; i++) {
+      if (!ColumnType.areColTypesCompatible(
+          ColumnType.getTypeName(oldCols.get(i).getType()),
+          ColumnType.getTypeName(newCols.get(i).getType()))) {
+        incompatibleCols.add(newCols.get(i).getName());
+      }
+    }
+    if (!incompatibleCols.isEmpty()) {
+      Collection<String> exceptedTableSerdes = MetastoreConf.getStringCollection(conf,
+          MetastoreConf.ConfVars.ALLOW_INCOMPATIBLE_COL_TYPE_CHANGES_TABLE_SERDES);
+      SerDeInfo serDeInfo = oldTable.getSd().getSerdeInfo();
+      String serializationLib =
+          serDeInfo == null ? null : serDeInfo.getSerializationLib();
+      if (exceptedTableSerdes.contains(serializationLib)) {
+        LOG.info(
+            "Allowing incompatible column type change of {} for table {}"
+                + " since the table serde {} is in excepted list of serdes",
+            incompatibleCols, (oldTable.getDbName() + "." + oldTable.getTableName()),
+            serializationLib);
+        return;
+      }
+      throw new InvalidOperationException(
+          "The following columns have types incompatible with the existing " +
+              "columns in their respective positions :\n" +
+              org.apache.commons.lang.StringUtils.join(incompatibleCols, ',')
+      );
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -193,16 +193,10 @@ public class HiveAlterHandler implements AlterHandler {
         isPartitionedTable = true;
       }
 
-      // Views derive the column type from the base table definition.  So the view definition
-      // can be altered to change the column types.  The column type compatibility checks should
-      // be done only for non-views.
-      if (MetastoreConf.getBoolVar(handler.getConf(),
-            MetastoreConf.ConfVars.DISALLOW_INCOMPATIBLE_COL_TYPE_CHANGES) &&
-          !oldt.getTableType().equals(TableType.VIRTUAL_VIEW.toString())) {
-        // Throws InvalidOperationException if the new column types are not
-        // compatible with the current column types.
-        checkColTypeChangeCompatible(oldt.getSd().getCols(), newt.getSd().getCols());
-      }
+      // Throws InvalidOperationException if the new column types are not
+      // compatible with the current column types.
+      DefaultIncompatibleTableChangeHandler.get()
+          .allowChange(handler.getConf(), oldt, newt);
 
       //check that partition keys have not changed, except for virtual views
       //however, allow the partition comments to change

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -1169,25 +1169,4 @@ public class HiveAlterHandler implements AlterHandler {
 
     return newPartsColStats;
   }
-
-  private void checkColTypeChangeCompatible(List<FieldSchema> oldCols, List<FieldSchema> newCols)
-      throws InvalidOperationException {
-    List<String> incompatibleCols = new ArrayList<>();
-    int maxCols = Math.min(oldCols.size(), newCols.size());
-    for (int i = 0; i < maxCols; i++) {
-      if (!ColumnType.areColTypesCompatible(
-          ColumnType.getTypeName(oldCols.get(i).getType()),
-          ColumnType.getTypeName(newCols.get(i).getType()))) {
-        incompatibleCols.add(newCols.get(i).getName());
-      }
-    }
-    if (!incompatibleCols.isEmpty()) {
-      throw new InvalidOperationException(
-          "The following columns have types incompatible with the existing " +
-              "columns in their respective positions :\n" +
-              org.apache.commons.lang3.StringUtils.join(incompatibleCols, ',')
-      );
-    }
-  }
-
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreIncompatibleChangeHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/IMetaStoreIncompatibleChangeHandler.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.InvalidOperationException;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+/**
+ * This interface defines an API which can be used to process incompatible changes to
+ * tables in the {@link HiveAlterHandler}
+ */
+public interface IMetaStoreIncompatibleChangeHandler  {
+
+  /**
+   * Checks if the old table can be altered to the new table. If not, throws
+   * {@link InvalidOperationException}
+   * @param oldTable
+   * @param newTable
+   * @throws InvalidOperationException
+   */
+  void allowChange(Configuration conf, Table oldTable, Table newTable)
+      throws InvalidOperationException;
+}


### PR DESCRIPTION


### What changes were proposed in this pull request?
hive.metastore.disallow.incompatible.col.type.check config currently checks if a alter table operation is making a incompatible schema change to the table. By default it is set to true which would error out the alter table call when such a change is detected. However, this change is too restrictive for certain file-formats like Kudu. In case of Kudu, it is allowed to drop a column which could result in the schema to be incompatible according to current implementation of this check. This causes a bad user-experience for Kudu users and there is no real work-around than to disable this check all together. Disabling the check is not an option since for file-formats like Parquet this is should be true to avoid data corruption/incorrect results.

This change introduces a new config which can be used by users to provide a exception list based on table serde library name. If a table belongs to such a serde, the check is skipped. By default currently, only Kudu tables are added to this config.

### Why are the changes needed?
See above.

### Does this PR introduce _any_ user-facing change?
This introduces a new configuration option for metastore.

### How was this patch tested?
A new unit-test was added to exercise the specific use-case. Existing tests make sure that previous behavior is not changed.