### PR TITLE
HIVE-25194: Add support for STORED AS ORC/PARQUET/AVRO for Iceberg

### DIFF
--- a/hbase-handler/src/test/queries/negative/create_table_stored_by_stored_as_failure.q
+++ b/hbase-handler/src/test/queries/negative/create_table_stored_by_stored_as_failure.q
@@ -1,0 +1,1 @@
+create external table test_table ( a int ) stored by 'org.apache.hadoop.hive.hbase.HBaseStorageHandler' stored as orc;

--- a/hbase-handler/src/test/results/negative/create_table_stored_by_stored_as_failure.q.out
+++ b/hbase-handler/src/test/results/negative/create_table_stored_by_stored_as_failure.q.out
@@ -1,0 +1,1 @@
+FAILED: SemanticException STORED AS is not supported for storage handler org.apache.hadoop.hive.hbase.HBaseStorageHandler

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -60,6 +60,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -257,6 +258,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   @Override
   public boolean supportsPartitionTransform() {
     return true;
+  }
+
+  @Override
+  public String getFileFormatPropertyKey() {
+    return TableProperties.DEFAULT_FILE_FORMAT;
   }
 
   public boolean addDynamicSplitPruningEdge(org.apache.hadoop.hive.ql.metadata.Table table,

--- a/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_stored_as_with_serdeproperties_failure.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_stored_as_with_serdeproperties_failure.q
@@ -1,0 +1,3 @@
+set hive.vectorized.execution.enabled=false;
+DROP TABLE IF EXISTS ice_orc;
+CREATE EXTERNAL TABLE ice_orc (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('write.format.default'='orc') STORED AS ORC;

--- a/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_stored_as_with_tableproperties_failure.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/create_iceberg_table_stored_as_with_tableproperties_failure.q
@@ -1,0 +1,3 @@
+set hive.vectorized.execution.enabled=false;
+DROP TABLE IF EXISTS ice_orc;
+CREATE EXTERNAL TABLE ice_orc (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS ORC TBLPROPERTIES('write.format.default'='orc');

--- a/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_as_fileformat.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/create_iceberg_table_stored_as_fileformat.q
@@ -1,0 +1,24 @@
+set hive.vectorized.execution.enabled=false;
+DROP TABLE IF EXISTS ice_orc;
+CREATE EXTERNAL TABLE ice_orc (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS ORC;
+DESCRIBE FORMATTED ice_orc;
+DROP TABLE ice_orc;
+
+DROP TABLE IF EXISTS ice_parquet;
+CREATE EXTERNAL TABLE ice_parquet (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS PARQUET;
+DESCRIBE FORMATTED ice_parquet;
+DROP TABLE ice_parquet;
+
+DROP TABLE IF EXISTS ice_avro;
+CREATE EXTERNAL TABLE ice_avro (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS AVRO;
+DESCRIBE FORMATTED ice_avro;
+DROP TABLE ice_avro;
+
+DROP TABLE IF EXISTS ice_t;
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' STORED AS AVRO;
+DESCRIBE FORMATTED ice_t;
+DROP TABLE ice_t;
+
+CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('dummy'='dummy_value') STORED AS ORC;
+DESCRIBE FORMATTED ice_t;
+DROP TABLE ice_t;

--- a/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_stored_as_with_serdeproperties_failure.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_stored_as_with_serdeproperties_failure.q.out
@@ -1,0 +1,5 @@
+PREHOOK: query: DROP TABLE IF EXISTS ice_orc
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_orc
+POSTHOOK: type: DROPTABLE
+FAILED: SemanticException Provide only one of the following: STORED BY ORC or WITH SERDEPROPERTIES('write.format.default'='ORC')

--- a/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_stored_as_with_tableproperties_failure.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/create_iceberg_table_stored_as_with_tableproperties_failure.q.out
@@ -1,0 +1,5 @@
+PREHOOK: query: DROP TABLE IF EXISTS ice_orc
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_orc
+POSTHOOK: type: DROPTABLE
+FAILED: SemanticException Provide only one of the following: STORED BY orc or WITH SERDEPROPERTIES('write.format.default'='orc') or TBLPROPERTIES('write.format.default'='orc')

--- a/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_as_fileformat.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/create_iceberg_table_stored_as_fileformat.q.out
@@ -1,0 +1,312 @@
+PREHOOK: query: DROP TABLE IF EXISTS ice_orc
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_orc
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE EXTERNAL TABLE ice_orc (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_orc
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_orc (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_orc
+PREHOOK: query: DESCRIBE FORMATTED ice_orc
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@ice_orc
+POSTHOOK: query: DESCRIBE FORMATTED ice_orc
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@ice_orc
+# col_name            	data_type           	comment             
+i                   	int                 	from deserializer   
+s                   	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+d                   	date                	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"d\":\"true\",\"i\":\"true\",\"s\":\"true\",\"ts\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	TRUE                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	ORC                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: DROP TABLE ice_orc
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ice_orc
+PREHOOK: Output: default@ice_orc
+POSTHOOK: query: DROP TABLE ice_orc
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ice_orc
+POSTHOOK: Output: default@ice_orc
+PREHOOK: query: DROP TABLE IF EXISTS ice_parquet
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_parquet
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE EXTERNAL TABLE ice_parquet (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS PARQUET
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_parquet
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_parquet (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS PARQUET
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_parquet
+PREHOOK: query: DESCRIBE FORMATTED ice_parquet
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@ice_parquet
+POSTHOOK: query: DESCRIBE FORMATTED ice_parquet
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@ice_parquet
+# col_name            	data_type           	comment             
+i                   	int                 	from deserializer   
+s                   	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+d                   	date                	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"d\":\"true\",\"i\":\"true\",\"s\":\"true\",\"ts\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	TRUE                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	PARQUET             
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: DROP TABLE ice_parquet
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ice_parquet
+PREHOOK: Output: default@ice_parquet
+POSTHOOK: query: DROP TABLE ice_parquet
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ice_parquet
+POSTHOOK: Output: default@ice_parquet
+PREHOOK: query: DROP TABLE IF EXISTS ice_avro
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_avro
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE EXTERNAL TABLE ice_avro (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS AVRO
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_avro
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_avro (i int, s string, ts timestamp, d date) STORED BY ICEBERG STORED AS AVRO
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_avro
+PREHOOK: query: DESCRIBE FORMATTED ice_avro
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@ice_avro
+POSTHOOK: query: DESCRIBE FORMATTED ice_avro
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@ice_avro
+# col_name            	data_type           	comment             
+i                   	int                 	from deserializer   
+s                   	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+d                   	date                	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"d\":\"true\",\"i\":\"true\",\"s\":\"true\",\"ts\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	TRUE                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	AVRO                
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: DROP TABLE ice_avro
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ice_avro
+PREHOOK: Output: default@ice_avro
+POSTHOOK: query: DROP TABLE ice_avro
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ice_avro
+POSTHOOK: Output: default@ice_avro
+PREHOOK: query: DROP TABLE IF EXISTS ice_t
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE IF EXISTS ice_t
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' STORED AS AVRO
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_t
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler' STORED AS AVRO
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_t
+PREHOOK: query: DESCRIBE FORMATTED ice_t
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@ice_t
+POSTHOOK: query: DESCRIBE FORMATTED ice_t
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@ice_t
+# col_name            	data_type           	comment             
+i                   	int                 	from deserializer   
+s                   	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+d                   	date                	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"d\":\"true\",\"i\":\"true\",\"s\":\"true\",\"ts\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	TRUE                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	AVRO                
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: DROP TABLE ice_t
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ice_t
+PREHOOK: Output: default@ice_t
+POSTHOOK: query: DROP TABLE ice_t
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ice_t
+POSTHOOK: Output: default@ice_t
+PREHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('dummy'='dummy_value') STORED AS ORC
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@ice_t
+POSTHOOK: query: CREATE EXTERNAL TABLE ice_t (i int, s string, ts timestamp, d date) STORED BY ICEBERG WITH SERDEPROPERTIES('dummy'='dummy_value') STORED AS ORC
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@ice_t
+PREHOOK: query: DESCRIBE FORMATTED ice_t
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@ice_t
+POSTHOOK: query: DESCRIBE FORMATTED ice_t
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@ice_t
+# col_name            	data_type           	comment             
+i                   	int                 	from deserializer   
+s                   	string              	from deserializer   
+ts                  	timestamp           	from deserializer   
+d                   	date                	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"d\":\"true\",\"i\":\"true\",\"s\":\"true\",\"ts\":\"true\"}}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	dummy               	dummy_value         
+	engine.hive.enabled 	true                
+	external.table.purge	TRUE                
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	ORC                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: DROP TABLE ice_t
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@ice_t
+PREHOOK: Output: default@ice_t
+POSTHOOK: query: DROP TABLE ice_t
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@ice_t
+POSTHOOK: Output: default@ice_t

--- a/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
+++ b/parser/src/java/org/apache/hadoop/hive/ql/parse/HiveParser.g
@@ -2032,10 +2032,12 @@ tableFileFormat
       -> ^(TOK_TABLEFILEFORMAT $inFmt $outFmt $inDriver? $outDriver?)
       | KW_STORED KW_BY storageHandler=StringLiteral
          (KW_WITH KW_SERDEPROPERTIES serdeprops=tableProperties)?
-      -> ^(TOK_STORAGEHANDLER $storageHandler $serdeprops?)
+         (KW_STORED KW_AS fileformat=identifier)?
+      -> ^(TOK_STORAGEHANDLER $storageHandler $serdeprops? ^(TOK_FILEFORMAT_GENERIC $fileformat)?)
       | KW_STORED KW_BY genericSpec=identifier
          (KW_WITH KW_SERDEPROPERTIES serdeprops=tableProperties)?
-      -> ^(TOK_STORAGEHANDLER $genericSpec $serdeprops?)
+         (KW_STORED KW_AS fileformat=identifier)?
+      -> ^(TOK_STORAGEHANDLER $genericSpec $serdeprops? ^(TOK_FILEFORMAT_GENERIC $fileformat)?)
       | KW_STORED KW_AS genericSpec=identifier
       -> ^(TOK_FILEFORMAT_GENERIC $genericSpec)
     ;

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -255,4 +255,12 @@ public interface HiveStorageHandler extends Configurable {
   default boolean supportsPartitionTransform() {
     return false;
   }
+
+  /**
+   * Get file format property key, if the file format is configured through a table property.
+   * @return table property key, can be null
+   */
+  default String getFileFormatPropertyKey() {
+    return null;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -29,6 +29,9 @@ import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.io.IOConstants;
 import org.apache.hadoop.hive.ql.io.StorageFormatDescriptor;
 import org.apache.hadoop.hive.ql.io.StorageFormatFactory;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,11 +84,37 @@ public class StorageFormat {
       }
       break;
     case HiveParser.TOK_STORAGEHANDLER:
-      storageHandler = processStorageHandler(child.getChild(0).getText());
-      if (child.getChildCount() == 2) {
-        BaseSemanticAnalyzer.readProps(
-          (ASTNode) (child.getChild(1).getChild(0)),
-          serdeProps);
+      for (int i = 0; i < child.getChildCount(); i++) {
+        ASTNode grandChild = (ASTNode) child.getChild(i);
+        switch (grandChild.getToken().getType()) {
+          case HiveParser.TOK_FILEFORMAT_GENERIC:
+            HiveStorageHandler handler;
+            try {
+              handler = HiveUtils.getStorageHandler(conf, storageHandler);
+            } catch (HiveException e) {
+              throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
+            }
+
+            String fileFormatPropertyKey = handler.getFileFormatPropertyKey();
+            if (fileFormatPropertyKey != null) {
+              String fileFormat = grandChild.getChild(0).getText();
+              if (serdeProps.containsKey(fileFormatPropertyKey)) {
+                throw new SemanticException("Provide only one of the following: STORED BY " + fileFormat +
+                    " or WITH SERDEPROPERTIES('" + fileFormatPropertyKey + "'='" + fileFormat + "')");
+              }
+
+              serdeProps.put(fileFormatPropertyKey, fileFormat);
+            } else {
+              throw new SemanticException("STORED BY is not supported for storage handler " +
+                  handler.getClass().getName());
+            }
+            break;
+          case HiveParser.TOK_TABLEPROPERTIES:
+            BaseSemanticAnalyzer.readProps((ASTNode) grandChild.getChild(0), serdeProps);
+            break;
+          default:
+            storageHandler = processStorageHandler(grandChild.getText());
+        }
       }
       break;
     case HiveParser.TOK_FILEFORMAT_GENERIC:

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/StorageFormat.java
@@ -105,7 +105,7 @@ public class StorageFormat {
 
               serdeProps.put(fileFormatPropertyKey, fileFormat);
             } else {
-              throw new SemanticException("STORED BY is not supported for storage handler " +
+              throw new SemanticException("STORED AS is not supported for storage handler " +
                   handler.getClass().getName());
             }
             break;


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Support `STORED AS fileformat` syntax together with `STORED BY ICEBERG` or `STORED BY 'org.apache.iceberg.mr.hive.HiveIcebergStorageHandler'`

Work covered in this PR:
- Enhance semantic rule to support both`STORED AS` and `STORED BY` together
- Updated SemanticAnalyzer and StorageFormat to parse the new query format
- Created q tests

<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Currently, the file format is configurable through the `TBLPROPERTIES` which can be inconvenient, if the end-user doesn't know which table property key should be used to specify the file format. 
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
New syntax:
`CREATE TABLE ... STORED BY ICEBERG [WITH SERDEPROPERTIES()][STORED AS fileformat]`
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Manual test, q test
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
