### PR TITLE
HIVE-25252: All new compaction metrics should be lower case

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Cleaner.java
@@ -169,7 +169,8 @@ public class Cleaner extends MetaStoreCompactorThread {
   private void clean(CompactionInfo ci, long minOpenTxnGLB, boolean metricsEnabled) throws MetaException {
     LOG.info("Starting cleaning for " + ci);
     PerfLogger perfLogger = PerfLogger.getPerfLogger(false);
-    String cleanerMetric = MetricsConstants.COMPACTION_CLEANER_CYCLE + "_" + ci.type;
+    String cleanerMetric = MetricsConstants.COMPACTION_CLEANER_CYCLE + "_" +
+        (ci.type != null ? ci.type.toString().toLowerCase() : null);
     try {
       if (metricsEnabled) {
         perfLogger.perfLogBegin(CLASS_NAME, cleanerMetric);

--- a/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/txn/compactor/Worker.java
@@ -404,7 +404,8 @@ public class Worker extends RemoteCompactorThread implements MetaStoreThread {
       checkInterrupt();
 
       if (MetastoreConf.getBoolVar(conf, MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_EXT_ON)) {
-        workerMetric = MetricsConstants.COMPACTION_WORKER_CYCLE + "_" + ci.type;
+        workerMetric = MetricsConstants.COMPACTION_WORKER_CYCLE + "_" +
+            (ci.type != null ? ci.type.toString().toLowerCase() : null);
         perfLogger.perfLogBegin(CLASS_NAME, workerMetric);
       }
 

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -306,9 +306,9 @@ public class TestCompactionMetrics  extends CompactorTest {
   @Test
   public void testCleanerPerfMetricsEnabled() throws Exception {
     long cleanerCyclesMinor = Objects.requireNonNull(
-        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MINOR)).getCount();
+        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MINOR.toString().toLowerCase())).getCount();
     long cleanerCyclesMajor = Objects.requireNonNull(
-        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR)).getCount();
+        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR.toString().toLowerCase())).getCount();
 
     Table t = newTable("default", "camipc", true);
     List<Partition> partitions = new ArrayList<>();
@@ -339,7 +339,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
 
     Assert.assertEquals(cleanerCyclesMinor + 10, Objects.requireNonNull(
-        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MINOR)).getCount());
+        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MINOR.toString().toLowerCase())).getCount());
 
     for (int i = 0; i < 10; i++) {
       p = partitions.get(i);
@@ -359,7 +359,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
 
     Assert.assertEquals(cleanerCyclesMajor + 10, Objects.requireNonNull(
-        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR)).getCount());
+        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR.toString().toLowerCase())).getCount());
   }
 
   @Test
@@ -368,7 +368,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     Metrics.initialize(conf);
 
     long cleanerCyclesMinor = Objects.requireNonNull(
-      Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR)).getCount();
+      Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR.toString().toLowerCase())).getCount();
 
     Table t = newTable("default", "camipc", true);
     Partition p = newPartition(t, "today");
@@ -392,7 +392,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     Assert.assertEquals(TxnStore.SUCCEEDED_RESPONSE, rsp.getCompacts().get(0).getState());
 
     Assert.assertEquals(cleanerCyclesMinor, Objects.requireNonNull(
-        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR)).getCount());
+        Metrics.getOrCreateTimer(CLEANER_CYCLE_KEY + "_" + CompactionType.MAJOR.toString().toLowerCase())).getCount());
   }
 
   @Test
@@ -424,7 +424,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     CodahaleMetrics metrics = (CodahaleMetrics) MetricsFactory.getInstance();
     String json = metrics.dumpJson();
     MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.TIMER,
-        WORKER_CYCLE_KEY + "_" + CompactionType.MINOR, 1);
+        WORKER_CYCLE_KEY + "_" + CompactionType.MINOR.toString().toLowerCase(), 1);
 
     rqst = new CompactionRequest("default", "mapwb", CompactionType.MAJOR);
     rqst.setPartitionname("ds=today");
@@ -438,7 +438,7 @@ public class TestCompactionMetrics  extends CompactorTest {
 
     json = metrics.dumpJson();
     MetricsTestUtils.verifyMetricsJson(json, MetricsTestUtils.TIMER,
-        WORKER_CYCLE_KEY + "_" + CompactionType.MAJOR, 1);
+        WORKER_CYCLE_KEY + "_" + CompactionType.MAJOR.toString().toLowerCase(), 1);
   }
 
   @Test


### PR DESCRIPTION
What changes were proposed in this pull request?
All newly introduced compaction related metrics should be lower case.

Why are the changes needed?
Some consumers of the metrics only accept lower case names.

Does this PR introduce any user-facing change?
No

How was this patch tested?
Unit test