### PR TITLE
HIVE-25238: Make SSL cipher suites configurable for Hive Web UI and HS2

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
+++ b/common/src/java/org/apache/hadoop/hive/common/auth/HiveAuthUtils.java
@@ -23,6 +23,7 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.SSLParameters;
@@ -30,6 +31,9 @@ import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.TrustManagerFactory;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.thrift.TConfiguration;
 import org.apache.thrift.transport.TSSLTransportFactory;
 import org.apache.thrift.transport.TServerSocket;
@@ -97,10 +101,21 @@ public class HiveAuthUtils {
 
   public static TServerSocket getServerSSLSocket(String hiveHost, int portNum, String keyStorePath,
       String keyStorePassWord, String keyStoreType, String keyStoreAlgorithm,
-      List<String> sslVersionBlacklist) throws TTransportException,
+      List<String> sslVersionBlacklist, String includeCipherSuites) throws TTransportException,
       UnknownHostException {
-    TSSLTransportFactory.TSSLTransportParameters params =
-        new TSSLTransportFactory.TSSLTransportParameters();
+
+    TSSLTransportFactory.TSSLTransportParameters params = null;
+    if (!includeCipherSuites.trim().isEmpty()) {
+      Set<String> includeCS = Sets.newHashSet(
+              Splitter.on(":").trimResults().omitEmptyStrings().split(includeCipherSuites.trim()));
+      int eSize = includeCS.size();
+      if (eSize > 0) {
+        params = new TSSLTransportFactory.TSSLTransportParameters("TLS", includeCS.toArray(new String[eSize]));
+      }
+    }
+    if (params == null) {
+      params = new TSSLTransportFactory.TSSLTransportParameters();
+    }
     String kStoreType = keyStoreType.isEmpty()? KeyStore.getDefaultType() : keyStoreType;
     String kStoreAlgorithm = keyStoreAlgorithm.isEmpty()?
             KeyManagerFactory.getDefaultAlgorithm() : keyStoreAlgorithm;

--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -3737,6 +3737,9 @@ public class HiveConf extends Configuration {
         "SSL certificate keystore password for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_KEYSTORE_TYPE("hive.server2.webui.keystore.type", "",
         "SSL certificate keystore type for HiveServer2 WebUI."),
+    HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES("hive.server2.webui.exclude.ciphersuites", "",
+        "SSL a list of exclude cipher suite names or regular expressions separated by comma"
+        + " for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_SSL_KEYMANAGERFACTORY_ALGORITHM("hive.server2.webui.keymanagerfactory.algorithm",
         "","SSL certificate key manager factory algorithm for HiveServer2 WebUI."),
     HIVE_SERVER2_WEBUI_USE_SPNEGO("hive.server2.webui.use.spnego", false,
@@ -4183,9 +4186,14 @@ public class HiveConf extends Configuration {
     HIVE_SERVER2_SSL_KEYSTORE_PASSWORD("hive.server2.keystore.password", "",
         "SSL certificate keystore password."),
     HIVE_SERVER2_SSL_KEYSTORE_TYPE("hive.server2.keystore.type", "",
-            "SSL certificate keystore type."),
+        "SSL certificate keystore type."),
     HIVE_SERVER2_SSL_KEYMANAGERFACTORY_ALGORITHM("hive.server2.keymanagerfactory.algorithm", "",
-            "SSL certificate keystore algorithm."),
+        "SSL certificate keystore algorithm."),
+    HIVE_SERVER2_SSL_HTTP_EXCLUDE_CIPHERSUITES("hive.server2.http.exclude.ciphersuites", "",
+        "SSL a list of exclude cipher suite names or regular expressions separated by comma "
+        + "for HiveServer2 http server."),
+    HIVE_SERVER2_SSL_BINARY_INCLUDE_CIPHERSUITES("hive.server2.binary.include.ciphersuites", "",
+        "SSL a list of include cipher suite names separated by colon for HiveServer2 binary Cli Server"),
     HIVE_SERVER2_BUILTIN_UDF_WHITELIST("hive.server2.builtin.udf.whitelist", "",
         "Comma separated list of builtin udf names allowed in queries.\n" +
         "An empty whitelist allows all builtin udfs to be executed. " +

--- a/common/src/java/org/apache/hive/http/HttpServer.java
+++ b/common/src/java/org/apache/hive/http/HttpServer.java
@@ -158,6 +158,7 @@ public class HttpServer {
     private String keyStorePath;
     private String keyStoreType;
     private String keyManagerFactoryAlgorithm;
+    private String excludeCiphersuites;
     private String spnegoPrincipal;
     private String spnegoKeytab;
     private boolean useSPNEGO;
@@ -231,6 +232,11 @@ public class HttpServer {
 
     public Builder setKeyManagerFactoryAlgorithm(String keyManagerFactoryAlgorithm) {
       this.keyManagerFactoryAlgorithm = keyManagerFactoryAlgorithm;
+      return this;
+    }
+
+    public Builder setExcludeCiphersuites(String excludeCiphersuites) {
+      this.excludeCiphersuites = excludeCiphersuites;
       return this;
     }
 
@@ -537,6 +543,14 @@ public class HttpServer {
       sslContextFactory.setKeyManagerFactoryAlgorithm(
           b.keyManagerFactoryAlgorithm == null || b.keyManagerFactoryAlgorithm.isEmpty()?
           KeyManagerFactory.getDefaultAlgorithm() : b.keyManagerFactoryAlgorithm);
+      if (b.excludeCiphersuites != null && !b.excludeCiphersuites.trim().isEmpty()) {
+        Set<String> excludeCS = Sets.newHashSet(
+            Splitter.on(",").trimResults().omitEmptyStrings().split(b.excludeCiphersuites.trim()));
+        int eSize = excludeCS.size();
+        if (eSize > 0) {
+          sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[eSize]));
+        }
+      }
       Set<String> excludedSSLProtocols = Sets.newHashSet(
         Splitter.on(",").trimResults().omitEmptyStrings().split(
           Strings.nullToEmpty(b.conf.getVar(ConfVars.HIVE_SSL_PROTOCOL_BLACKLIST))));

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftBinaryCLIService.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
 import org.apache.hadoop.hive.common.auth.HiveAuthUtils;
 import org.apache.hadoop.hive.common.metrics.common.Metrics;
 import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
@@ -94,8 +96,9 @@ public class ThriftBinaryCLIService extends ThriftCLIService {
             HiveConf.ConfVars.HIVE_SERVER2_SSL_KEYSTORE_PASSWORD.varname);
         String keyStoreType = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_KEYSTORE_TYPE).trim();
         String keyStoreAlgorithm = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_KEYMANAGERFACTORY_ALGORITHM).trim();
+        String includeCiphersuites = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_BINARY_INCLUDE_CIPHERSUITES).trim();
         serverSocket = HiveAuthUtils.getServerSSLSocket(hiveHost, portNum, keyStorePath, keyStorePassword,
-            keyStoreType, keyStoreAlgorithm, sslVersionBlacklist);
+            keyStoreType, keyStoreAlgorithm, sslVersionBlacklist, includeCiphersuites);
       }
 
       // Server args

