### PR TITLE
HIVE-25243: Llap external client - Handle nested values when the parent struct is null

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniLlapVectorArrow.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniLlapVectorArrow.java
@@ -238,7 +238,10 @@ public class TestJdbcWithMiniLlapVectorArrow extends BaseJdbcWithMiniLlap {
     assertEquals(Date.valueOf("2013-01-01"), rowValues[19]);
     assertEquals("abc123", rowValues[20]);
     assertEquals("abc123         ", rowValues[21]);
-    assertArrayEquals("X'01FF'".getBytes("UTF-8"), (byte[]) rowValues[22]);
+
+    // one of the above assertions already has assertEquals(null, rowValues[22])
+    // and below assertion fails with - java.lang.AssertionError: actual array was null
+    // assertArrayEquals("X'01FF'".getBytes("UTF-8"), (byte[]) rowValues[22]);
   }
 
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniLlapVectorArrow.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestJdbcWithMiniLlapVectorArrow.java
@@ -239,9 +239,7 @@ public class TestJdbcWithMiniLlapVectorArrow extends BaseJdbcWithMiniLlap {
     assertEquals("abc123", rowValues[20]);
     assertEquals("abc123         ", rowValues[21]);
 
-    // one of the above assertions already has assertEquals(null, rowValues[22])
-    // and below assertion fails with - java.lang.AssertionError: actual array was null
-    // assertArrayEquals("X'01FF'".getBytes("UTF-8"), (byte[]) rowValues[22]);
+    assertArrayEquals("X'01FF'".getBytes("UTF-8"), (byte[]) rowValues[22]);
   }
 
 

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestMiniLlapVectorArrowWithLlapIODisabled.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestMiniLlapVectorArrowWithLlapIODisabled.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.jdbc;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.llap.LlapArrowRowInputFormat;
+import org.apache.hadoop.hive.llap.Row;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapred.InputFormat;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * TestMiniLlapVectorArrowWithLlapIODisabled - turns off llap io while testing LLAP external client flow.
+ * The aim of turning off LLAP IO is -
+ * when we create table through this test, LLAP caches them and returns the same
+ * when we do a read query, due to this we miss some code paths which may have been hit otherwise.
+ */
+public class TestMiniLlapVectorArrowWithLlapIODisabled extends BaseJdbcWithMiniLlap {
+
+  @BeforeClass
+  public static void beforeTest() throws Exception {
+    HiveConf conf = defaultConf();
+    conf.setBoolVar(ConfVars.LLAP_OUTPUT_FORMAT_ARROW, true);
+    conf.setBoolVar(ConfVars.HIVE_VECTORIZATION_FILESINK_ARROW_NATIVE_ENABLED, true);
+    conf.set(ConfVars.LLAP_IO_ENABLED.varname, "false");
+    BaseJdbcWithMiniLlap.beforeTest(conf);
+  }
+
+  @Override
+  protected InputFormat<NullWritable, Row> getInputFormat() {
+    //For unit testing, no harm in hard-coding allocator ceiling to LONG.MAX_VALUE
+    return new LlapArrowRowInputFormat(Long.MAX_VALUE);
+  }
+
+  @Test
+  public void testNullsInStructFields() throws Exception {
+    createDataTypesTable("datatypes");
+    RowCollector2 rowCollector = new RowCollector2();
+    // c8 struct<r:string,s:int,t:double>
+    String query = "select c8 from datatypes";
+    int rowCount = processQuery(query, 1, rowCollector);
+    assertEquals(3, rowCount);
+  }
+
+
+  @Override
+  @Ignore
+  public void testLlapInputFormatEndToEnd() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testMultipleBatchesOfComplexTypes() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testLlapInputFormatEndToEndWithMultipleBatches() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testInvalidReferenceCountScenario() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testNonAsciiStrings() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testEscapedStrings() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testDataTypes() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testComplexQuery() throws Exception {
+    // To be implemented
+  }
+
+  @Override
+  @Ignore
+  public void testKillQuery() throws Exception {
+    // To be implemented
+  }
+}
+

--- a/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestMiniLlapVectorArrowWithLlapIODisabled.java
+++ b/itests/hive-unit/src/test/java/org/apache/hive/jdbc/TestMiniLlapVectorArrowWithLlapIODisabled.java
@@ -58,11 +58,19 @@ public class TestMiniLlapVectorArrowWithLlapIODisabled extends BaseJdbcWithMiniL
     createDataTypesTable("datatypes");
     RowCollector2 rowCollector = new RowCollector2();
     // c8 struct<r:string,s:int,t:double>
-    String query = "select c8 from datatypes";
+    // c15 struct<r:int,s:struct<a:int,b:string>>
+    // c16 array<struct<m:map<string,string>,n:int>>
+    String query = "select c8, c15, c16 from datatypes";
     int rowCount = processQuery(query, 1, rowCollector);
     assertEquals(3, rowCount);
   }
 
+  @Override
+  public void testDataTypes() throws Exception {
+    // the test should be exactly identical to TestJdbcWithMiniLlapVectorArrow
+    TestJdbcWithMiniLlapVectorArrow testJdbcWithMiniLlapVectorArrow = new TestJdbcWithMiniLlapVectorArrow();
+    testJdbcWithMiniLlapVectorArrow.testDataTypes();
+  }
 
   @Override
   @Ignore
@@ -100,11 +108,6 @@ public class TestMiniLlapVectorArrowWithLlapIODisabled extends BaseJdbcWithMiniL
     // To be implemented
   }
 
-  @Override
-  @Ignore
-  public void testDataTypes() throws Exception {
-    // To be implemented
-  }
 
   @Override
   @Ignore

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
@@ -356,6 +356,7 @@ public class Serializer {
         if (hiveVector.isNull[i]) {
           for (ColumnVector fieldVector : hiveFieldVectors) {
             fieldVector.isNull[i] = true;
+            fieldVector.noNulls = false;
           }
         }
       }

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Serializer.java
@@ -347,6 +347,20 @@ public class Serializer {
     final ColumnVector[] hiveFieldVectors = hiveVector == null ? null : hiveVector.fields;
     final int fieldSize = fieldTypeInfos.size();
 
+    // This is to handle following scenario -
+    // if any struct value itself is NULL, we get structVector.isNull[i]=true
+    // but we don't get the same for it's child fields which later causes exceptions while setting to arrow vectors
+    // see - https://issues.apache.org/jira/browse/HIVE-25243
+    if (hiveVector != null && hiveFieldVectors != null) {
+      for (int i = 0; i < size; i++) {
+        if (hiveVector.isNull[i]) {
+          for (ColumnVector fieldVector : hiveFieldVectors) {
+            fieldVector.isNull[i] = true;
+          }
+        }
+      }
+    }
+
     for (int fieldIndex = 0; fieldIndex < fieldSize; fieldIndex++) {
       final TypeInfo fieldTypeInfo = fieldTypeInfos.get(fieldIndex);
       final ColumnVector hiveFieldVector = hiveVector == null ? null : hiveFieldVectors[fieldIndex];


### PR DESCRIPTION

### What changes were proposed in this pull request?
Handled the scenario mentioned in - https://issues.apache.org/jira/browse/HIVE-25243
If we get struct value as null, we set isNull[i] = true for all the fields of the struct as well.


### Why are the changes needed?
To avoid NPE in arrow serializer


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Created a new test for it - TestMiniLlapVectorArrowWithLlapIODisabled
