### PR TITLE
HIVE-25220: Query with union fails CBO with OOM

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1658,14 +1658,15 @@ public class CalcitePlanner extends SemanticAnalyzer {
       RexExecutor executorProvider = new HiveRexExecutorImpl();
       calcitePlan.getCluster().getPlanner().setExecutor(executorProvider);
 
+      // Create and set MD provider
+      HiveDefaultRelMetadataProvider mdProvider = new HiveDefaultRelMetadataProvider(conf, HIVE_REL_NODE_CLASSES);
+      RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(mdProvider.getMetadataProvider()));
+      optCluster.invalidateMetadataQuery();
+
       // We need to get the ColumnAccessInfo and viewToTableSchema for views.
       HiveRelFieldTrimmer.get()
           .trim(HiveRelFactories.HIVE_BUILDER.create(optCluster, null),
               calcitePlan, this.columnAccessInfo, this.viewProjectToTableSchema);
-
-      // Create and set MD provider
-      HiveDefaultRelMetadataProvider mdProvider = new HiveDefaultRelMetadataProvider(conf, HIVE_REL_NODE_CLASSES);
-      RelMetadataQuery.THREAD_PROVIDERS.set(JaninoRelMetadataProvider.of(mdProvider.getMetadataProvider()));
 
       //Remove subquery
       if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Create and setup `HiveDefaultRelMetadataProvider` before the first call of `HiveRelFieldTrimmer`.
2. Invalidate the metadata query on the current `RelOptCluster` instance to trigger the newly set MetadataQuery instantiation.

### Why are the changes needed?
`HiveRelFieldTrimmer` uses `RelMetadataProvider` to get expression lineage. If the query contains several union operators determining expression lineage can result into exponential number of expressions due to UNIONs which can lead to OOM.
We already have a fix for this issue (HIVE-24304) but prior this patch the fix was not used because it is part of `HiveDefaultRelMetadataProvider` which is not used when `HiveRelFieldTrimmer` was called the first time.

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
It is not straight forward to repro this issue from q tests since the RelMetadataProvider is stored in a ThreadLocal instance and the ddl statements prior the failing query initializes MD provider with the Hive version. 
To avoid this I setup a small cluster with Hive, Hadoop and Tez.