### PR TITLE
HIVE-24425: Create table in REMOTE db should fail

### DIFF
--- a/ql/src/test/queries/clientnegative/createTbl_remoteDB_fail.q
+++ b/ql/src/test/queries/clientnegative/createTbl_remoteDB_fail.q
@@ -1,0 +1,16 @@
+-- CREATE IF NOT EXISTS already
+CREATE CONNECTOR IF NOT EXISTS mysql_test
+TYPE 'mysql'
+URL 'jdbc:mysql://nightly1.apache.org:3306/hive1'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="hive1",
+"hive.sql.dbcp.password"="hive1");
+SHOW CONNECTORS;
+
+-- CREATE and USE remote database
+CREATE REMOTE database mysql_db using mysql_test with DBPROPERTIES("connector.remoteDbName"="hive1");
+USE mysql_db;
+
+-- CREATE TABLE is not allowed in remote database
+create table bees (id int, name string);

--- a/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
+++ b/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
@@ -39,4 +39,4 @@ PREHOOK: query: create table bees (id int, name string)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:mysql_db
 PREHOOK: Output: mysql_db@bees
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Could not instantiate a provider for database mysql_db)
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Create table in REMOTE database mysql_db is not allowed)

--- a/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
+++ b/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
@@ -1,0 +1,42 @@
+PREHOOK: query: CREATE CONNECTOR IF NOT EXISTS mysql_test
+TYPE 'mysql'
+URL 'jdbc:mysql://nightly1.apache.org:3306/hive1'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="hive1",
+"hive.sql.dbcp.password"="hive1")
+PREHOOK: type: CREATEDATACONNECTOR
+PREHOOK: Output: connector:mysql_test
+POSTHOOK: query: CREATE CONNECTOR IF NOT EXISTS mysql_test
+TYPE 'mysql'
+URL 'jdbc:mysql://nightly1.apache.org:3306/hive1'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="hive1",
+"hive.sql.dbcp.password"="hive1")
+POSTHOOK: type: CREATEDATACONNECTOR
+POSTHOOK: Output: connector:mysql_test
+PREHOOK: query: SHOW CONNECTORS
+PREHOOK: type: SHOWDATACONNECTORS
+POSTHOOK: query: SHOW CONNECTORS
+POSTHOOK: type: SHOWDATACONNECTORS
+mysql_test
+PREHOOK: query: CREATE REMOTE database mysql_db using mysql_test with DBPROPERTIES("connector.remoteDbName"="hive1")
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Output: database:mysql_db
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: CREATE REMOTE database mysql_db using mysql_test with DBPROPERTIES("connector.remoteDbName"="hive1")
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Output: database:mysql_db
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: USE mysql_db
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:mysql_db
+POSTHOOK: query: USE mysql_db
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:mysql_db
+PREHOOK: query: create table bees (id int, name string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:mysql_db
+PREHOOK: Output: mysql_db@bees
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Create table in REMOTE database mysql_db is not allowed)

--- a/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
+++ b/ql/src/test/results/clientnegative/createTbl_remoteDB_fail.q.out
@@ -24,11 +24,11 @@ mysql_test
 PREHOOK: query: CREATE REMOTE database mysql_db using mysql_test with DBPROPERTIES("connector.remoteDbName"="hive1")
 PREHOOK: type: CREATEDATABASE
 PREHOOK: Output: database:mysql_db
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: CREATE REMOTE database mysql_db using mysql_test with DBPROPERTIES("connector.remoteDbName"="hive1")
 POSTHOOK: type: CREATEDATABASE
 POSTHOOK: Output: database:mysql_db
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 PREHOOK: query: USE mysql_db
 PREHOOK: type: SWITCHDATABASE
 PREHOOK: Input: database:mysql_db
@@ -39,4 +39,4 @@ PREHOOK: query: create table bees (id int, name string)
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:mysql_db
 PREHOOK: Output: mysql_db@bees
-FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Create table in REMOTE database mysql_db is not allowed)
+FAILED: Execution Error, return code 40000 from org.apache.hadoop.hive.ql.ddl.DDLTask. MetaException(message:Could not instantiate a provider for database mysql_db)

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -2381,7 +2381,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     Database db = get_database_core(tbl.getCatName(), tbl.getDbName());
     if (db != null && db.getType().equals(DatabaseType.REMOTE)) {
-      // HIVE-24396: Create table in REMOTE db should fail
+      // HIVE-24425: Create table in REMOTE db should fail
       throw new MetaException("Create table in REMOTE database " + db.getName() + " is not allowed");
     }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -2381,8 +2381,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
     Database db = get_database_core(tbl.getCatName(), tbl.getDbName());
     if (db != null && db.getType().equals(DatabaseType.REMOTE)) {
-      DataConnectorProviderFactory.getDataConnectorProvider(db).createTable(tbl);
-      return;
+      // HIVE-24396: Create table in REMOTE db should fail
+      throw new MetaException("Create table in REMOTE database " + db.getName() + " is not allowed");
     }
 
     if (transformer != null) {


### PR DESCRIPTION

[HIVE-24425](https://issues.apache.org/jira/browse/HIVE-24425): Create table in REMOTE db should fail