### PR TITLE
HIVE-25270 : To create external table without schema should use db schema instead of the metastore default fs

### DIFF
--- a/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCleanerWithReplication.java
+++ b/itests/hive-unit/src/test/java/org/apache/hadoop/hive/ql/txn/compactor/TestCleanerWithReplication.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
 import org.apache.hadoop.hive.metastore.api.Table;
 import static org.apache.hadoop.hive.metastore.ReplChangeManager.SOURCE_OF_REPLICATION;
 import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.hadoop.hive.metastore.conf.MetastoreConf;
 import org.apache.hadoop.hive.metastore.utils.TestTxnDbUtil;
 import org.apache.hadoop.hive.metastore.txn.TxnStore;
 import org.apache.hadoop.hive.metastore.txn.TxnUtils;
@@ -73,6 +74,9 @@ public class TestCleanerWithReplication extends CompactorTest {
     Database db = new Database();
     db.putToParameters(SOURCE_OF_REPLICATION, "1,2,3");
     db.setName(dbName);
+    String whRootString = MetastoreConf.getVar(conf, MetastoreConf.ConfVars.WAREHOUSE);
+    Path whP = new Path(whRootString);
+    db.setLocationUri(fs.getUri().toString() + whP.toUri().getPath());
     ms.createDatabase(db);
   }
 

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/Warehouse.java
@@ -366,6 +366,16 @@ public class Warehouse {
         new Path(dbPath, MetaStoreUtils.encodeTableName(tableName.toLowerCase())));
   }
 
+  public Path getExternalTablePath(Path tblPath,Database db)
+          throws MetaException {
+    if (tblPath.toUri().getAuthority() != null) {
+      return getDnsPath(tblPath);
+    }
+    Path dbPath = getDatabasePath(db);
+    return getDnsPath(new Path(dbPath.toUri().getScheme(), dbPath.toUri().getAuthority(), tblPath
+            .toUri().getPath()));
+  }
+
   public Path getDefaultManagedTablePath(Database db, String tableName) throws MetaException {
     Path dbPath = getDatabaseManagedPath(db);
     return getDnsPath(

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -2390,7 +2390,8 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
             LOG.warn("Location: " + tbl.getSd().getLocation()
                 + " specified for non-external table:" + tbl.getTableName());
           }
-          tblPath = wh.getDnsPath(new Path(tbl.getSd().getLocation()));
+          tblPath = wh.getExternalTablePath(new Path(tbl.getSd().getLocation()),
+                  ms.getDatabase(tbl.getCatName(),tbl.getDbName()));
         }
         tbl.getSd().setLocation(tblPath.toString());
       }


### PR DESCRIPTION
…H format by default

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->
create external table without schema will use db location's schema , instead of the metastore default fs.


### Why are the changes needed?
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->
In some cases, there will be multiple hadoop namenodes, such as using hadoop federation or hadoop rbf.
And if you create table without location, it will use db location as base location, this behavior is similar to that case.

### Does this PR introduce _any_ user-facing change?
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->
yes , if user create external table without schema, it will use db location schema.



### How was this patch tested?
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->

1. start metastore with hdfs nameservive (e.g. hdfs://cluster ) , than create a database with other schema. like
```
create database myhive  location  'hdfs://testing/my/myhive.db'; 
```
2. than in myhive , create a external table without schema , like
```
CREATE EXTERNAL TABLE `user.test_tbl` (
id string,
name string
)
LOCATION '/user/data/test_tbl'
```
3. show table location to check table location is : hdfs://testing/user/data/test_tbl
