### PR TITLE
HIVE-25208: Refactor Iceberg commit to the MoveTask/MoveWork

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -288,7 +288,6 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     if (jobContext.isPresent()) {
       OutputCommitter committer = new HiveIcebergOutputCommitter();
       try {
-        // Committing the job
         committer.commitJob(jobContext.get());
       } catch (Throwable e) {
         // Aborting the job if the commit has failed
@@ -300,7 +299,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           LOG.error("Error while trying to abort failed job. There might be uncleaned data files.", ioe);
           // no throwing here because the original exception should be propagated
         }
-        throw new HiveException("Error committing job: " + jobContext.get().getJobID() + " for table: " + tableName);
+        throw new HiveException(
+            "Error committing job: " + jobContext.get().getJobID() + " for table: " + tableName, e);
       }
     }
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -300,7 +300,7 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
           LOG.error("Error while trying to abort failed job. There might be uncleaned data files.", ioe);
           // no throwing here because the original exception should be propagated
         }
-        throw new HiveException("Error committing job", e);
+        throw new HiveException("Error committing job: " + jobContext.get().getJobID() + " for table: " + tableName);
       }
     }
   }

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -280,8 +280,8 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
   }
 
   @Override
-  public void nativeCommit(Properties tableProperties, boolean overwrite) {
-    String tableName = tableProperties.getProperty(Catalogs.NAME);
+  public void nativeCommit(Properties commitProperties, boolean overwrite) {
+    String tableName = commitProperties.getProperty(Catalogs.NAME);
     Configuration configuration = SessionState.getSessionConf();
     Optional<JobContext> jobContext = getJobContextForCommitOrAbort(configuration, tableName, overwrite);
     if (jobContext.isPresent()) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.metastore.api.Order;
 import org.apache.hadoop.hive.metastore.utils.MetaStoreUtils;
 import org.apache.hadoop.hive.ql.ErrorMsg;
 import org.apache.hadoop.hive.ql.ddl.DDLUtils;
+import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
 import org.apache.hadoop.hive.ql.exec.mr.MapRedTask;
 import org.apache.hadoop.hive.ql.exec.mr.MapredLocalTask;
 import org.apache.hadoop.hive.ql.exec.repl.util.ReplUtils;
@@ -48,6 +49,8 @@ import org.apache.hadoop.hive.ql.lockmgr.LockException;
 import org.apache.hadoop.hive.ql.log.PerfLogger;
 import org.apache.hadoop.hive.ql.metadata.Hive;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 import org.apache.hadoop.hive.ql.optimizer.physical.BucketingSortingCtx.BucketCol;
@@ -74,12 +77,11 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * MoveTask implementation.
@@ -317,6 +319,36 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
     }
 
     try (LocalTableLock lock = acquireLockForFileMove(work.getLoadTableWork())) {
+      String storageHandlerClass = null;
+      Properties tableProperties = null;
+      boolean overwrite = false;
+
+      if (work.getLoadTableWork() != null) {
+        // Get the info from the table data
+        TableDesc tableDesc = work.getLoadTableWork().getTable();
+        storageHandlerClass = tableDesc.getProperties().getProperty(
+            org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE);
+        tableProperties = tableDesc.getProperties();
+        overwrite = work.getLoadTableWork().isInsertOverwrite();
+      } else if (work.getLoadFileWork() != null && work.getLoadFileWork().getCtasCreateTableDesc() != null) {
+        // Get the info from the create table data
+        CreateTableDesc createTableDesc = work.getLoadFileWork().getCtasCreateTableDesc();
+        if (createTableDesc != null) {
+          storageHandlerClass = createTableDesc.getStorageHandler();
+          tableProperties = new Properties();
+          tableProperties.putAll(createTableDesc.getTblProps());
+        }
+      }
+
+      // If the storage handler supports native commits the use that instead of moving files
+      if (storageHandlerClass != null) {
+        HiveStorageHandler storageHandler = HiveUtils.getStorageHandler(conf, storageHandlerClass);
+        if (storageHandler.useNativeCommit()) {
+          storageHandler.nativeCommit(tableProperties, overwrite);
+          return 0;
+        }
+      }
+
       Hive db = getHive();
 
       // Do any hive related operations like moving tables and files

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/MoveTask.java
@@ -331,7 +331,7 @@ public class MoveTask extends Task<MoveWork> implements Serializable {
             org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE);
         commitProperties = new Properties(tableDesc.getProperties());
         overwrite = work.getLoadTableWork().isInsertOverwrite();
-      } else if (work.getLoadFileWork() != null && work.getLoadFileWork().getCtasCreateTableDesc() != null) {
+      } else if (work.getLoadFileWork() != null) {
         // Get the info from the create table data
         CreateTableDesc createTableDesc = work.getLoadFileWork().getCtasCreateTableDesc();
         if (createTableDesc != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
 
 import java.util.Map;
+import java.util.Properties;
 
 /**
  * HiveStorageHandler defines a pluggable interface for adding
@@ -262,5 +263,23 @@ public interface HiveStorageHandler extends Configurable {
    */
   default String getFileFormatPropertyKey() {
     return null;
+  }
+
+  /**
+   * Check if we should use the {@link #nativeCommit(Properties, boolean)} method for committing inserts instead of
+   * using file copy in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}-s.
+   * @return
+   */
+  default boolean useNativeCommit() {
+    return false;
+  }
+
+  /**
+   * Commits the inserts for the non-native tables. Used in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}.
+   * @param properties Table properties from LoadTableWork/TableDesc and LoadFileWork/CreateTableDesc
+   * @param overwrite If this is an INSERT OVERWRITE then it is true
+   */
+  default void nativeCommit(Properties properties, boolean overwrite) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -278,8 +278,9 @@ public interface HiveStorageHandler extends Configurable {
    * Commits the inserts for the non-native tables. Used in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}.
    * @param commitProperties Commit properties which are needed for the native commit
    * @param overwrite If this is an INSERT OVERWRITE then it is true
+   * @throws HiveException If there is an error during commit
    */
-  default void nativeCommit(Properties commitProperties, boolean overwrite) {
+  default void nativeCommit(Properties commitProperties, boolean overwrite) throws HiveException {
     throw new UnsupportedOperationException();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -276,10 +276,10 @@ public interface HiveStorageHandler extends Configurable {
 
   /**
    * Commits the inserts for the non-native tables. Used in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}.
-   * @param properties Table properties from LoadTableWork/TableDesc and LoadFileWork/CreateTableDesc
+   * @param commitProperties Commit properties which are needed for the native commit
    * @param overwrite If this is an INSERT OVERWRITE then it is true
    */
-  default void nativeCommit(Properties properties, boolean overwrite) {
+  default void nativeCommit(Properties commitProperties, boolean overwrite) {
     throw new UnsupportedOperationException();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -266,21 +266,22 @@ public interface HiveStorageHandler extends Configurable {
   }
 
   /**
-   * Check if we should use the {@link #nativeCommit(Properties, boolean)} method for committing inserts instead of
-   * using file copy in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}-s.
-   * @return
+   * Checks if we should keep the {@link org.apache.hadoop.hive.ql.exec.MoveTask} and use the
+   * {@link #storageHandlerCommit(Properties, boolean)} method for committing inserts instead of
+   * {@link org.apache.hadoop.hive.metastore.DefaultHiveMetaHook#commitInsertTable(Table, boolean)}.
+   * @return Returns true if we should use the {@link #storageHandlerCommit(Properties, boolean)} method
    */
-  default boolean useNativeCommit() {
+  default boolean commitInMoveTask() {
     return false;
   }
 
   /**
    * Commits the inserts for the non-native tables. Used in the {@link org.apache.hadoop.hive.ql.exec.MoveTask}.
-   * @param commitProperties Commit properties which are needed for the native commit
+   * @param commitProperties Commit properties which are needed for the handler based commit
    * @param overwrite If this is an INSERT OVERWRITE then it is true
    * @throws HiveException If there is an error during commit
    */
-  default void nativeCommit(Properties commitProperties, boolean overwrite) throws HiveException {
+  default void storageHandlerCommit(Properties commitProperties, boolean overwrite) throws HiveException {
     throw new UnsupportedOperationException();
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7316,7 +7316,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       destTableId++;
       // Create the work for moving the table
       // NOTE: specify Dynamic partitions in dest_tab for WriteEntity
-      if (!isNonNativeTable) {
+      if (!isNonNativeTable || destinationTable.getStorageHandler().useNativeCommit()) {
         if (destTableIsTransactional) {
           acidOp = getAcidType(tableDescriptor.getOutputFileFormatClass(), dest, isMmTable);
           checkAcidConstraints();
@@ -7771,21 +7771,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         if (!outputs.add(new WriteEntity(destinationPath, !isDfsDir, isDestTempFile))) {
           throw new SemanticException(ErrorMsg.OUTPUT_SPECIFIED_MULTIPLE_TIMES
               .getMsg(destinationPath.toUri().toString()));
-        }
-      }
-
-      // For normal, non-direct insert CTAS cases, the TaskCompiler#patchUpAfterCTASorMaterializedView
-      // adds a DDL table creation task to the execution plan. Once that's done, the SemanticAnalyzer later appends a
-      // PreInsertTableDesc hook to this DDL task. However, for direct insert CTAS this table creation task is not
-      // added to the plan, therefore we need to add the PreInsertTableDesc to the plan here manually to ensure that the
-      // HiveMetaHook#commitInsertTable is called
-      if (qb.isCTAS() && tableDesc != null && tableDesc.getStorageHandler() != null) {
-        try {
-          if (HiveUtils.getStorageHandler(conf, tableDesc.getStorageHandler()).directInsertCTAS()) {
-            createPreInsertDesc(destinationTable, false);
-          }
-        } catch (HiveException e) {
-          throw new SemanticException("Failed to load storage handler:  " + e.getMessage());
         }
       }
       break;
@@ -13210,6 +13195,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
     if (isCTAS) {
       retValue.put(TABLE_IS_CTAS, Boolean.toString(isCTAS));
+      retValue.put(hive_metastoreConstants.META_TABLE_NAME, qualifiedTableName);
     }
     return retValue;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13195,7 +13195,6 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     }
     if (isCTAS) {
       retValue.put(TABLE_IS_CTAS, Boolean.toString(isCTAS));
-      retValue.put(hive_metastoreConstants.META_TABLE_NAME, qualifiedTableName);
     }
     return retValue;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7316,7 +7316,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
       destTableId++;
       // Create the work for moving the table
       // NOTE: specify Dynamic partitions in dest_tab for WriteEntity
-      if (!isNonNativeTable || destinationTable.getStorageHandler().useNativeCommit()) {
+      if (!isNonNativeTable || destinationTable.getStorageHandler().commitInMoveTask()) {
         if (destTableIsTransactional) {
           acidOp = getAcidType(tableDescriptor.getOutputFileFormatClass(), dest, isMmTable);
           checkAcidConstraints();
@@ -7733,7 +7733,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         // this order needs to be enforced because metastore expects a table to exist before we can
         // add any partitions to it.
         isNonNativeTable = tableDescriptor.isNonNative();
-        if (!isNonNativeTable || destinationTable.getStorageHandler().useNativeCommit()) {
+        if (!isNonNativeTable || destinationTable.getStorageHandler().commitInMoveTask()) {
           AcidUtils.Operation acidOp = AcidUtils.Operation.NOT_ACID;
           if (destTableIsTransactional) {
             acidOp = getAcidType(tableDescriptor.getOutputFileFormatClass(), dest, isMmTable);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -7733,7 +7733,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         // this order needs to be enforced because metastore expects a table to exist before we can
         // add any partitions to it.
         isNonNativeTable = tableDescriptor.isNonNative();
-        if (!isNonNativeTable) {
+        if (!isNonNativeTable || destinationTable.getStorageHandler().useNativeCommit()) {
           AcidUtils.Operation acidOp = AcidUtils.Operation.NOT_ACID;
           if (destTableIsTransactional) {
             acidOp = getAcidType(tableDescriptor.getOutputFileFormatClass(), dest, isMmTable);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -282,8 +282,7 @@ public abstract class TaskCompiler {
           setLoadFileLocation(pCtx, lfd);
           oneLoadFileForCtas = false;
         }
-        mvTask.add(TaskFactory
-            .get(new MoveWork(null, null, null, lfd, false)));
+        mvTask.add(TaskFactory.get(new MoveWork(null, null, null, lfd, false)));
       }
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/TaskCompiler.java
@@ -282,11 +282,8 @@ public abstract class TaskCompiler {
           setLoadFileLocation(pCtx, lfd);
           oneLoadFileForCtas = false;
         }
-        // for direct insert CTAS, we don't need this MoveTask since the data will be inserted into its final location
-        if (!directInsertCtas) {
-          mvTask.add(TaskFactory
-              .get(new MoveWork(null, null, null, lfd, false)));
-        }
+        mvTask.add(TaskFactory
+            .get(new MoveWork(null, null, null, lfd, false)));
       }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
We should use the MoveTask to commit the changes (inserts/insert overwrites)

### Why are the changes needed?
MoveTask is used for multiple things, like stat generation. When we removed the Move tasks, we caused several unseen issues. We should reintroduce the MoveTask

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests