### PR TITLE
HIVE-25203: HiveQueryResultSet and client operation are not expected to be closed twice

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcDriver2.java
@@ -79,7 +79,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.regex.Pattern;
-import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.junit.rules.TestName;
 
 import static java.sql.ResultSet.CONCUR_READ_ONLY;
@@ -3289,6 +3288,21 @@ public class TestJdbcDriver2 {
     assertFalse(stmt.isClosed());
     res.close();
     assertTrue(stmt.isClosed());
+  }
+
+  @Test
+  public void testResultSetShouldNotCloseStatement() throws SQLException {
+    Statement stmt = con.createStatement();
+    ResultSet res = stmt.executeQuery("select under_col from " + tableName + " limit 1");
+    res.next();
+    assertFalse(stmt.isClosed());
+    assertFalse(((HiveStatement)stmt).isQueryClosed());
+    res.close();
+    assertFalse(stmt.isClosed());
+    assertFalse(((HiveStatement)stmt).isQueryClosed()); // check HIVE-25203
+    stmt.close();
+    assertTrue(stmt.isClosed());
+    assertTrue(((HiveStatement)stmt).isQueryClosed());
   }
 
   @Test

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveQueryResultSet.java
@@ -274,8 +274,12 @@ public class HiveQueryResultSet extends HiveBaseResultSet {
   @Override
   public void close() throws SQLException {
     if (this.statement != null && (this.statement instanceof HiveStatement)) {
+      /*
+       * HIVE-25203: Be aware that a ResultSet is not supposed to control its parent Statement's
+       * lifecycle, so before adding any logic into this branch, make sure if it's really correct.
+       * One known exception is Statement#closeOnCompletion, which is part of the Statement API.
+       */
       HiveStatement s = (HiveStatement) this.statement;
-      s.closeClientOperation();
       s.closeOnResultSetCompletion();
     } else {
       // for those stmtHandle passed from HiveDatabaseMetaData instead of Statement

--- a/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/HiveStatement.java
@@ -237,7 +237,9 @@ public class HiveStatement implements java.sql.Statement {
     closeClientOperation();
     client = null;
     if (resultSet != null) {
-      resultSet.close();
+      if (!resultSet.isClosed()){
+        resultSet.close();
+      }
       resultSet = null;
     }
     isClosed = true;
@@ -594,6 +596,10 @@ public class HiveStatement implements java.sql.Statement {
   @Override
   public boolean isClosed() throws SQLException {
     return isClosed;
+  }
+
+  public boolean isQueryClosed() throws SQLException {
+    return isQueryClosed;
   }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
