### PR TITLE
HIVE-25279: Fix q.outs caused by concurrent commits of HIVE-25240 and HIVE-25229

### DIFF
--- a/ql/src/test/results/clientpositive/llap/masking_mv_by_text_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/masking_mv_by_text_2.q.out
@@ -25,6 +25,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@masking_test_n_mv
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@masking_test_view_n_mv
+POSTHOOK: Lineage: masking_test_view_n_mv.col0 EXPRESSION [(masking_test_n_mv)masking_test_n_mv.FieldSchema(name:key, type:int, comment:null), (masking_test_n_mv)masking_test_n_mv.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: explain cbo
 select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
 PREHOOK: type: QUERY
@@ -61,6 +62,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@masking_test_n_mv
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@masking_test_view_n_mv_masked
+POSTHOOK: Lineage: masking_test_view_n_mv_masked.col0 EXPRESSION [(masking_test_n_mv)masking_test_n_mv.FieldSchema(name:key, type:int, comment:null), (masking_test_n_mv)masking_test_n_mv.FieldSchema(name:value, type:string, comment:null), ]
 PREHOOK: query: explain cbo
 select col0 from (select cast(key as string) col0 from `masking_test_n_mv` union select value col0 from `masking_test_n_mv`) sub
 PREHOOK: type: QUERY

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_6.q.out
@@ -49,6 +49,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
+POSTHOOK: Lineage: mat1.col0 EXPRESSION []
 PREHOOK: query: create materialized view mat2 as
 select col0 from t1 where col0 = 3
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
@@ -61,6 +62,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat2
+POSTHOOK: Lineage: mat2.col0 SIMPLE []
 Warning: Shuffle Join MERGEJOIN[16][tables = [$hdt$_0, $hdt$_1]] in Stage 'Reducer 2' is a cross product
 PREHOOK: query: explain cbo
 select col0 from t2 where exists (

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_7.q.out
@@ -21,6 +21,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
+POSTHOOK: Lineage: mat1.col0 EXPRESSION [(t1)t1.FieldSchema(name:col0, type:int, comment:null), ]
 PREHOOK: query: create materialized view mat2 as
 select col0 from t1 where col0 > 30
 PREHOOK: type: CREATE_MATERIALIZED_VIEW
@@ -33,6 +34,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat2
+POSTHOOK: Lineage: mat2.col0 SIMPLE [(t1)t1.FieldSchema(name:col0, type:int, comment:null), ]
 PREHOOK: query: explain cbo
 select col0 from
   (select col0 from t1 where col0 > 30) sub

--- a/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_rewrite_by_text_8.q.out
@@ -21,6 +21,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat1
+POSTHOOK: Lineage: mat1.col0 EXPRESSION [(t1)t1.FieldSchema(name:col0, type:int, comment:null), ]
 Only query text based automatic rewriting is available for materialized view. Statement has unsupported operator: union.
 PREHOOK: query: create materialized view mat2 as
 select col0 from
@@ -38,6 +39,7 @@ POSTHOOK: type: CREATE_MATERIALIZED_VIEW
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: database:default
 POSTHOOK: Output: default@mat2
+POSTHOOK: Lineage: mat2.col0 EXPRESSION [(t1)t1.FieldSchema(name:col0, type:int, comment:null), ]
 PREHOOK: query: explain cbo
 select col0 from
   (select col0 from t1 where col0 between 1 and 10 union select col0 from t1 where col0 = 20) sub


### PR DESCRIPTION
### What changes were proposed in this pull request?
q.out updates

### Why are the changes needed?
The tests are failing

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Run the tests