### PR TITLE
HIVE-25219: Backward incompatible timestamp serialization in Avro for certain timezones

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -2242,8 +2242,13 @@ public class HiveConf extends Configuration {
         "This value controls whether date and timestamp type in Avro files was written using the hybrid or proleptic\n" +
         "calendar. Hybrid is the default."),
     HIVE_AVRO_TIMESTAMP_LEGACY_CONVERSION_ENABLED("hive.avro.timestamp.legacy.conversion.enabled", true,
-        "This value controls whether we use former Java time API to convert between timezones on files where timezone\n" +
-        "is not encoded in the metadata. This is for debugging."),
+        "Whether to use former Java date/time APIs to convert between timezones when reading timestamps from " +
+        "Avro files. The property has no effect when the file contains explicit metadata about the conversion " + 
+        "used to write the data; in this case reading conversion is based on the metadata."),
+    HIVE_AVRO_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED("hive.avro.timestamp.write.legacy.conversion.enabled", false,
+        "Whether to use former Java date/time APIs to convert between timezones when writing timestamps in " +
+        "Avro files. Once data are written to the file the effect is permanent (also reflected in the metadata)." +
+        "Changing the value of this property affects only new data written to the file."),
     HIVE_INT_TIMESTAMP_CONVERSION_IN_SECONDS("hive.int.timestamp.conversion.in.seconds", false,
         "Boolean/tinyint/smallint/int/bigint value is interpreted as milliseconds during the timestamp conversion.\n" +
         "Set this flag to true to interpret the value as seconds to be consistent with float/double." ),

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_multi_part_table_to_iceberg.q.out
@@ -654,7 +654,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	1591                
+	totalSize           	1843                
 #### A masked pattern was here ####
 	write.format.default	avro                
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_part_table_to_iceberg.q.out
@@ -519,7 +519,7 @@ Table Parameters:
 	previous_metadata_location	hdfs://### HDFS PATH ###
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	910                 
+	totalSize           	1054                
 #### A masked pattern was here ####
 	write.format.default	avro                
 	 	 

--- a/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/alter_table_to_iceberg.q.out
@@ -391,7 +391,7 @@ Table Parameters:
 	rawDataSize         	0                   
 	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
 	table_type          	ICEBERG             
-	totalSize           	315                 
+	totalSize           	351                 
 #### A masked pattern was here ####
 	write.format.default	avro                
 	 	 

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroContainerOutputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroContainerOutputFormat.java
@@ -83,6 +83,8 @@ public class AvroContainerOutputFormat
     dfw.setMeta(AvroSerDe.WRITER_TIME_ZONE, TimeZone.getDefault().toZoneId().toString());
     dfw.setMeta(AvroSerDe.WRITER_PROLEPTIC, String.valueOf(
         HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.HIVE_AVRO_PROLEPTIC_GREGORIAN)));
+    dfw.setMeta(AvroSerDe.WRITER_ZONE_CONVERSION_LEGACY, String
+        .valueOf(HiveConf.getBoolVar(jobConf, HiveConf.ConfVars.HIVE_AVRO_TIMESTAMP_WRITE_LEGACY_CONVERSION_ENABLED)));
     dfw.create(schema, path.getFileSystem(jobConf).create(path));
     return new AvroGenericRecordWriter(dfw);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/avro/AvroGenericRecordReader.java
@@ -65,6 +65,7 @@ public class AvroGenericRecordReader implements
   final private long stop;
   private ZoneId writerTimezone;
   private Boolean writerProleptic;
