### PR TITLE
HIVE-25253: Incremental rebuild of partitioned insert only materialized views

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -391,6 +391,8 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
 
       RelOptHiveTable hiveTable = (RelOptHiveTable) materialization.tableRel.getTable();
       if (!AcidUtils.isInsertOnlyTable(hiveTable.getHiveTableMD())) {
+        // TODO: plan may contains TS on fully ACID table and aggregate functions which are not supported the
+        // record level incremental rewriting rules but partition based can be applied.
         return applyPreJoinOrderingTransforms(basePlan, mdProvider, executorProvider);
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -312,6 +312,8 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
           }
         }
       } else if (materialization.isSourceTablesUpdateDeleteModified()) {
+        // calcitePreMVRewritingPlan is already got the optimizations by applyPreJoinOrderingTransforms prior calling
+        // applyMaterializedViewRewriting in CalcitePlanner.CalcitePlannerAction.apply
         return calcitePreMVRewritingPlan;
       } else {
         return applyPreJoinOrderingTransforms(basePlan, mdProvider, executorProvider);
@@ -380,6 +382,10 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
             HiveRelOptMaterialization materialization, RelNode calcitePreMVRewritingPlan) {
 
       if (materialization.isSourceTablesUpdateDeleteModified()) {
+        // TODO: Create rewrite rule to transform the plan to partition based incremental rebuild
+        // addressing deleted records. The rule should enable fetching deleted rows and count deleted records
+        // with a negative sign when calculating sum and count functions in top aggregate.
+        // This type of rewrite also requires the existence of count(*) function call in view definition.
         return calcitePreMVRewritingPlan;
       }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/HiveCalciteUtil.java
@@ -1252,4 +1252,18 @@ public class HiveCalciteUtil {
     }
     return refs.build();
   }
