### PR TITLE
HIVE-24135: Delete DB managed directory on drop db (Naveen Gangam)

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -1715,8 +1715,12 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
       Path path = new Path(db.getLocationUri()).getParent();
       if (!wh.isWritable(path)) {
-        throw new MetaException("Database not dropped since " +
-            path + " is not writable by " +
+        throw new MetaException("Database not dropped since its external warehouse location " + path + " is not writable by " +
+            SecurityUtils.getUser());
+      }
+      path = wh.getDatabaseManagedPath(db).getParent();
+      if (!wh.isWritable(path)) {
+        throw new MetaException("Database not dropped since its managed warehouse location " + path + " is not writable by " +
             SecurityUtils.getUser());
       }
 
@@ -1844,23 +1848,36 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
         for (Path tablePath : tablePaths) {
           deleteTableData(tablePath, false, db);
         }
-        // Delete the data in the database
+        final Database dbFinal = db;
+        final Path path = (dbFinal.getManagedLocationUri() != null) ?
+            new Path(dbFinal.getManagedLocationUri()) : wh.getDatabaseManagedPath(dbFinal);
         try {
-          if (db.getManagedLocationUri() != null) {
-            wh.deleteDir(new Path(db.getManagedLocationUri()), true, db);
+
+          Boolean deleted = UserGroupInformation.getLoginUser().doAs(new PrivilegedExceptionAction<Boolean>() {
+            @Override public Boolean run() throws IOException, MetaException {
+              return wh.deleteDir(path, true, dbFinal);
+            }
+          });
+          if (!deleted) {
+            LOG.error("Failed to delete database's managed warehouse directory: " + path);
           }
         } catch (Exception e) {
-          LOG.error("Failed to delete database directory: " + db.getManagedLocationUri() +
-              " " + e.getMessage());
+          LOG.error("Failed to delete database's managed warehouse directory: " + path + " " + e.getMessage());
         }
-        // Delete the data in the database's location only if it is a legacy db path?
+
         try {
-          wh.deleteDir(new Path(db.getLocationUri()), true, db);
-        } catch (Exception e) {
-          LOG.error("Failed to delete database directory: " + db.getLocationUri() +
-              " " + e.getMessage());
+          Boolean deleted = UserGroupInformation.getCurrentUser().doAs(new PrivilegedExceptionAction<Boolean>() {
+            @Override public Boolean run() throws MetaException {
+              return wh.deleteDir(new Path(dbFinal.getLocationUri()), true, dbFinal);
+            }
+          });
+          if (!deleted) {
+            LOG.error("Failed to delete database external warehouse directory " + db.getLocationUri());
+          }
+        } catch (IOException | InterruptedException | UndeclaredThrowableException e) {
+          LOG.error("Failed to delete the database external warehouse directory: " + db.getLocationUri() + " " + e
+              .getMessage());
         }
-        // it is not a terrible thing even if the data is not deleted
       }
 
       if (!listeners.isEmpty()) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -1278,6 +1278,52 @@ public abstract class TestHiveMetaStore {
 
 
   @Test
+  public void testDatabaseLocationOnDrop() throws Throwable {
+    try {
+      // clear up any existing databases
+      silentDropDatabase(TEST_DB1_NAME);
+
+      String dbLocation =
+          MetastoreConf.getVar(conf, ConfVars.WAREHOUSE_EXTERNAL) + "/testdb1.db";
+      String mgdLocation =
+          MetastoreConf.getVar(conf, ConfVars.WAREHOUSE) + "/testdb1.db";
+      new DatabaseBuilder()
+          .setName(TEST_DB1_NAME)
+          .setLocation(dbLocation)
+          .setManagedLocation(mgdLocation)
+          .create(client, conf);
+
+      Database db = client.getDatabase(TEST_DB1_NAME);
+
+      assertEquals("name of returned db is different from that of inserted db",
+          TEST_DB1_NAME, db.getName());
+      assertEquals("location of the returned db is different from that of inserted db",
+          warehouse.getDnsPath(new Path(dbLocation)).toString(), db.getLocationUri());
+      assertEquals("managed location of the returned db is different from that of inserted db",
+          warehouse.getDnsPath(new Path(mgdLocation)).toString(), db.getManagedLocationUri());
+
+      client.dropDatabase(TEST_DB1_NAME, true, false, true);
+
+      boolean objectNotExist = false;
+      try {
+        client.getDatabase(TEST_DB1_NAME);
+      } catch (NoSuchObjectException e) {
+        objectNotExist = true;
+      }
+      assertTrue("Database " + TEST_DB1_NAME + " exists ", objectNotExist);
+
+      FileSystem fs = FileSystem.get(new Path(dbLocation).toUri(), conf);
+      assertFalse("Database's location not deleted", fs.exists(new Path(dbLocation)));
+      fs = FileSystem.get(new Path(mgdLocation).toUri(), conf);
+      assertFalse("Database's managed location not deleted", fs.exists(new Path(mgdLocation)));
+    } catch (Throwable e) {
+      System.err.println(StringUtils.stringifyException(e));
+      System.err.println("testDatabaseLocationOnDrop() failed.");
+      throw e;
+    }
+  }
+
+  @Test
   public void testSimpleTypeApi() throws Exception {
     try {
       client.dropType(ColumnType.INT_TYPE_NAME);


### PR DESCRIPTION


### What changes were proposed in this pull request?
The database's managed location is not deleted when the database is dropped. This fix addresses the issue.

### Why are the changes needed?
Even though db.getManagedLocation() might be null, there is always a default managed location for the database. On a drop database, we check to see if this location is null and only drop it if not null. But regardless of whether or not it is null, there is always an assigned location that needs to be dropped.

### Does this PR introduce _any_ user-facing change?
NO

### How was this patch tested?
Unit test + manually