### PR TITLE
HIVE-25189: Fetch validWriteIdList for tables before table request.

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2690,6 +2690,10 @@ public class HiveConf extends Configuration {
     HIVE_OPTIMIZE_HMS_QUERY_CACHE_ENABLED("hive.optimize.metadata.query.cache.enabled", true,
         "This property enables caching metadata for repetitive requests on a per-query basis"),
 
+    HIVE_OPTIMIZE_VIEW_CACHE_ENABLED("hive.optimize.view.tables.cache.enabled", true,
+        "This property enables caching of views and their underlying tables. The cache in memory may be stale, but "
+            + " provides an optimization if it is accurate."),
+
     // CTE
     HIVE_CTE_MATERIALIZE_THRESHOLD("hive.optimize.cte.materialize.threshold", 3,
         "If the number of references to a CTE clause exceeds this threshold, Hive will materialize it\n" +

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/FromClauseParser.g
@@ -25,6 +25,8 @@ k=3;
 }
 
 @members {
+  public List<Pair<String, String>> tables = new ArrayList<Pair<String, String>>();
+
   @Override
   public Object recoverFromMismatchedSet(IntStream input,
       RecognitionException re, BitSet follow) throws RecognitionException {
@@ -216,9 +218,11 @@ tableName
 @after { gParent.popMsg(state); }
     :
     db=identifier DOT tab=identifier
+    {tables.add(new ImmutablePair<>($db.text, $tab.text));}
     -> ^(TOK_TABNAME $db $tab)
     |
     tab=identifier
+    {tables.add(new ImmutablePair<>(null, $tab.text));}
     -> ^(TOK_TABNAME $tab)
     ;
 

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -495,8 +495,12 @@ TOK_IGNORE_NULLS;
 package org.apache.hadoop.hive.ql.parse;
 
 import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 }

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseDriver.java
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseDriver.java
@@ -19,6 +19,7 @@
 package org.apache.hadoop.hive.ql.parse;
 
 
+import java.util.List;
 import org.antlr.runtime.CommonToken;
 import org.antlr.runtime.ParserRuleReturnScope;
 import org.antlr.runtime.RecognitionException;
@@ -28,6 +29,7 @@ import org.antlr.runtime.TokenStream;
 import org.antlr.runtime.tree.CommonTree;
 import org.antlr.runtime.tree.CommonTreeAdaptor;
 import org.antlr.runtime.tree.TreeAdaptor;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,7 +135,7 @@ public class ParseDriver {
 
     ASTNode tree = (ASTNode) r.getTree();
     tree.setUnknownTokenBoundaries();
-    return new ParseResult(tree, tokens);
+    return new ParseResult(tree, tokens, parser.gFromClauseParser.tables);
   }
 
   /*
@@ -200,7 +202,7 @@ public class ParseDriver {
       throw new ParseException(parser.errors);
     }
 
-    return new ParseResult((ASTNode) r.getTree(), tokens);
+    return new ParseResult((ASTNode) r.getTree(), tokens, parser.gFromClauseParser.tables);
   }
   public ASTNode parseExpression(String command) throws ParseException {
     LOG.debug("Parsing expression: {}", command);

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseResult.java
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/ParseResult.java
@@ -17,7 +17,9 @@
  */
 package org.apache.hadoop.hive.ql.parse;
 
+import java.util.List;
 import org.antlr.runtime.TokenRewriteStream;
+import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * Contains result of {@link ParseDriver#parse(String)}.
@@ -25,10 +27,13 @@ import org.antlr.runtime.TokenRewriteStream;
 public class ParseResult {
   private final ASTNode tree;
   private final TokenRewriteStream tokenRewriteStream;
+  private final List<Pair<String, String>> tables;
 
-  public ParseResult(ASTNode tree, TokenRewriteStream tokenRewriteStream) {
+  public ParseResult(ASTNode tree, TokenRewriteStream tokenRewriteStream,
+      List<Pair<String, String>> tables) {
     this.tree = tree;
     this.tokenRewriteStream = tokenRewriteStream;
+    this.tables = tables;
   }
 
   public ASTNode getTree() {
@@ -37,5 +42,9 @@ public class ParseResult {
 
   public TokenRewriteStream getTokenRewriteStream() {
     return tokenRewriteStream;
+  }
+
+  public List<Pair<String, String>> getTables() {
+    return tables;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -23,6 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.antlr.runtime.TokenRewriteStream;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileStatus;
@@ -186,6 +188,8 @@ public class Context {
    * See {@link org.apache.hadoop.hive.ql.ddl.view.materialized.alter.rebuild.AlterMaterializedViewRebuildAnalyzer}.
    */
   private boolean scheduledQuery;
+
+  private List<Pair<String, String>> parsedTables = new ArrayList<>();
 
   public void setOperation(Operation operation) {
     this.operation = operation;
@@ -1307,5 +1311,13 @@ public class Context {
 
   public void setScheduledQuery(boolean scheduledQuery) {
     this.scheduledQuery = scheduledQuery;
+  }
+
+  public void setParsedTables(List<Pair<String, String>> parsedTables) {
+    this.parsedTables = parsedTables;
+  }
+
+  public List<Pair<String, String>> getParsedTables() {
+    return parsedTables;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -1540,7 +1540,8 @@ public class Hive {
       request.setEngine(Constants.HIVE_ENGINE);
       if (checkTransactional) {
         ValidWriteIdList validWriteIdList = null;
-        long txnId = SessionState.get().getTxnMgr() != null ? SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
+        long txnId = SessionState.get() != null && SessionState.get().getTxnMgr() != null ?
+             SessionState.get().getTxnMgr().getCurrentTxnId() : 0;
         if (txnId > 0) {
           validWriteIdList = AcidUtils.getTableValidWriteIdListWithTxnList(conf, dbName, tableName);
         }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql.parse;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.hadoop.hive.common.ValidTxnList;
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
+import org.apache.hadoop.hive.ql.session.SessionState;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Class to help populate the cache at the beginning of query analysis. We would like
+ * to minimize the number of calls to fetch validWriteIdLists from the metastore. HMS
+ * has an API to request this object for multiple tables within one call, and this class
+ * uses that API.
+ *
+ * The sole purpose of this class is to help populate the HMS query cache. Nothing is returned
+ * from the public methods. In this way, if another method attempts to fetch a validWriteIdList,
+ * the SessionHiveMetaStoreClient query cache will contain the information.
+ *
+ * Because this class is only responsible for cache population, it is not a requirement for
+ * a caller to supply all the tables necessary for the query. It is also not a requirement
+ * for the tables to be part of the query. Of course, the query qill benefit if those
+ * conditions were true, but if the table is not in the cache, a later call fetching the writeids
+ * will hit the HMS server and will not fail.
+ *
+ * One tricky aspect to this class is that if a view is passed in, we want to fetch the
+ * validWriteIdLists for the underlying tables. At the beginning of the query, it is impossible
+ * to know the underlying tables without contacting HMS.
+ *
+ * In order to handle the underlying tables to the views, we keep a cache that holds our
+ * best guess. If we see a view in any query, we set up a server-wide cache that tracks
+ * the underlying tables to the view. If the view doesn't change, then this information
+ * will be accurate and allow us to fetch the underlying tables on our next query. If the
+ * view does change and the underlying tables are different, our fetch won't retrieve the
+ * correct information. But that's ok...remember what was said earlier that it is not
+ * a requirement for the tables to be part of the query. Later on in the query, this class
+ * will be called on the view level via the populateCacheForView call. At that point, if
+ * something changed, it will populate the cache with the newly detected tables. It will also
+ * change the underying table information for the view to optimize the next query using
+ * the view.
+ */
+public class CacheTableHelper {
+  protected static final Logger LOG = LoggerFactory.getLogger(CacheTableHelper.class);
+
+  // Server wide cache used to hold what we currently think are the underlying tables
+  // for a view (which is the key). This information can go stale, but that's ok. The only
+  // repercussion of a stale view is that we will have to make an additional HMS call
+  // to retrieve the validWriteIdList for the changed tables.
+  // Will hold 10000 objects, can't imagine that being more than a couple of M, tops.
+  private static final Cache<String, Set<String>> underlyingTableHints = Caffeine.newBuilder()
+      .maximumSize(10000)
+      .build();
+
+  /**
+   * Populates the cache for the given table pairs. The tables passed in are a Pair
+   * containing the dbname (null if not given) and the table name.
+   */
+  public void populateCache(List<Pair<String, String>> tables, HiveConf conf,
+      HiveTxnManager txnMgr) {
+    // if there is no transaction, then we don't need to fetch the validWriteIds.
+    if (txnMgr == null || !txnMgr.isTxnOpen()) {
+      return;
+    }
+
+    List<String> fullTableNamesList = new ArrayList<>(getAllUniqueViewsAndTables(tables));
+    LOG.debug("Populating query cache");
+    for (String s : fullTableNamesList) {
+      LOG.debug("Populating table " + s);
+    }
+    String validTxnList = conf.get(ValidTxnList.VALID_TXNS_KEY);
+    try {
+      txnMgr.getValidWriteIds(fullTableNamesList, validTxnList);
+    } catch (Exception e) {
+      LOG.info("Population of valid write id list cache failed, will be done later in query.");
+    }
+  }
+
+  /**
+   * Populates the cache for the given table pairs associated with a viewName.
+   * If the table names provided match the table names that we think are associated
+   * with the view, we just return, because we presume that they have already been
+   * popuated via the "populateCache" method. If they are different, we populate the cache
+   * with the new associated tables and change our associated tables for the view.
+   */
+  public void populateCacheForView(List<Pair<String, String>> tables, HiveConf conf,
+      HiveTxnManager txnMgr, String viewName) {
+    if (!conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_VIEW_CACHE_ENABLED)) {
+      return;
+    }
+
+    // The viewname passed in is of the form "view@table", so we replace the "@" with
+    // a ".".
+    viewName = viewName.replace("@", ".");
+    LOG.debug("Found view while parsing: " + viewName);
+    Set<String> underlyingTablesAndViews = getUniqueNames(tables);
+    // If the tables passed in match our cache, assume the cache has already
+    // been populated.
+    if (underlyingTablesAndViews.equals(underlyingTableHints.getIfPresent(viewName))) {
+      LOG.debug("View already cached.");
+      return;
+    }
+    // populate the metastore cache for this view.
+    populateCache(tables, conf, txnMgr);
+    // cache the names of the tables for the given view in our server-wide cache.
+    underlyingTableHints.put(viewName, underlyingTablesAndViews);
+  }
+
+  /**
+   * Return all the unique views and tables given a list of tables. We iterate
+   * through all the tables passed in. If it is a table in the list, we add the
+   * table to our unique list. If it is a view, we add what we think are the
+   * tables and views used by the view and iterate through those.
+   *
+   * In order to generate a unique list, we need to add the dbname (from the SessionState)
+   * if the db was not provided in the query from the user.
+   */
+  private Set<String> getAllUniqueViewsAndTables(List<Pair<String, String>> tables) {
+    Set<String> fullTableNames = new HashSet<>();
+    Queue<Pair<String, String>> queue = new LinkedList<>(tables);
+    LOG.debug("Getting all tables.");
+    while (queue.peek() != null) {
+      String tableOrView = getTableName(queue.remove());
+      LOG.debug("Getting table " + tableOrView);
+      Set<String> underlyingTables = underlyingTableHints.getIfPresent(tableOrView);
+      if (underlyingTables != null) {
+        // don't process the same table twice.
+        if (fullTableNames.contains(tableOrView)) {
+          continue;
+        }
+        // it's a view.
+        LOG.debug("View in cache, adding its tables to queue.");
+        for (String viewTable : underlyingTables) {
+          LOG.debug("View table is " + viewTable);
+          String[] dbTableArray = viewTable.split("\\.");
+          Preconditions.checkNotNull(dbTableArray[0]);
+          Preconditions.checkNotNull(dbTableArray[1]);
+          queue.offer(new ImmutablePair<String, String>(dbTableArray[0], dbTableArray[1]));
+        }
+      }
+      // We'll fetch validWriteIdList information whether it's a view or a table.
+      fullTableNames.add(tableOrView);
+    }
+    return fullTableNames;
+  }
+
+  /**
+   * Get the unique names from a table list. The list may contain some cases where
+   * both the dbname and tablename are provided and some cases where the dbname is
+   * null, in which case we need to grab the dbname from the SessionState.
+   */
+  private Set<String> getUniqueNames(List<Pair<String, String>> tables) {
+    Set<String> names = new HashSet<>();
+    for (Pair<String, String> table : tables) {
+      names.add(getTableName(table));
+    }
+    return names;
+  }
+
+  /**
+   * Get the table name from a dbname/tablename pair. If the dbname is
+   * null, use the SessionState to provide the dbname.
+   */
+  private String getTableName(Pair<String, String> dbTablePair) {
+    String dbName = dbTablePair.getLeft() == null
+        ? SessionState.get().getCurrentDatabase() : dbTablePair.getLeft();
+    return dbName + "." + dbTablePair.getRight();
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
@@ -118,26 +118,24 @@ public class CacheTableHelper {
    * with the new associated tables and change our associated tables for the view.
    */
   public void populateCacheForView(List<Pair<String, String>> tables, HiveConf conf,
-      HiveTxnManager txnMgr, String viewName) {
+      HiveTxnManager txnMgr, String dbName, String viewName) {
     if (!conf.getBoolVar(ConfVars.HIVE_OPTIMIZE_VIEW_CACHE_ENABLED)) {
       return;
     }
 
-    // The viewname passed in is of the form "dbname@table", so we replace the "@" with
-    // a ".".
-    viewName = viewName.replaceFirst("@", ".");
-    LOG.debug("Found view while parsing: " + viewName);
+    String completeViewName = dbName + "." + viewName;
+    LOG.debug("Found view while parsing: " + completeViewName);
     Set<String> underlyingTablesAndViews = getUniqueNames(tables);
     // If the tables passed in match our cache, assume the cache has already
     // been populated.
-    if (underlyingTablesAndViews.equals(underlyingTableHints.getIfPresent(viewName))) {
+    if (underlyingTablesAndViews.equals(underlyingTableHints.getIfPresent(completeViewName))) {
       LOG.debug("View already cached.");
       return;
     }
     // populate the metastore cache for this view.
     populateCache(tables, conf, txnMgr);
     // cache the names of the tables for the given view in our server-wide cache.
-    underlyingTableHints.put(viewName, underlyingTablesAndViews);
+    underlyingTableHints.put(completeViewName, underlyingTablesAndViews);
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CacheTableHelper.java
@@ -123,9 +123,9 @@ public class CacheTableHelper {
       return;
     }
 
-    // The viewname passed in is of the form "view@table", so we replace the "@" with
+    // The viewname passed in is of the form "dbname@table", so we replace the "@" with
     // a ".".
-    viewName = viewName.replace("@", ".");
+    viewName = viewName.replaceFirst("@", ".");
     LOG.debug("Found view while parsing: " + viewName);
     Set<String> underlyingTablesAndViews = getUniqueNames(tables);
     // If the tables passed in match our cache, assume the cache has already

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -5247,7 +5247,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
     final String  dbName = names[0];
     final String fullyQualName = dbName + "." + tableName;
     if (!tabNameToTabObject.containsKey(fullyQualName)) {
-      Table table = db.getTable(dbName, tableName, throwException);
+      Table table = db.getTable(dbName, tableName, throwException, true);
       if (table != null) {
         tabNameToTabObject.put(fullyQualName, table);
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/ParseUtils.java
@@ -99,6 +99,7 @@ public final class ParseUtils {
         // It is a view
         ctx.addViewTokenRewriteStream(viewFullyQualifiedName, parseResult.getTokenRewriteStream());
       }
+      ctx.setParsedTables(parseResult.getTables());
     }
     ASTNode tree = parseResult.getTree();
     tree = findRootNonNullToken(tree);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -347,6 +347,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
   private final Map<TableScanOperator, Map<String, ExprNodeDesc>> opToPartToSkewedPruner;
   private Map<SelectOperator, Table> viewProjectToTableSchema;
   private Operator<? extends OperatorDesc> sinkOp;
+  private final CacheTableHelper cacheTableHelper = new CacheTableHelper();
+
   /**
    * a map for the split sampling, from alias to an instance of SplitSample
    * that describes percentage and number.
@@ -2659,6 +2661,8 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       String viewText = tab.getViewExpandedText();
       TableMask viewMask = new TableMask(this, conf, false);
       viewTree = ParseUtils.parse(viewText, ctx, tab.getCompleteName());
+      cacheTableHelper.populateCacheForView(ctx.getParsedTables(), conf,
+          getTxnMgr(), viewFullyQualifiedName);
       if (viewMask.isEnabled() && analyzeRewrite == null) {
         ParseResult parseResult = rewriteASTWithMaskAndFilter(viewMask, viewTree,
             ctx.getViewTokenRewriteStream(viewFullyQualifiedName),
@@ -12271,12 +12275,13 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         Context rewriteCtx = new Context(conf);
         ctx.addSubContext(rewriteCtx);
         rewrittenTree = ParseUtils.parse(rewrittenQuery, rewriteCtx);
-        return new ParseResult(rewrittenTree, rewriteCtx.getTokenRewriteStream());
+        return new ParseResult(rewrittenTree, rewriteCtx.getTokenRewriteStream(),
+            rewriteCtx.getParsedTables());
       } catch (ParseException e) {
         throw new SemanticException(e);
       }
     } else {
-      return new ParseResult(ast, ctx.getTokenRewriteStream());
+      return new ParseResult(ast, ctx.getTokenRewriteStream(), ctx.getParsedTables());
     }
   }
 
@@ -12455,6 +12460,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     boolean needsTransform = needsTransform();
     //change the location of position alias process here
     processPositionAlias(ast);
+    cacheTableHelper.populateCache(ctx.getParsedTables(), conf, getTxnMgr());
     PlannerContext plannerCtx = pcf.get();
     if (!genResolvedParseTree(ast, plannerCtx)) {
       return;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -2662,7 +2662,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       TableMask viewMask = new TableMask(this, conf, false);
       viewTree = ParseUtils.parse(viewText, ctx, tab.getCompleteName());
       cacheTableHelper.populateCacheForView(ctx.getParsedTables(), conf,
-          getTxnMgr(), viewFullyQualifiedName);
+          getTxnMgr(), tab.getDbName(), tab.getTableName());
       if (viewMask.isEnabled() && analyzeRewrite == null) {
         ParseResult parseResult = rewriteASTWithMaskAndFilter(viewMask, viewTree,
             ctx.getViewTokenRewriteStream(viewFullyQualifiedName),


### PR DESCRIPTION
Added code to ensure the validWriteIdList for all tables are fetched
before any table request is done.

The tables are now gathered at parsing time within FromClauseParser.g.
One of the initial steps while parsing is to make an HMS call to fetch
the validWriteIdList for all parsed tables. This is done within a newly
added class called CacheTableHelper. The only purpose of this class is
to populate the query HMS cache for future calls to HMS. The methods to
this class do not contain any return values.

One complication to sending the request up front is when the query contains
views. The views will have underlying physical tables that need fetching but
we won't know these tables until after doing an HMS call. This is handled
by using the underlying tables of the most recent time a query used this view.
The idea here is that views don't change very often, so we will most likely
be able to cache these tables by guessing that these tables are still in the
view. On the chance that the view did change, we may be doing a fetch of
validWriteIdLists on tables no longer used or we may miss tables added on
the new definition of the view. If that happens, the only downside is an
extra HMS call as we get the updated information of the view (which cannot
be optimized). The view will then be updated so that the next query will
be optimized.

Because this view information is cached at a server level, a cap of 10000
tables to track was used. Also, on the low chance there is a problem with
memory consumption on this feature, it can be turned off via the
HIVE_OPTIMIZE_VIEW_CACHE_ENABLED conf variable.

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
The fetch of validWriteIdList from HMS will be done at the beginning of the query with all parsed tables.

### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
Slight performance boost. The get_table_req will only have to be done once with the validWriteIdList.  Also, all validWriteIdLists will be batched together in one HMS call.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
Run through unit tests.