+
+  public static Set<RexTableInputRef> findRexTableInputRefs(RexNode rexNode) {
+    Set<RexTableInputRef> rexTableInputRefs = new HashSet<>();
+    RexVisitor<RexTableInputRef> visitor = new RexVisitorImpl<RexTableInputRef>(true) {
+      @Override
+      public RexTableInputRef visitTableInputRef(RexTableInputRef ref) {
+        rexTableInputRefs.add(ref);
+        return ref;
+      }
+    };
+
+    rexNode.accept(visitor);
+    return rexTableInputRefs;
+  }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -1,0 +1,152 @@
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.core.Union;
+import org.apache.calcite.rel.metadata.RelMetadataQuery;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexTableInputRef;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
+import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil.findRexTableInputRefs;
+
+/**
+ * Rule to prepare the plan for incremental view maintenance if the view is partitioned and insert only:
+ * Insert overwrite the partitions which are affected since the last rebuild only and leave the
+ * rest of the partitions intact.
+ *
+ * Assume that we have a materialized view partitioned on column a and writeId was 1 at the last rebuild:
+ *
+ * CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+ * SELECT a, b, sum(c) sumc FROM t1 GROUP BY b, a;
+ *
+ * 1. Query all rows from source tables since the last rebuild.
+ * 2. Query all rows from MV which are in any of the partitions queried in 1.
+ * 3. Take the union of rows from 1. and 2. and perform the same aggregations defined in the MV
+ *
+ * SELECT b, sum(sumc), a FROM (
+ *     SELECT b, sumc, a FROM mat1
+ *     LEFT SEMI JOIN (SELECT b, sum(c), a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+ *     UNION ALL
+ *     SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+ * ) sub
+ * GROUP BY a, b
+ */
+public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveAggregatePartitionIncrementalRewritingRule.class);
+
+  public static final HiveAggregatePartitionIncrementalRewritingRule INSTANCE =
+          new HiveAggregatePartitionIncrementalRewritingRule();
+
+  private HiveAggregatePartitionIncrementalRewritingRule() {
+    super(operand(Aggregate.class, operand(Union.class, any())),
+            HiveRelFactories.HIVE_BUILDER, "HiveJoinPartitionIncrementalRewritingRule");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    RexBuilder rexBuilder = call.builder().getRexBuilder();
+
+    final Aggregate aggregate = call.rel(0);
+    final Union union = call.rel(1);
+    final RelNode queryBranch = union.getInput(0);
+    final RelNode mvBranch = union.getInput(1);
+
+    // find Partition col indexes in mvBranch top operator row schema
+    // mvBranch can be more complex than just a TS on the MV and the partition columns indexes in the top Operator's
+    // row schema may differ from the one in the TS row schema. Example:
+    // Project($2, $0, $1)
+    //   TableScan(table=materialized_view1, schema=a, b, part_col)
+    RelMetadataQuery relMetadataQuery = RelMetadataQuery.instance();
+    int partitionColumnCount = -1;
+    List<Integer> partitionColumnIndexes = new ArrayList<>();
+    for (int i = 0; i < mvBranch.getRowType().getFieldList().size(); ++i) {
+      RelDataTypeField relDataTypeField = mvBranch.getRowType().getFieldList().get(i);
+      RexInputRef inputRef = rexBuilder.makeInputRef(relDataTypeField.getType(), i);
+
+      Set<RexNode> expressionLineage = relMetadataQuery.getExpressionLineage(mvBranch, inputRef);
+      if (expressionLineage == null || expressionLineage.size() != 1) {
+        continue;
+      }
+
+      Set<RexTableInputRef> tableInputRefs = findRexTableInputRefs(expressionLineage.iterator().next());
+      if (tableInputRefs.size() != 1) {
+        continue;
+      }
+
+      RexTableInputRef tableInputRef = tableInputRefs.iterator().next();
+      RelOptHiveTable relOptHiveTable = (RelOptHiveTable) tableInputRef.getTableRef().getTable();
+      if (!(relOptHiveTable.getHiveTableMD().isMaterializedView())) {
+        continue;
+      }
+
+      partitionColumnCount = relOptHiveTable.getPartColInfoMap().size();
+      if (relOptHiveTable.getPartColInfoMap().containsKey(tableInputRef.getIndex())) {
+        partitionColumnIndexes.add(i);
+      }
+    }
+
+    if (partitionColumnCount == 0 || partitionColumnIndexes.size() != partitionColumnCount) {
+      LOG.debug("Could not found all partition column lineages, bail out.");
+      return;
+    }
+
+    List<RexNode> joinConjs = new ArrayList<>();
+    for (int partColIndex: partitionColumnIndexes) {
+      RexNode leftRef = rexBuilder.makeInputRef(
+              mvBranch.getRowType().getFieldList().get(partColIndex).getType(), partColIndex);
+      RexNode rightRef = rexBuilder.makeInputRef(
+              queryBranch.getRowType().getFieldList().get(partColIndex).getType(),
+              partColIndex + mvBranch.getRowType().getFieldCount());
+
+      joinConjs.add(rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_DISTINCT_FROM, leftRef, rightRef));
+    }
+
+    RexNode joinCond = RexUtil.composeConjunction(rexBuilder, joinConjs);
+
+    RelBuilder builder = call.builder();
+    RelNode newNode = builder
+            .push(mvBranch)
+            .push(queryBranch)
+            .join(JoinRelType.SEMI, joinCond)
+            .push(queryBranch)
+            .union(union.all)
+            .aggregate(builder.groupKey(aggregate.getGroupSet()), aggregate.getAggCallList())
+            .build();
+    call.transformTo(newNode);
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -16,7 +16,6 @@ package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;/*
  * limitations under the License.
  */
 
-import com.google.common.collect.ImmutableList;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
@@ -30,7 +29,6 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexUtil;
-import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
@@ -58,13 +56,13 @@ import static org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil.findRe
  * 2. Query all rows from MV which are in any of the partitions queried in 1.
  * 3. Take the union of rows from 1. and 2. and perform the same aggregations defined in the MV
  *
