### PR TITLE
HIVE-25240: Query Text based MaterializedView rewrite of subqueries

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1894,6 +1894,9 @@ public class HiveConf extends Configuration {
     HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SQL("hive.materializedview.rewriting.sql", true,
         "Whether to try to rewrite queries using the materialized views enabled for rewriting by comparing the sql " +
                 "query text with the materialized views query text"),
+    HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SUBQUERY_SQL("hive.materializedview.rewriting.sql.subquery", true,
+        "Whether to try to rewrite sub-queries using the materialized views enabled for rewriting by comparing the sql " +
+                "sub-query text with the materialized views query text"),
     HIVE_MATERIALIZED_VIEW_REWRITING_SELECTION_STRATEGY("hive.materializedview.rewriting.strategy", "heuristic",
         new StringSet("heuristic", "costbased"),
         "The strategy that should be used to cost and select the materialized view rewriting. \n" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/Context.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/Context.java
@@ -362,7 +362,8 @@ public class Context {
     // identifiers) to the stored Materialized view query definitions. We have to enable unparsing for generating
     // the extended query text when auto rewriting is enabled.
     enableUnparse =
-        HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SQL);
+        HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SQL) ||
+        HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SUBQUERY_SQL);
     scheduledQuery = false;
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -186,7 +186,7 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
     public MVRebuildCalcitePlannerAction(Map<String, PrunedPartitionList> partitionCache,
                                          StatsSource statsSource,
                                          ColumnAccessInfo columnAccessInfo) {
-      super(partitionCache, statsSource, columnAccessInfo);
+      super(partitionCache, statsSource, columnAccessInfo, getQB());
     }
 
     @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveRelOptMaterialization.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveMaterializedV
 
 import java.util.EnumSet;
 import java.util.List;
+import java.util.function.Predicate;
 
 import static org.apache.commons.collections.CollectionUtils.intersection;
 
