### PR TITLE
HIVE-25222: Fix column name issue with commas

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -207,6 +207,7 @@ public class InputFormatConfig {
     if (readColumns == null || readColumns.isEmpty()) {
       return null;
     }
+
     return readColumns.split(conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA)));
   }
 

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/InputFormatConfig.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.mr;
 
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
+import org.apache.hadoop.hive.serde2.SerDeUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -201,8 +203,11 @@ public class InputFormatConfig {
   }
 
   public static String[] selectedColumns(Configuration conf) {
-    String[] readColumns = conf.getStrings(InputFormatConfig.SELECTED_COLUMNS);
-    return readColumns != null && readColumns.length > 0 ? readColumns : null;
+    String readColumns = conf.get(InputFormatConfig.SELECTED_COLUMNS);
+    if (readColumns == null || readColumns.isEmpty()) {
+      return null;
+    }
+    return readColumns.split(conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA)));
   }
 
   private static Schema schema(Configuration conf, String key) {

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergInputFormat.java
@@ -65,8 +65,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
       }
     }
 
-    String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
-    job.setStrings(InputFormatConfig.SELECTED_COLUMNS, selectedColumns);
+    job.set(InputFormatConfig.SELECTED_COLUMNS, job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, ""));
 
     String location = job.get(InputFormatConfig.TABLE_LOCATION);
     return Arrays.stream(super.getSplits(job, numSplits))
@@ -77,8 +76,7 @@ public class HiveIcebergInputFormat extends MapredIcebergInputFormat<Record>
   @Override
   public RecordReader<Void, Container<Record>> getRecordReader(InputSplit split, JobConf job,
                                                                Reporter reporter) throws IOException {
-    String[] selectedColumns = ColumnProjectionUtils.getReadColumnNames(job);
-    job.setStrings(InputFormatConfig.SELECTED_COLUMNS, selectedColumns);
+    job.set(InputFormatConfig.SELECTED_COLUMNS, job.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR, ""));
     return super.getRecordReader(split, job, reporter);
   }
 

--- a/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde.serdeConstants;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.hive.common.util.HiveStringUtils;
 import org.slf4j.Logger;
@@ -202,7 +203,7 @@ public final class ColumnProjectionUtils {
   public static String[] getReadColumnNames(Configuration conf) {
     String colNames = conf.get(READ_COLUMN_NAMES_CONF_STR, READ_COLUMN_IDS_CONF_STR_DEFAULT);
     if (colNames != null && !colNames.isEmpty()) {
-      return colNames.split(",");
+      return colNames.split(conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA)));
     }
     return new String[] {};
   }
@@ -228,17 +229,12 @@ public final class ColumnProjectionUtils {
 
   private static void appendReadColumnNames(Configuration conf, List<String> cols) {
     String old = conf.get(READ_COLUMN_NAMES_CONF_STR, "");
-    StringBuilder result = new StringBuilder(old);
-    boolean first = old.isEmpty();
-    for(String col: cols) {
-      if (first) {
-        first = false;
-      } else {
-        result.append(',');
-      }
-      result.append(col);
+    String delim = conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA));
+    String result = String.join(delim, cols);
+    if (!old.isEmpty()) {
+      result = old + delim + result;
     }
-    conf.set(READ_COLUMN_NAMES_CONF_STR, result.toString());
+    conf.set(READ_COLUMN_NAMES_CONF_STR, result);
   }
 
   private static String toReadColumnIDString(List<Integer> ids) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
When putting together the column name list for projection pruning, use the `serdeConstant` delimiter value instead of blindly using the comma as the separator.

### Why are the changes needed?
Currently, `ColumnProjectionUtils` saves the list of columns as a string into the job conf for projection pruning purposes. However, it mistakenly uses comma as the separator in all cases, which can lead to problems when we use a comma in one of the column names. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Unit tests
