### PR TITLE
HIVE-25200: Alter table add columns support for Iceberg tables

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -139,19 +139,19 @@ public final class HiveSchemaUtil {
 
   /**
    * Produces the difference of two FieldSchema lists by only taking into account the field name and type.
-   * @param subtrahendCollection List of fields to subtract from
-   * @param minuendCollection List of fields to subtract
+   * @param minuendCollection Collection of fields to subtract from
+   * @param subtrahendCollection Collection of fields to subtract
    * @return the result list of difference
    */
   public static Collection<FieldSchema> schemaDifference(
-      Collection<FieldSchema> subtrahendCollection, Collection<FieldSchema> minuendCollection) {
+      Collection<FieldSchema> minuendCollection, Collection<FieldSchema> subtrahendCollection) {
 
     Function<FieldSchema, FieldSchema> unsetCommentFunc = fs -> new FieldSchema(fs.getName(), fs.getType(), null);
-    Set<FieldSchema> minuendsWithoutComment =
-        minuendCollection.stream().map(unsetCommentFunc).collect(Collectors.toSet());
+    Set<FieldSchema> subtrahendWithoutComment =
+        subtrahendCollection.stream().map(unsetCommentFunc).collect(Collectors.toSet());
 
-    return subtrahendCollection.stream()
-        .filter(fs -> !minuendsWithoutComment.contains(unsetCommentFunc.apply(fs))).collect(Collectors.toList());
+    return minuendCollection.stream()
+        .filter(fs -> !subtrahendWithoutComment.contains(unsetCommentFunc.apply(fs))).collect(Collectors.toList());
   }
 
   private static String convertToTypeString(Type type) {

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -20,6 +20,8 @@
 package org.apache.iceberg.hive;
 
 import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
@@ -132,6 +134,28 @@ public final class HiveSchemaUtil {
    */
   public static Type convert(TypeInfo typeInfo) {
     return HiveSchemaConverter.convert(typeInfo, false);
+  }
+
+  /**
+   * Produces the difference of two FieldSchema lists by only taking into account the field name and type.
+   * @param from List of fields to subtract from
+   * @param to List of fields to subtract
+   * @return the result list of difference
+   */
+  public static List<FieldSchema> schemaDifference(List<FieldSchema> from, List<FieldSchema> to) {
+    List<FieldSchema> result = new LinkedList<>(from);
+    Iterator<FieldSchema> it = result.iterator();
+    while (it.hasNext()) {
+      FieldSchema fromSchemaField = it.next();
+      for (FieldSchema toSchemaField : to) {
+        if (fromSchemaField.getName().equals(toSchemaField.getName()) &&
+            fromSchemaField.getType().equals(toSchemaField.getType())) {
+          it.remove();
+          break;
+        }
+      }
+    }
+    return result;
   }
 
   private static String convertToTypeString(Type type) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -348,8 +348,8 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
             throw new MetaException(
                 "Unsupported ALTER TABLE operation type for Iceberg tables, must be: " + allowedAlterTypes.toString());
           }
-          return;
         }
+        return;
       }
     }
     throw new MetaException("ALTER TABLE operation type could not be determined.");

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -22,6 +22,7 @@ package org.apache.iceberg.mr.hive;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -90,7 +91,7 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
       // Initially we'd like to cache the partition spec in HMS, but not push it down later to Iceberg during alter
       // table commands since by then the HMS info can be stale + Iceberg does not store its partition spec in the props
       InputFormatConfig.PARTITION_SPEC);