@@ -50,6 +51,10 @@ public class HiveRelOptMaterialization extends RelOptMaterialization {
 
     public static final EnumSet<RewriteAlgorithm> ALL = EnumSet.allOf(RewriteAlgorithm.class);
 
+    public static final Predicate<EnumSet<RewriteAlgorithm>> ANY =
+            rewriteAlgorithms -> true;
+    public static final Predicate<EnumSet<RewriteAlgorithm>> NON_CALCITE =
+            rewriteAlgorithms -> !rewriteAlgorithms.contains(HiveRelOptMaterialization.RewriteAlgorithm.CALCITE);
   }
 
   public enum IncrementalRebuildMode {

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveFilter.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/reloperators/HiveFilter.java
@@ -23,6 +23,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelShuttle;
 import org.apache.calcite.rel.core.Filter;
 import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexCorrelVariable;
@@ -99,9 +100,13 @@ public class HiveFilter extends Filter implements HiveRelNode {
   // Note that correlated variables are supported in Filter only i.e. Where & Having
   private static void traverseFilter(RexNode node, Set<CorrelationId> allVars) {
       if(node instanceof RexSubQuery) {
+          RexSubQuery rexSubQuery = (RexSubQuery) node;
           //we expect correlated variables in HiveFilter only for now.
           // Also check for case where operator has 0 inputs .e.g TableScan
-          RelNode input = ((RexSubQuery)node).rel.getInput(0);
+          if (rexSubQuery.rel.getInputs().isEmpty()) {
+            return;
+          }
+          RelNode input = rexSubQuery.rel.getInput(0);
           while(input != null && !(input instanceof HiveFilter)
                   && input.getInputs().size() >=1) {
               //we don't expect corr vars within UNION for now

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3419,7 +3419,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
             QB qbSQ = new QB(qb.getId(), sbQueryAlias, true);
             qbSQ.setInsideView(qb.isInsideView());
             Phase1Ctx ctx1 = initPhase1Ctx();
-            ASTNode subQueryRoot = (ASTNode) node.getChild(1);
+            ASTNode subQueryRoot = (ASTNode) next.getChild(1);
             doPhase1(subQueryRoot, qbSQ, ctx1, null);
             getMetaData(qbSQ);
             this.subqueryId++;

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -1347,7 +1347,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
           Map<String, PrunedPartitionList> partitionCache,
           StatsSource statsSource,
           ColumnAccessInfo columnAccessInfo) {
-    return new CalcitePlannerAction(partitionCache, statsSource, columnAccessInfo);
+    return new CalcitePlannerAction(partitionCache, statsSource, columnAccessInfo, getQB());
   }
 
   /**
@@ -1588,6 +1588,7 @@ public class CalcitePlanner extends SemanticAnalyzer {
     private final Map<String, ColumnStatsList>            colStatsCache;
     private final ColumnAccessInfo columnAccessInfo;
     private Map<HiveProject, Table> viewProjectToTableSchema;
+    private final QB rootQB;
 
     // correlated vars across subqueries within same query needs to have different ID
     private int subqueryId;
@@ -1603,11 +1604,12 @@ public class CalcitePlanner extends SemanticAnalyzer {
     private final StatsSource statsSource;
 
     protected CalcitePlannerAction(
-        Map<String, PrunedPartitionList> partitionCache,
-        StatsSource statsSource,
-        ColumnAccessInfo columnAccessInfo) {
+            Map<String, PrunedPartitionList> partitionCache,
+            StatsSource statsSource,
+            ColumnAccessInfo columnAccessInfo, QB rootQB) {
       this.partitionCache = partitionCache;
       this.statsSource = statsSource;
+      this.rootQB = rootQB;
       this.colStatsCache = ctx.getOpContext().getColStatsCache();
       this.columnAccessInfo = columnAccessInfo;
     }
@@ -1647,11 +1649,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
         LOG.debug("Initial CBO Plan:\n" + RelOptUtil.toString(calcitePlan));
       }
 
-      if (isMaterializedViewRewritingByTextEnabled()) {
-        RelNode rewrittenPlan = applyMaterializedViewRewritingByText(calcitePlan, optCluster);
-        if (rewrittenPlan != null) {
-          return rewrittenPlan;
-        }
+      RelNode rewrittenPlan = applyMaterializedViewRewritingByText(ast, calcitePlan, optCluster);
+      if (rewrittenPlan != null) {
+        return rewrittenPlan;
       }
 
       // Create executor
@@ -2065,15 +2065,27 @@ public class CalcitePlanner extends SemanticAnalyzer {
     private boolean isMaterializedViewRewritingByTextEnabled() {
       return conf.getBoolVar(ConfVars.HIVE_MATERIALIZED_VIEW_ENABLE_AUTO_REWRITING_SQL) &&
               mvRebuildMode == MaterializationRebuildMode.NONE &&
-              !getQB().isMaterializedView() && !ctx.isLoadingMaterializedView() && !getQB().isCTAS() &&
-              getQB().getIsQuery() &&
-              getQB().hasTableDefined();
+              !rootQB.isMaterializedView() && !ctx.isLoadingMaterializedView() && !rootQB.isCTAS() &&
+              rootQB.getIsQuery() &&
+              rootQB.hasTableDefined();
     }
 
-    private RelNode applyMaterializedViewRewritingByText(RelNode calciteGenPlan, RelOptCluster optCluster) {
+    private RelNode applyMaterializedViewRewritingByText(
+            ASTNode queryToRewrite, RelNode calciteGenPlan, RelOptCluster optCluster) {
+      if (!isMaterializedViewRewritingByTextEnabled()) {
+        return null;
+      }
+
       unparseTranslator.applyTranslations(ctx.getTokenRewriteStream(), EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM);
-      String expandedQueryText = ctx.getTokenRewriteStream()
-              .toString(EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM, ast.getTokenStartIndex(), ast.getTokenStopIndex());
+      String expandedQueryText = ctx.getTokenRewriteStream().toString(
+              EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM,
+              queryToRewrite.getTokenStartIndex(),
+              queryToRewrite.getTokenStopIndex());
+      return getMaterializedViewByQueryText(expandedQueryText, calciteGenPlan, optCluster);
+    }
+
+    private RelNode getMaterializedViewByQueryText(
+            String expandedQueryText, RelNode calciteGenPlan, RelOptCluster optCluster) {
       try {
         List<HiveRelOptMaterialization> relOptMaterializationList = db.getMaterializedViewsBySql(
                 expandedQueryText, getTablesUsed(calciteGenPlan), getTxnMgr());
@@ -3394,11 +3406,26 @@ public class CalcitePlanner extends SemanticAnalyzer {
             QB qbSQ = new QB(qb.getId(), sbQueryAlias, true);
             qbSQ.setInsideView(qb.isInsideView());
             Phase1Ctx ctx1 = initPhase1Ctx();
-            doPhase1((ASTNode) next.getChild(1), qbSQ, ctx1, null);
+            ASTNode subQueryRoot = (ASTNode) node.getChild(1);
+            doPhase1(subQueryRoot, qbSQ, ctx1, null);
             getMetaData(qbSQ);
             this.subqueryId++;
             RelNode subQueryRelNode =
                 genLogicalPlan(qbSQ, false, relToHiveColNameCalcitePosMap.get(srcRel), relToHiveRR.get(srcRel));
+
+            if (isMaterializedViewRewritingByTextEnabled()) {
+              unparseTranslator.applyTranslations(ctx.getTokenRewriteStream(), EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM);
+              String expandedSubQueryText = ctx.getTokenRewriteStream()
+                      .toString(EXPANDED_QUERY_TOKEN_REWRITE_PROGRAM, subQueryRoot.getTokenStartIndex(), subQueryRoot.getTokenStopIndex());
+
+              expandedSubQueryText = expandedSubQueryText.substring(1, expandedSubQueryText.length() - 1).trim();
+
+              RelNode mv = getMaterializedViewByQueryText(expandedSubQueryText, subQueryRelNode, cluster);
+              if (mv != null) {
+                subQueryRelNode = mv;
+              }
+            }
+
             subQueryToRelNode.put(next, parseInfo.setSubQueryRelNode(subQueryRelNode));
             //keep track of subqueries which are scalar, correlated and contains aggregate
             // subquery expression. This will later be special cased in Subquery remove rule
@@ -4973,6 +5000,19 @@ public class CalcitePlanner extends SemanticAnalyzer {
       for (String subqAlias : qb.getSubqAliases()) {
         QBExpr qbexpr = qb.getSubqForAlias(subqAlias);
         RelNode relNode = genLogicalPlan(qbexpr);
+
+        ASTNode subqueryRoot = qbexpr.getSubQueryRoot();
+        if (subqueryRoot != null) {
+          RelNode mv = applyMaterializedViewRewritingByText(subqueryRoot, relNode, cluster);
+          if (mv != null) {
+            RowResolver rr = relToHiveRR.remove(relNode);
+            relToHiveRR.put(mv, rr);
+            ImmutableMap<String, Integer> tmp = relToHiveColNameCalcitePosMap.remove(relNode);
+            relToHiveColNameCalcitePosMap.put(mv, tmp);
+            relNode = mv;
+          }
+        }
+
         aliasToRel.put(subqAlias, relNode);
         if (qb.getViewToTabSchema().containsKey(subqAlias)) {
           if (relNode instanceof HiveProject) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/CalcitePlanner.java
@@ -3432,7 +3432,9 @@ public class CalcitePlanner extends SemanticAnalyzer {
                       subQueryRoot.getTokenStartIndex(),
                       subQueryRoot.getTokenStopIndex());
 
-              expandedSubQueryText = expandedSubQueryText.substring(1, expandedSubQueryText.length() - 1).trim();
+              if (expandedSubQueryText.length() >= 2) {
+                expandedSubQueryText = expandedSubQueryText.substring(1, expandedSubQueryText.length() - 1).trim();
+              }
 
               RelNode mv = getMaterializedViewByQueryText(expandedSubQueryText, subQueryRelNode, cluster, NON_CALCITE);
               if (mv != null) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/QBExpr.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/QBExpr.java
@@ -44,6 +44,7 @@ public class QBExpr {
   private QBExpr qbexpr2;
   private QB qb;
   private String alias;
+  private ASTNode subQueryRoot;
 
   public String getAlias() {
     return alias;
@@ -54,7 +55,12 @@ public class QBExpr {
   }
 
   public QBExpr(String alias) {
+    this(alias, null);
+  }
+
+  public QBExpr(String alias, ASTNode subQueryRoot) {
     setAlias(alias);
+    this.subQueryRoot = subQueryRoot;
   }
 
   public QBExpr(QB qb) {
@@ -98,6 +104,10 @@ public class QBExpr {
 
   public QBExpr getQBExpr2() {
     return qbexpr2;
+  }
+
+  public ASTNode getSubQueryRoot() {
+    return subQueryRoot;
   }
 
   public void print(String msg) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -1230,7 +1230,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
     String alias = unescapeIdentifier(subq.getChild(1).getText());
 
     // Recursively do the first phase of semantic analysis for the subquery
-    QBExpr qbexpr = new QBExpr(alias);
+    QBExpr qbexpr = new QBExpr(alias, subqref);
 
     doPhase1QBExpr(subqref, qbexpr, qb.getId(), alias, qb.isInsideView(), null);
 

--- a/ql/src/test/queries/clientpositive/masking_mv_by_text_2.q
+++ b/ql/src/test/queries/clientpositive/masking_mv_by_text_2.q
@@ -1,0 +1,33 @@
+--! qt:dataset:srcpart
+--! qt:dataset:src
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.mapred.mode=nonstrict;
+set hive.security.authorization.enabled=true;
+set hive.security.authorization.manager=org.apache.hadoop.hive.ql.security.authorization.plugin.sqlstd.SQLStdHiveAuthorizerFactoryForTest;
+set hive.materializedview.rewriting=false;
+
+
+create table `masking_test_n_mv` stored as orc TBLPROPERTIES ('transactional'='true') as
+select cast(key as int) as key, value from src;
+
+create materialized view `masking_test_view_n_mv` as
+select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`;
+
+-- Masking/filtering is added when query is rewritten -> no exact sql text matches -> mv is not used.
+explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub;
+
+
+create materialized view `masking_test_view_n_mv_masked` as
+select cast(key as string) `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv` union select `value` `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv`;
+
+-- This will use the MV `masking_test_view_n_mv_masked` because it already has the required masking/filtering for the following query
+explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub;
+
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub;
+
+drop materialized view `masking_test_view_n_mv`;
+drop materialized view `masking_test_view_n_mv_masked`;
+drop table `masking_test_n_mv`;

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_6.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_6.q
@@ -1,0 +1,25 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.materializedview.rewriting=false;
+
+create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true');
+
+create table t2(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true');
+
+insert into t1(col0) values (1), (NULL);
+insert into t2(col0) values (1), (2), (3), (NULL);
+
+create materialized view mat1 as
+select col0 from t1 where col0 = 1;
+
+explain cbo
+select col0 from t2 where exists (
+ select col0 from t1 where col0 = 1);
+
+explain cbo
+select col0 from t2 where col0 in (
+ select col0 from t1 where col0 = 1);
+
+drop materialized view mat1;

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_6.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_6.q
@@ -12,14 +12,20 @@ insert into t1(col0) values (1), (NULL);
 insert into t2(col0) values (1), (2), (3), (NULL);
 
 create materialized view mat1 as
-select col0 from t1 where col0 = 1;
+select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2;
+
+create materialized view mat2 as
+select col0 from t1 where col0 = 3;
 
 explain cbo
 select col0 from t2 where exists (
- select col0 from t1 where col0 = 1);
+ select col0 from t1 where col0 = 3);
 
 explain cbo
-select col0 from t2 where col0 in (
- select col0 from t1 where col0 = 1);
+select col0 from t2 where exists (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2);
+
+explain cbo
+select col0 from t2 where col0 in (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2);
 
 drop materialized view mat1;
+drop materialized view mat2;

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_7.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_7.q
@@ -6,11 +6,20 @@ create table t1(col0 int) STORED AS ORC
                           TBLPROPERTIES ('transactional'='true');
 
 create materialized view mat1 as
-select col0 from t1 where col0 > 1;
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20;
+
+create materialized view mat2 as
+select col0 from t1 where col0 > 30;
 
 explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 > 30) sub
+where col0 = 10;
+
+explain cbo
+select col0 from
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 = 10;
 
 drop materialized view mat1;
+drop materialized view mat2;

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_7.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_7.q
@@ -1,0 +1,16 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.materializedview.rewriting=false;
+
+create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true');
+
+create materialized view mat1 as
+select col0 from t1 where col0 > 1;
+
+explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 = 10;
+
+drop materialized view mat1;

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_8.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_8.q
@@ -6,45 +6,43 @@ create table t1(col0 int) STORED AS ORC
                           TBLPROPERTIES ('transactional'='true');
 
 create materialized view mat1 as
-select col0 from t1 where col0 > 1;
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20;
 
+-- create MV mat2 contains mat1 definiton as subquery, no rewrite
 create materialized view mat2 as
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100;
 
+-- rewrite to scan mat2
 explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100;
 
+-- rewrite subquery sub2 to scan mat2
 explain cbo
 select col0 from (
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 ) sub2
 where col0 = 10;
 
+-- rewrite subquery sub to scan mat1, can not rewrite to scan mat2 because indentation does not match
 explain cbo
 select col0 from (
     select col0 from
-      (select col0 from t1 where col0 > 1) sub
+      (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
     where col0 < 100
 ) sub2
 where col0 = 10;
 
-explain cbo
-select col0 from t1 where col0 in (
-select col0 from
-  (select col0 from t1 where col0 > 1) sub
-where col0 < 100
-);
-
+-- rewrite subquery sub2 to scan mat2
 explain cbo
 select col0 from t1 where col0 in (
   select col0 from
-    (select col0 from t1 where col0 > 1) sub
+    (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 );
 

--- a/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_8.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_rewrite_by_text_8.q
@@ -1,0 +1,52 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.materializedview.rewriting=false;
+
+create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true');
+
+create materialized view mat1 as
+select col0 from t1 where col0 > 1;
+
+create materialized view mat2 as
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100;
+
+explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100;
+
+explain cbo
+select col0 from (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+) sub2
+where col0 = 10;
+
+explain cbo
+select col0 from (
+    select col0 from
+      (select col0 from t1 where col0 > 1) sub
+    where col0 < 100
+) sub2
+where col0 = 10;
+
+explain cbo
+select col0 from t1 where col0 in (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+);
+
+explain cbo
+select col0 from t1 where col0 in (
+  select col0 from
+    (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+);
+
+drop materialized view mat2;
+drop materialized view mat1;

--- a/ql/src/test/results/clientpositive/llap/masking_mv_by_text_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_mv_by_text_2.q.out
@@ -1,0 +1,124 @@
+PREHOOK: query: create table `masking_test_n_mv` stored as orc TBLPROPERTIES ('transactional'='true') as
+select cast(key as int) as key, value from src
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: default@src
+PREHOOK: Output: database:default
+PREHOOK: Output: default@masking_test_n_mv
+POSTHOOK: query: create table `masking_test_n_mv` stored as orc TBLPROPERTIES ('transactional'='true') as
+select cast(key as int) as key, value from src
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: default@src
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@masking_test_n_mv
+POSTHOOK: Lineage: masking_test_n_mv.key EXPRESSION [(src)src.FieldSchema(name:key, type:string, comment:default), ]
+POSTHOOK: Lineage: masking_test_n_mv.value SIMPLE [(src)src.FieldSchema(name:value, type:string, comment:default), ]
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
+PREHOOK: query: create materialized view `masking_test_view_n_mv` as
+select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Output: database:default
+PREHOOK: Output: default@masking_test_view_n_mv
+POSTHOOK: query: create materialized view `masking_test_view_n_mv` as
+select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@masking_test_view_n_mv
+PREHOOK: query: explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+PREHOOK: type: QUERY
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Input: default@masking_test_view_n_mv
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Input: default@masking_test_view_n_mv
+#### A masked pattern was here ####
+CBO PLAN:
+HiveAggregate(group=[{0}])
+  HiveProject(col0=[$0])
+    HiveUnion(all=[true])
+      HiveProject(col0=[CAST($0):VARCHAR(2147483647) CHARACTER SET "UTF-16LE"])
+        HiveFilter(condition=[AND(<($0, 10), =(MOD($0, 2), 0))])
+          HiveTableScan(table=[[default, masking_test_n_mv]], table:alias=[masking_test_n_mv])
+      HiveProject(value=[reverse($1)])
+        HiveFilter(condition=[AND(<($0, 10), =(MOD($0, 2), 0))])
+          HiveTableScan(table=[[default, masking_test_n_mv]], table:alias=[masking_test_n_mv])
+
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
+PREHOOK: query: create materialized view `masking_test_view_n_mv_masked` as
+select cast(key as string) `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv` union select `value` `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv`
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Output: database:default
+PREHOOK: Output: default@masking_test_view_n_mv_masked
+POSTHOOK: query: create materialized view `masking_test_view_n_mv_masked` as
+select cast(key as string) `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv` union select `value` `col0` from (SELECT `key`, CAST(reverse(value) AS string) AS `value`, BLOCK__OFFSET__INSIDE__FILE, INPUT__FILE__NAME, ROW__ID, ROW__IS__DELETED FROM `default`.`masking_test_n_mv`  WHERE key % 2 = 0 and key < 10)`masking_test_n_mv`
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@masking_test_view_n_mv_masked
+PREHOOK: query: explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+PREHOOK: type: QUERY
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Input: default@masking_test_view_n_mv
+PREHOOK: Input: default@masking_test_view_n_mv_masked
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Input: default@masking_test_view_n_mv
+POSTHOOK: Input: default@masking_test_view_n_mv_masked
+#### A masked pattern was here ####
+CBO PLAN:
+HiveTableScan(table=[[default, masking_test_view_n_mv_masked]], table:alias=[default.masking_test_view_n_mv_masked])
+
+PREHOOK: query: select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+PREHOOK: type: QUERY
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Input: default@masking_test_view_n_mv
+PREHOOK: Input: default@masking_test_view_n_mv_masked
+#### A masked pattern was here ####
+POSTHOOK: query: select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Input: default@masking_test_view_n_mv
+POSTHOOK: Input: default@masking_test_view_n_mv_masked
+#### A masked pattern was here ####
+2_lav
+4
+4_lav
+0
+0_lav
+2
+8
+8_lav
+PREHOOK: query: drop materialized view `masking_test_view_n_mv`
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@masking_test_view_n_mv
+PREHOOK: Output: default@masking_test_view_n_mv
+POSTHOOK: query: drop materialized view `masking_test_view_n_mv`
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@masking_test_view_n_mv
+POSTHOOK: Output: default@masking_test_view_n_mv
+PREHOOK: query: drop materialized view `masking_test_view_n_mv_masked`
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@masking_test_view_n_mv_masked
+PREHOOK: Output: default@masking_test_view_n_mv_masked
+POSTHOOK: query: drop materialized view `masking_test_view_n_mv_masked`
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@masking_test_view_n_mv_masked
+POSTHOOK: Output: default@masking_test_view_n_mv_masked
+PREHOOK: query: drop table `masking_test_n_mv`
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@masking_test_n_mv
+PREHOOK: Output: default@masking_test_n_mv
+POSTHOOK: query: drop table `masking_test_n_mv`
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@masking_test_n_mv
+POSTHOOK: Output: default@masking_test_n_mv

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
@@ -1,0 +1,109 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: create table t2(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t2
+POSTHOOK: query: create table t2(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t2
+PREHOOK: query: insert into t1(col0) values (1), (NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: insert into t1(col0) values (1), (NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.col0 SCRIPT []
+PREHOOK: query: insert into t2(col0) values (1), (2), (3), (NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t2
+POSTHOOK: query: insert into t2(col0) values (1), (2), (3), (NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t2
+POSTHOOK: Lineage: t2.col0 SCRIPT []
+PREHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 = 1
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+POSTHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 = 1
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain cbo
+select col0 from t2 where exists (
+ select col0 from t1 where col0 = 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from t2 where exists (
+ select col0 from t1 where col0 = 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[true], joinType=[semi])
+  HiveProject(col0=[$0])
+    HiveTableScan(table=[[default, t2]], table:alias=[t2])
+  HiveProject($f0=[$0])
+    HiveAggregate(group=[{0}])
+      HiveProject($f0=[true])
+        HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: explain cbo
+select col0 from t2 where col0 in (
+ select col0 from t1 where col0 = 1)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from t2 where col0 in (
+ select col0 from t1 where col0 = 1)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $1)], joinType=[semi])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, t2]], table:alias=[t2])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: drop materialized view mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: drop materialized view mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
@@ -36,30 +36,66 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t2
 POSTHOOK: Lineage: t2.col0 SCRIPT []
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
 PREHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 = 1
+select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@t1
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
 POSTHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 = 1
+select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
-Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: create materialized view mat2 as
+select col0 from t1 where col0 = 3
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat2
+POSTHOOK: query: create materialized view mat2 as
+select col0 from t1 where col0 = 3
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat2
+Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain cbo
 select col0 from t2 where exists (
- select col0 from t1 where col0 = 1)
+ select col0 from t1 where col0 = 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Input: default@t2
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from t2 where exists (
+ select col0 from t1 where col0 = 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Input: default@t2
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[true], joinType=[semi])
+  HiveProject(col0=[$0])
+    HiveTableScan(table=[[default, t2]], table:alias=[t2])
+  HiveProject($f0=[$0])
+    HiveAggregate(group=[{0}])
+      HiveProject($f0=[true])
+        HiveFilter(condition=[=($0, 3)])
+          HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+Warning: Shuffle Join MERGEJOIN[14][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
+PREHOOK: query: explain cbo
+select col0 from t2 where exists (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@t1
 PREHOOK: Input: default@t2
 #### A masked pattern was here ####
 POSTHOOK: query: explain cbo
-select col0 from t2 where exists (
- select col0 from t1 where col0 = 1)
+select col0 from t2 where exists (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@t1
@@ -75,16 +111,14 @@ HiveSemiJoin(condition=[true], joinType=[semi])
         HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
 
 PREHOOK: query: explain cbo
-select col0 from t2 where col0 in (
- select col0 from t1 where col0 = 1)
+select col0 from t2 where col0 in (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2)
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@t1
 PREHOOK: Input: default@t2
 #### A masked pattern was here ####
 POSTHOOK: query: explain cbo
-select col0 from t2 where col0 in (
- select col0 from t1 where col0 = 1)
+select col0 from t2 where col0 in (select col0 from t1 where col0 = 1 union select col0 from t1 where col0 = 2)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@t1
@@ -107,3 +141,11 @@ POSTHOOK: query: drop materialized view mat1
 POSTHOOK: type: DROP_MATERIALIZED_VIEW
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: default@mat1
+PREHOOK: query: drop materialized view mat2
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat2
+PREHOOK: Output: default@mat2
+POSTHOOK: query: drop materialized view mat2
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat2
+POSTHOOK: Output: default@mat2

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
@@ -8,21 +8,53 @@ POSTHOOK: query: create table t1(col0 int) STORED AS ORC
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
 PREHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 > 1
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@t1
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
 POSTHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 > 1
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
+PREHOOK: query: create materialized view mat2 as
+select col0 from t1 where col0 > 30
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat2
+POSTHOOK: query: create materialized view mat2 as
+select col0 from t1 where col0 > 30
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat2
 PREHOOK: query: explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 > 30) sub
+where col0 = 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 30) sub
+where col0 = 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSortLimit(fetch=[0])
+  HiveProject(col0=[$0])
+    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 = 10
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -30,7 +62,7 @@ PREHOOK: Input: default@t1
 #### A masked pattern was here ####
 POSTHOOK: query: explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 = 10
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
@@ -49,3 +81,11 @@ POSTHOOK: query: drop materialized view mat1
 POSTHOOK: type: DROP_MATERIALIZED_VIEW
 POSTHOOK: Input: default@mat1
 POSTHOOK: Output: default@mat1
+PREHOOK: query: drop materialized view mat2
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat2
+PREHOOK: Output: default@mat2
+POSTHOOK: query: drop materialized view mat2
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat2
+POSTHOOK: Output: default@mat2

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
@@ -1,0 +1,51 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 > 1
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+POSTHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 > 1
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+PREHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 = 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 = 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(col0=[CAST(10):INTEGER])
+  HiveFilter(condition=[=($0, 10)])
+    HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: drop materialized view mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: drop materialized view mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
@@ -1,0 +1,185 @@
+PREHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: create table t1(col0 int) STORED AS ORC
+                          TBLPROPERTIES ('transactional'='true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 > 1
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+POSTHOOK: query: create materialized view mat1 as
+select col0 from t1 where col0 > 1
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+PREHOOK: query: create materialized view mat2 as
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat2
+POSTHOOK: query: create materialized view mat2 as
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat2
+PREHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat2
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat2
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveTableScan(table=[[default, mat2]], table:alias=[default.mat2])
+
+PREHOOK: query: explain cbo
+select col0 from (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+) sub2
+where col0 = 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat2
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+) sub2
+where col0 = 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat2
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(col0=[CAST(10):INTEGER])
+  HiveFilter(condition=[=($0, 10)])
+    HiveTableScan(table=[[default, mat2]], table:alias=[default.mat2])
+
+PREHOOK: query: explain cbo
+select col0 from (
+    select col0 from
+      (select col0 from t1 where col0 > 1) sub
+    where col0 < 100
+) sub2
+where col0 = 10
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from (
+    select col0 from
+      (select col0 from t1 where col0 > 1) sub
+    where col0 < 100
+) sub2
+where col0 = 10
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveProject(col0=[CAST(10):INTEGER])
+  HiveFilter(condition=[=($0, 10)])
+    HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: explain cbo
+select col0 from t1 where col0 in (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat2
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from t1 where col0 in (
+select col0 from
+  (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat2
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $1)], joinType=[semi])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[IS NOT NULL($0)])
+      HiveTableScan(table=[[default, mat2]], table:alias=[default.mat2])
+
+PREHOOK: query: explain cbo
+select col0 from t1 where col0 in (
+  select col0 from
+    (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: explain cbo
+select col0 from t1 where col0 in (
+  select col0 from
+    (select col0 from t1 where col0 > 1) sub
+where col0 < 100
+)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+CBO PLAN:
+HiveSemiJoin(condition=[=($0, $1)], joinType=[semi])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[<($0, 100)])
+      HiveTableScan(table=[[default, t1]], table:alias=[t1])
+  HiveProject(col0=[$0])
+    HiveFilter(condition=[<($0, 100)])
+      HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: drop materialized view mat2
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat2
+PREHOOK: Output: default@mat2
+POSTHOOK: query: drop materialized view mat2
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat2
+POSTHOOK: Output: default@mat2
+PREHOOK: query: drop materialized view mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: drop materialized view mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
@@ -8,21 +8,23 @@ POSTHOOK: query: create table t1(col0 int) STORED AS ORC
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@t1
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
 PREHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 > 1
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@t1
 PREHOOK: Output: database:default
 PREHOOK: Output: default@mat1
 POSTHOOK: query: create materialized view mat1 as
-select col0 from t1 where col0 > 1
+select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
+Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
 PREHOOK: query: create materialized view mat2 as
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
 PREHOOK: Input: default@t1
@@ -30,7 +32,7 @@ PREHOOK: Output: database:default
 PREHOOK: Output: default@mat2
 POSTHOOK: query: create materialized view mat2 as
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
@@ -38,7 +40,7 @@ POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat2
 PREHOOK: query: explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat2
@@ -46,7 +48,7 @@ PREHOOK: Input: default@t1
 #### A masked pattern was here ####
 POSTHOOK: query: explain cbo
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat2
@@ -58,7 +60,7 @@ HiveTableScan(table=[[default, mat2]], table:alias=[default.mat2])
 PREHOOK: query: explain cbo
 select col0 from (
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 ) sub2
 where col0 = 10
@@ -69,7 +71,7 @@ PREHOOK: Input: default@t1
 POSTHOOK: query: explain cbo
 select col0 from (
 select col0 from
-  (select col0 from t1 where col0 > 1) sub
+  (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 ) sub2
 where col0 = 10
@@ -85,7 +87,7 @@ HiveProject(col0=[CAST(10):INTEGER])
 PREHOOK: query: explain cbo
 select col0 from (
     select col0 from
-      (select col0 from t1 where col0 > 1) sub
+      (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
     where col0 < 100
 ) sub2
 where col0 = 10
@@ -96,7 +98,7 @@ PREHOOK: Input: default@t1
 POSTHOOK: query: explain cbo
 select col0 from (
     select col0 from
-      (select col0 from t1 where col0 > 1) sub
+      (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
     where col0 < 100
 ) sub2
 where col0 = 10
@@ -111,37 +113,8 @@ HiveProject(col0=[CAST(10):INTEGER])
 
 PREHOOK: query: explain cbo
 select col0 from t1 where col0 in (
-select col0 from
-  (select col0 from t1 where col0 > 1) sub
-where col0 < 100
-)
-PREHOOK: type: QUERY
-PREHOOK: Input: default@mat2
-PREHOOK: Input: default@t1
-#### A masked pattern was here ####
-POSTHOOK: query: explain cbo
-select col0 from t1 where col0 in (
-select col0 from
-  (select col0 from t1 where col0 > 1) sub
-where col0 < 100
-)
-POSTHOOK: type: QUERY
-POSTHOOK: Input: default@mat2
-POSTHOOK: Input: default@t1
-#### A masked pattern was here ####
-CBO PLAN:
-HiveSemiJoin(condition=[=($0, $1)], joinType=[semi])
-  HiveProject(col0=[$0])
-    HiveFilter(condition=[IS NOT NULL($0)])
-      HiveTableScan(table=[[default, t1]], table:alias=[t1])
-  HiveProject(col0=[$0])
-    HiveFilter(condition=[IS NOT NULL($0)])
-      HiveTableScan(table=[[default, mat2]], table:alias=[default.mat2])
-
-PREHOOK: query: explain cbo
-select col0 from t1 where col0 in (
   select col0 from
-    (select col0 from t1 where col0 > 1) sub
+    (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 )
 PREHOOK: type: QUERY
@@ -151,7 +124,7 @@ PREHOOK: Input: default@t1
 POSTHOOK: query: explain cbo
 select col0 from t1 where col0 in (
   select col0 from
-    (select col0 from t1 where col0 > 1) sub
+    (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub
 where col0 < 100
 )
 POSTHOOK: type: QUERY


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Generate expanded query text of subqueries and use it to lookup materializations.
2. If materialization exists replace the subquery Calcite plan with materialized view scan.

### Why are the changes needed?
Improve query text based materialized view query rewrite.

### Does this PR introduce _any_ user-facing change?
Yes. `Explain` and `Explain cbo` output can change.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_rewrite_by_text_8.q,materialized_view_rewrite_by_text_7.q,materialized_view_rewrite_by_text_6.q -pl itests/qtest -Pitests
```
