### PR TITLE
Handle Iceberg queries with partition clauses

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -955,7 +955,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
         optional(1, "customer_id", Types.IntegerType.get()),
         optional(2, "first_name", Types.StringType.get(), "This is first name"),
         optional(3, "last_name", Types.StringType.get(), "This is last name"),
-        optional(4, "address",  Types.StructType.of(
+        optional(4, "address", Types.StructType.of(
             optional(5, "city", Types.StringType.get()),
             optional(6, "street", Types.StringType.get())), null)
     );
@@ -1065,6 +1065,26 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     metaHook.preAlterTable(hmsTable, environmentContext);
     metaHook.commitAlterTable(hmsTable, environmentContext, null);
+  }
+
+  @Test
+  public void testCommandsWithPartitionClauseThrow() {
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("last_name").build();
+    testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, FileFormat.PARQUET, ImmutableList.of());
+
+    String[] commands = {
+        "INSERT INTO target PARTITION (last_name='Johnson') VALUES (1, 'Rob')",
+        "DESCRIBE target PARTITION (last_name='Johnson')"
+    };
+
+    for (String command : commands) {
+      AssertHelpers.assertThrows("Should throw unsupported operation exception for queries with partition spec",
+          IllegalArgumentException.class, "Using partition spec in query is unsupported",
+          () -> shell.executeStatement(command));
+    }
   }
 
   /**

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -1077,7 +1077,9 @@ public class TestHiveIcebergStorageHandlerNoScan {
 
     String[] commands = {
         "INSERT INTO target PARTITION (last_name='Johnson') VALUES (1, 'Rob')",
-        "DESCRIBE target PARTITION (last_name='Johnson')"
+        "INSERT OVERWRITE TABLE target PARTITION (last_name='Johnson') SELECT * FROM target WHERE FALSE",
+        "DESCRIBE target PARTITION (last_name='Johnson')",
+        "TRUNCATE target PARTITION (last_name='Johnson')"
     };
 
     for (String command : commands) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
@@ -102,6 +102,8 @@ public class TruncateTableAnalyzer extends AbstractBaseAlterTableAnalyzer {
       throw new SemanticException(ErrorMsg.TRUNCATE_FOR_NON_MANAGED_TABLE.format(tableName));
     }
 
+    validateUnsupportedPartitionClause(table, root.getChildCount() > 1);
+
     if (table.isNonNative()) {
       throw new SemanticException(ErrorMsg.TRUNCATE_FOR_NON_NATIVE_TABLE.format(tableName)); //TODO
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AbstractDropPartitionAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/drop/AbstractDropPartitionAnalyzer.java
@@ -90,13 +90,14 @@ abstract class AbstractDropPartitionAnalyzer extends AbstractAlterTableAnalyzer 
         throw se;
       }
     }
+    validateAlterTableType(table, AlterTableType.DROPPARTITION, expectView());
+
     Map<Integer, List<ExprNodeGenericFuncDesc>> partitionSpecs = ParseUtils.getFullPartitionSpecs(command, table,
         conf, canGroupExprs);
     if (partitionSpecs.isEmpty()) { // nothing to do
       return;
     }
 
-    validateAlterTableType(table, AlterTableType.DROPPARTITION, expectView());
     ReadEntity re = new ReadEntity(table);
     re.noLockNeeded();
     inputs.add(re);

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -1605,6 +1605,12 @@ public abstract class BaseSemanticAnalyzer {
 
   public static void validatePartSpec(Table tbl, Map<String, String> partSpec,
       ASTNode astNode, HiveConf conf, boolean shouldBeFull) throws SemanticException {
+    if (tbl.getStorageHandler() != null && tbl.getStorageHandler().alwaysUnpartitioned() &&
+        partSpec != null && !partSpec.isEmpty()) {
+      throw new UnsupportedOperationException("Using partition spec in query is unsupported for non-native table" +
+          " backed by: " + tbl.getStorageHandler().toString());
+    }
+
     tbl.validatePartColumnNames(partSpec, shouldBeFull);
     validatePartColumnType(tbl, partSpec, astNode, conf);
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/BaseSemanticAnalyzer.java
@@ -1605,14 +1605,27 @@ public abstract class BaseSemanticAnalyzer {
 
   public static void validatePartSpec(Table tbl, Map<String, String> partSpec,
       ASTNode astNode, HiveConf conf, boolean shouldBeFull) throws SemanticException {
-    if (tbl.getStorageHandler() != null && tbl.getStorageHandler().alwaysUnpartitioned() &&
-        partSpec != null && !partSpec.isEmpty()) {
-      throw new UnsupportedOperationException("Using partition spec in query is unsupported for non-native table" +
-          " backed by: " + tbl.getStorageHandler().toString());
-    }
+    validateUnsupportedPartitionClause(tbl, partSpec != null && !partSpec.isEmpty());
 
     tbl.validatePartColumnNames(partSpec, shouldBeFull);
     validatePartColumnType(tbl, partSpec, astNode, conf);
+  }
+
+  /**
+   * Throws an UnsupportedOperationException in case the query has a partition clause but the table is never partitioned
+   * on the HMS-level. Even though table is not partitioned from the HMS's point of view, it might have some other
+   * notion of partitioning under the hood (e.g. Iceberg tables). In these cases, we might decide to proactively throw a
+   * more descriptive, unified error message instead of failing on some other semantic analysis validation step, which
+   * could provide a more counter-intuitive exception message.
+   *
+   * @param tbl The table object, should not be null.
+   * @param partitionClausePresent Whether a partition clause is present in the query (e.g. PARTITION(last_name='Don'))
+   */
+  protected static void validateUnsupportedPartitionClause(Table tbl, boolean partitionClausePresent) {
+    if (partitionClausePresent && tbl.getStorageHandler() != null && tbl.getStorageHandler().alwaysUnpartitioned()) {
+      throw new UnsupportedOperationException("Using partition spec in query is unsupported for non-native table" +
+          " backed by: " + tbl.getStorageHandler().toString());
+    }
   }
 
   public static void validatePartColumnType(Table tbl, Map<String, String> partSpec,


### PR DESCRIPTION
Iceberg tables are unpartitioned from the HMS's POV even when the underlying Iceberg table itself is partitioned. It is non-user-friendly to leak this implementation detail to the user, and let them face a SemanticException saying it's an unpartitioned table. Instead, we should introduce some point at which we throw a unified exception message saying it's an unsupported op.