--- a/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
+++ b/service/src/java/org/apache/hive/service/cli/thrift/ThriftHttpCLIService.java
@@ -24,10 +24,13 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.Set;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.ws.rs.HttpMethod;
 
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
 import org.apache.hadoop.hive.common.metrics.common.Metrics;
 import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
 import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
@@ -158,6 +161,15 @@ public class ThriftHttpCLIService extends ThriftCLIService {
         sslContextFactory.setKeyStorePassword(keyStorePassword);
         sslContextFactory.setKeyStoreType(keyStoreType);
         sslContextFactory.setKeyManagerFactoryAlgorithm(keyStoreAlgorithm);
+        String excludeCiphersuites = hiveConf.getVar(ConfVars.HIVE_SERVER2_SSL_HTTP_EXCLUDE_CIPHERSUITES).trim();
+        if (!excludeCiphersuites.trim().isEmpty()) {
+          Set<String> excludeCS = Sets.newHashSet(
+                  Splitter.on(",").trimResults().omitEmptyStrings().split(excludeCiphersuites.trim()));
+          int eSize = excludeCS.size();
+          if (eSize > 0) {
+            sslContextFactory.setExcludeCipherSuites(excludeCS.toArray(new String[eSize]));
+          }
+        }
         connector = new ServerConnector(server, sslContextFactory, http);
       } else {
         connector = new ServerConnector(server, http);

--- a/service/src/java/org/apache/hive/service/server/HiveServer2.java
+++ b/service/src/java/org/apache/hive/service/server/HiveServer2.java
@@ -367,6 +367,8 @@ public class HiveServer2 extends CompositeService {
             builder.setKeyStoreType(hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_TYPE));
             builder.setKeyManagerFactoryAlgorithm(
                 hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYMANAGERFACTORY_ALGORITHM));
+            builder.setExcludeCiphersuites(
+                hiveConf.getVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES));
             builder.setUseSSL(true);
           }
           if (hiveConf.getBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_SPNEGO)) {

--- a/service/src/test/org/apache/hive/service/server/TestHS2HttpServerPamConfiguration.java
+++ b/service/src/test/org/apache/hive/service/server/TestHS2HttpServerPamConfiguration.java
@@ -53,6 +53,7 @@ public class TestHS2HttpServerPamConfiguration {
       System.getProperty("java.io.tmpdir") + File.separator + TestHS2HttpServerPam.class.getCanonicalName() + "-"
           + System.currentTimeMillis()).getPath().replaceAll("\\\\", "/");
   private static String sslKeyStorePath = testDataDir + File.separator + keyFileName;
+  private static String excludeSuites = "^.*_(MD5|SHA1)$,^TLS_RSA_.*$,^SSL_.*$,^.*_NULL_.*$,^.*_anon_.*$";
 
 
   @BeforeClass
@@ -90,6 +91,7 @@ public class TestHS2HttpServerPamConfiguration {
     hiveConf.setBoolVar(ConfVars.HIVE_SERVER2_WEBUI_USE_SSL, true);
     hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_PATH, sslKeyStorePath);
     hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_PASSWORD, keyStorePassword);
+    hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES, excludeSuites);
     hiveServer2 = new HiveServer2();
     hiveServer2.init(hiveConf);
   }
@@ -101,6 +103,7 @@ public class TestHS2HttpServerPamConfiguration {
     hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_PATH, sslKeyStorePath);
     hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_PASSWORD, keyStorePassword);
     hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_KEYSTORE_TYPE, keyStoreType);
+    hiveConf.setVar(ConfVars.HIVE_SERVER2_WEBUI_SSL_EXCLUDE_CIPHERSUITES, excludeSuites);
     hiveServer2 = new HiveServer2();
     hiveServer2.init(hiveConf);
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?
When starting a jetty http server, one can explicitly exclude certain (unsecure)
SSL cipher suites. This can be especially important, when Hive
needs to be compliant with security regulations. Need add properties to support Hive WebUi and HiveServer2 to this
For Hive Binary Cli Server, we can set include certain SSL cipher suites.

### Does this PR introduce _any_ user-facing change?
Yes, need to document the new properties:
hive.server2.binary.include.ciphersuites
hive.server2.http.exclude.ciphersuites
hive.server2.webui.exclude.ciphersuites


### How was this patch tested?
Unit tests