### PR TITLE
HIVE-25293: Alter partitioned table with "cascade" option create too many columns records.

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -162,13 +162,15 @@ public class HiveAlterHandler implements AlterHandler {
         //Currently only column related changes can be cascaded in alter table
         if(MetaStoreUtils.isCascadeNeededInAlterTable(oldt, newt)) {
           List<Partition> parts = msdb.getPartitions(dbname, name, -1);
+          List<List<String>> partValues = Lists.newArrayList();
           for (Partition part : parts) {
             List<FieldSchema> oldCols = part.getSd().getCols();
             part.getSd().setCols(newt.getSd().getCols());
             String oldPartName = Warehouse.makePartName(oldt.getPartitionKeys(), part.getValues());
             updatePartColumnStatsForAlterColumns(msdb, part, oldPartName, part.getValues(), oldCols, part);
-            msdb.alterPartition(dbname, name, part.getValues(), part);
+            partValues.add(part.getValues());
           }
+          msdb.alterPartitions(dbname, name, partValues ,parts);
         } else {
           LOG.warn("Alter table does not cascade changes to its partitions.");
         }

--- a/metastore/src/test/org/apache/hadoop/hive/metastore/TestObjectStore.java
+++ b/metastore/src/test/org/apache/hadoop/hive/metastore/TestObjectStore.java
@@ -17,12 +17,10 @@
  */
 package org.apache.hadoop.hive.metastore;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
+import com.google.common.collect.Lists;
+import org.apache.commons.collections.ListUtils;
 import org.apache.hadoop.hive.common.metrics.common.MetricsConstant;
 import org.apache.hadoop.hive.common.metrics.common.MetricsFactory;
 import org.apache.hadoop.hive.common.metrics.metrics2.CodahaleMetrics;
@@ -261,6 +259,19 @@ public class TestObjectStore {
 
     numPartitions  = objectStore.getNumPartitionsByFilter(DB1, TABLE1, "country = \"US\"");
     Assert.assertEquals(2, numPartitions);
+
+    List<List<String>> partValues = Lists.newArrayList();
+    List<FieldSchema> cols = Lists.newArrayList();
+    cols.add(new FieldSchema("col1", serdeConstants.STRING_TYPE_NAME, ""));
+    for (Partition partition : partitions) {
+      partition.getSd().setCols(cols);
+      partValues.add(partition.getValues());
+    }
+    objectStore.alterPartitions(DB1, TABLE1, partValues, partitions);
+    partitions = objectStore.getPartitions(DB1, TABLE1, 10);
+    Assert.assertEquals(2, partitions.size());
+    Assert.assertTrue(ListUtils.isEqualList(cols, partitions.get(0).getSd().getCols()));
+    Assert.assertTrue(ListUtils.isEqualList(cols, partitions.get(1).getSd().getCols()));
 
     objectStore.dropPartition(DB1, TABLE1, value1);
     partitions = objectStore.getPartitions(DB1, TABLE1, 10);


### PR DESCRIPTION

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
1. if partitions was updated with a set of same columns, only create one set of columns and these partitions can share one 'CD_ID'.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
When alter partitioned table with "cascade" option, all partitions supports to be updated. Currently, a CD_ID will be created for each partition, associated with a set of Columns, which will cause a large amount of redundant data in the metadata database.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
No

### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
mvn test -Dtest=TestObjectStore