+  private final Boolean writerZoneConversionLegacy;
   protected JobConf jobConf;
   final private boolean isEmptyInput;
   /**
@@ -108,6 +109,7 @@ public class AvroGenericRecordReader implements
 
       this.writerTimezone = extractWriterTimezoneFromMetadata(job, split, gdr);
       this.writerProleptic = extractWriterProlepticFromMetadata(job, split, gdr);
+      this.writerZoneConversionLegacy = extractWriterZoneConversionLegacy(job, split, gdr);
     } catch (Exception e) {
       if (this.reader != null) {
         try {
@@ -211,6 +213,33 @@ public class AvroGenericRecordReader implements
     return null;
   }
 
+  private Boolean extractWriterZoneConversionLegacy(JobConf job, FileSplit split,
+      GenericDatumReader<GenericRecord> gdr) {
+    assert job != null;
+    assert split != null;
+    assert gdr != null;
+    if (split.getPath() == null) {
+      return null;
+    }
+    try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<GenericRecord>(
+        new FsInput(split.getPath(), job), gdr)) {
+      byte[] meta = dataFileReader.getMeta(AvroSerDe.WRITER_ZONE_CONVERSION_LEGACY);
+      if (meta != null) {
+        String v = new String(meta, StandardCharsets.UTF_8);
+        if (v.equalsIgnoreCase("true")) {
+          return Boolean.TRUE;
+        } else if (v.equalsIgnoreCase("false")) {
+          return Boolean.FALSE;
+        } else {
+          LOG.warn("Invalid " + AvroSerDe.WRITER_ZONE_CONVERSION_LEGACY + " metadata: " + v);
+        }
+      }
+    } catch (IOException exception) {
+      LOG.warn("Problem extracting " + AvroSerDe.WRITER_ZONE_CONVERSION_LEGACY + " metadata.", exception);
+    }
+    return null;
+  }
+
   private boolean pathIsInPartition(Path split, Path partitionPath) {
     boolean schemeless = split.toUri().getScheme() == null;
     if (schemeless) {
@@ -243,7 +272,7 @@ public class AvroGenericRecordReader implements
 
   @Override
   public AvroGenericRecordWritable createValue() {
-    return new AvroGenericRecordWritable(writerTimezone, writerProleptic);
+    return new AvroGenericRecordWritable(writerTimezone, writerProleptic, writerZoneConversionLegacy);
   }
 
   @Override

--- a/ql/src/test/queries/clientpositive/avro_write_legacy_timestamp.q
+++ b/ql/src/test/queries/clientpositive/avro_write_legacy_timestamp.q
@@ -1,0 +1,20 @@
+-- HIVE-25104: Backward incompatible timestamp serialization in Avro for certain timezones
+-- Test writing timestamps in Avro tables using old and new date/time APIs
+-- using the appropriate configuration properties. 
+CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO;
+-- Rows written using legacy conversion enabled are backwards compatible and
+-- can be read correctly by older versions of Hive (e.g., Hive 2).
+SET hive.avro.timestamp.write.legacy.conversion.enabled=true;
+INSERT INTO employee VALUES (1, '1220-01-01 00:00:00');
+INSERT INTO employee VALUES (2, '1880-01-01 00:00:00');
+INSERT INTO employee VALUES (3, '1884-01-01 00:00:00');
+INSERT INTO employee VALUES (4, '1990-01-01 00:00:00');
+-- No matter how timestamps are written they are always read correctly by the current
+-- version of Hive by exploiting the metadata in the file
+SELECT eid, birth FROM employee ORDER BY eid;
+-- Changing the read property does not have any effect in the current version of Hive
+-- since the file metadata contains the appropriate information to read them correctly 
+SET hive.avro.timestamp.legacy.conversion.enabled=false;
+SELECT eid, birth FROM employee ORDER BY eid;
+SET hive.avro.timestamp.legacy.conversion.enabled=true;
+SELECT eid, birth FROM employee ORDER BY eid;

--- a/ql/src/test/queries/clientpositive/avro_write_new_timestamp.q
+++ b/ql/src/test/queries/clientpositive/avro_write_new_timestamp.q
@@ -1,0 +1,21 @@
+-- HIVE-25104: Backward incompatible timestamp serialization in Avro for certain timezones
+-- Test writing timestamps in Avro tables using old and new date/time APIs
+-- using the appropriate configuration properties. 
+CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO;
+-- Rows written using legacy conversion disabled are not backwards compatible.
+-- Reading those rows in older versions of Hive (or other applications) might show
+-- the timestamps (1, 2) shifted for some timezones (e.g., US/Pacific).
+SET hive.avro.timestamp.write.legacy.conversion.enabled=false;
+INSERT INTO employee VALUES (1, '1220-01-01 00:00:00');
+INSERT INTO employee VALUES (2, '1880-01-01 00:00:00');
+INSERT INTO employee VALUES (3, '1884-01-01 00:00:00');
+INSERT INTO employee VALUES (4, '1990-01-01 00:00:00');
+-- No matter how timestamps are written they are always read correctly by the current
+-- version of Hive by exploiting the metadata in the file
+SELECT eid, birth FROM employee ORDER BY eid;
+-- Changing the read property does not have any effect in the current version of Hive
+-- since the file metadata contains the appropriate information to read them correctly 
+SET hive.avro.timestamp.legacy.conversion.enabled=false;
+SELECT eid, birth FROM employee ORDER BY eid;
+SET hive.avro.timestamp.legacy.conversion.enabled=true;
+SELECT eid, birth FROM employee ORDER BY eid;

--- a/ql/src/test/results/clientpositive/llap/avro_schema_evolution_native.q.out
+++ b/ql/src/test/results/clientpositive/llap/avro_schema_evolution_native.q.out
@@ -108,7 +108,7 @@ Table Parameters:
 	numPartitions       	7                   
 	numRows             	8                   
 	rawDataSize         	0                   
-	totalSize           	3455                
+	totalSize           	3707                
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 
@@ -220,7 +220,7 @@ Table Parameters:
 	numPartitions       	7                   
 	numRows             	8                   
 	rawDataSize         	0                   
-	totalSize           	3455                
+	totalSize           	3707                
 #### A masked pattern was here ####
 	 	 
 # Storage Information	 	 

--- a/ql/src/test/results/clientpositive/llap/avro_write_legacy_timestamp.q.out
+++ b/ql/src/test/results/clientpositive/llap/avro_write_legacy_timestamp.q.out
@@ -1,0 +1,84 @@
+PREHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@employee
+POSTHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@employee
+PREHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00

--- a/ql/src/test/results/clientpositive/llap/avro_write_new_timestamp.q.out
+++ b/ql/src/test/results/clientpositive/llap/avro_write_new_timestamp.q.out
@@ -1,0 +1,84 @@
+PREHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@employee
+POSTHOOK: query: CREATE TABLE employee(eid INT,birth TIMESTAMP) STORED AS AVRO
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@employee
+PREHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (1, '1220-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (2, '1880-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (3, '1884-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@employee
+POSTHOOK: query: INSERT INTO employee VALUES (4, '1990-01-01 00:00:00')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@employee
+POSTHOOK: Lineage: employee.birth SCRIPT []
+POSTHOOK: Lineage: employee.eid SCRIPT []
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00
+PREHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+PREHOOK: type: QUERY
+PREHOOK: Input: default@employee
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT eid, birth FROM employee ORDER BY eid
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@employee
+#### A masked pattern was here ####
+1	1220-01-01 00:00:00
+2	1880-01-01 00:00:00
+3	1884-01-01 00:00:00
+4	1990-01-01 00:00:00

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroGenericRecordWritable.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroGenericRecordWritable.java
@@ -53,6 +53,8 @@ public class AvroGenericRecordWritable implements Writable{
   private ZoneId writerTimezone = null;
 
   private Boolean writerProleptic = null;
+  
+  private final Boolean writerZoneConversionLegacy;
 
   /**
    * Unique Id determine which record reader created this record
@@ -74,15 +76,19 @@ public class AvroGenericRecordWritable implements Writable{
     this.record = record;
   }
 
-  public AvroGenericRecordWritable() {}
+  public AvroGenericRecordWritable() {
+    this.writerZoneConversionLegacy = null;
+  }
 
   public AvroGenericRecordWritable(GenericRecord record) {
     this.record = record;
+    this.writerZoneConversionLegacy = null;
   }
 
-  public AvroGenericRecordWritable(ZoneId writerTimezone, Boolean writerProleptic) {
+  public AvroGenericRecordWritable(ZoneId writerTimezone, Boolean writerProleptic, Boolean writerZoneConversionLegacy) {
     this.writerTimezone = writerTimezone;
     this.writerProleptic = writerProleptic;
+    this.writerZoneConversionLegacy = writerZoneConversionLegacy;
   }
 
   @Override
@@ -159,5 +165,9 @@ public class AvroGenericRecordWritable implements Writable{
 
   public Boolean getWriterProleptic() {
     return writerProleptic;
+  }
+  
+  Boolean getWriterZoneConversionLegacy() {
+    return writerZoneConversionLegacy;
   }
 }

--- a/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerDe.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/avro/AvroSerDe.java
@@ -60,6 +60,7 @@ public class AvroSerDe extends AbstractSerDe {
   public static final String TIMESTAMP_TYPE_NAME = "timestamp-millis";
   public static final String WRITER_TIME_ZONE = "writer.time.zone";
   public static final String WRITER_PROLEPTIC = "writer.proleptic";
+  public static final String WRITER_ZONE_CONVERSION_LEGACY = "writer.zone.conversion.legacy";
   public static final String AVRO_PROP_LOGICAL_TYPE = "logicalType";
   public static final String AVRO_PROP_PRECISION = "precision";
   public static final String AVRO_PROP_SCALE = "scale";

--- a/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroDeserializer.java
+++ b/serde/src/test/org/apache/hadoop/hive/serde2/avro/TestAvroDeserializer.java
@@ -293,7 +293,7 @@ public class TestAvroDeserializer {
     record.put("timestampField", 1546387200999L);
     assertTrue(GENERIC_DATA.validate(readerSchema, record));
 
-    AvroGenericRecordWritable agrw = new AvroGenericRecordWritable(ZoneId.of("America/New_York"), false);
+    AvroGenericRecordWritable agrw = new AvroGenericRecordWritable(ZoneId.of("America/New_York"), false, false);
     agrw.setRecord(record);
     agrw.setFileSchema(readerSchema);
     agrw.setRecordReaderID(new UID());


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add new read/write config properties to control legacy zone conversions in Avro.
2. Exploit file metadata and property to choose between new/old conversion rules.

### Why are the changes needed?
Provide the end-users the possibility to write backward compatible timestamps in Parquet files so that files can be read correctly by older versions.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
1. New qtests for writting Avro timestamps (`avro_write_legacy_timestamp.q`, `avro_write_new_timestamp.q`)
2. Manual tests
* Export Avro table with current Hive version setting `hive.avro.timestamp.write.legacy.conversion.enabled=true`
* Read from external Parquet table with Hive 2 (commit 324f9fa)
