### PR TITLE
hive

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1486,6 +1486,11 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
     client.alter_partitions_with_environment_context(dbName, tblName, newParts, environmentContext);
 }
 
+  public void alter_partitions(String dbName, String tblName, List<Partition> newParts)
+          throws InvalidOperationException, MetaException, TException {
+    client.alter_partitions(dbName, tblName, newParts);
+  }
+
   @Override
   public void alterDatabase(String dbName, Database db)
       throws MetaException, NoSuchObjectException, TException {


### PR DESCRIPTION
<!--
 project JIRA: https://issues.apache.org/jira/browse/HIVE-24609

 concise example :

public static void descFormatTable(String dbName, String tableName) {
        try {
		    String confPath = "hive-site.xml";
		    HiveConf hc = new HiveConf();
		    hc.addResource(confPath);
		    HiveMetaStoreClient hmsc = new HiveMetaStoreClient(hc);
		     hmsc.alter_partitions(dbName, tableName, list);
        } catch (TException e) {
            e.printStackTrace();
        }
	
	}
-->

### What changes were proposed in this pull request?
<!--

class hierarchy :
  org.apache.hadoop.hive.metastore.HiveMetaStoreClient
  
-->


### Why are the changes needed?
<!--
  why it is a bug?
  The HIVE2.1.1 underlying code provides alter_partitions to modify Hive1.1.0 partition information, but does not expose it to the developer. Therefore, using the HIVE2.1.1 alter_partitions API to modify Hive1.1.0 partition information will cause an error.
-->


### Does this PR introduce _any_ user-facing change?
<!--
No
-->


### How was this patch tested?
<!--
First, create a Hive1.1.0 Hadoop cluster. Second, use Hive to create a partition table. Finally, use Hive2.1.1's alter_partitions method to modify the partition table information.

-->
