### PR TITLE
HIVE-25268: Restore the functionality of date_format UDF

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -84,7 +84,7 @@ public class GenericUDFDateFormat extends GenericUDF {
             timeZone = SessionState.get() == null ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
                 .getLocalTimeZone();
           }
-          formatter = DateTimeFormatter.ofPattern(fmtStr).withZone(timeZone);
+          formatter = DateTimeFormatter.ofPattern(fmtStr);
         } catch (IllegalArgumentException e) {
           // ignore
         }
@@ -110,13 +110,9 @@ public class GenericUDFDateFormat extends GenericUDF {
       return null;
     }
 
-    // We are doing an extra timestamp conversion from timeZone to UTC and then UTC to timeZone to maintain the
-    // same zone format semantics as that of SimpleDateFormat for some specific locale. E.g. PST/PDT, CST
-    // If this conversion is not there PDT -> PT and CST -> CT
-    Timestamp ts2 = TimestampTZUtil.convertTimestampToZone(ts, timeZone, ZoneId.of("UTC"));
-    Instant instant = Instant.ofEpochSecond(ts2.toEpochSecond(), ts2.getNanos());
+    Instant instant = Instant.ofEpochSecond(ts.toEpochSecond(), ts.getNanos());
     ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
-    String res = formatter.format(zonedDateTime);
+    String res = formatter.format(zonedDateTime.withZoneSameLocal(timeZone));
 
     output.set(res);
     return output;

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -53,7 +53,7 @@ import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveO
 @Description(name = "date_format", value = "_FUNC_(date/timestamp/string, fmt) - converts a date/timestamp/string "
     + "to a value of string in the format specified by the date format fmt.",
     extended = "Supported formats are DateTimeFormatter formats - "
-        + "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html"
+        + "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html. "
         + "Second argument fmt should be constant.\n"
         + "Example: > SELECT _FUNC_('2015-04-08', 'y');\n '2015'")
 public class GenericUDFDateFormat extends GenericUDF {

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -110,6 +110,9 @@ public class GenericUDFDateFormat extends GenericUDF {
       return null;
     }
 
+    // We are doing an extra timestamp conversion from timeZone to UTC and then UTC to timeZone to maintain the
+    // same zone format semantics as that of SimpleDateFormat for some specific locale. E.g. PST/PDT, CST
+    // If this conversion is not there PDT -> PT and CST -> CT
     Timestamp ts2 = TimestampTZUtil.convertTimestampToZone(ts, timeZone, ZoneId.of("UTC"));
     Instant instant = Instant.ofEpochSecond(ts2.toEpochSecond(), ts2.getNanos());
     ZonedDateTime zonedDateTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hive.ql.udf.generic;
 
 import org.apache.hadoop.hive.common.type.Timestamp;
-import org.apache.hadoop.hive.common.type.TimestampTZUtil;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.Description;
 import org.apache.hadoop.hive.ql.exec.UDFArgumentException;

--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/generic/GenericUDFDateFormat.java
@@ -52,8 +52,8 @@ import static org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveO
  */
 @Description(name = "date_format", value = "_FUNC_(date/timestamp/string, fmt) - converts a date/timestamp/string "
     + "to a value of string in the format specified by the date format fmt.",
-    extended = "Supported formats are SimpleDateFormat formats - "
-        + "https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html. "
+    extended = "Supported formats are DateTimeFormatter formats - "
+        + "https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html"
         + "Second argument fmt should be constant.\n"
         + "Example: > SELECT _FUNC_('2015-04-08', 'y');\n '2015'")
 public class GenericUDFDateFormat extends GenericUDF {

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/DateTimeMath.java
@@ -617,21 +617,4 @@ public class DateTimeMath {
     return calendar;
   }
 
-  /**
-   * TODO - this is a temporary fix for handling Julian calendar dates.
-   * Returns a Gregorian calendar that can be used from year 0+ instead of default 1582.10.15.
-   * This is desirable for some UDFs that work on dates which normally would use Julian calendar.
-   * Julian calendar only works with UTC time zone only.
-   * @return the calendar
-   */
-  public static Calendar getTimeZonedProlepticGregorianCalendar() {
-    ZoneId id = SessionState.get() == null ? new HiveConf().getLocalTimeZone() : SessionState.get().getConf()
-        .getLocalTimeZone();
-    GregorianCalendar calendar = new GregorianCalendar(TimeZone.getTimeZone(id));
-
-    if (id.getId().equals("UTC"))
-      calendar.setGregorianChange(new java.util.Date(Long.MIN_VALUE));
-
-    return calendar;
-  }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
@@ -164,7 +164,7 @@ public class TestGenericUDFDateFormat {
   public void testWrongFmt() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
-    Text fmtText = new Text("Q");
+    Text fmtText = new Text("B");
     ObjectInspector valueOI1 = PrimitiveObjectInspectorFactory
         .getPrimitiveWritableConstantObjectInspector(TypeInfoFactory.stringTypeInfo, fmtText);
     ObjectInspector[] arguments = { valueOI0, valueOI1 };
@@ -176,7 +176,6 @@ public class TestGenericUDFDateFormat {
 
 
   @Test
-  @Ignore
   public void testJulianDates() throws HiveException {
     GenericUDFDateFormat udf = new GenericUDFDateFormat();
     ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;

--- a/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/udf/generic/TestGenericUDFDateFormat.java
@@ -187,6 +187,19 @@ public class TestGenericUDFDateFormat {
     runAndVerifyStr("1001-01-05", fmtText, "05---01--1001", udf);
   }
 
+  @Test
+  public void testTimestampPriorTo1900() throws HiveException {
+    GenericUDFDateFormat udf = new GenericUDFDateFormat();
+    ObjectInspector valueOI0 = PrimitiveObjectInspectorFactory.writableStringObjectInspector;
+    Text fmtText = new Text("yyyy-MM-dd HH:mm:ss.SSS z");
+    ObjectInspector valueOI1 = PrimitiveObjectInspectorFactory
+        .getPrimitiveWritableConstantObjectInspector(TypeInfoFactory.stringTypeInfo, fmtText);
+    ObjectInspector[] arguments = { valueOI0, valueOI1 };
+    udf.initialize(arguments);
+    runAndVerifyStr("1400-01-14 01:01:10.123", fmtText, "1400-01-14 01:01:10.123 PST", udf);
+    runAndVerifyStr("1800-01-14 01:01:10.123", fmtText, "1800-01-14 01:01:10.123 PST", udf);
+  }
+
   private void runAndVerifyStr(String str, Text fmtText, String expResult, GenericUDF udf)
       throws HiveException {
     DeferredObject valueObj0 = new DeferredJavaObject(str != null ? new Text(str) : null);

--- a/ql/src/test/queries/clientpositive/udf_date_format.q
+++ b/ql/src/test/queries/clientpositive/udf_date_format.q
@@ -79,7 +79,15 @@ select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
 set hive.local.time.zone=UTC;
 select date_format("1001-01-05","dd---MM--yyyy");
 
---dates prior to 1900 in another time zone
+--dates prior to 1900
 set hive.local.time.zone=Asia/Bangkok;
-select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z');
-select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z');
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+
+set hive.local.time.zone=Europe/Berlin;
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+
+set hive.local.time.zone=Africa/Johannesburg;
+select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');
+select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z');

--- a/ql/src/test/queries/clientpositive/udf_date_format.q
+++ b/ql/src/test/queries/clientpositive/udf_date_format.q
@@ -63,7 +63,7 @@ date_format(cast(null as timestamp), 'HH');
 -- wrong fmt
 select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q');
+date_format('2015-04-08', 'B');
 
 -- with time zone
 set hive.local.time.zone=Asia/Bangkok;
@@ -78,3 +78,8 @@ select date_format("2015-04-08 10:30:45","yyyy-MM-dd HH:mm:ss.SSS z");
 --julian date
 set hive.local.time.zone=UTC;
 select date_format("1001-01-05","dd---MM--yyyy");
+
+--dates prior to 1900 in another time zone
+set hive.local.time.zone=Asia/Bangkok;
+select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z');
+select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z');

--- a/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
@@ -196,21 +196,57 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 05---01--1001
-PREHOOK: query: select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-POSTHOOK: query: select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-1400-01-14 01:00:00 ICT
-PREHOOK: query: select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+1400-01-14 01:01:10.123 ICT
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-POSTHOOK: query: select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-1800-01-14 01:00:00 ICT
+1800-01-14 01:01:10.123 ICT
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:01:10.123 CET
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:01:10.123 CET
+PREHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:01:10.123 SAST
+PREHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:01:10.123', 'yyyy-MM-dd HH:mm:ss.SSS z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:01:10.123 SAST

--- a/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
@@ -8,7 +8,7 @@ PREHOOK: type: DESCFUNCTION
 POSTHOOK: query: DESC FUNCTION EXTENDED date_format
 POSTHOOK: type: DESCFUNCTION
 date_format(date/timestamp/string, fmt) - converts a date/timestamp/string to a value of string in the format specified by the date format fmt.
-Supported formats are SimpleDateFormat formats - https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html. Second argument fmt should be constant.
+Supported formats are DateTimeFormatter formats - https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html. Second argument fmt should be constant.
 Example: > SELECT date_format('2015-04-08', 'y');
  '2015'
 Function class:org.apache.hadoop.hive.ql.udf.generic.GenericUDFDateFormat

--- a/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_date_format.q.out
@@ -92,7 +92,7 @@ date_format(cast(null as string), 'dd')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
-10	30	45	09 PM	08	123	08	08	NULL
+10	30	45	09 PM	08	1	08	08	NULL
 PREHOOK: query: select
 date_format(cast('2015-04-08' as date), 'EEEE'),
 date_format(cast('2015-04-08' as date), 'G'),
@@ -149,13 +149,13 @@ POSTHOOK: Input: _dummy_database@_dummy_table
 10	30	45	10 AM	08	123	123	NULL
 PREHOOK: query: select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q')
+date_format('2015-04-08', 'B')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 POSTHOOK: query: select
 date_format('2015-04-08', ''),
-date_format('2015-04-08', 'Q')
+date_format('2015-04-08', 'B')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
@@ -196,3 +196,21 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 #### A masked pattern was here ####
 05---01--1001
+PREHOOK: query: select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1400-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1400-01-14 01:00:00 ICT
+PREHOOK: query: select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+POSTHOOK: query: select date_format('1800-01-14 01:00:00', 'yyyy-MM-dd HH:mm:ss z')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+#### A masked pattern was here ####
+1800-01-14 01:00:00 ICT


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Use new java time APIs to get the result instead of older APIs to restore functionality


### Why are the changes needed?
date_format UDF gives 
1. incorrect time values for dates prior to 1901-01-01 00:00:00 if the timezone is not UTC
2. incorrect date and time values for dates prior to October 15, 1582 (Default Gregorian Calendar change)

These changes fix both of the above issues


### Does this PR introduce _any_ user-facing change?
The functionality is restored for the date_format UDF


### How was this patch tested?
1. Unit tests
2. Local tests with MiniHS2 functionality
