### PR TITLE
HIVE-25242. Query performs extremely slow with vectorized.adaptor = chosen

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizationContext.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/VectorizationContext.java
@@ -1462,9 +1462,12 @@ import com.google.common.annotations.VisibleForTesting;
                    || arg0Type(expr).equals("double")
                    || arg0Type(expr).equals("float"))) {
       return true;
-    } else {
-      return gudf instanceof GenericUDFBetween && (mode == VectorExpressionDescriptor.Mode.PROJECTION);
+    } else if (gudf instanceof GenericUDFBetween && (mode == VectorExpressionDescriptor.Mode.PROJECTION)) {
+      return true;
+    } else if (gudf instanceof GenericUDFConcat && (mode == VectorExpressionDescriptor.Mode.PROJECTION)) {
+      return true;
     }
+    return false;
   }
 
   public static boolean isCastToIntFamily(Class<? extends UDF> udfClass) {

--- a/ql/src/test/queries/clientpositive/vector_adaptor_usage_mode.q
+++ b/ql/src/test/queries/clientpositive/vector_adaptor_usage_mode.q
@@ -32,6 +32,10 @@ INSERT OVERWRITE TABLE DECIMAL_UDF_n1 SELECT * FROM DECIMAL_UDF_txt_n0;
 -- Add a single NULL row that will come from ORC as isRepeated.
 insert into DECIMAL_UDF_n1 values (NULL, NULL);
 
+-- concat vectorization
+drop table if exists tbl_dates;
+create table tbl_dates (year string, month string, day string);
+
 drop table if exists count_case_groupby;
 
 create table count_case_groupby (key string, bool boolean) STORED AS orc;
@@ -83,6 +87,9 @@ from varchar_udf_1_n0;
 
 
 set hive.vectorized.adaptor.usage.mode=chosen;
+
+explain vectorization expression
+select count(*) from tbl_dates where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01');
 
 explain vectorization expression
 select
@@ -182,6 +189,7 @@ drop table varchar_udf_1_n0;
 
 DROP TABLE DECIMAL_UDF_txt_n0;
 DROP TABLE DECIMAL_UDF_n1;
+DROP TABLE tbl_dates;
 
 drop table count_case_groupby;
 

--- a/ql/src/test/results/clientpositive/llap/vector_adaptor_usage_mode.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_adaptor_usage_mode.q.out
@@ -384,12 +384,12 @@ PREHOOK: query: explain vectorization expression
 select count(*) from tbl_dates where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01')
 PREHOOK: type: QUERY
 PREHOOK: Input: default@tbl_dates
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: explain vectorization expression
 select count(*) from tbl_dates where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@tbl_dates
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 PLAN VECTORIZATION:
   enabled: true
   enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
@@ -418,7 +418,7 @@ STAGE PLANS:
                     Filter Vectorization:
                         className: VectorFilterOperator
                         native: true
-                        predicateExpression: FilterLongColumnBetween(col 6:date, left 17866, right 18687)(children: VectorUDFDateTimestamp(col 5:timestamp)(children: CastStringToTimestamp(col 4:string)(children: VectorUDFAdaptor(concat(year, '-', month, '-', day)) -> 4:string) -> 5:timestamp) -> 6:date)
+                        predicateExpression: FilterLongColumnBetween(col 7:date, left 17866, right 18687)(children: VectorUDFDateTimestamp(col 6:timestamp)(children: CastStringToTimestamp(col 5:string)(children: VectorUDFAdaptor(concat(year, '-', month, '-', day)) -> 5:string) -> 6:timestamp) -> 7:date)
                     predicate: to_date(CAST( concat(year, '-', month, '-', day) AS TIMESTAMP)) BETWEEN DATE'2018-12-01' AND DATE'2021-03-01' (type: boolean)
                     Statistics: Num rows: 1 Data size: 552 Basic stats: COMPLETE Column stats: NONE
                     Select Operator

--- a/ql/src/test/results/clientpositive/llap/vector_adaptor_usage_mode.q.out
+++ b/ql/src/test/results/clientpositive/llap/vector_adaptor_usage_mode.q.out
@@ -96,6 +96,18 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@decimal_udf_n1
 POSTHOOK: Lineage: decimal_udf_n1.key EXPRESSION []
 POSTHOOK: Lineage: decimal_udf_n1.value EXPRESSION []
+PREHOOK: query: drop table if exists tbl_dates
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists tbl_dates
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create table tbl_dates (year string, month string, day string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@tbl_dates
+POSTHOOK: query: create table tbl_dates (year string, month string, day string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@tbl_dates
 PREHOOK: query: drop table if exists count_case_groupby
 PREHOOK: type: DROPTABLE
 POSTHOOK: query: drop table if exists count_case_groupby
@@ -368,6 +380,124 @@ POSTHOOK: Input: default@varchar_udf_1_n0
 #### A masked pattern was here ####
 NULL	NULL	NULL
 replaced_238	replaced_238	true
+PREHOOK: query: explain vectorization expression
+select count(*) from tbl_dates where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01')
+PREHOOK: type: QUERY
+PREHOOK: Input: default@tbl_dates
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: explain vectorization expression
+select count(*) from tbl_dates where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@tbl_dates
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PLAN VECTORIZATION:
+  enabled: true
+  enabledConditionsMet: [hive.vectorized.execution.enabled IS true]
+
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (CUSTOM_SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: tbl_dates
+                  filterExpr: to_date(CAST( concat(year, '-', month, '-', day) AS TIMESTAMP)) BETWEEN DATE'2018-12-01' AND DATE'2021-03-01' (type: boolean)
+                  Statistics: Num rows: 1 Data size: 552 Basic stats: COMPLETE Column stats: NONE
+                  TableScan Vectorization:
+                      native: true
+                  Filter Operator
+                    Filter Vectorization:
+                        className: VectorFilterOperator
+                        native: true
+                        predicateExpression: FilterLongColumnBetween(col 6:date, left 17866, right 18687)(children: VectorUDFDateTimestamp(col 5:timestamp)(children: CastStringToTimestamp(col 4:string)(children: VectorUDFAdaptor(concat(year, '-', month, '-', day)) -> 4:string) -> 5:timestamp) -> 6:date)
+                    predicate: to_date(CAST( concat(year, '-', month, '-', day) AS TIMESTAMP)) BETWEEN DATE'2018-12-01' AND DATE'2021-03-01' (type: boolean)
+                    Statistics: Num rows: 1 Data size: 552 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      Select Vectorization:
+                          className: VectorSelectOperator
+                          native: true
+                          projectedOutputColumnNums: []
+                      Statistics: Num rows: 1 Data size: 552 Basic stats: COMPLETE Column stats: NONE
+                      Group By Operator
+                        aggregations: count()
+                        Group By Vectorization:
+                            aggregators: VectorUDAFCountStar(*) -> bigint
+                            className: VectorGroupByOperator
+                            groupByMode: HASH
+                            native: false
+                            vectorProcessingMode: HASH
+                            projectedOutputColumnNums: [0]
+                        minReductionHashAggr: 0.99
+                        mode: hash
+                        outputColumnNames: _col0
+                        Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: NONE
+                        Reduce Output Operator
+                          null sort order: 
+                          sort order: 
+                          Reduce Sink Vectorization:
+                              className: VectorReduceSinkEmptyKeyOperator
+                              native: true
+                              nativeConditionsMet: hive.vectorized.execution.reducesink.new.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true, No PTF TopN IS true, No DISTINCT columns IS true, BinarySortableSerDe for keys IS true, LazyBinarySerDe for values IS true
+                          Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: NONE
+                          value expressions: _col0 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: all inputs
+            Map Vectorization:
+                enabled: true
+                enabledConditionsMet: hive.vectorized.use.vector.serde.deserialize IS true
+                inputFormatFeatureSupport: [DECIMAL_64]
+                featureSupportInUse: [DECIMAL_64]
+                inputFileFormats: org.apache.hadoop.mapred.TextInputFormat
+                allNative: false
+                usesVectorUDFAdaptor: true
+                vectorized: true
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Vectorization:
+                enabled: true
+                enableConditionsMet: hive.vectorized.execution.reduce.enabled IS true, hive.execution.engine tez IN [tez, spark] IS true
+                allNative: false
+                usesVectorUDFAdaptor: false
+                vectorized: true
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: count(VALUE._col0)
+                Group By Vectorization:
+                    aggregators: VectorUDAFCountMerge(col 0:bigint) -> bigint
+                    className: VectorGroupByOperator
+                    groupByMode: MERGEPARTIAL
+                    native: false
+                    vectorProcessingMode: GLOBAL
+                    projectedOutputColumnNums: [0]
+                mode: mergepartial
+                outputColumnNames: _col0
+                Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: NONE
+                File Output Operator
+                  compressed: false
+                  File Sink Vectorization:
+                      className: VectorFileSinkOperator
+                      native: false
+                  Statistics: Num rows: 1 Data size: 560 Basic stats: COMPLETE Column stats: NONE
+                  table:
+                      input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                      output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                      serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
 PREHOOK: query: explain vectorization expression
 select
   c2 regexp 'val',
@@ -1288,6 +1418,14 @@ POSTHOOK: query: DROP TABLE DECIMAL_UDF_n1
 POSTHOOK: type: DROPTABLE
 POSTHOOK: Input: default@decimal_udf_n1
 POSTHOOK: Output: default@decimal_udf_n1
+PREHOOK: query: DROP TABLE tbl_dates
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@tbl_dates
+PREHOOK: Output: default@tbl_dates
+POSTHOOK: query: DROP TABLE tbl_dates
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@tbl_dates
+POSTHOOK: Output: default@tbl_dates
 PREHOOK: query: drop table count_case_groupby
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@count_case_groupby


### PR DESCRIPTION
If hive.vectorized.adaptor.usage.mode is set to chosen only certain UDFS are vectorized through the vectorized adaptor.

Queries like this one, performs very slowly because the concat is not chosen to be vectorized.

```
select count(*) from tbl where to_date(concat(year, '-', month, '-', day)) between to_date('2018-12-01') and to_date('2021-03-01');  
```