### PR TITLE
HIVE-25316: Map partition key columns when pushing TNK op through select

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/topnkey/TopNKeyPushdownProcessor.java
@@ -112,6 +112,7 @@ public class TopNKeyPushdownProcessor implements SemanticNodeProcessor {
 
     LOG.debug("Pushing {} through {}", topNKey.getName(), select.getName());
     topNKeyDesc.setKeyColumns(mappedColumns);
+    topNKeyDesc.setPartitionKeyColumns(mappedColumns.subList(0, topNKeyDesc.getPartitionKeyColumns().size()));
     moveDown(topNKey);
     pushdown(topNKey);
   }

--- a/ql/src/test/queries/clientpositive/external_jdbc_table_perf.q
+++ b/ql/src/test/queries/clientpositive/external_jdbc_table_perf.q
@@ -1940,6 +1940,24 @@ ORDER  BY cd_gender,
           cd_purchase_estimate,
           cd_credit_rating
 LIMIT  100;
+
+explain
+SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5;
+
+SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5;
+
 set hive.auto.convert.anti.join=true;
 
 DROP TABLE catalog_sales;

--- a/ql/src/test/results/clientpositive/llap/external_jdbc_table_perf.q.out
+++ b/ql/src/test/results/clientpositive/llap/external_jdbc_table_perf.q.out
@@ -7126,6 +7126,140 @@ POSTHOOK: Input: default@date_dim
 POSTHOOK: Input: default@store_sales
 POSTHOOK: Input: default@web_sales
 #### A masked pattern was here ####
+PREHOOK: query: explain
+SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+POSTHOOK: query: explain
+SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-0 depends on stages: Stage-1
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: store_sales
+                  properties:
+                    hive.sql.query SELECT "ss_store_sk", SUM("ss_net_profit") AS "$f1"
+FROM "STORE_SALES"
+GROUP BY "ss_store_sk"
+                    hive.sql.query.fieldNames ss_store_sk,$f1
+                    hive.sql.query.fieldTypes int,decimal(17,2)
+                    hive.sql.query.split false
+                  Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                  Top N Key Operator
+                    sort order: ++
+                    keys: ss_store_sk (type: int), $f1 (type: decimal(17,2))
+                    null sort order: az
+                    Map-reduce partition columns: ss_store_sk (type: int)
+                    Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                    top n: 6
+                    Select Operator
+                      expressions: ss_store_sk (type: int), $f1 (type: decimal(17,2))
+                      outputColumnNames: _col0, _col1
+                      Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                      Reduce Output Operator
+                        key expressions: _col0 (type: int), _col1 (type: decimal(17,2))
+                        null sort order: az
+                        sort order: ++
+                        Map-reduce partition columns: _col0 (type: int)
+                        Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+            Execution mode: vectorized, llap
+            LLAP IO: no inputs
+        Reducer 2 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Select Operator
+                expressions: KEY.reducesinkkey0 (type: int), KEY.reducesinkkey1 (type: decimal(17,2))
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                PTF Operator
+                  Function definitions:
+                      Input definition
+                        input alias: ptf_0
+                        output shape: _col0: int, _col1: decimal(17,2)
+                        type: WINDOWING
+                      Windowing table definition
+                        input alias: ptf_1
+                        name: windowingtablefunction
+                        order by: _col1 ASC NULLS LAST
+                        partition by: _col0
+                        raw input shape:
+                        window functions:
+                            window function definition
+                              alias: rank_window_0
+                              arguments: _col1
+                              name: rank
+                              window function: GenericUDAFRankEvaluator
+                              window frame: ROWS PRECEDING(MAX)~FOLLOWING(MAX)
+                              isPivotResult: true
+                  Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                  Filter Operator
+                    predicate: (rank_window_0 <= 5) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                    Select Operator
+                      expressions: rank_window_0 (type: int)
+                      outputColumnNames: _col0
+                      Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                      File Output Operator
+                        compressed: false
+                        Statistics: Num rows: 1 Data size: 116 Basic stats: COMPLETE Column stats: NONE
+                        table:
+                            input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                            output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                            serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+
+  Stage: Stage-0
+    Fetch Operator
+      limit: -1
+      Processor Tree:
+        ListSink
+
+PREHOOK: query: SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5
+PREHOOK: type: QUERY
+PREHOOK: Input: default@store_sales
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT ranking
+FROM
+    (SELECT rank() OVER (PARTITION BY ss_store_sk
+        ORDER BY sum(ss_net_profit)) AS ranking
+     FROM store_sales
+     GROUP BY ss_store_sk) tmp1
+WHERE ranking <= 5
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@store_sales
+#### A masked pattern was here ####
 PREHOOK: query: DROP TABLE catalog_sales
 PREHOOK: type: DROPTABLE
 PREHOOK: Input: default@catalog_sales


### PR DESCRIPTION
### What changes were proposed in this pull request?
Map partition key columns in TNK operator to columns in parent select operator when pushing TNK through Select.

### Why are the changes needed?
Partition key columns are not mapped and may contains invalid column references to parent operator schema.

### Does this PR introduce _any_ user-facing change?
Yes. Queries with plan mentioned in the jira won't fail with `can not find <colref>` error at execution time.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=external_jdbc_table_perf.q -pl itests/qtest -Pitests
```