### PR TITLE
HIVE-25251 : Reduce overhead of adding partitions during batch loading of partitions

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -362,6 +362,17 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public HMSHandler(String name, Configuration conf, boolean init) throws MetaException {
     super(name);
     this.conf = conf;
+
+    boolean usePostgres = this.conf.get("test.postgres") != null;
+    //if (usePostgres) {
+      this.conf.set("javax.jdo.option.ConnectionURL",
+              "jdbc:postgresql://localhost:5432/metastore?createDatabaseIfNotExist=true");
+      this.conf.set("javax.jdo.option.ConnectionPassword", "password");
+      this.conf.set("javax.jdo.option.ConnectionUserName", "hiveuser");
+      this.conf.set("hive.metastore.transactional.event.listeners",
+              "org.apache.hive.hcatalog.listener.DbNotificationListener");
+    //}
+
     isInTest = MetastoreConf.getBoolVar(this.conf, ConfVars.HIVE_IN_TEST);
     if (threadPool == null) {
       synchronized (HMSHandler.class) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -362,17 +362,6 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public HMSHandler(String name, Configuration conf, boolean init) throws MetaException {
     super(name);
     this.conf = conf;
-
-    boolean usePostgres = this.conf.get("test.postgres") != null;
-    //if (usePostgres) {
-      this.conf.set("javax.jdo.option.ConnectionURL",
-              "jdbc:postgresql://localhost:5432/metastore?createDatabaseIfNotExist=true");
-      this.conf.set("javax.jdo.option.ConnectionPassword", "password");
-      this.conf.set("javax.jdo.option.ConnectionUserName", "hiveuser");
-      this.conf.set("hive.metastore.transactional.event.listeners",
-              "org.apache.hive.hcatalog.listener.DbNotificationListener");
-    //}
-
     isInTest = MetastoreConf.getBoolVar(this.conf, ConfVars.HIVE_IN_TEST);
     if (threadPool == null) {
       synchronized (HMSHandler.class) {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3061,14 +3061,12 @@ class MetaStoreDirectSql {
       long batchSizeMax = MetastoreConf.getIntVar(conf, ConfVars.JDBC_MAX_BATCH_SIZE);
 
       if (PartitionHelper.needToAddPrivilegeInfo(dbConn, tblId)) {
-        final long grantId = PartitionHelper.getNextValueFromSequenceTable(dbConn,
-                "org.apache.hadoop.hive.metastore.model.MTablePrivilege", numPart * 2, dbType);
-        PartitionHelper.addPartitionPrivilegeInfo(dbConn, parts, tblId, partId, grantId, batchSizeMax);
-        PartitionHelper.addPartitionColPrivilegeInfo(dbConn, parts, tblId, partId, grantId, batchSizeMax);
+        PartitionHelper.addPartitionPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
+        PartitionHelper.addPartitionColPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
       }
 
       PartitionHelper.addSerdeInfo(dbConn, parts, serId, batchSizeMax);
-      PartitionHelper.addColDescInfo(dbConn, parts, colDescId, batchSizeMax);
+      PartitionHelper.addColDescInfo(dbConn, numPart, colDescId, batchSizeMax);
       PartitionHelper.addSDInfo(dbConn, parts, sdId, serId, colDescId, dbType, batchSizeMax);
       PartitionHelper.addColV2Info(dbConn, parts, colDescId, batchSizeMax);
       PartitionHelper.addSDParaInfo(dbConn, parts, sdId, batchSizeMax);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -21,9 +21,13 @@ package org.apache.hadoop.hive.metastore;
 import static org.apache.commons.lang3.StringUtils.join;
 import static org.apache.commons.lang3.StringUtils.normalizeSpace;
 import static org.apache.commons.lang3.StringUtils.repeat;
+import static org.apache.hadoop.hive.metastore.DirectSqlUpdateStat.quoteString;
 import static org.apache.hadoop.hive.metastore.MetastoreDirectSqlUtils.throwMetaOrRuntimeException;
+import static org.apache.hadoop.hive.metastore.Warehouse.makePartName;
 
 import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.text.ParseException;
@@ -3034,7 +3038,405 @@ class MetaStoreDirectSql {
       ColumnStatistics colStats = (ColumnStatistics) entry.getValue();
       numStats += colStats.getStatsObjSize();
     }
-    long csId = updateStat.getNextCSIdForMPartitionColumnStatistics(numStats);
+    long csId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics", numStats, true);
     return updateStat.updatePartitionColumnStatistics(partColStatsMap, tbl, csId, validWriteIds, writeId, listeners);
+  }
+
+  public boolean addPartitions(long tblId, List<FieldSchema> partKeys, List<Partition> parts) throws MetaException {
+    ResultSet rs = null;
+    Connection dbConn;
+    JDOConnection jdoConn = null;
+
+    // The whole thing will be executed under the same transaction started in HMS handler. So no commit or rollback
+    // is done here.
+
+    final long partId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MPartition", parts.size(), false);
+
+    final long grantId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MTablePrivilege", parts.size() * 2, false);
+
+    final long serId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MSerDeInfo", parts.size(), false);
+
+    final long sdId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MStorageDescriptor", parts.size(), false);
+
+    final long colDescId = updateStat.getNextValueFromSequenceTable(
+            "org.apache.hadoop.hive.metastore.model.MColumnDescriptor", parts.size(), false);
+
+    try {
+      jdoConn = pm.getDataStoreConnection();
+      dbConn = (Connection) (jdoConn.getNativeConnection());
+
+      boolean needGrant = false;
+      try (Statement statement = dbConn.createStatement()) {
+        String query = "SELECT \"PARAM_VALUE\" FROM \"TABLE_PARAMS\" WHERE \"PARAM_KEY\"= "
+                + quoteString("PARTITION_LEVEL_PRIVILEGE")
+                + " AND  \"TBL_ID\" = " + tblId;
+        LOG.debug("Going to execute query " + query);
+        rs = statement.executeQuery(query);
+        if (rs.next()) {
+          String grantInfo = rs.getString(1);
+          if ("TRUE".equalsIgnoreCase(grantInfo)) {
+            needGrant = true;
+          }
+        }
+      } finally {
+        updateStat.close(rs);
+      }
+
+      int now = (int) (System.currentTimeMillis() / 1000);
+
+      long numPartPrivGrant = 0;
+      long numPartColPrivGrant = 0;
+      if (needGrant) {
+        try (Statement statement = dbConn.createStatement()) {
+          String query = "SELECT COUNT(*) FROM \"TBL_PRIVS\" WHERE  \"TBL_ID \" = " + tblId;
+          rs = statement.executeQuery(query);
+          if (rs.next()) {
+            numPartPrivGrant = rs.getLong(1);
+          }
+        } finally {
+          updateStat.close(rs);
+        }
+
+        try (Statement statement = dbConn.createStatement()) {
+          String query = "SELECT COUNT(*) FROM \"TBL_COL_PRIVS\" WHERE  \"TBL_ID \" = " + tblId;
+          rs = statement.executeQuery(query);
+          if (rs.next()) {
+            numPartColPrivGrant = rs.getLong(1);
+          }
+        } finally {
+          updateStat.close(rs);
+        }
+      }
+
+      long grantIdIdx = grantId;
+
+      if (numPartPrivGrant != 0) {
+        String insertPartPrev = "INSERT INTO \"PART_PRIVS\" "
+                + " (\"PART_GRANT_ID\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PART_ID\","
+                + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_PRIV\", \"AUTHORIZER\") "
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+
+        List<Integer> grantOptionList = new ArrayList<>();
+        List<String> grantorList = new ArrayList<>();
+        List<String> grantTypeList = new ArrayList<>();
+        List<String> principalNameList = new ArrayList<>();
+        List<String> principalTypeList = new ArrayList<>();
+        List<String> tblPrivList = new ArrayList<>();
+        List<String> authorizerList = new ArrayList<>();
+
+        try (Statement statement = dbConn.createStatement()) {
+          String query = "SELECT \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\", "
+                  + " \"PRINCIPAL_TYPE\", \"TBL_PRIV\", \"AUTHORIZER\" "
+                  + " FROM \"TBL_PRIVS\""
+                  + " WHERE  \"TBL_ID \" = " + tblId;
+          LOG.debug("Going to execute query " + query);
+          rs = statement.executeQuery(query);
+          while (rs.next()) {
+            grantOptionList.add(rs.getInt(1));
+            grantorList.add(rs.getString(2));
+            grantTypeList.add(rs.getString(3));
+            principalNameList.add(rs.getString(4));
+            principalTypeList.add(rs.getString(5));
+            tblPrivList.add(rs.getString(6));
+            authorizerList.add(rs.getString(7));
+          }
+        } finally {
+          updateStat.close(rs);
+        }
+
+        try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
+          long partIdx = partId;
+          for (int j = 0; j < parts.size(); j++) {
+            for (int i = 0; i < grantOptionList.size(); i++) {
+              pst.setLong(1, grantIdIdx++);
+              pst.setInt(2, now);
+              pst.setInt(3, grantOptionList.get(i));
+              pst.setString(4, grantorList.get(i));
+              pst.setString(5, grantTypeList.get(i));
+              pst.setLong(6, partIdx);
+              pst.setString(7, principalNameList.get(i));
+              pst.setString(8, principalTypeList.get(i));
+              pst.setString(9, tblPrivList.get(i));
+              pst.setString(10, authorizerList.get(i));
+              pst.addBatch();
+            }
+            partIdx++;
+          }
+        }
+      }
+
+      if (numPartColPrivGrant != 0) {
+        List<String> colNameList = new ArrayList<>();
+        List<Integer> grantOptionList = new ArrayList<>();
+        List<String> grantorList = new ArrayList<>();
+        List<String> grantTypeList = new ArrayList<>();
+        List<String> principalNameList = new ArrayList<>();
+        List<String> principalTypeList = new ArrayList<>();
+        List<String> tblColPrivList = new ArrayList<>();
+        List<String> authorizerList = new ArrayList<>();
+        try (Statement statement = dbConn.createStatement()) {
+          String query = "SELECT \"COLUMN_NAME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\","
+                  + " \"PRINCIPAL_TYPE\", \"TBL_COL_PRIV\", \"AUTHORIZER\" "
+                  + " FROM \"TBL_COL_PRIVS\""
+                  + " WHERE  \"TBL_ID \" = " + tblId;
+          LOG.debug("Going to execute query " + query);
+          rs = statement.executeQuery(query);
+          while (rs.next()) {
+            colNameList.add(rs.getString(1));
+            grantOptionList.add(rs.getInt(2));
+            grantorList.add(rs.getString(3));
+            grantTypeList.add(rs.getString(4));
+            principalNameList.add(rs.getString(5));
+            principalTypeList.add(rs.getString(6));
+            tblColPrivList.add(rs.getString(7));
+            authorizerList.add(rs.getString(8));
+          }
+        } finally {
+          updateStat.close(rs);
+        }
+
+
+        String insertPartPrev = "INSERT INTO \"PART_COL_PRIVS\" "
+                + " (\"PART_COLUMN_GRANT_ID\", \"COLUMN_NAME\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PART_ID\","
+                + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_COL_PRIV\", \"AUTHORIZER\") "
+                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+        try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
+          long partIdx = partId;
+          for (int j = 0; j < parts.size(); j++) {
+            for (int i = 0; i < grantOptionList.size(); i++) {
+              pst.setLong(1, grantIdIdx++);
+              pst.setString(2, colNameList.get(i));
+              pst.setInt(3, now);
+              pst.setInt(4, grantOptionList.get(i));
+              pst.setString(5, grantorList.get(i));
+              pst.setString(6, grantTypeList.get(i));
+              pst.setLong(7, partIdx);
+              pst.setString(8, principalNameList.get(i));
+              pst.setString(9, principalTypeList.get(i));
+              pst.setString(10, tblColPrivList.get(i));
+              pst.setString(11, authorizerList.get(i));
+              pst.addBatch();
+            }
+            partIdx++;
+          }
+        }
+      }
+
+      String insertSerdeInfo = "INSERT INTO \"SERDES\" (\"SERDE_ID\", \"NAME\", \"SLIB\", \"DESCRIPTION\","
+              + " \"SERIALIZER_CLASS\", \"DESERIALIZER_CLASS\", \"SERDE_TYPE\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdeInfo)) {
+        long serdeIdIdx = serId;
+        for (Partition part : parts) {
+          if (part.getSd() == null) {
+            continue;
+          }
+          SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
+          preparedStatement.setLong(1, serdeIdIdx++);
+          preparedStatement.setObject(2, serDeInfo.getName());
+          preparedStatement.setObject(3, serDeInfo.getSerializationLib());
+          preparedStatement.setObject(4, serDeInfo.getDescription());
+          preparedStatement.setObject(5, serDeInfo.getSerializerClass());
+          preparedStatement.setObject(6, serDeInfo.getDeserializerClass());
+          preparedStatement.setLong(7, serDeInfo.getSerdeType() != null ?
+                  serDeInfo.getSerdeType().getValue() : 0);
+          preparedStatement.addBatch();
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertCDInfo = "INSERT INTO \"CDS\" (\"CD_ID\") VALUES (?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertCDInfo)) {
+        long cdIdIdx = colDescId;
+        for (Partition part : parts) {
+          preparedStatement.setLong(1, cdIdIdx++);
+          preparedStatement.addBatch();
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertSDInfo = "INSERT INTO \"SDS\" (\"SD_ID\", \"INPUT_FORMAT\", \"IS_COMPRESSED\", \"LOCATION\","
+              + " \"NUM_BUCKETS\", \"OUTPUT_FORMAT\", \"SERDE_ID\", \"CD_ID\", \"IS_STOREDASSUBDIRECTORIES\")"
+              + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDInfo)) {
+        long sdIdIdx = sdId;
+        long serdeIdIdx = serId;
+        long cdIdIdx = colDescId;
+        for (Partition part : parts) {
+          StorageDescriptor sd = part.getSd();
+          if (sd == null) {
+            continue;
+          }
+          preparedStatement.setLong(1, sdIdIdx++);
+          preparedStatement.setObject(2, sd.getInputFormat());
+          preparedStatement.setObject(4, sd.getLocation());
+          preparedStatement.setObject(5, sd.getNumBuckets());
+          preparedStatement.setObject(6, sd.getOutputFormat());
+          preparedStatement.setLong(7, serdeIdIdx++);
+          preparedStatement.setObject(8, sd.getCols() == null ? null : cdIdIdx);
+          cdIdIdx++;
+
+          if (dbType.isDERBY()) {
+            // In Derby schema file, constraint is added for the value to be either Y or N.
+            preparedStatement.setObject(3, sd.isCompressed() ? "Y" : "N");
+            preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? "Y" : "N");
+          } else if (dbType.isORACLE()) {
+            // In Oracle schema file, constraint is added for the value to be either 1 or 0.
+            preparedStatement.setObject(3, sd.isCompressed() ? 1 : 0);
+            preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? 1 : 0);
+          } else if (dbType.isMYSQL() || dbType.isPOSTGRES() || dbType.isSQLSERVER()) {
+            // For postgres the column is of type is boolean. For mysql its bit(1) and for sql server its bit.
+            // For both, the conversion is done automatically from boolean to bit.
+            preparedStatement.setBoolean(3, sd.isCompressed());
+            preparedStatement.setBoolean(9, sd.isStoredAsSubDirectories());
+          } else {
+            throw new IllegalArgumentException("Unsupported DB type: " + dbType);
+          }
+
+          preparedStatement.addBatch();
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertColInfo = "INSERT INTO \"COLUMNS_V2\" (\"CD_ID\", \"COMMENT\", \"COLUMN_NAME\", \"TYPE_NAME\","
+              + " \"INTEGER_IDX\") VALUES (?, ?, ?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertColInfo)) {
+        long cdIdIdx = colDescId;
+        for (Partition part : parts) {
+          StorageDescriptor sd = part.getSd();
+          if (sd == null) {
+            continue;
+          }
+          List<FieldSchema> cols = sd.getCols();
+          if (cols == null) {
+            continue;
+          }
+          int colIdx = 0;
+          for (FieldSchema col : cols) {
+            preparedStatement.setLong(1, cdIdIdx);
+            preparedStatement.setString(2, col.getComment());
+            preparedStatement.setString(3, col.getName());
+            preparedStatement.setString(4, col.getType());
+            preparedStatement.setLong(5, colIdx++);
+            preparedStatement.addBatch();
+          }
+          cdIdIdx++;
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertSDParamInfo = "INSERT INTO \"SD_PARAMS\" (\"SD_ID\", \"PARAM_KEY\", \"PARAM_VALUE\")" +
+              " VALUES (?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDParamInfo)) {
+        long sdIdIdx = sdId;
+        for (Partition part : parts) {
+          StorageDescriptor sd = part.getSd();
+          if (sd == null) {
+            continue;
+          }
+          for (Map.Entry entry : sd.getParameters().entrySet()) {
+            String key = (String) entry.getKey();
+            String value = (String) entry.getValue();
+            preparedStatement.setLong(1, sdIdIdx);
+            preparedStatement.setString(2, key);
+            preparedStatement.setString(3, value);
+            preparedStatement.addBatch();
+          }
+          sdIdIdx++;
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertSerdePara = "INSERT INTO \"SERDE_PARAMS\" (\"SERDE_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdePara)) {
+        long serdeIdIdx = serId;
+        for (Partition part : parts) {
+          if (part.getSd() == null) {
+            continue;
+          }
+          SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
+          for (Map.Entry entry : serDeInfo.getParameters().entrySet()) {
+            String key = (String) entry.getKey();
+            String value = (String) entry.getValue();
+            preparedStatement.setLong(1, serdeIdIdx);
+            preparedStatement.setString(2, key);
+            preparedStatement.setString(3, value);
+            preparedStatement.addBatch();
+          }
+          serdeIdIdx++;
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertPartition = "INSERT INTO \"PARTITIONS\" (\"PART_ID\", \"CREATE_TIME\", \"LAST_ACCESS_TIME\", "
+              + "\"PART_NAME\", \"SD_ID\", \"TBL_ID\", \"WRITE_ID\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartition)) {
+        long sdIdIdx = sdId;
+        long partIdIdx = partId;
+        for (Partition part : parts) {
+          preparedStatement.setLong(1, partIdIdx++);
+          preparedStatement.setObject(2, part.getCreateTime());
+          preparedStatement.setObject(3, part.getLastAccessTime());
+          preparedStatement.setString(4,
+                  makePartName(partKeys, part.getValues(), null));
+          preparedStatement.setObject(5, part.getSd() == null ? null : sdIdIdx);
+          preparedStatement.setLong(6, tblId);
+          preparedStatement.setLong(7, part.getWriteId());
+          sdIdIdx++;
+          preparedStatement.addBatch();
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertParamKeys = "INSERT INTO \"PARTITION_PARAMS\" (\"PART_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertParamKeys)) {
+        long partIdIdx = partId;
+        for (Partition part : parts) {
+          for (Map.Entry entry : part.getParameters().entrySet()) {
+            String key = (String) entry.getKey();
+            String value = (String) entry.getValue();
+            preparedStatement.setLong(1, partIdIdx);
+            preparedStatement.setString(2, key);
+            preparedStatement.setString(3, value);
+            preparedStatement.addBatch();
+          }
+          partIdIdx++;
+        }
+        preparedStatement.executeBatch();
+      }
+
+      String insertPartKeyVals = "INSERT INTO \"PARTITION_KEY_VALS\" (\"PART_ID\", \"PART_KEY_VAL\", \"INTEGER_IDX\") VALUES (?, ?, ?) ";
+      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartKeyVals)) {
+        long partIdIdx = partId;
+        for (Partition part : parts) {
+          int idx = 0;
+          for (String value : part.getValues()) {
+            preparedStatement.setLong(1, partIdIdx);
+            preparedStatement.setString(2, value);
+            preparedStatement.setLong(3, idx++);
+            preparedStatement.addBatch();
+          }
+          partIdIdx++;
+        }
+        preparedStatement.executeBatch();
+      }
+    } catch (Exception e) {
+      LOG.error("Failed to add partition", e);
+      throw new MetaException("Failed to add partition" + e.getMessage());
+    } finally {
+      if (rs != null) {
+        try {
+          rs.close();
+        } catch (SQLException throwables) {
+          throwables.printStackTrace();
+        }
+      }
+      jdoConn.close();
+    }
+    return true;
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3038,403 +3038,49 @@ class MetaStoreDirectSql {
       ColumnStatistics colStats = (ColumnStatistics) entry.getValue();
       numStats += colStats.getStatsObjSize();
     }
-    long csId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MPartitionColumnStatistics", numStats, true);
+    long csId = updateStat.getNextCSIdForMPartitionColumnStatistics(numStats);
     return updateStat.updatePartitionColumnStatistics(partColStatsMap, tbl, csId, validWriteIds, writeId, listeners);
   }
 
+  // The whole thing will be executed under the transaction started in HMS handler. So no commit or rollback
+  // is done here.
   public boolean addPartitions(long tblId, List<FieldSchema> partKeys, List<Partition> parts) throws MetaException {
-    ResultSet rs = null;
-    Connection dbConn;
+    assert pm.currentTransaction().isActive();
     JDOConnection jdoConn = null;
-
-    // The whole thing will be executed under the same transaction started in HMS handler. So no commit or rollback
-    // is done here.
-
-    final long partId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MPartition", parts.size(), false);
-
-    final long grantId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MTablePrivilege", parts.size() * 2, false);
-
-    final long serId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MSerDeInfo", parts.size(), false);
-
-    final long sdId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MStorageDescriptor", parts.size(), false);
-
-    final long colDescId = updateStat.getNextValueFromSequenceTable(
-            "org.apache.hadoop.hive.metastore.model.MColumnDescriptor", parts.size(), false);
+    long numPart = parts.size();
 
     try {
       jdoConn = pm.getDataStoreConnection();
-      dbConn = (Connection) (jdoConn.getNativeConnection());
+      Connection dbConn = (Connection) (jdoConn.getNativeConnection());
 
-      boolean needGrant = false;
-      try (Statement statement = dbConn.createStatement()) {
-        String query = "SELECT \"PARAM_VALUE\" FROM \"TABLE_PARAMS\" WHERE \"PARAM_KEY\"= "
-                + quoteString("PARTITION_LEVEL_PRIVILEGE")
-                + " AND  \"TBL_ID\" = " + tblId;
-        LOG.debug("Going to execute query " + query);
-        rs = statement.executeQuery(query);
-        if (rs.next()) {
-          String grantInfo = rs.getString(1);
-          if ("TRUE".equalsIgnoreCase(grantInfo)) {
-            needGrant = true;
-          }
-        }
-      } finally {
-        updateStat.close(rs);
+      final long partId = PartitionHelper.getNextValueFromSequenceTable(
+              dbConn, "org.apache.hadoop.hive.metastore.model.MPartition", numPart, dbType);
+      final long grantId = PartitionHelper.getNextValueFromSequenceTable(
+              dbConn, "org.apache.hadoop.hive.metastore.model.MTablePrivilege", numPart * 2, dbType);
+      final long serId = PartitionHelper.getNextValueFromSequenceTable(
+              dbConn, "org.apache.hadoop.hive.metastore.model.MSerDeInfo", numPart, dbType);
+      final long sdId = PartitionHelper.getNextValueFromSequenceTable(
+              dbConn, "org.apache.hadoop.hive.metastore.model.MStorageDescriptor", numPart, dbType);
+      final long colDescId = PartitionHelper.getNextValueFromSequenceTable(
+              dbConn, "org.apache.hadoop.hive.metastore.model.MColumnDescriptor", numPart, dbType);
+
+      if (PartitionHelper.needToAddPrivilegeInfo(dbConn, tblId)) {
+        PartitionHelper.addPartitionPrivilegeInfo(dbConn, parts, tblId, partId, grantId);
+        PartitionHelper.addPartitionColPrivilegeInfo(dbConn, parts, tblId, partId, grantId);
       }
-
-      int now = (int) (System.currentTimeMillis() / 1000);
-
-      long numPartPrivGrant = 0;
-      long numPartColPrivGrant = 0;
-      if (needGrant) {
-        try (Statement statement = dbConn.createStatement()) {
-          String query = "SELECT COUNT(*) FROM \"TBL_PRIVS\" WHERE  \"TBL_ID \" = " + tblId;
-          rs = statement.executeQuery(query);
-          if (rs.next()) {
-            numPartPrivGrant = rs.getLong(1);
-          }
-        } finally {
-          updateStat.close(rs);
-        }
-
-        try (Statement statement = dbConn.createStatement()) {
-          String query = "SELECT COUNT(*) FROM \"TBL_COL_PRIVS\" WHERE  \"TBL_ID \" = " + tblId;
-          rs = statement.executeQuery(query);
-          if (rs.next()) {
-            numPartColPrivGrant = rs.getLong(1);
-          }
-        } finally {
-          updateStat.close(rs);
-        }
-      }
-
-      long grantIdIdx = grantId;
-
-      if (numPartPrivGrant != 0) {
-        String insertPartPrev = "INSERT INTO \"PART_PRIVS\" "
-                + " (\"PART_GRANT_ID\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PART_ID\","
-                + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_PRIV\", \"AUTHORIZER\") "
-                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
-
-        List<Integer> grantOptionList = new ArrayList<>();
-        List<String> grantorList = new ArrayList<>();
-        List<String> grantTypeList = new ArrayList<>();
-        List<String> principalNameList = new ArrayList<>();
-        List<String> principalTypeList = new ArrayList<>();
-        List<String> tblPrivList = new ArrayList<>();
-        List<String> authorizerList = new ArrayList<>();
-
-        try (Statement statement = dbConn.createStatement()) {
-          String query = "SELECT \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\", "
-                  + " \"PRINCIPAL_TYPE\", \"TBL_PRIV\", \"AUTHORIZER\" "
-                  + " FROM \"TBL_PRIVS\""
-                  + " WHERE  \"TBL_ID \" = " + tblId;
-          LOG.debug("Going to execute query " + query);
-          rs = statement.executeQuery(query);
-          while (rs.next()) {
-            grantOptionList.add(rs.getInt(1));
-            grantorList.add(rs.getString(2));
-            grantTypeList.add(rs.getString(3));
-            principalNameList.add(rs.getString(4));
-            principalTypeList.add(rs.getString(5));
-            tblPrivList.add(rs.getString(6));
-            authorizerList.add(rs.getString(7));
-          }
-        } finally {
-          updateStat.close(rs);
-        }
-
-        try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
-          long partIdx = partId;
-          for (int j = 0; j < parts.size(); j++) {
-            for (int i = 0; i < grantOptionList.size(); i++) {
-              pst.setLong(1, grantIdIdx++);
-              pst.setInt(2, now);
-              pst.setInt(3, grantOptionList.get(i));
-              pst.setString(4, grantorList.get(i));
-              pst.setString(5, grantTypeList.get(i));
-              pst.setLong(6, partIdx);
-              pst.setString(7, principalNameList.get(i));
-              pst.setString(8, principalTypeList.get(i));
-              pst.setString(9, tblPrivList.get(i));
-              pst.setString(10, authorizerList.get(i));
-              pst.addBatch();
-            }
-            partIdx++;
-          }
-        }
-      }
-
-      if (numPartColPrivGrant != 0) {
-        List<String> colNameList = new ArrayList<>();
-        List<Integer> grantOptionList = new ArrayList<>();
-        List<String> grantorList = new ArrayList<>();
-        List<String> grantTypeList = new ArrayList<>();
-        List<String> principalNameList = new ArrayList<>();
-        List<String> principalTypeList = new ArrayList<>();
-        List<String> tblColPrivList = new ArrayList<>();
-        List<String> authorizerList = new ArrayList<>();
-        try (Statement statement = dbConn.createStatement()) {
-          String query = "SELECT \"COLUMN_NAME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\","
-                  + " \"PRINCIPAL_TYPE\", \"TBL_COL_PRIV\", \"AUTHORIZER\" "
-                  + " FROM \"TBL_COL_PRIVS\""
-                  + " WHERE  \"TBL_ID \" = " + tblId;
-          LOG.debug("Going to execute query " + query);
-          rs = statement.executeQuery(query);
-          while (rs.next()) {
-            colNameList.add(rs.getString(1));
-            grantOptionList.add(rs.getInt(2));
-            grantorList.add(rs.getString(3));
-            grantTypeList.add(rs.getString(4));
-            principalNameList.add(rs.getString(5));
-            principalTypeList.add(rs.getString(6));
-            tblColPrivList.add(rs.getString(7));
-            authorizerList.add(rs.getString(8));
-          }
-        } finally {
-          updateStat.close(rs);
-        }
-
-
-        String insertPartPrev = "INSERT INTO \"PART_COL_PRIVS\" "
-                + " (\"PART_COLUMN_GRANT_ID\", \"COLUMN_NAME\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PART_ID\","
-                + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_COL_PRIV\", \"AUTHORIZER\") "
-                + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
-        try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
-          long partIdx = partId;
-          for (int j = 0; j < parts.size(); j++) {
-            for (int i = 0; i < grantOptionList.size(); i++) {
-              pst.setLong(1, grantIdIdx++);
-              pst.setString(2, colNameList.get(i));
-              pst.setInt(3, now);
-              pst.setInt(4, grantOptionList.get(i));
-              pst.setString(5, grantorList.get(i));
-              pst.setString(6, grantTypeList.get(i));
-              pst.setLong(7, partIdx);
-              pst.setString(8, principalNameList.get(i));
-              pst.setString(9, principalTypeList.get(i));
-              pst.setString(10, tblColPrivList.get(i));
-              pst.setString(11, authorizerList.get(i));
-              pst.addBatch();
-            }
-            partIdx++;
-          }
-        }
-      }
-
-      String insertSerdeInfo = "INSERT INTO \"SERDES\" (\"SERDE_ID\", \"NAME\", \"SLIB\", \"DESCRIPTION\","
-              + " \"SERIALIZER_CLASS\", \"DESERIALIZER_CLASS\", \"SERDE_TYPE\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdeInfo)) {
-        long serdeIdIdx = serId;
-        for (Partition part : parts) {
-          if (part.getSd() == null) {
-            continue;
-          }
-          SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
-          preparedStatement.setLong(1, serdeIdIdx++);
-          preparedStatement.setObject(2, serDeInfo.getName());
-          preparedStatement.setObject(3, serDeInfo.getSerializationLib());
-          preparedStatement.setObject(4, serDeInfo.getDescription());
-          preparedStatement.setObject(5, serDeInfo.getSerializerClass());
-          preparedStatement.setObject(6, serDeInfo.getDeserializerClass());
-          preparedStatement.setLong(7, serDeInfo.getSerdeType() != null ?
-                  serDeInfo.getSerdeType().getValue() : 0);
-          preparedStatement.addBatch();
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertCDInfo = "INSERT INTO \"CDS\" (\"CD_ID\") VALUES (?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertCDInfo)) {
-        long cdIdIdx = colDescId;
-        for (Partition part : parts) {
-          preparedStatement.setLong(1, cdIdIdx++);
-          preparedStatement.addBatch();
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertSDInfo = "INSERT INTO \"SDS\" (\"SD_ID\", \"INPUT_FORMAT\", \"IS_COMPRESSED\", \"LOCATION\","
-              + " \"NUM_BUCKETS\", \"OUTPUT_FORMAT\", \"SERDE_ID\", \"CD_ID\", \"IS_STOREDASSUBDIRECTORIES\")"
-              + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDInfo)) {
-        long sdIdIdx = sdId;
-        long serdeIdIdx = serId;
-        long cdIdIdx = colDescId;
-        for (Partition part : parts) {
-          StorageDescriptor sd = part.getSd();
-          if (sd == null) {
-            continue;
-          }
-          preparedStatement.setLong(1, sdIdIdx++);
-          preparedStatement.setObject(2, sd.getInputFormat());
-          preparedStatement.setObject(4, sd.getLocation());
-          preparedStatement.setObject(5, sd.getNumBuckets());
-          preparedStatement.setObject(6, sd.getOutputFormat());
-          preparedStatement.setLong(7, serdeIdIdx++);
-          preparedStatement.setObject(8, sd.getCols() == null ? null : cdIdIdx);
-          cdIdIdx++;
-
-          if (dbType.isDERBY()) {
-            // In Derby schema file, constraint is added for the value to be either Y or N.
-            preparedStatement.setObject(3, sd.isCompressed() ? "Y" : "N");
-            preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? "Y" : "N");
-          } else if (dbType.isORACLE()) {
-            // In Oracle schema file, constraint is added for the value to be either 1 or 0.
-            preparedStatement.setObject(3, sd.isCompressed() ? 1 : 0);
-            preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? 1 : 0);
-          } else if (dbType.isMYSQL() || dbType.isPOSTGRES() || dbType.isSQLSERVER()) {
-            // For postgres the column is of type is boolean. For mysql its bit(1) and for sql server its bit.
-            // For both, the conversion is done automatically from boolean to bit.
-            preparedStatement.setBoolean(3, sd.isCompressed());
-            preparedStatement.setBoolean(9, sd.isStoredAsSubDirectories());
-          } else {
-            throw new IllegalArgumentException("Unsupported DB type: " + dbType);
-          }
-
-          preparedStatement.addBatch();
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertColInfo = "INSERT INTO \"COLUMNS_V2\" (\"CD_ID\", \"COMMENT\", \"COLUMN_NAME\", \"TYPE_NAME\","
-              + " \"INTEGER_IDX\") VALUES (?, ?, ?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertColInfo)) {
-        long cdIdIdx = colDescId;
-        for (Partition part : parts) {
-          StorageDescriptor sd = part.getSd();
-          if (sd == null) {
-            continue;
-          }
-          List<FieldSchema> cols = sd.getCols();
-          if (cols == null) {
-            continue;
-          }
-          int colIdx = 0;
-          for (FieldSchema col : cols) {
-            preparedStatement.setLong(1, cdIdIdx);
-            preparedStatement.setString(2, col.getComment());
-            preparedStatement.setString(3, col.getName());
-            preparedStatement.setString(4, col.getType());
-            preparedStatement.setLong(5, colIdx++);
-            preparedStatement.addBatch();
-          }
-          cdIdIdx++;
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertSDParamInfo = "INSERT INTO \"SD_PARAMS\" (\"SD_ID\", \"PARAM_KEY\", \"PARAM_VALUE\")" +
-              " VALUES (?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDParamInfo)) {
-        long sdIdIdx = sdId;
-        for (Partition part : parts) {
-          StorageDescriptor sd = part.getSd();
-          if (sd == null) {
-            continue;
-          }
-          for (Map.Entry entry : sd.getParameters().entrySet()) {
-            String key = (String) entry.getKey();
-            String value = (String) entry.getValue();
-            preparedStatement.setLong(1, sdIdIdx);
-            preparedStatement.setString(2, key);
-            preparedStatement.setString(3, value);
-            preparedStatement.addBatch();
-          }
-          sdIdIdx++;
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertSerdePara = "INSERT INTO \"SERDE_PARAMS\" (\"SERDE_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdePara)) {
-        long serdeIdIdx = serId;
-        for (Partition part : parts) {
-          if (part.getSd() == null) {
-            continue;
-          }
-          SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
-          for (Map.Entry entry : serDeInfo.getParameters().entrySet()) {
-            String key = (String) entry.getKey();
-            String value = (String) entry.getValue();
-            preparedStatement.setLong(1, serdeIdIdx);
-            preparedStatement.setString(2, key);
-            preparedStatement.setString(3, value);
-            preparedStatement.addBatch();
-          }
-          serdeIdIdx++;
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertPartition = "INSERT INTO \"PARTITIONS\" (\"PART_ID\", \"CREATE_TIME\", \"LAST_ACCESS_TIME\", "
-              + "\"PART_NAME\", \"SD_ID\", \"TBL_ID\", \"WRITE_ID\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartition)) {
-        long sdIdIdx = sdId;
-        long partIdIdx = partId;
-        for (Partition part : parts) {
-          preparedStatement.setLong(1, partIdIdx++);
-          preparedStatement.setObject(2, part.getCreateTime());
-          preparedStatement.setObject(3, part.getLastAccessTime());
-          preparedStatement.setString(4,
-                  makePartName(partKeys, part.getValues(), null));
-          preparedStatement.setObject(5, part.getSd() == null ? null : sdIdIdx);
-          preparedStatement.setLong(6, tblId);
-          preparedStatement.setLong(7, part.getWriteId());
-          sdIdIdx++;
-          preparedStatement.addBatch();
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertParamKeys = "INSERT INTO \"PARTITION_PARAMS\" (\"PART_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertParamKeys)) {
-        long partIdIdx = partId;
-        for (Partition part : parts) {
-          for (Map.Entry entry : part.getParameters().entrySet()) {
-            String key = (String) entry.getKey();
-            String value = (String) entry.getValue();
-            preparedStatement.setLong(1, partIdIdx);
-            preparedStatement.setString(2, key);
-            preparedStatement.setString(3, value);
-            preparedStatement.addBatch();
-          }
-          partIdIdx++;
-        }
-        preparedStatement.executeBatch();
-      }
-
-      String insertPartKeyVals = "INSERT INTO \"PARTITION_KEY_VALS\" (\"PART_ID\", \"PART_KEY_VAL\", \"INTEGER_IDX\") VALUES (?, ?, ?) ";
-      try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartKeyVals)) {
-        long partIdIdx = partId;
-        for (Partition part : parts) {
-          int idx = 0;
-          for (String value : part.getValues()) {
-            preparedStatement.setLong(1, partIdIdx);
-            preparedStatement.setString(2, value);
-            preparedStatement.setLong(3, idx++);
-            preparedStatement.addBatch();
-          }
-          partIdIdx++;
-        }
-        preparedStatement.executeBatch();
-      }
+      PartitionHelper.addSerdeInfo(dbConn, parts, serId);
+      PartitionHelper.addColDescInfo(dbConn, parts, colDescId);
+      PartitionHelper.addSDInfo(dbConn, parts, sdId, serId, colDescId, dbType);
+      PartitionHelper.addColV2Info(dbConn, parts, colDescId);
+      PartitionHelper.addSDParaInfo(dbConn, parts, sdId);
+      PartitionHelper.addSerdeParaInfo(dbConn, parts, serId);
+      PartitionHelper.addPartitionInfo(dbConn, parts, partKeys, tblId, partId, sdId);
+      PartitionHelper.addPartitionParaInfo(dbConn, parts, partId);
+      PartitionHelper.addPartitionKeyValInfo(dbConn, parts, partId);
     } catch (Exception e) {
       LOG.error("Failed to add partition", e);
       throw new MetaException("Failed to add partition" + e.getMessage());
     } finally {
-      if (rs != null) {
-        try {
-          rs.close();
-        } catch (SQLException throwables) {
-          throwables.printStackTrace();
-        }
-      }
       jdoConn.close();
     }
     return true;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3068,6 +3068,13 @@ class MetaStoreDirectSql {
       PartitionHelper.addSerdeInfo(dbConn, parts, serId, batchSizeMax);
       PartitionHelper.addColDescInfo(dbConn, numPart, colDescId, batchSizeMax);
       PartitionHelper.addSDInfo(dbConn, parts, sdId, serId, colDescId, dbType, batchSizeMax);
+      PartitionHelper.addToSortColsTable(dbConn, parts, sdId, batchSizeMax);
+      PartitionHelper.addToBucketColsTable(dbConn, parts, sdId, batchSizeMax);
+      long numSkewedString = PartitionHelper.addSkewedColsName(dbConn, parts, sdId, batchSizeMax);
+      if (numSkewedString != 0) {
+        long startSkewedId = PartitionHelper.addSkewedStringListId(dbConn, batchSizeMax, numSkewedString);
+        PartitionHelper.addSkewedStringListValues(dbConn, parts, startSkewedId, sdId, batchSizeMax);
+      }
       PartitionHelper.addColV2Info(dbConn, parts, colDescId, batchSizeMax);
       PartitionHelper.addSDParaInfo(dbConn, parts, sdId, batchSizeMax);
       PartitionHelper.addSerdeParaInfo(dbConn, parts, serId, batchSizeMax);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3072,6 +3072,12 @@ class MetaStoreDirectSql {
       PartitionHelper.addToBucketColsTable(dbConn, parts, sdId, batchSizeMax);
       long numSkewedString = PartitionHelper.addSkewedColsName(dbConn, parts, sdId, batchSizeMax);
       if (numSkewedString != 0) {
+        // addSkewedStringListId will insert the unique skewed list id for each skewed key. To avoid some other
+        // thread concurrently inserting the same value, table lock is taken.
+        String lockCommand = "lock table \"SKEWED_STRING_LIST\" in exclusive mode";
+        try (Statement statement = dbConn.createStatement()) {
+          statement.executeUpdate(lockCommand);
+        }
         long startSkewedId = PartitionHelper.addSkewedStringListId(dbConn, batchSizeMax, numSkewedString);
         PartitionHelper.addSkewedStringListValues(dbConn, parts, startSkewedId, sdId, batchSizeMax);
       }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3067,13 +3067,7 @@ class MetaStoreDirectSql {
       PartitionHelper.addToBucketColsTable(dbConn, parts, sdId, batchSizeMax);
       long numSkewedString = PartitionHelper.addSkewedColsName(dbConn, parts, sdId, batchSizeMax);
       if (numSkewedString != 0) {
-        // addSkewedStringListId will insert the unique skewed list id for each skewed key. To avoid some other
-        // thread concurrently inserting the same value, table lock is taken.
-        String lockCommand = "lock table \"SKEWED_STRING_LIST\" in exclusive mode";
-        try (Statement statement = dbConn.createStatement()) {
-          statement.executeUpdate(lockCommand);
-        }
-        long startSkewedId = PartitionHelper.addSkewedStringListId(dbConn, batchSizeMax, numSkewedString);
+        long startSkewedId = PartitionHelper.addSkewedStringListId(dbConn, batchSizeMax, numSkewedString, dbType);
         PartitionHelper.addSkewedStringListValues(dbConn, parts, startSkewedId, sdId, batchSizeMax);
       }
       PartitionHelper.addColV2Info(dbConn, parts, colDescId, batchSizeMax);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetaStoreDirectSql.java
@@ -3060,11 +3060,6 @@ class MetaStoreDirectSql {
 
       long batchSizeMax = MetastoreConf.getIntVar(conf, ConfVars.JDBC_MAX_BATCH_SIZE);
 
-      if (PartitionHelper.needToAddPrivilegeInfo(dbConn, tblId)) {
-        PartitionHelper.addPartitionPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
-        PartitionHelper.addPartitionColPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
-      }
-
       PartitionHelper.addSerdeInfo(dbConn, parts, serId, batchSizeMax);
       PartitionHelper.addColDescInfo(dbConn, numPart, colDescId, batchSizeMax);
       PartitionHelper.addSDInfo(dbConn, parts, sdId, serId, colDescId, dbType, batchSizeMax);
@@ -3087,6 +3082,11 @@ class MetaStoreDirectSql {
       PartitionHelper.addPartitionInfo(dbConn, parts, partKeys, tblId, partId, sdId, batchSizeMax);
       PartitionHelper.addPartitionParaInfo(dbConn, parts, partId, batchSizeMax);
       PartitionHelper.addPartitionKeyValInfo(dbConn, parts, partId, batchSizeMax);
+
+      if (PartitionHelper.needToAddPrivilegeInfo(dbConn, tblId)) {
+        PartitionHelper.addPartitionPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
+        PartitionHelper.addPartitionColPrivilegeInfo(dbConn, parts, tblId, partId, dbType, batchSizeMax);
+      }
     } catch (Exception e) {
       LOG.error("Failed to add partition", e);
       throw new MetaException("Failed to add partition" + e.getMessage());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -399,7 +399,7 @@ class MetastoreDirectSqlUtils {
     String queryText;
     queryText =
           "select " + SKEWED_COL_VALUE_LOC_MAP + ".\"SD_ID\","
-        + " " + SKEWED_STRING_LIST_VALUES + ".STRING_LIST_ID,"
+        + " " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_ID\","
         + " " + SKEWED_COL_VALUE_LOC_MAP + ".\"LOCATION\","
         + " " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_VALUE\" "
         + "from " + SKEWED_COL_VALUE_LOC_MAP + ""

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -356,27 +356,6 @@ class MetastoreDirectSqlUtils {
       PersistenceManager pm, TreeMap<Long, StorageDescriptor> sds, String sdIds)
       throws MetaException {
     String queryText;
-
-    queryText = "select \"PART_ID\" from \"PARTITIONS\"";
-    try (Query query = pm.newQuery("javax.jdo.query.SQL", queryText)) {
-      Object result = query.execute();
-      if (result == null) {
-        ;
-      }
-    } catch (Exception e) {
-
-    }
-
-    queryText = "select * from \"SEQUENCE_TABLE\" where \"SEQUENCE_NAME\" = 'MPartition'";
-    try (Query query = pm.newQuery("javax.jdo.query.SQL", queryText)) {
-      Object result = query.execute();
-      if (result == null) {
-        ;
-      }
-    } catch (Exception e) {
-
-    }
-
     queryText =
           "select " + SKEWED_VALUES + ".\"SD_ID_OID\","
         + "  " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_ID\","

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/MetastoreDirectSqlUtils.java
@@ -356,6 +356,27 @@ class MetastoreDirectSqlUtils {
       PersistenceManager pm, TreeMap<Long, StorageDescriptor> sds, String sdIds)
       throws MetaException {
     String queryText;
+
+    queryText = "select \"PART_ID\" from \"PARTITIONS\"";
+    try (Query query = pm.newQuery("javax.jdo.query.SQL", queryText)) {
+      Object result = query.execute();
+      if (result == null) {
+        ;
+      }
+    } catch (Exception e) {
+
+    }
+
+    queryText = "select * from \"SEQUENCE_TABLE\" where \"SEQUENCE_NAME\" = 'MPartition'";
+    try (Query query = pm.newQuery("javax.jdo.query.SQL", queryText)) {
+      Object result = query.execute();
+      if (result == null) {
+        ;
+      }
+    } catch (Exception e) {
+
+    }
+
     queryText =
           "select " + SKEWED_VALUES + ".\"SD_ID_OID\","
         + "  " + SKEWED_STRING_LIST_VALUES + ".\"STRING_LIST_ID\","

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2553,15 +2553,15 @@ public class ObjectStore implements RawStore, Configurable {
         protected Boolean getJdoResult(GetHelper<Boolean> ctx) throws MetaException, NoSuchObjectException {
           try {
             return addPartitionsInternal(catName, dbName, tblName, parts);
-          } catch (Exception e) {
+          } catch (InvalidObjectException e) {
             LOG.error("Failed to addPartitionsInternal ", e);
-            throw new MetaException(e.getMessage());
+            throw new NoSuchObjectException(e.getMessage());
           }
         }
       }.run(true);
     } catch (NoSuchObjectException e) {
       LOG.error("Failed to addPartitionsInternal ", e);
-      throw new MetaException(e.getMessage());
+      throw new InvalidObjectException(e.getMessage());
     }
   }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -2536,8 +2536,13 @@ public class ObjectStore implements RawStore, Configurable {
                 + dbName + "." + tblName + ": " + part);
       }
     }
+    boolean allowSql = false;
+    if (sqlGenerator.getDbProduct().isPOSTGRES()) {
+      // Currently this path is tested only for postgres.
+      allowSql = true;
+    }
     try {
-      return new GetHelper<Boolean>(catName, dbName, tblName, true, false) {
+      return new GetHelper<Boolean>(catName, dbName, tblName, allowSql, !allowSql) {
         @Override
         protected String describeResult() {
           return null;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
@@ -1,0 +1,491 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jdo.PersistenceManager;
+import javax.jdo.datastore.JDOConnection;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.hadoop.hive.metastore.DirectSqlUpdateStat.quoteString;
+import static org.apache.hadoop.hive.metastore.Warehouse.makePartName;
+
+/**
+ * This class contains the optimizations for MetaStore that rely on direct SQL access to
+ * the underlying database. It should use ANSI SQL and be compatible with common databases
+ * such as MySQL (note that MySQL doesn't use full ANSI mode by default), Postgres, etc.
+ *
+ * This class implements some helper method for operations related to partition.
+ */
+class PartitionHelper {
+  private static final Logger LOG = LoggerFactory.getLogger(PartitionHelper.class);
+
+  private static void close(ResultSet rs) {
+    try {
+      if (rs != null && !rs.isClosed()) {
+        rs.close();
+      }
+    } catch(SQLException ex) {
+      LOG.warn("Failed to close statement ", ex);
+    }
+  }
+
+  /**
+   * Gets the next value from SEQUENCE_TABLE table for given sequence. The sequence value is updated by numValues and
+   * the current value is returned. write lock is taken on the SEQUENCE_TABLE to avoid race condition of multiple
+   * thread trying to insert the initial value.
+   * @return The sequence value before update.
+   */
+  public static long getNextValueFromSequenceTable(Connection dbConn, String seqName, long numValues,
+                                            DatabaseProduct dbType) throws MetaException {
+    try {
+      try (Statement stmt = dbConn.createStatement()) {
+        String lockTableSql = dbType.lockTable("SEQUENCE_TABLE", false);
+        stmt.executeUpdate(lockTableSql);
+      }
+
+      String updateQuery;
+      ResultSet rs = null;
+      long currValue;
+      try (Statement stmt = dbConn.createStatement()) {
+        String query = "SELECT \"NEXT_VAL\" FROM \"SEQUENCE_TABLE\" WHERE \"SEQUENCE_NAME\"= " + quoteString(seqName);
+        rs = stmt.executeQuery(query);
+        if (rs.next()) {
+          currValue = rs.getLong(1);
+          long nextValue = currValue + numValues;
+          updateQuery = "UPDATE \"SEQUENCE_TABLE\" SET \"NEXT_VAL\" = " + nextValue + " WHERE \"SEQUENCE_NAME\" = "
+                  + quoteString(seqName);
+        } else {
+          currValue = 1;
+          long nextValue = currValue + numValues ;
+          updateQuery = "INSERT INTO \"SEQUENCE_TABLE\" (\"SEQUENCE_NAME\", \"NEXT_VAL\")  VALUES ( "
+                  + quoteString(seqName) + "," + nextValue
+                  + ")";
+        }
+      } finally {
+        close(rs);
+      }
+
+      try (Statement stmt = dbConn.createStatement()) {
+        stmt.executeUpdate(updateQuery);
+      }
+      return currValue;
+    } catch (SQLException e){
+      LOG.error("Failed to get next value for sequence " + seqName + " with numValues " + numValues, e);
+      throw new MetaException(e.getMessage());
+    }
+  }
+
+  // Check if partition privilege tables needs to be updated. This is done by checking the table privilege table. If
+  // table privilege info is present for table, then the same info is added for partitions also.
+  public static boolean needToAddPrivilegeInfo(Connection dbConn, long tblId) throws SQLException {
+    ResultSet rs = null;
+    try (Statement statement = dbConn.createStatement()) {
+      String query = "SELECT \"PARAM_VALUE\" FROM \"TABLE_PARAMS\" WHERE \"PARAM_KEY\"= "
+              + quoteString("PARTITION_LEVEL_PRIVILEGE")
+              + " AND  \"TBL_ID\" = " + tblId;
+      LOG.debug("Going to execute query " + query);
+      rs = statement.executeQuery(query);
+      if (rs.next()) {
+        String grantInfo = rs.getString(1);
+        if ("TRUE".equalsIgnoreCase(grantInfo)) {
+          return true;
+        }
+      }
+    } finally {
+      close(rs);
+    }
+    return false;
+  }
+
+  public static void addPartitionPrivilegeInfo(Connection dbConn, List<Partition> parts,
+                                                long tblId, long partId, long grantId ) throws SQLException {
+    ResultSet rs = null;
+    long numPartGrant = 0;
+    try (Statement statement = dbConn.createStatement()) {
+      String query = "SELECT COUNT(*) FROM \"TBL_PRIVS\" WHERE  \"TBL_ID\" = " + tblId;
+      rs = statement.executeQuery(query);
+      if (rs.next()) {
+        numPartGrant = rs.getLong(1);
+      }
+    } finally {
+      close(rs);
+    }
+
+    if (numPartGrant == 0) {
+      return;
+    }
+
+    long grantIdIdx = grantId;
+    int now = (int) (System.currentTimeMillis() / 1000);
+    String insertPartPrev = "INSERT INTO \"PART_PRIVS\" "
+            + " (\"PART_GRANT_ID\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PART_ID\","
+            + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_PRIV\", \"AUTHORIZER\") "
+            + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+    List<Integer> grantOptionList = new ArrayList<>();
+    List<String> grantorList = new ArrayList<>();
+    List<String> grantTypeList = new ArrayList<>();
+    List<String> principalNameList = new ArrayList<>();
+    List<String> principalTypeList = new ArrayList<>();
+    List<String> tblPrivList = new ArrayList<>();
+    List<String> authorizerList = new ArrayList<>();
+
+    try (Statement statement = dbConn.createStatement()) {
+      String query = "SELECT \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\", "
+              + " \"PRINCIPAL_TYPE\", \"TBL_PRIV\", \"AUTHORIZER\" "
+              + " FROM \"TBL_PRIVS\""
+              + " WHERE  \"TBL_ID\" = " + tblId;
+      LOG.debug("Going to execute query " + query);
+      rs = statement.executeQuery(query);
+      while (rs.next()) {
+        grantOptionList.add(rs.getInt(1));
+        grantorList.add(rs.getString(2));
+        grantTypeList.add(rs.getString(3));
+        principalNameList.add(rs.getString(4));
+        principalTypeList.add(rs.getString(5));
+        tblPrivList.add(rs.getString(6));
+        authorizerList.add(rs.getString(7));
+      }
+    } finally {
+      close(rs);
+    }
+
+    try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
+      long partIdx = partId;
+      for (int j = 0; j < parts.size(); j++) {
+        for (int i = 0; i < grantOptionList.size(); i++) {
+          pst.setLong(1, grantIdIdx++);
+          pst.setInt(2, now);
+          pst.setInt(3, grantOptionList.get(i));
+          pst.setString(4, grantorList.get(i));
+          pst.setString(5, grantTypeList.get(i));
+          pst.setLong(6, partIdx);
+          pst.setString(7, principalNameList.get(i));
+          pst.setString(8, principalTypeList.get(i));
+          pst.setString(9, tblPrivList.get(i));
+          pst.setString(10, authorizerList.get(i));
+          pst.addBatch();
+        }
+        partIdx++;
+      }
+    }
+  }
+
+  public static void addPartitionColPrivilegeInfo(Connection dbConn, List<Partition> parts,
+                                               long tblId, long startPartId, long startGrantId ) throws SQLException {
+    ResultSet rs = null;
+    long numPartColGrant = 0;
+    try (Statement statement = dbConn.createStatement()) {
+      String query = "SELECT COUNT(*) FROM \"TBL_COL_PRIVS\" WHERE  \"TBL_ID\" = " + tblId;
+      rs = statement.executeQuery(query);
+      if (rs.next()) {
+        numPartColGrant = rs.getLong(1);
+      }
+    } finally {
+      close(rs);
+    }
+
+    if (numPartColGrant == 0) {
+      return;
+    }
+
+    List<String> colNameList = new ArrayList<>();
+    List<Integer> grantOptionList = new ArrayList<>();
+    List<String> grantorList = new ArrayList<>();
+    List<String> grantTypeList = new ArrayList<>();
+    List<String> principalNameList = new ArrayList<>();
+    List<String> principalTypeList = new ArrayList<>();
+    List<String> tblColPrivList = new ArrayList<>();
+    List<String> authorizerList = new ArrayList<>();
+    rs = null;
+    try (Statement statement = dbConn.createStatement()) {
+      String query = "SELECT \"COLUMN_NAME\", \"GRANT_OPTION\", \"GRANTOR\", \"GRANTOR_TYPE\", \"PRINCIPAL_NAME\","
+              + " \"PRINCIPAL_TYPE\", \"TBL_COL_PRIV\", \"AUTHORIZER\" "
+              + " FROM \"TBL_COL_PRIVS\""
+              + " WHERE  \"TBL_ID\" = " + tblId;
+      LOG.debug("Going to execute query " + query);
+      rs = statement.executeQuery(query);
+      while (rs.next()) {
+        colNameList.add(rs.getString(1));
+        grantOptionList.add(rs.getInt(2));
+        grantorList.add(rs.getString(3));
+        grantTypeList.add(rs.getString(4));
+        principalNameList.add(rs.getString(5));
+        principalTypeList.add(rs.getString(6));
+        tblColPrivList.add(rs.getString(7));
+        authorizerList.add(rs.getString(8));
+      }
+    } finally {
+      close(rs);
+    }
+
+    String insertPartPrev = "INSERT INTO \"PART_COL_PRIVS\" "
+            + " (\"PART_COLUMN_GRANT_ID\", \"COLUMN_NAME\", \"CREATE_TIME\", \"GRANT_OPTION\", \"GRANTOR\","
+            + " \"GRANTOR_TYPE\", \"PART_ID\","
+            + " \"PRINCIPAL_NAME\", \"PRINCIPAL_TYPE\", \"PART_COL_PRIV\", \"AUTHORIZER\") "
+            + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+    try (PreparedStatement pst = dbConn.prepareStatement(insertPartPrev)) {
+      long partIdx = startPartId;
+      long grantIdIdx = startGrantId;
+      int now = (int) (System.currentTimeMillis() / 1000);
+      for (int j = 0; j < parts.size(); j++) {
+        for (int i = 0; i < grantOptionList.size(); i++) {
+          pst.setLong(1, grantIdIdx++);
+          pst.setString(2, colNameList.get(i));
+          pst.setInt(3, now);
+          pst.setInt(4, grantOptionList.get(i));
+          pst.setString(5, grantorList.get(i));
+          pst.setString(6, grantTypeList.get(i));
+          pst.setLong(7, partIdx);
+          pst.setString(8, principalNameList.get(i));
+          pst.setString(9, principalTypeList.get(i));
+          pst.setString(10, tblColPrivList.get(i));
+          pst.setString(11, authorizerList.get(i));
+          pst.addBatch();
+        }
+        partIdx++;
+      }
+    }
+  }
+
+  public static void addSerdeInfo(Connection dbConn, List<Partition> parts, long serdeIdIdx) throws SQLException {
+    String insertSerdeInfo = "INSERT INTO \"SERDES\" (\"SERDE_ID\", \"NAME\", \"SLIB\", \"DESCRIPTION\","
+            + " \"SERIALIZER_CLASS\", \"DESERIALIZER_CLASS\", \"SERDE_TYPE\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdeInfo)) {
+      for (Partition part : parts) {
+        if (part.getSd() == null) {
+          continue;
+        }
+        SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
+        preparedStatement.setLong(1, serdeIdIdx++);
+        preparedStatement.setObject(2, serDeInfo.getName());
+        preparedStatement.setObject(3, serDeInfo.getSerializationLib());
+        preparedStatement.setObject(4, serDeInfo.getDescription());
+        preparedStatement.setObject(5, serDeInfo.getSerializerClass());
+        preparedStatement.setObject(6, serDeInfo.getDeserializerClass());
+        preparedStatement.setLong(7, serDeInfo.getSerdeType() != null ?
+                serDeInfo.getSerdeType().getValue() : 0);
+        preparedStatement.addBatch();
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addColDescInfo(Connection dbConn, List<Partition> parts, long cdIdIdx) throws SQLException {
+    String insertCDInfo = "INSERT INTO \"CDS\" (\"CD_ID\") VALUES (?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertCDInfo)) {
+      for (Partition ignored : parts) {
+        preparedStatement.setLong(1, cdIdIdx++);
+        preparedStatement.addBatch();
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addSDInfo(Connection dbConn, List<Partition> parts, long sdIdIdx,
+                               long serdeIdIdx, long cdIdIdx, DatabaseProduct dbType) throws SQLException {
+    String insertSDInfo = "INSERT INTO \"SDS\" (\"SD_ID\", \"INPUT_FORMAT\", \"IS_COMPRESSED\", \"LOCATION\","
+            + " \"NUM_BUCKETS\", \"OUTPUT_FORMAT\", \"SERDE_ID\", \"CD_ID\", \"IS_STOREDASSUBDIRECTORIES\")"
+            + " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDInfo)) {
+      for (Partition part : parts) {
+        StorageDescriptor sd = part.getSd();
+        if (sd == null) {
+          continue;
+        }
+        preparedStatement.setLong(1, sdIdIdx++);
+        preparedStatement.setObject(2, sd.getInputFormat());
+        preparedStatement.setObject(4, sd.getLocation());
+        preparedStatement.setObject(5, sd.getNumBuckets());
+        preparedStatement.setObject(6, sd.getOutputFormat());
+        preparedStatement.setLong(7, serdeIdIdx++);
+        preparedStatement.setObject(8, sd.getCols() == null ? null : cdIdIdx);
+        cdIdIdx++;
+
+        if (dbType.isDERBY()) {
+          // In Derby schema file, constraint is added for the value to be either Y or N.
+          preparedStatement.setObject(3, sd.isCompressed() ? "Y" : "N");
+          preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? "Y" : "N");
+        } else if (dbType.isORACLE()) {
+          // In Oracle schema file, constraint is added for the value to be either 1 or 0.
+          preparedStatement.setObject(3, sd.isCompressed() ? 1 : 0);
+          preparedStatement.setObject(9, sd.isStoredAsSubDirectories() ? 1 : 0);
+        } else if (dbType.isMYSQL() || dbType.isPOSTGRES() || dbType.isSQLSERVER()) {
+          // For postgres the column is of type is boolean. For mysql its bit(1) and for sql server its bit.
+          // For both, the conversion is done automatically from boolean to bit.
+          preparedStatement.setBoolean(3, sd.isCompressed());
+          preparedStatement.setBoolean(9, sd.isStoredAsSubDirectories());
+        } else {
+          throw new IllegalArgumentException("Unsupported DB type: " + dbType);
+        }
+
+        preparedStatement.addBatch();
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addColV2Info(Connection dbConn, List<Partition> parts, long cdIdIdx) throws SQLException {
+    String insertColInfo = "INSERT INTO \"COLUMNS_V2\" (\"CD_ID\", \"COMMENT\", \"COLUMN_NAME\", \"TYPE_NAME\","
+            + " \"INTEGER_IDX\") VALUES (?, ?, ?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertColInfo)) {
+      for (Partition part : parts) {
+        StorageDescriptor sd = part.getSd();
+        if (sd == null) {
+          continue;
+        }
+        List<FieldSchema> cols = sd.getCols();
+        if (cols == null) {
+          continue;
+        }
+        int colIdx = 0;
+        for (FieldSchema col : cols) {
+          preparedStatement.setLong(1, cdIdIdx);
+          preparedStatement.setString(2, col.getComment());
+          preparedStatement.setString(3, col.getName());
+          preparedStatement.setString(4, col.getType());
+          preparedStatement.setLong(5, colIdx++);
+          preparedStatement.addBatch();
+        }
+        cdIdIdx++;
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addSDParaInfo(Connection dbConn, List<Partition> parts, long sdIdIdx) throws SQLException {
+    String insertSDParamInfo = "INSERT INTO \"SD_PARAMS\" (\"SD_ID\", \"PARAM_KEY\", \"PARAM_VALUE\")" +
+            " VALUES (?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSDParamInfo)) {
+      for (Partition part : parts) {
+        StorageDescriptor sd = part.getSd();
+        if (sd == null) {
+          continue;
+        }
+        for (Map.Entry entry : sd.getParameters().entrySet()) {
+          String key = (String) entry.getKey();
+          String value = (String) entry.getValue();
+          preparedStatement.setLong(1, sdIdIdx);
+          preparedStatement.setString(2, key);
+          preparedStatement.setString(3, value);
+          preparedStatement.addBatch();
+        }
+        sdIdIdx++;
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addSerdeParaInfo(Connection dbConn, List<Partition> parts, long serdeIdIdx) throws SQLException {
+    String insertSerdePara
+            = "INSERT INTO \"SERDE_PARAMS\" (\"SERDE_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertSerdePara)) {
+      for (Partition part : parts) {
+        if (part.getSd() == null) {
+          continue;
+        }
+        SerDeInfo serDeInfo = part.getSd().getSerdeInfo();
+        for (Map.Entry entry : serDeInfo.getParameters().entrySet()) {
+          String key = (String) entry.getKey();
+          String value = (String) entry.getValue();
+          preparedStatement.setLong(1, serdeIdIdx);
+          preparedStatement.setString(2, key);
+          preparedStatement.setString(3, value);
+          preparedStatement.addBatch();
+        }
+        serdeIdIdx++;
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addPartitionInfo(Connection dbConn, List<Partition> parts, List<FieldSchema> partKeys,
+                                       long tblId, long partIdIdx, long sdIdIdx) throws MetaException, SQLException {
+    String insertPartition = "INSERT INTO \"PARTITIONS\" (\"PART_ID\", \"CREATE_TIME\", \"LAST_ACCESS_TIME\", "
+            + "\"PART_NAME\", \"SD_ID\", \"TBL_ID\", \"WRITE_ID\") VALUES (?, ?, ?, ?, ?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartition)) {
+      for (Partition part : parts) {
+        preparedStatement.setLong(1, partIdIdx++);
+        preparedStatement.setObject(2, part.getCreateTime());
+        preparedStatement.setObject(3, part.getLastAccessTime());
+        preparedStatement.setString(4,
+                makePartName(partKeys, part.getValues(), null));
+        preparedStatement.setObject(5, part.getSd() == null ? null : sdIdIdx);
+        preparedStatement.setLong(6, tblId);
+        preparedStatement.setLong(7, part.getWriteId());
+        sdIdIdx++;
+        preparedStatement.addBatch();
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addPartitionParaInfo(Connection dbConn, List<Partition> parts,
+                                          long partIdIdx) throws SQLException {
+    String insertParamKeys =
+            "INSERT INTO \"PARTITION_PARAMS\" (\"PART_ID\", \"PARAM_KEY\", \"PARAM_VALUE\") VALUES (?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertParamKeys)) {
+      for (Partition part : parts) {
+        for (Map.Entry entry : part.getParameters().entrySet()) {
+          String key = (String) entry.getKey();
+          String value = (String) entry.getValue();
+          preparedStatement.setLong(1, partIdIdx);
+          preparedStatement.setString(2, key);
+          preparedStatement.setString(3, value);
+          preparedStatement.addBatch();
+        }
+        partIdIdx++;
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+
+  public static void addPartitionKeyValInfo(Connection dbConn, List<Partition> parts,
+                                            long partIdIdx) throws SQLException {
+    String insertPartKeyVals
+            = "INSERT INTO \"PARTITION_KEY_VALS\" (\"PART_ID\", \"PART_KEY_VAL\", \"INTEGER_IDX\") VALUES (?, ?, ?) ";
+    try (PreparedStatement preparedStatement = dbConn.prepareStatement(insertPartKeyVals)) {
+      for (Partition part : parts) {
+        int idx = 0;
+        for (String value : part.getValues()) {
+          preparedStatement.setLong(1, partIdIdx);
+          preparedStatement.setString(2, value);
+          preparedStatement.setLong(3, idx++);
+          preparedStatement.addBatch();
+        }
+        partIdIdx++;
+      }
+      preparedStatement.executeBatch();
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
@@ -154,12 +154,12 @@ class PartitionHelper {
   }
   
   private static long addBatch(PreparedStatement pst, long numRecords, long maxBatchSize) throws SQLException {
+    pst.addBatch();
+    numRecords++;
     if (numRecords == maxBatchSize) {
       executeBatch(pst, numRecords);
       numRecords = 0;
     }
-    pst.addBatch();
-    numRecords++;
     return numRecords;
   }
   
@@ -399,6 +399,9 @@ class PartitionHelper {
           pst.setString(3, col.getName());
           pst.setString(4, col.getType());
           pst.setLong(5, idx++);
+          LOG.debug("Executing insert numRecords " + numRecords  + " maxBatchSize " + maxBatchSize +
+                          insertColInfo.replaceAll("\\?", "{}"),
+                  cdIdIdx, col.getComment(), col.getName(), col.getType(), idx);
           numRecords = addBatch(pst, numRecords, maxBatchSize);
         }
         cdIdIdx++;

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
@@ -557,25 +557,28 @@ class PartitionHelper {
         if (skewedInfo == null) {
           continue;
         }
+        long idx1 = 0;
+        Map<List<String>,String> listStringMap = skewedInfo.getSkewedColValueLocationMaps();
         for (List<String> values : skewedInfo.getSkewedColValues()) {
           long idx = 0;
-          long idx1 = 0;
           for (String value : values) {
             pst.setLong(1, listId);
             pst.setString(2, value);
             pst.setLong(3, idx++);
             numRecords = addBatch(pst, numRecords, maxBatchSize);
-
-            pstValues.setLong(1, sdId);
-            pstValues.setLong(2, listId);
-            pstValues.setLong(3, idx1++);
-            numRecordsVals = addBatch(pstValues, numRecordsVals, maxBatchSize);
           }
 
-          pstMap.setLong(1, sdId);
-          pstMap.setLong(2, listId);
-          pstMap.setString(3, skewedInfo.getSkewedColValueLocationMaps().get(values));
-          numRecordsMap = addBatch(pstMap, numRecordsMap, maxBatchSize);
+          pstValues.setLong(1, sdId);
+          pstValues.setLong(2, listId);
+          pstValues.setLong(3, idx1++);
+          numRecordsVals = addBatch(pstValues, numRecordsVals, maxBatchSize);
+
+          if (listStringMap.containsKey(values)) {
+            pstMap.setLong(1, sdId);
+            pstMap.setLong(2, listId);
+            pstMap.setString(3, listStringMap.get(values));
+            numRecordsMap = addBatch(pstMap, numRecordsMap, maxBatchSize);
+          }
 
           listId++;
         }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/PartitionHelper.java
@@ -507,18 +507,10 @@ class PartitionHelper {
     return numSkewedString;
   }
 
-  public static long addSkewedStringListId(Connection dbConn, long maxBatchSize, long numSkewedString)
-          throws SQLException {
-    long maxListId = 1;
-    ResultSet rs = null;
-    try (Statement statement = dbConn.createStatement()) {
-      rs = statement.executeQuery("SELECT MAX(\"STRING_LIST_ID\") FROM \"SKEWED_STRING_LIST\"");
-      if (rs.next()) {
-        maxListId = rs.getLong(1) + 1;
-      }
-    } finally {
-      close(rs);
-    }
+  public static long addSkewedStringListId(Connection dbConn, long maxBatchSize, long numSkewedString, DatabaseProduct dbType)
+          throws SQLException, MetaException {
+    final long maxListId = PartitionHelper.getNextValueFromSequenceTable(
+            dbConn, "org.apache.hadoop.hive.metastore.model.MStringList", numSkewedString, dbType);
 
     String insertSDParamInfo = "INSERT INTO \"SKEWED_STRING_LIST\" (\"STRING_LIST_ID\") VALUES (?)";
     try (PreparedStatement pst = dbConn.prepareStatement(insertSDParamInfo)) {

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAddPartitions.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestAddPartitions.java
@@ -1539,6 +1539,7 @@ public class TestAddPartitions extends MetaStoreClientTest {
   @Test
   public void testAddPartitionFailNotification() throws Exception {
     Table table = createTable();
+    org.junit.Assume.assumeFalse(table.isTemporary());
     Partition partition =
             buildPartition(Lists.newArrayList(DEFAULT_YEAR_VALUE), getYearPartCol(), 1);
 

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestHMSDbNotificationListener.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/client/TestHMSDbNotificationListener.java
@@ -1,0 +1,20 @@
+package org.apache.hadoop.hive.metastore.client;
+
+import org.apache.hadoop.hive.metastore.TransactionalMetaStoreEventListener;
+import org.apache.hadoop.hive.metastore.events.AddPartitionEvent;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.metastore.api.MetaException;
+
+public class TestHMSDbNotificationListener extends TransactionalMetaStoreEventListener {
+    public static boolean throwException = false;
+    public TestHMSDbNotificationListener(Configuration config) throws MetaException {
+        super(config);
+    }
+
+    @Override
+    public void onAddPartition(AddPartitionEvent partitionEvent) throws MetaException {
+        if (throwException) {
+            throw new MetaException("Add partition failed in onAddPartition");
+        }
+    }
+}


### PR DESCRIPTION
….

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Batched the sql statements used for adding the partition info into backend RDBMS.



### Why are the changes needed?
Performance improvement.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test added. Performance improvements were tested by comparing the execution time of adding 10k partitions.
