### PR TITLE
HIVE-25190 Fix many small allocations in BytesColumnVector

### DIFF
--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -185,7 +185,7 @@
         <version>3.0.0-M4</version>
         <configuration>
           <reuseForks>false</reuseForks>
-          <argLine>-Xmx2048m</argLine>
+          <argLine>-Xmx3g</argLine>
           <failIfNoTests>false</failIfNoTests>
           <systemPropertyVariables>
             <test.tmp.dir>${project.build.directory}/tmp</test.tmp.dir>

--- a/storage-api/src/test/org/apache/hadoop/hive/ql/exec/vector/TestBytesColumnVector.java
+++ b/storage-api/src/test/org/apache/hadoop/hive/ql/exec/vector/TestBytesColumnVector.java
@@ -18,10 +18,16 @@
 
 package org.apache.hadoop.hive.ql.exec.vector;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
+import org.apache.hadoop.hive.ql.exec.vector.expressions.StringExpr;
 import org.junit.Test;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public class TestBytesColumnVector {
   @Test
@@ -35,33 +41,41 @@ public class TestBytesColumnVector {
     col.reset();
 
     // Initial write (small value)
-    byte[] bytes1 = writeToBytesColumnVector(rowIdx, col, smallWriteSize, (byte) 1);
+    byte[] bytes1 = writeToBytesColumnVector(rowIdx, col, smallWriteSize, 1);
     bytesWrittenToBytes1 += smallWriteSize;
+    assertEquals(0, col.start[0]);
+    assertEquals(smallWriteSize, col.length[0]);
 
     // Write a large value. This should use a different byte buffer
     rowIdx++;
-    byte[] bytes2 = writeToBytesColumnVector(rowIdx, col, largeWriteSize, (byte) 2);
-    assertFalse(bytes1 == bytes2);
+    byte[] bytes2 = writeToBytesColumnVector(rowIdx, col, largeWriteSize, -1);
+    assertNotSame(bytes1, bytes2);
+    assertEquals(0, col.start[1]);
+    assertEquals(largeWriteSize, col.length[1]);
 
     // Another small write. smallBuffer should be re-used for this write
     rowIdx++;
-    byte[] bytes3 = writeToBytesColumnVector(rowIdx, col, smallWriteSize, (byte) 1);
+    byte[] bytes3 = writeToBytesColumnVector(rowIdx, col, smallWriteSize, 2);
     bytesWrittenToBytes1 += smallWriteSize;
-    assertTrue(bytes1 == bytes3);
+    assertSame(bytes1, bytes3);
+    assertEquals(smallWriteSize, col.start[2]);
+    assertEquals(smallWriteSize, col.length[2]);
 
     // Write another large value. This should use a different byte buffer
     rowIdx++;
-    byte[] bytes4 = writeToBytesColumnVector(rowIdx, col, largeWriteSize, (byte) 3);
-    assertFalse(bytes1 == bytes4);
-    assertFalse(bytes2 == bytes4);
+    byte[] bytes4 = writeToBytesColumnVector(rowIdx, col, largeWriteSize, -2);
+    assertNotSame(bytes1, bytes4);
+    assertNotSame(bytes2, bytes4);
+    assertEquals(0, col.start[3]);
+    assertEquals(largeWriteSize, col.length[3]);
 
     // Eventually enough small writes should result in another buffer getting created
     boolean gotNewBuffer = false;
     // Test is dependent on getting a new buffer within 1MB.
     // This may need to change as the implementation changes.
-    for (int i = 0; i < 1024; ++i) {
+    for (int i = 3; i < 1024; ++i) {
       rowIdx++;
-      byte[] currBytes = writeToBytesColumnVector(rowIdx, col, smallWriteSize, (byte) 1);
+      byte[] currBytes = writeToBytesColumnVector(rowIdx, col, smallWriteSize, i);
       if (currBytes == bytes1) {
         bytesWrittenToBytes1 += smallWriteSize;
       } else {
@@ -74,16 +88,97 @@ public class TestBytesColumnVector {
 
     // All small writes to the first buffer should be in contiguous memory
     for (int i = 0; i < bytesWrittenToBytes1; ++i) {
-      assertEquals((byte) 1, bytes1[i]);
+      assertEquals((byte) (i / smallWriteSize + 1), bytes1[i]);
     }
   }
 
-  // Write a value to the column vector, and return back the byte buffer used.
-  private static byte[] writeToBytesColumnVector(int rowIdx, BytesColumnVector col, int writeSize, byte val) {
+  /**
+   * Test the setVal, setConcat, and StringExpr.padRight methods.
+   */
+  @Test
+  public void testConcatAndPadding() {
+    BytesColumnVector col = new BytesColumnVector();
+    col.reset();
+    byte[] prefix = "緑".getBytes(StandardCharsets.UTF_8);
+
+    // fill the column with 'test'
+    for(int row=0; row < col.vector.length; ++row) {
+      col.setVal(row, prefix, 0, prefix.length);
+    }
+    for(int row=0; row < col.vector.length; ++row) {
+      assertEquals("row " + row, "緑", col.toString(row));
+    }
+
+    // pad out to 6 characters
+    for(int row=0; row < col.vector.length; ++row) {
+      StringExpr.padRight(col, row, col.vector[row], col.start[row],
+          col.length[row], 6);
+    }
+    for(int row=0; row < col.vector.length; ++row) {
+      assertEquals("row " + row, "緑     ", col.toString(row));
+    }
+
+    // concat the row digits
+    for(int row=0; row < col.vector.length; ++row) {
+      byte[] rowStr = Integer.toString(row).getBytes(StandardCharsets.UTF_8);
+      col.setConcat(row, col.vector[row], col.start[row], col.length[row],
+          rowStr, 0, rowStr.length);
+    }
+    for(int row=0; row < col.vector.length; ++row) {
+      assertEquals("row " + row, "緑     " + row, col.toString(row));
+    }
+
+    // We end up allocating 20k, so we should have expanded the small buffer
+    assertEquals(32 * 1024, col.bufferSize());
+  }
+
+  @Test
+  public void testBufferOverflow() {
+    BytesColumnVector col = new BytesColumnVector(2048);
+    col.reset();
+    assertEquals(BytesColumnVector.DEFAULT_BUFFER_SIZE, col.bufferSize());
+
+    // pick a size below 1m so that we use the small buffer;
+    final int size = BytesColumnVector.MAX_SIZE_FOR_SMALL_ITEM - 1024;
+
+    // run through once to expand the small value buffer
+    for(int row=0; row < col.vector.length; ++row) {
+      writeToBytesColumnVector(row, col, size, row);
+    }
+    // it should have resized a bunch of times
+    byte[] smallBuffer = col.getValPreallocatedBytes();
+    assertNotSame(smallBuffer, col.vector[0]);
+    assertSame(smallBuffer, col.vector[1024]);
+
+    // reset the column, but make sure the buffer isn't reallocated
+    col.reset();
+    assertEquals(BytesColumnVector.MAX_SIZE_FOR_SMALL_BUFFER, col.bufferSize());
+
+    // fill up the vector now with the large buffer
+    for(int row=0; row < col.vector.length; ++row) {
+      writeToBytesColumnVector(row, col, size, row);
+    }
+    assertEquals(BytesColumnVector.MAX_SIZE_FOR_SMALL_BUFFER, col.bufferSize());
+    // now the first 1025 rows should all be the small buffer
+    for(int row=0; row < 1025; ++row) {
+      assertSame("row " + row, smallBuffer, col.vector[row]);
+      assertEquals("row " + row, row * size, col.start[row]);
+      assertEquals("row " + row, size, col.length[row]);
+    }
+    // the rest should be custom buffers
+    for(int row=1025; row < col.vector.length; ++row) {
+      assertNotSame("row " + row, smallBuffer, col.vector[row]);
+      assertEquals("row " + row, 0, col.start[row]);
+      assertEquals("row " + row, size, col.length[row]);
+    }
+  }
+
+    // Write a value to the column vector, and return back the byte buffer used.
+  private static byte[] writeToBytesColumnVector(int rowIdx, BytesColumnVector col, int writeSize, int val) {
     col.ensureValPreallocated(writeSize);
     byte[] bytes = col.getValPreallocatedBytes();
     int startIdx = col.getValPreallocatedStart();
-    Arrays.fill(bytes, startIdx, startIdx + writeSize, val);
+    Arrays.fill(bytes, startIdx, startIdx + writeSize, (byte) val);
     col.setValPreallocated(rowIdx, writeSize);
     return bytes;
   }


### PR DESCRIPTION

### What changes were proposed in this pull request?

This change fixes BytesColumnVector so that it will not try to increase the small item buffer to be larger than 1gb. Any allocations after that will use individual buffers.

It also adds new tests to verify the changed behavior. Since the new test needs to allocate more than 1gb of data, I needed to bump up the test memory from 2 to 3gb.

I also restructured the internal details of the BytesColumnVector and the way that the small value buffer is managed. Now, the fields buffer and nextFree are only used to store the location of the current value allocation. The long term buffer is always stored in smallBuffer and smallBufferNextFree. (It previously had moved back and forth between the two sets of variables depending on context.)

### Why are the changes needed?

Users are hitting the exception when the small value buffer crosses over 1gb.

### Does this PR introduce _any_ user-facing change?

It removes the public method BytesColumnVector.increaseBufferSpace, which was only called from within storage-api. Users should use the more popular ensureValPreallocated method, which is increaseBufferSpace with a check to see if the increase is necessary.

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
