### PR TITLE
HIVE-25287

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -278,7 +278,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       }
       HiveTableUtil.importFiles(preAlterTableProperties.tableLocation, preAlterTableProperties.format,
           partitionSpecProxy, preAlterTableProperties.partitionKeys, catalogProperties, conf);
-    } else {
+    } else if (currentAlterTableOp != null) {
       Map<String, String> contextProperties = context.getProperties();
       switch (currentAlterTableOp) {
         case ADDCOLS:
@@ -288,7 +288,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
           break;
         case ADDPROPS:
         case DROPPROPS:
-          alterTableProperties(hmsTable, context.getProperties());
+          alterTableProperties(hmsTable, contextProperties);
           break;
         case SETPARTITIONSPEC:
           IcebergTableUtil.updateSpec(conf, icebergTable);


### PR DESCRIPTION
NPE is thrown upon inserting values into an Iceberg table, as statistics generation triggers an alter table operation with undefined (alter)operation type