### PR TITLE
HIVE-25308: Use new Tez API to get JobID for Iceberg commits

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandlerTestUtils.java
@@ -98,12 +98,6 @@ public class HiveIcebergStorageHandlerTestUtils {
     shell.setHiveSessionValue("hive.jar.directory", temp.getRoot().getAbsolutePath());
     shell.setHiveSessionValue("tez.staging-dir", temp.getRoot().getAbsolutePath());
 
-    // temporarily disabling vectorization in Tez, since it doesn't work with projection pruning (fix: TEZ-4248)
-    // TODO: remove this once TEZ-4248 has been released and the Tez dependencies updated here
-    if (engine.equals("tez")) {
-      shell.setHiveSessionValue("hive.vectorized.execution.enabled", "false");
-    }
-
     // Until HADOOP-16435 we have to manually remove the RpcMetrics for every run otherwise we might end up with OOM
     // We have to initialize the metrics as TestMetrics, so shutdown will remove them
     DefaultMetricsSystem.instance().init("TestMetrics");

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -71,7 +71,6 @@ import org.junit.Assert;
 import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -749,7 +748,6 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, records, 0);
   }
 
-  @Ignore("Ignored until new Tez release has come out")
   @Test
   public void testInsertFromSelectWithProjection() throws IOException {
     Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
@@ -767,7 +765,6 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Ignore("Ignored until new Tez release has come out")
   @Test
   public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
     List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
@@ -791,7 +788,6 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     HiveIcebergTestUtils.validateData(table, expected, 0);
   }
 
-  @Ignore("Ignored until new Tez release has come out")
   @Test
   public void testInsertFromJoiningTwoIcebergTables() throws IOException {
     PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)


### PR DESCRIPTION
When committing Iceberg writes, currently we only have the JobID without the vertexID, therefore we have to list the folder `<tableLocation>/temp` first, and parse out the full JobIDs (incl. vertexID) from the resulting folder names. 

With Tez 0.10.1 released, now we have a new API we can call to acquire the full JobID, making the file listing unnecessary.