### PR TITLE
HIVE-25195: Store Iceberg write commit and ctas information in QueryState

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -52,7 +52,6 @@ public class InputFormatConfig {
   public static final String CATALOG = "iceberg.mr.catalog";
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
-  public static final String IS_CTAS_QUERY = "iceberg.mr.is.ctas";
   public static final String CTAS_TABLE_NAME = "iceberg.mr.ctas.table.name";
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -52,8 +52,8 @@ public class InputFormatConfig {
   public static final String CATALOG = "iceberg.mr.catalog";
   public static final String HADOOP_CATALOG_WAREHOUSE_LOCATION = "iceberg.mr.catalog.hadoop.warehouse.location";
   public static final String CATALOG_LOADER_CLASS = "iceberg.mr.catalog.loader.class";
-  public static final String IS_CTAS_QUERY_TEMPLATE = "%s.iceberg.mr.is.ctas";
-  public static final String CTAS_TABLE_NAME_TEMPLATE = "%s.iceberg.mr.ctas.table.name";
+  public static final String IS_CTAS_QUERY = "iceberg.mr.is.ctas";
+  public static final String CTAS_TABLE_NAME = "iceberg.mr.ctas.table.name";
   public static final String SELECTED_COLUMNS = "iceberg.mr.selected.columns";
   public static final String EXTERNAL_TABLE_PURGE = "external.table.purge";
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergOutputCommitter.java
@@ -191,11 +191,12 @@ public class HiveIcebergOutputCommitter extends OutputCommitter {
           .stopOnFailure()
           .executeWith(tableExecutor)
           .run(output -> {
-            if (SessionStateUtil.getResource(jobConf, output) instanceof Table) {
-              Table table = (Table) SessionStateUtil.getResource(jobConf, output);
+            Optional<Table> table =
+                SessionStateUtil.getResource(jobConf, output).filter(o -> o instanceof Table).map(o -> (Table) o);
+            if (table.isPresent()) {
               String catalogName = HiveIcebergStorageHandler.catalogName(jobConf, output);
-              jobLocations.add(generateJobLocation(table.location(), jobConf, jobContext.getJobID()));
-              commitTable(table.io(), fileExecutor, jobContext, output, table.location(), catalogName);
+              jobLocations.add(generateJobLocation(table.get().location(), jobConf, jobContext.getJobID()));
+              commitTable(table.get().io(), fileExecutor, jobContext, output, table.get().location(), catalogName);
             } else {
               LOG.info("CommitJob found no table object in query state for table: {}. Skipping job commit.", output);
             }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHook;
 import org.apache.hadoop.hive.ql.hooks.QueryLifeTimeHookContext;
+import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.slf4j.Logger;
@@ -57,18 +58,12 @@ public class HiveIcebergQueryLifeTimeHook implements QueryLifeTimeHook {
 
   private void checkAndRollbackIcebergCTAS(QueryLifeTimeHookContext ctx) {
     HiveConf conf = ctx.getHiveConf();
-    String queryId = conf.getVar(HiveConf.ConfVars.HIVEQUERYID);
-    if (conf.getBoolean(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId), false)) {
-      try {
-        String tableName = conf.get(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId));
-        LOG.info("Dropping the following CTAS target table as part of rollback: {}", tableName);
-        Properties props = new Properties();
-        props.put(Catalogs.NAME, tableName);
-        Catalogs.dropTable(conf, props);
-      } finally {
-        conf.unset(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId));
-        conf.unset(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId));
-      }
+    if (Boolean.parseBoolean(SessionStateUtil.getProperty(conf, InputFormatConfig.IS_CTAS_QUERY))) {
+      String tableName = SessionStateUtil.getProperty(conf, InputFormatConfig.CTAS_TABLE_NAME);
+      LOG.info("Dropping the following CTAS target table as part of rollback: {}", tableName);
+      Properties props = new Properties();
+      props.put(Catalogs.NAME, tableName);
+      Catalogs.dropTable(conf, props);
     }
   }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergQueryLifeTimeHook.java
@@ -58,8 +58,11 @@ public class HiveIcebergQueryLifeTimeHook implements QueryLifeTimeHook {
 
   private void checkAndRollbackIcebergCTAS(QueryLifeTimeHookContext ctx) {
     HiveConf conf = ctx.getHiveConf();
-    if (Boolean.parseBoolean(SessionStateUtil.getProperty(conf, InputFormatConfig.IS_CTAS_QUERY))) {
-      String tableName = SessionStateUtil.getProperty(conf, InputFormatConfig.CTAS_TABLE_NAME);
+    boolean isCTAS = SessionStateUtil.getProperty(conf, InputFormatConfig.IS_CTAS_QUERY)
+        .map(Boolean::parseBoolean)
+        .orElse(Boolean.FALSE);
+    if (isCTAS && SessionStateUtil.getProperty(conf, InputFormatConfig.CTAS_TABLE_NAME).isPresent()) {
+      String tableName = SessionStateUtil.getProperty(conf, InputFormatConfig.CTAS_TABLE_NAME).get();
       LOG.info("Dropping the following CTAS target table as part of rollback: {}", tableName);
       Properties props = new Properties();
       props.put(Catalogs.NAME, tableName);

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -31,10 +31,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.ColumnType;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.hive.serde2.AbstractSerDe;
 import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
@@ -183,10 +183,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         serDeProperties.get(Catalogs.NAME), tableSchema, serDeProperties.get(InputFormatConfig.PARTITION_SPEC));
     Catalogs.createTable(configuration, serDeProperties);
 
-    // set these in the global conf so that we can rollback the table in the lifecycle hook in case of failures
-    String queryId = configuration.get(HiveConf.ConfVars.HIVEQUERYID.varname);
-    configuration.set(String.format(InputFormatConfig.IS_CTAS_QUERY_TEMPLATE, queryId), "true");
-    configuration.set(String.format(InputFormatConfig.CTAS_TABLE_NAME_TEMPLATE, queryId),
+    // set these in the query state so that we can rollback the table in the lifecycle hook in case of failures
+    SessionStateUtil.addResource(configuration, InputFormatConfig.IS_CTAS_QUERY, "true");
+    SessionStateUtil.addResource(configuration, InputFormatConfig.CTAS_TABLE_NAME,
         serDeProperties.getProperty(Catalogs.NAME));
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -183,8 +183,7 @@ public class HiveIcebergSerDe extends AbstractSerDe {
         serDeProperties.get(Catalogs.NAME), tableSchema, serDeProperties.get(InputFormatConfig.PARTITION_SPEC));
     Catalogs.createTable(configuration, serDeProperties);
 
-    // set these in the query state so that we can rollback the table in the lifecycle hook in case of failures
-    SessionStateUtil.addResource(configuration, InputFormatConfig.IS_CTAS_QUERY, "true");
+    // set this in the query state so that we can rollback the table in the lifecycle hook in case of failures
     SessionStateUtil.addResource(configuration, InputFormatConfig.CTAS_TABLE_NAME,
         serDeProperties.getProperty(Catalogs.NAME));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/tez/TezTask.java
@@ -391,6 +391,7 @@ public class TezTask extends Task<TezWork> {
                   icebergProperties.put(entry.getKey(), entry.getValue());
                 }
               }
+
               // save information for each target table
               tables.forEach(table -> SessionStateUtil.addCommitInfo(jobConf, table, jobIdStr,
                   status.getProgress().getSucceededTaskCount(), icebergProperties));

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
@@ -34,45 +34,75 @@ public class SessionStateUtil {
   private SessionStateUtil() {
 
   }
-  
-  public static Optional<QueryState> getQueryState(Configuration conf) {
-    return Optional.ofNullable(SessionState.get())
-        .map(session -> session.getQueryState(conf.get(HiveConf.ConfVars.HIVEQUERYID.varname)));
+
+  /**
+   * @param conf Configuration object used for getting the query state, should contain the query id
+   * @param key The resource identifier
+   * @return The requested resource, or an empty Optional if either the SessionState, QueryState or the resource itself
+   * could not be found
+   */
+  public static Optional<Object> getResource(Configuration conf, String key) {
+    return getQueryState(conf).map(state -> state.getResource(key));
   }
 
-  public static Object getResource(Configuration conf, String key) {
-    return getQueryState(conf).map(state -> state.getResource(key)).orElse(null);
+  /**
+   * @param conf Configuration object used for getting the query state, should contain the query id
+   * @param key The resource identifier
+   * @return The requested string property, or an empty Optional if either the SessionState, QueryState or the
+   * resource itself could not be found, or the resource is not of type String
+   */
+  public static Optional<String> getProperty(Configuration conf, String key) {
+    return getResource(conf, key).filter(o -> o instanceof String).map(o -> (String) o);
   }
 
-  public static String getProperty(Configuration conf, String key) {
-    return (String) getResource(conf, key);
+  /**
+   * @param conf Configuration object used for getting the query state, should contain the query id
+   * @param key The resource identifier
+   * @param resource The resource to save into the QueryState
+   * @return whether operation succeeded
+   */
+  public static boolean addResource(Configuration conf, String key, Object resource) {
+    Optional<QueryState> queryState = getQueryState(conf);
+    if (queryState.isPresent()) {
+      queryState.get().addResource(key, resource);
+      return true;
+    } else {
+      return false;
+    }
   }
 
-  public static void addResource(Configuration conf, String key, Object resource) {
-    getQueryState(conf).ifPresent(state -> state.addResource(key, resource));
-  }
-
+  /**
+   * @param conf Configuration object used for getting the query state, should contain the query id
+   * @param tableName Name of the table for which the commit info should be retrieved
+   * @return the CommitInfo, or empty Optional if not present
+   */
   public static Optional<CommitInfo> getCommitInfo(Configuration conf, String tableName) {
-    return Optional.ofNullable(getResource(conf, COMMIT_INFO_PREFIX + tableName))
+    return getResource(conf, COMMIT_INFO_PREFIX + tableName)
         .filter(o -> o instanceof CommitInfo)
         .map(o -> (CommitInfo) o);
   }
 
-  public static CommitInfo newCommitInfo() {
-    return new CommitInfo();
+  public static CommitInfo newCommitInfo(Configuration conf, String tableName) {
+    return new CommitInfo(conf, tableName);
+  }
+
+  private static Optional<QueryState> getQueryState(Configuration conf) {
+    return Optional.ofNullable(SessionState.get())
+        .map(session -> session.getQueryState(conf.get(HiveConf.ConfVars.HIVEQUERYID.varname)));
   }
 
   public static class CommitInfo {
 
+    public CommitInfo(Configuration conf, String tableName) {
+      this.conf = conf;
+      this.tableName = tableName;
+    }
+
+    Configuration conf;
     String tableName;
     String jobIdStr;
     int taskNum;
     Map<String, String> props;
-
-    public CommitInfo withTableName(String tableName) {
-      this.tableName = tableName;
-      return this;
-    }
 
     public CommitInfo withJobID(String jobIdStr) {
       this.jobIdStr = jobIdStr;
@@ -89,8 +119,15 @@ public class SessionStateUtil {
       return this;
     }
 
-    public void save(QueryState queryState) {
-      queryState.addResource(COMMIT_INFO_PREFIX + tableName, this);
+    /**
+     * Saves the commit information it contains into the QueryState.
+     * Once save() has been called on the CommitInfo object, it cannot be reused.
+     * @return whether the operation succeeded
+     */
+    public boolean save() {
+      boolean success = addResource(conf, COMMIT_INFO_PREFIX + tableName, this);
+      this.conf = null; // nulling this out so as not to accidentally keep it from being GC-ed
+      return success;
     }
 
     public String getTableName() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionStateUtil.java
@@ -93,7 +93,6 @@ public class SessionStateUtil {
   public static boolean addCommitInfo(Configuration conf, String tableName, String jobId, int taskNum,
                                          Map<String, String> additionalProps) {
     CommitInfo commitInfo = new CommitInfo()
-        .withTableName(tableName)
         .withJobID(jobId)
         .withTaskNum(taskNum)
         .withProps(additionalProps);
@@ -109,15 +108,9 @@ public class SessionStateUtil {
    * Container class for job commit information.
    */
   public static class CommitInfo {
-    String tableName;
     String jobIdStr;
     int taskNum;
     Map<String, String> props;
-
-    public CommitInfo withTableName(String tableName) {
-      this.tableName = tableName;
-      return this;
-    }
 
     public CommitInfo withJobID(String jobIdStr) {
       this.jobIdStr = jobIdStr;
@@ -132,10 +125,6 @@ public class SessionStateUtil {
     public CommitInfo withProps(Map<String, String> props) {
       this.props = props;
       return this;
-    }
-
-    public String getTableName() {
-      return tableName;
     }
 
     public String getJobIdStr() {


### PR DESCRIPTION
### What changes were proposed in this pull request?
Store CTAS and write commit related information in the QueryState object. Use a util class to help add and get resources (including commit info) from the session state.

### Why are the changes needed?
Makes it cleaner not to have convoluted conf prefixes, avoids accidental session conf pollution

### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
manual tests