- * SELECT b, sum(sumc), a FROM (
- *     SELECT b, sumc, a FROM mat1
- *     LEFT SEMI JOIN (SELECT b, sum(c), a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+ * SELECT a, b, sum(sumc) FROM (
+ *     SELECT a, b, sumc FROM mat1
+ *     LEFT SEMI JOIN (SELECT a, b, sum(c) FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
  *     UNION ALL
- *     SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+ *     SELECT a, b, sum(c) sumc FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
  * ) sub
- * GROUP BY a, b
+ * GROUP BY b, a
  */
 public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
   private static final Logger LOG = LoggerFactory.getLogger(HiveAggregatePartitionIncrementalRewritingRule.class);

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -72,7 +72,7 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
 
   private HiveAggregatePartitionIncrementalRewritingRule() {
     super(operand(Aggregate.class, operand(Union.class, any())),
-            HiveRelFactories.HIVE_BUILDER, "HiveJoinPartitionIncrementalRewritingRule");
+            HiveRelFactories.HIVE_BUILDER, "HiveAggregatePartitionIncrementalRewritingRule");
   }
 
   @Override

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -119,7 +119,7 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
     }
 
     if (partitionColumnCount == 0 || partitionColumnIndexes.size() != partitionColumnCount) {
-      LOG.debug("Could not found all partition column lineages, bail out.");
+      LOG.debug("Could not find all partition column lineages, bail out.");
       return;
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -109,7 +109,8 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
       RexTableInputRef tableInputRef = tableInputRefs.iterator().next();
       RelOptHiveTable relOptHiveTable = (RelOptHiveTable) tableInputRef.getTableRef().getTable();
       if (!(relOptHiveTable.getHiveTableMD().isMaterializedView())) {
-        continue;
+        LOG.warn("{} is not a materialized view, bail out.", relOptHiveTable.getQualifiedName());
+        return;
       }
 
       partitionColumnCount = relOptHiveTable.getPartColInfoMap().size();

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionIncrementalRewritingRule.java
@@ -1,4 +1,5 @@
-package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;/*
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -119,7 +120,7 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
       }
     }
 
-    if (partitionColumnCount == 0 || partitionColumnIndexes.size() != partitionColumnCount) {
+    if (partitionColumnCount <= 0 || partitionColumnIndexes.size() != partitionColumnCount) {
       LOG.debug("Could not find all partition column lineages, bail out.");
       return;
     }

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
@@ -1,0 +1,44 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true');
+
+INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4),
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100),
+(null, 4, 200);
+
+CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc FROM t1 GROUP BY b, a;
+
+INSERT INTO t1(a, b, c) VALUES
+(1, 1, 3),
+(1, 3, 110),
+(null, 4, 20);
+
+SELECT b, sum(sumc), a FROM (
+    SELECT b, sumc, a FROM mat1
+    LEFT SEMI JOIN (SELECT b, sum(c), a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+ORDER BY a, b;
+
+EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+
+SELECT b, sumc, a FROM mat1
+order by a, b;
+
+DROP MATERIALIZED VIEW mat1;
+
+SELECT b, sum(c), a sumc FROM t1 GROUP BY b, a
+order by a, b;

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
@@ -26,7 +26,7 @@ SELECT b, sum(sumc), a FROM (
     UNION ALL
     SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
 ) sub
-GROUP BY a, b
+GROUP BY b, a
 ORDER BY a, b;
 
 EXPLAIN CBO

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_2.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_2.q
@@ -1,0 +1,36 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+
+CREATE TABLE t1(a int, b int, c int, d string, e float) STORED AS ORC TBLPROPERTIES ('transactional' = 'true');
+
+INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 1, 1, "one", 1.1),
+(1, 4, 1, "one", 4.2),
+(2, 2, 2, "two", 2.2),
+(1, 10, 1, "one", 10.1),
+(2, 2, 2, "two", 2.2),
+(1, 3, 1, "one", 3.1),
+(null, 4, null, "unknown", 4.6),
+(null, 4, 2, "unknown", 4.7);
+
+CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a, c, d) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, sum(b) sumb, c, d, sum(e) sume FROM t1 GROUP BY a, c, d;
+
+INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 3, 1, "one", 3.3),
+(1, 110, 1, "one", 110.11),
+(null, 20, null, "unknown", 20.22);
+
+EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+
+SELECT a, sumb, c, d, sume FROM mat1
+order by a, c, d;
+
+DROP MATERIALIZED VIEW mat1;
+
+SELECT a, sum(b), c, d, sum(e) FROM t1 GROUP BY a, c, d
+order by a, c, d;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
@@ -1,0 +1,477 @@
+PREHOOK: query: CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4),
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100),
+(null, 4, 200)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4),
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100),
+(null, 4, 200)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+PREHOOK: query: CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc FROM t1 GROUP BY b, a
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc FROM t1 GROUP BY b, a
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1
+POSTHOOK: Output: default@mat1@a=2
+POSTHOOK: Output: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Lineage: mat1 PARTITION(a=1).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 3),
+(1, 3, 110),
+(null, 4, 20)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 3),
+(1, 3, 110),
+(null, 4, 20)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+PREHOOK: query: SELECT b, sum(sumc), a FROM (
+    SELECT b, sumc, a FROM mat1
+    LEFT SEMI JOIN (SELECT b, sum(c), a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT b, sum(sumc), a FROM (
+    SELECT b, sumc, a FROM mat1
+    LEFT SEMI JOIN (SELECT b, sum(c), a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	8	1
+2	10	1
+3	210	1
+4	220	NULL
+PREHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(b=[$0], sumc=[$2], a=[$1])
+  HiveAggregate(group=[{0, 1}], agg#0=[sum($2)])
+    HiveProject(b=[$0], a=[$1], sumc=[$2])
+      HiveUnion(all=[true])
+        HiveProject(b=[$0], a=[$1], sumc=[$2])
+          HiveSemiJoin(condition=[IS NOT DISTINCT FROM($1, $4)], joinType=[semi])
+            HiveProject(b=[$0], a=[$2], sumc=[$1])
+              HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+            HiveProject(b=[$1], a=[$0])
+              HiveAggregate(group=[{0, 1}])
+                HiveFilter(condition=[<(1, $5.writeid)])
+                  HiveTableScan(table=[[default, t1]], table:alias=[t1])
+        HiveProject(b=[$1], a=[$0], $f2=[$2])
+          HiveAggregate(group=[{0, 1}], agg#0=[sum($2)])
+            HiveFilter(condition=[<(1, $5.writeid)])
+              HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+  Stage-4 depends on stages: Stage-3
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: default.mat1
+                  Statistics: Num rows: 6 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: b (type: int), a (type: int), sumc (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2
+                    Statistics: Num rows: 6 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 6 Data size: 96 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col2 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (ROW__ID.writeid > 1L) (type: boolean)
+                  Statistics: Num rows: 10 Data size: 76 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ROW__ID.writeid > 1L) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: int)
+                      outputColumnNames: a, b
+                      Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: a (type: int), b (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                          Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: int), c (type: int)
+                      outputColumnNames: a, b, c
+                      Statistics: Num rows: 3 Data size: 36 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(c)
+                        keys: b (type: int), a (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                          Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col2 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 4 Data size: 64 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.4285714
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int), _col2 (type: bigint), _col1 (type: int)
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                        serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                        name: default.mat1
+                    Write Type: INSERT
+                  Select Operator
+                    expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: int)
+                    outputColumnNames: b, sumc, a
+                    Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(b), max(b), count(1), count(b), compute_bit_vector_hll(b), min(sumc), max(sumc), count(sumc), compute_bit_vector_hll(sumc)
+                      keys: a (type: int)
+                      minReductionHashAggr: 0.4
+                      mode: hash
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                      Statistics: Num rows: 2 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int)
+                        null sort order: z
+                        sort order: +
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 2 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                        value expressions: _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: binary), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: binary)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9
+                Statistics: Num rows: 2 Data size: 680 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'LONG' (type: string), UDFToLong(_col1) (type: bigint), UDFToLong(_col2) (type: bigint), (_col3 - _col4) (type: bigint), COALESCE(ndv_compute_bit_vector(_col5),0) (type: bigint), _col5 (type: binary), 'LONG' (type: string), _col6 (type: bigint), _col7 (type: bigint), (_col3 - _col8) (type: bigint), COALESCE(ndv_compute_bit_vector(_col9),0) (type: bigint), _col9 (type: binary), _col0 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12
+                  Statistics: Num rows: 2 Data size: 1064 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 2 Data size: 1064 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 3 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 3 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: int)
+                    minReductionHashAggr: 0.4
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 2 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col2)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.4285714
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 3 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            a 
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mat1
+          Write Type: INSERT
+          micromanaged table: true
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: b, sumc
+          Column Types: int, bigint
+          Table: default.mat1
+
+  Stage: Stage-4
+    Materialized View Update
+      name: default.mat1
+      update creation metadata: true
+
+PREHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1
+POSTHOOK: Output: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Lineage: mat1 PARTITION(a=1).b EXPRESSION [(mat1)default.mat1.FieldSchema(name:b, type:int, comment:null), (t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).sumc EXPRESSION [(mat1)default.mat1.FieldSchema(name:sumc, type:bigint, comment:null), (t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__).b EXPRESSION [(mat1)default.mat1.FieldSchema(name:b, type:int, comment:null), (t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__).sumc EXPRESSION [(mat1)default.mat1.FieldSchema(name:sumc, type:bigint, comment:null), (t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: SELECT b, sumc, a FROM mat1
+order by a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT b, sumc, a FROM mat1
+order by a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+#### A masked pattern was here ####
+1	8	1
+2	10	1
+3	210	1
+1	2	2
+2	11	2
+4	220	NULL
+PREHOOK: query: DROP MATERIALIZED VIEW mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: DROP MATERIALIZED VIEW mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: SELECT b, sum(c), a sumc FROM t1 GROUP BY b, a
+order by a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT b, sum(c), a sumc FROM t1 GROUP BY b, a
+order by a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	8	1
+2	10	1
+3	210	1
+1	2	2
+2	11	2
+4	220	NULL

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
@@ -77,7 +77,7 @@ PREHOOK: query: SELECT b, sum(sumc), a FROM (
     UNION ALL
     SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
 ) sub
-GROUP BY a, b
+GROUP BY b, a
 ORDER BY a, b
 PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
@@ -92,7 +92,7 @@ POSTHOOK: query: SELECT b, sum(sumc), a FROM (
     UNION ALL
     SELECT b, sum(c) sumc, a FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
 ) sub
-GROUP BY a, b
+GROUP BY b, a
 ORDER BY a, b
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_2.q.out
@@ -1,0 +1,440 @@
+PREHOOK: query: CREATE TABLE t1(a int, b int, c int, d string, e float) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1(a int, b int, c int, d string, e float) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 1, 1, "one", 1.1),
+(1, 4, 1, "one", 4.2),
+(2, 2, 2, "two", 2.2),
+(1, 10, 1, "one", 10.1),
+(2, 2, 2, "two", 2.2),
+(1, 3, 1, "one", 3.1),
+(null, 4, null, "unknown", 4.6),
+(null, 4, 2, "unknown", 4.7)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 1, 1, "one", 1.1),
+(1, 4, 1, "one", 4.2),
+(2, 2, 2, "two", 2.2),
+(1, 10, 1, "one", 10.1),
+(2, 2, 2, "two", 2.2),
+(1, 3, 1, "one", 3.1),
+(null, 4, null, "unknown", 4.6),
+(null, 4, 2, "unknown", 4.7)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
+POSTHOOK: Lineage: t1.e SCRIPT []
+PREHOOK: query: CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a, c, d) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, sum(b) sumb, c, d, sum(e) sume FROM t1 GROUP BY a, c, d
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a, c, d) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, sum(b) sumb, c, d, sum(e) sume FROM t1 GROUP BY a, c, d
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1/c=1/d=one
+POSTHOOK: Output: default@mat1@a=2/c=2/d=two
+POSTHOOK: Output: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+POSTHOOK: Output: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+POSTHOOK: Lineage: mat1 PARTITION(a=1,c=1,d=one).sumb EXPRESSION [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1,c=1,d=one).sume EXPRESSION [(t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2,c=2,d=two).sumb EXPRESSION [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2,c=2,d=two).sume EXPRESSION [(t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=2,d=unknown).sumb EXPRESSION [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=2,d=unknown).sume EXPRESSION [(t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=__HIVE_DEFAULT_PARTITION__,d=unknown).sumb EXPRESSION [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=__HIVE_DEFAULT_PARTITION__,d=unknown).sume EXPRESSION [(t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+PREHOOK: query: INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 3, 1, "one", 3.3),
+(1, 110, 1, "one", 110.11),
+(null, 20, null, "unknown", 20.22)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1(a, b, c, d, e) VALUES
+(1, 3, 1, "one", 3.3),
+(1, 110, 1, "one", 110.11),
+(null, 20, null, "unknown", 20.22)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+POSTHOOK: Lineage: t1.d SCRIPT []
+POSTHOOK: Lineage: t1.e SCRIPT []
+PREHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1/c=1/d=one
+PREHOOK: Input: default@mat1@a=2/c=2/d=two
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1/c=1/d=one
+POSTHOOK: Input: default@mat1@a=2/c=2/d=two
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(sumb=[$3], sume=[$4], a=[$0], c=[$1], d=[$2])
+  HiveAggregate(group=[{0, 1, 2}], agg#0=[sum($3)], agg#1=[sum($4)])
+    HiveProject(a=[$0], c=[$1], d=[$2], sumb=[$3], sume=[$4])
+      HiveUnion(all=[true])
+        HiveProject(a=[$0], c=[$1], d=[$2], sumb=[$3], sume=[$4])
+          HiveSemiJoin(condition=[AND(IS NOT DISTINCT FROM($0, $5), IS NOT DISTINCT FROM($1, $6), IS NOT DISTINCT FROM($2, $7))], joinType=[semi])
+            HiveProject(a=[$2], c=[$3], d=[$4], sumb=[$0], sume=[$1])
+              HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+            HiveProject(a=[$0], c=[$1], d=[$2])
+              HiveAggregate(group=[{0, 2, 3}])
+                HiveFilter(condition=[<(1, $7.writeid)])
+                  HiveTableScan(table=[[default, t1]], table:alias=[t1])
+        HiveProject(a=[$0], c=[$1], d=[$2], $f3=[$3], $f4=[$4])
+          HiveAggregate(group=[{0, 2, 3}], agg#0=[sum($1)], agg#1=[sum($4)])
+            HiveFilter(condition=[<(1, $7.writeid)])
+              HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1/c=1/d=one
+PREHOOK: Input: default@mat1@a=2/c=2/d=two
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1/c=1/d=one
+POSTHOOK: Input: default@mat1@a=2/c=2/d=two
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+  Stage-4 depends on stages: Stage-3
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 6 <- Map 5 (SIMPLE_EDGE)
+        Reducer 7 <- Map 5 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: default.mat1
+                  Statistics: Num rows: 4 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: a (type: int), c (type: int), d (type: string), sumb (type: bigint), sume (type: double)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                    Statistics: Num rows: 4 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                      null sort order: zzz
+                      sort order: +++
+                      Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                      Statistics: Num rows: 4 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col3 (type: bigint), _col4 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 5 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (ROW__ID.writeid > 1L) (type: boolean)
+                  Statistics: Num rows: 11 Data size: 1044 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ROW__ID.writeid > 1L) (type: boolean)
+                    Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), c (type: int), d (type: string)
+                      outputColumnNames: a, c, d
+                      Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: a (type: int), c (type: int), d (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2
+                        Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                          null sort order: zzz
+                          sort order: +++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                          Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: int), c (type: int), d (type: string), e (type: float)
+                      outputColumnNames: a, b, c, d, e
+                      Statistics: Num rows: 3 Data size: 312 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(b), sum(e)
+                        keys: a (type: int), c (type: int), d (type: string)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                        Statistics: Num rows: 3 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                          null sort order: zzz
+                          sort order: +++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                          Statistics: Num rows: 3 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col3 (type: bigint), _col4 (type: double)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                  1 _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                nullSafes: [true, true, true]
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 4 Data size: 832 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col3), sum(_col4)
+                  keys: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                  minReductionHashAggr: 0.4285714
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    null sort order: zzz
+                    sort order: +++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col3 (type: bigint), _col4 (type: double)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), sum(VALUE._col1)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col3 (type: bigint), _col4 (type: double), _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: bigint), _col1 (type: double), _col2 (type: int), _col3 (type: int), _col4 (type: string)
+                    outputColumnNames: sumb, sume, a, c, d
+                    Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                    Group By Operator
+                      aggregations: min(sumb), max(sumb), count(1), count(sumb), compute_bit_vector_hll(sumb), min(sume), max(sume), count(sume), compute_bit_vector_hll(sume)
+                      keys: a (type: int), c (type: int), d (type: string)
+                      mode: complete
+                      outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11
+                      Statistics: Num rows: 3 Data size: 1608 Basic stats: COMPLETE Column stats: COMPLETE
+                      Select Operator
+                        expressions: 'LONG' (type: string), _col3 (type: bigint), _col4 (type: bigint), (_col5 - _col6) (type: bigint), COALESCE(ndv_compute_bit_vector(_col7),0) (type: bigint), _col7 (type: binary), 'DOUBLE' (type: string), _col8 (type: double), _col9 (type: double), (_col5 - _col10) (type: bigint), COALESCE(ndv_compute_bit_vector(_col11),0) (type: bigint), _col11 (type: binary), _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14
+                        Statistics: Num rows: 3 Data size: 2166 Basic stats: COMPLETE Column stats: COMPLETE
+                        File Output Operator
+                          compressed: false
+                          Statistics: Num rows: 3 Data size: 2166 Basic stats: COMPLETE Column stats: COMPLETE
+                          table:
+                              input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                              output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                              serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+                  Select Operator
+                    expressions: _col0 (type: bigint), _col1 (type: double), _col2 (type: int), _col3 (type: int), _col4 (type: string)
+                    outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                    File Output Operator
+                      compressed: false
+                      Dp Sort State: PARTITION_SORTED
+                      Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                          serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                          name: default.mat1
+                      Write Type: INSERT
+        Reducer 6 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2
+                Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  keys: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2
+                  Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    null sort order: zzz
+                    sort order: +++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    Statistics: Num rows: 3 Data size: 288 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), sum(VALUE._col1)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int), KEY._col2 (type: string)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                Statistics: Num rows: 3 Data size: 336 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col3), sum(_col4)
+                  keys: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                  minReductionHashAggr: 0.4285714
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4
+                  Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    null sort order: zzz
+                    sort order: +++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int), _col2 (type: string)
+                    Statistics: Num rows: 3 Data size: 624 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col3 (type: bigint), _col4 (type: double)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            a 
+            c 
+            d 
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mat1
+          Write Type: INSERT
+          micromanaged table: true
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: sumb, sume
+          Column Types: bigint, double
+          Table: default.mat1
+
+  Stage: Stage-4
+    Materialized View Update
+      name: default.mat1
+      update creation metadata: true
+
+PREHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1/c=1/d=one
+PREHOOK: Input: default@mat1@a=2/c=2/d=two
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1/c=1/d=one
+POSTHOOK: Input: default@mat1@a=2/c=2/d=two
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1/c=1/d=one
+POSTHOOK: Output: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+POSTHOOK: Lineage: mat1 PARTITION(a=1,c=1,d=one).sumb EXPRESSION [(mat1)default.mat1.FieldSchema(name:sumb, type:bigint, comment:null), (t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1,c=1,d=one).sume EXPRESSION [(mat1)default.mat1.FieldSchema(name:sume, type:double, comment:null), (t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=__HIVE_DEFAULT_PARTITION__,d=unknown).sumb EXPRESSION [(mat1)default.mat1.FieldSchema(name:sumb, type:bigint, comment:null), (t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=__HIVE_DEFAULT_PARTITION__,c=__HIVE_DEFAULT_PARTITION__,d=unknown).sume EXPRESSION [(mat1)default.mat1.FieldSchema(name:sume, type:double, comment:null), (t1)t1.FieldSchema(name:e, type:float, comment:null), ]
+PREHOOK: query: SELECT a, sumb, c, d, sume FROM mat1
+order by a, c, d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1/c=1/d=one
+PREHOOK: Input: default@mat1@a=2/c=2/d=two
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, sumb, c, d, sume FROM mat1
+order by a, c, d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1/c=1/d=one
+POSTHOOK: Input: default@mat1@a=2/c=2/d=two
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=2/d=unknown
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__/c=__HIVE_DEFAULT_PARTITION__/d=unknown
+#### A masked pattern was here ####
+1	131	1	one	131.91000068187714
+2	4	2	two	4.400000095367432
+NULL	4	2	unknown	4.699999809265137
+NULL	24	NULL	unknown	24.81999921798706
+PREHOOK: query: DROP MATERIALIZED VIEW mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: DROP MATERIALIZED VIEW mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: SELECT a, sum(b), c, d, sum(e) FROM t1 GROUP BY a, c, d
+order by a, c, d
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, sum(b), c, d, sum(e) FROM t1 GROUP BY a, c, d
+order by a, c, d
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	131	1	one	131.91000068187714
+2	4	2	two	4.400000095367432
+NULL	4	2	unknown	4.699999809265137
+NULL	24	NULL	unknown	24.81999921798706


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Add rewrite rule: Insert overwrite the partitions which are affected since the last rebuild only and leave the rest of the partitions intact.

### Why are the changes needed?
Improve performance of MV rebuild if MV is partitioned insert only and contains aggregate.

### Does this PR introduce _any_ user-facing change?
No. However `explain` output may change.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_partitioned_create_rewrite_agg.q -pl itests/qtest -Pitests
```