-  private static final Set<Enum<?>> SUPPORTED_ALTER_OPS = ImmutableSet.of(
+  private static final EnumSet<AlterTableType> SUPPORTED_ALTER_OPS = EnumSet.of(
       AlterTableType.ADDCOLS, AlterTableType.ADDPROPS, AlterTableType.DROPPROPS);
 
   private final Configuration conf;
@@ -101,7 +102,7 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
   private TableMetadata deleteMetadata;
   private boolean canMigrateHiveTable;
   private PreAlterTableProperties preAlterTableProperties;
-  private Enum<?> currentAlterTableOp;
+  private Enum<AlterTableType> currentAlterTableOp;
   private UpdateSchema updateSchema;
 
   public HiveIcebergMetaHook(Configuration conf) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -340,21 +340,17 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
   }
 
   private void setupAlterOperationType(EnvironmentContext context) throws MetaException {
-    if (context != null) {
-      Map<String, String> contextProperties = context.getProperties();
-      if (contextProperties != null) {
-        String stringOpType = contextProperties.get(ALTER_TABLE_OPERATION_TYPE);
-        if (stringOpType != null) {
-          currentAlterTableOp = AlterTableType.valueOf(stringOpType);
-          if (SUPPORTED_ALTER_OPS.stream().noneMatch(op -> op.equals(currentAlterTableOp))) {
-            throw new MetaException(
-                "Unsupported ALTER TABLE operation type for Iceberg tables, must be: " + allowedAlterTypes.toString());
-          }
-        }
-        return;
+    if (context == null || context.getProperties() == null) {
+      throw new MetaException("ALTER TABLE operation type could not be determined.");
+    }
+    String stringOpType = context.getProperties().get(ALTER_TABLE_OPERATION_TYPE);
+    if (stringOpType != null) {
+      currentAlterTableOp = AlterTableType.valueOf(stringOpType);
+      if (SUPPORTED_ALTER_OPS.stream().noneMatch(op -> op.equals(currentAlterTableOp))) {
+        throw new MetaException(
+            "Unsupported ALTER TABLE operation type for Iceberg tables, must be: " + allowedAlterTypes.toString());
       }
     }
-    throw new MetaException("ALTER TABLE operation type could not be determined.");
   }
 
   private void setFileFormat() {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -258,6 +258,7 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
           Collections.emptyMap()));
       updateHmsTableProperties(hmsTable);
     }
+
     if (AlterTableType.ADDCOLS.equals(currentAlterTableOp)) {
       Collection<FieldSchema> addedCols =
           HiveSchemaUtil.schemaDifference(hmsTable.getSd().getCols(), HiveSchemaUtil.convert(icebergTable.schema()));

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.common.TableName;
 import org.apache.hadoop.hive.metastore.DefaultHiveMetaHook;
 import org.apache.hadoop.hive.metastore.HiveMetaHook;
 import org.apache.hadoop.hive.metastore.api.EnvironmentContext;
@@ -42,7 +43,6 @@ import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.metastore.utils.StringUtils;
 import org.apache.hadoop.hive.ql.ddl.table.AlterTableType;
-import org.apache.hadoop.hive.ql.exec.tez.TezTask;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.session.SessionStateUtil;
 import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
@@ -224,7 +224,7 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
   @Override
   public void preAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context)
       throws MetaException {
-    setupAlterOperationType(context);
+    setupAlterOperationType(hmsTable, context);
     catalogProperties = getCatalogProperties(hmsTable);
     try {
       icebergTable = IcebergTableUtil.getTable(conf, catalogProperties);
@@ -339,16 +339,20 @@ public class HiveIcebergMetaHook extends DefaultHiveMetaHook {
     }
   }
 
-  private void setupAlterOperationType(EnvironmentContext context) throws MetaException {
+  private void setupAlterOperationType(org.apache.hadoop.hive.metastore.api.Table hmsTable,
+      EnvironmentContext context) throws MetaException {
+    TableName tableName = new TableName(hmsTable.getCatName(), hmsTable.getDbName(), hmsTable.getTableName());
     if (context == null || context.getProperties() == null) {
-      throw new MetaException("ALTER TABLE operation type could not be determined.");
+      throw new MetaException("ALTER TABLE operation type on Iceberg table " + tableName +
+          " could not be determined.");
     }
     String stringOpType = context.getProperties().get(ALTER_TABLE_OPERATION_TYPE);
     if (stringOpType != null) {
       currentAlterTableOp = AlterTableType.valueOf(stringOpType);
       if (SUPPORTED_ALTER_OPS.stream().noneMatch(op -> op.equals(currentAlterTableOp))) {
         throw new MetaException(
-            "Unsupported ALTER TABLE operation type for Iceberg tables, must be: " + allowedAlterTypes.toString());
+            "Unsupported ALTER TABLE operation type on Iceberg table " + tableName + ", must be one of: " +
+                SUPPORTED_ALTER_OPS.toString());
       }
     }
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergSerDe.java
@@ -288,4 +288,9 @@ public class HiveIcebergSerDe extends AbstractSerDe {
   public Collection<String> partitionColumns() {
     return partitionColumns;
   }
+
+  @Override
+  public boolean shouldStoreFieldsInMetastore(Map<String, String> tableParams) {
+    return true;
+  }
 }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -99,6 +99,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
 
   @Override
   public HiveMetaHook getMetaHook() {
+    // Make sure to always return a new instance here, as HiveIcebergMetaHook might hold state relevant for the
+    // operation.
     return new HiveIcebergMetaHook(conf);
   }
 


### PR DESCRIPTION
Since Iceberg counts as being a non-native Hive table, addColumn operation needs to be implemented by the help of Hive meta hooks.