### PR TITLE
HIVE-25201: Remove Caffein shading from Iceberg

### DIFF
--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/CachedClientPool.java
@@ -19,13 +19,13 @@
 
 package org.apache.iceberg.hive;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Cache;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.util.PropertyUtil;

--- a/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
+++ b/iceberg/iceberg-catalog/src/main/java/org/apache/iceberg/hive/HiveCatalogs.java
@@ -19,10 +19,10 @@
 
 package org.apache.iceberg.hive;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Cache;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/serde/objectinspector/IcebergDecimalObjectInspector.java
@@ -19,6 +19,8 @@
 
 package org.apache.iceberg.mr.hive.serde.objectinspector;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.math.BigDecimal;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -26,8 +28,6 @@ import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.AbstractPrimitiveJavaObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.HiveDecimalObjectInspector;
 import org.apache.hadoop.hive.serde2.typeinfo.DecimalTypeInfo;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Cache;
-import org.apache.hive.iceberg.com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 public final class IcebergDecimalObjectInspector extends AbstractPrimitiveJavaObjectInspector

--- a/iceberg/iceberg-shading/pom.xml
+++ b/iceberg/iceberg-shading/pom.xml
@@ -117,6 +117,7 @@
                                             <include>org.apache.parquet:*</include>
                                             <include>com.google*:*</include>
                                             <include>com.fasterxml*:*</include>
+                                            <include>com.github.ben-manes*:*</include>
                                         </includes>
                                     </artifactSet>
                                     <filters>

--- a/iceberg/iceberg-shading/pom.xml
+++ b/iceberg/iceberg-shading/pom.xml
@@ -108,10 +108,6 @@
                                             <pattern>com.fasterxml</pattern>
                                             <shadedPattern>${shade.relocation.package.prefix}.com.fasterxml</shadedPattern>
                                         </relocation>
-                                        <relocation>
-                                            <pattern>com.github.benmanes</pattern>
-                                            <shadedPattern>${shade.relocation.package.prefix}.com.github.benmanes</shadedPattern>
-                                        </relocation>
                                     </relocations>
                                     <artifactSet>
                                         <includes>
@@ -121,7 +117,6 @@
                                             <include>org.apache.parquet:*</include>
                                             <include>com.google*:*</include>
                                             <include>com.fasterxml*:*</include>
-                                            <include>com.github.ben-manes*:*</include>
                                         </includes>
                                     </artifactSet>
                                     <filters>


### PR DESCRIPTION
### What changes were proposed in this pull request?
Remove benmanes caffeine shading

### Why are the changes needed?
So we do not include 2 versions of Caffeine cache which is not really needed

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests