### PR TITLE
HIVE-25318: Number of initiator hosts metric should ignore manually initiated compactions

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/process/show/compactions/ShowCompactionsOperation.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hive.ql.ddl.process.show.compactions;
 
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
@@ -31,6 +30,10 @@ import org.apache.hadoop.hive.ql.ddl.ShowUtils;
 import org.apache.hadoop.hive.ql.exec.Utilities;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.session.SessionState;
+
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.NO_VAL;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getHostFromId;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getThreadIdFromId;
 
 /**
  * Operation process of showing compactions.
@@ -98,8 +101,6 @@ public class ShowCompactionsOperation extends DDLOperation<ShowCompactionsDesc> 
     os.write(Utilities.newLineCode);
   }
 
-  private static final String NO_VAL = " --- ";
-
   private void writeRow(DataOutputStream os, ShowCompactResponseElement e) throws IOException {
     os.writeBytes(Long.toString(e.getId()));
     os.write(Utilities.tabCode);
@@ -132,20 +133,5 @@ public class ShowCompactionsOperation extends DDLOperation<ShowCompactionsDesc> 
     os.write(Utilities.tabCode);
     os.writeBytes(getThreadIdFromId(e.getInitiatorId()));
     os.write(Utilities.newLineCode);
-  }
-
-  private String getHostFromId(String id) {
-    if (id == null) {
-      return NO_VAL;
-    }
-    int lastDash = id.lastIndexOf('-');
-    return id.substring(0, lastDash > -1 ? lastDash : id.length());
-  }
-
-  private String getThreadIdFromId(String id) {
-    if (id == null) {
-      return NO_VAL;
-    }
-    return id.substring(id.lastIndexOf('-') + 1);
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -856,7 +856,7 @@ public class TestCompactionMetrics  extends CompactorTest {
     String runtimeId;
     if (manuallyInitiatedCompaction) {
       runtimeId ="hs2-host-" +
-          ThreadLocalRandom.current().nextInt(999) + HiveMetaStoreClient.MANUALLY_INITIATED_COMPACTION;
+          ThreadLocalRandom.current().nextInt(999) + "-" + HiveMetaStoreClient.MANUALLY_INITIATED_COMPACTION;
     } else {
       runtimeId = ServerUtils.hostname() + "-" + ThreadLocalRandom.current().nextInt(999);
     }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -104,7 +104,7 @@ import com.google.common.collect.Lists;
 public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
 
   private final String CLASS_NAME = HiveMetaStoreClient.class.getName();
-  public static final String MANUALLY_INITIATED_COMPACTION = "-manual";
+  public static final String MANUALLY_INITIATED_COMPACTION = "manual";
 
   /**
    * Capabilities of the current client. If this client talks to a MetaStore server in a manner
@@ -4076,7 +4076,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     cr.setType(type);
     cr.setProperties(tblproperties);
-    cr.setInitiatorId(JavaUtils.hostname() + MANUALLY_INITIATED_COMPACTION);
+    cr.setInitiatorId(JavaUtils.hostname() + "-" + MANUALLY_INITIATED_COMPACTION);
     cr.setInitiatorVersion(HiveMetaStoreClient.class.getPackage().getImplementationVersion());
     return client.compact2(cr);
   }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -104,6 +104,7 @@ import com.google.common.collect.Lists;
 public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
 
   private final String CLASS_NAME = HiveMetaStoreClient.class.getName();
+  public static final String MANUALLY_INITIATED_COMPACTION = "-manual";
 
   /**
    * Capabilities of the current client. If this client talks to a MetaStore server in a manner
@@ -4075,7 +4076,7 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
     }
     cr.setType(type);
     cr.setProperties(tblproperties);
-    cr.setInitiatorId(JavaUtils.hostname() + "-manual");
+    cr.setInitiatorId(JavaUtils.hostname() + MANUALLY_INITIATED_COMPACTION);
     cr.setInitiatorVersion(HiveMetaStoreClient.class.getPackage().getImplementationVersion());
     return client.compact2(cr);
   }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/utils/MetaStoreUtils.java
@@ -125,6 +125,8 @@ public class MetaStoreUtils {
       '!', '~', '#', '@', '`'
   };
 
+  public static final String NO_VAL = " --- ";
+
   /**
    * Catches exceptions that cannot be handled and wraps them in MetaException.
    *
@@ -1067,5 +1069,20 @@ public class MetaStoreUtils {
               parameters.get(hive_metastoreConstants.TABLE_NO_AUTO_COMPACT.toUpperCase());
     }
     return noAutoCompact != null && noAutoCompact.equalsIgnoreCase("true");
+  }
+
+  public static String getHostFromId(String id) {
+    if (id == null) {
+      return NO_VAL;
+    }
+    int lastDash = id.lastIndexOf('-');
+    return id.substring(0, lastDash > -1 ? lastDash : id.length());
+  }
+
+  public static String getThreadIdFromId(String id) {
+    if (id == null) {
+      return NO_VAL;
+    }
+    return id.substring(id.lastIndexOf('-') + 1);
   }
 }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
@@ -37,6 +37,7 @@ import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import static org.apache.hadoop.hive.metastore.HiveMetaStoreClient.MANUALLY_INITIATED_COMPACTION;
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.*;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.NO_VAL;
 import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getHostFromId;
@@ -151,7 +152,7 @@ public class AcidMetricService  implements MetastoreTaskThread {
 
     long initiatorsCount = lastElements.values().stream()
         //manually initiated compactions don't count
-        .filter(e -> !"manual".equals(getThreadIdFromId(e.getInitiatorId())))
+        .filter(e -> !MANUALLY_INITIATED_COMPACTION.equals(getThreadIdFromId(e.getInitiatorId())))
         .map(e -> getHostFromId(e.getInitiatorId())).distinct().filter(e -> !NO_VAL.equals(e)).count();
     Metrics.getOrCreateGauge(COMPACTION_NUM_INITIATORS).set((int) initiatorsCount);
     long workersCount = lastElements.values().stream()

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/metrics/AcidMetricService.java
@@ -38,6 +38,9 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.*;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.NO_VAL;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getHostFromId;
+import static org.apache.hadoop.hive.metastore.utils.MetaStoreUtils.getThreadIdFromId;
 
 /**
  * Collect and publish ACID and compaction related metrics.
@@ -45,7 +48,6 @@ import static org.apache.hadoop.hive.metastore.metrics.MetricsConstants.*;
 public class AcidMetricService  implements MetastoreTaskThread {
 
   private static final Logger LOG = LoggerFactory.getLogger(AcidMetricService.class);
-  private static final String NO_VAL = " --- ";
 
   private Configuration conf;
   private TxnStore txnHandler;
@@ -148,6 +150,8 @@ public class AcidMetricService  implements MetastoreTaskThread {
     }
 
     long initiatorsCount = lastElements.values().stream()
+        //manually initiated compactions don't count
+        .filter(e -> !"manual".equals(getThreadIdFromId(e.getInitiatorId())))
         .map(e -> getHostFromId(e.getInitiatorId())).distinct().filter(e -> !NO_VAL.equals(e)).count();
     Metrics.getOrCreateGauge(COMPACTION_NUM_INITIATORS).set((int) initiatorsCount);
     long workersCount = lastElements.values().stream()
@@ -171,14 +175,6 @@ public class AcidMetricService  implements MetastoreTaskThread {
   @Override
   public Configuration getConf() {
     return this.conf;
-  }
-
-  private static String getHostFromId(String id) {
-    if (id == null) {
-      return NO_VAL;
-    }
-    int lastDash = id.lastIndexOf('-');
-    return id.substring(0, lastDash > -1 ? lastDash : id.length());
   }
 
   @VisibleForTesting


### PR DESCRIPTION
### What changes were proposed in this pull request?
If compaction was manually initiated, it shouldn't count towards the total number of hosts running the initiator


### How was this patch tested?
Unit tests
