### PR TITLE
HIVE-25325: Add TRUNCATE TABLE support for Hive Iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergStorageHandler.java
@@ -339,6 +339,11 @@ public class HiveIcebergStorageHandler implements HiveStoragePredicateHandler, H
     return HiveIcebergMetaHook.SUPPORTED_ALTER_OPS.contains(opType);
   }
 
+  @Override
+  public boolean supportsTruncateOnNonNativeTables() {
+    return true;
+  }
+
   public boolean addDynamicSplitPruningEdge(org.apache.hadoop.hive.ql.metadata.Table table,
                                             ExprNodeDesc syntheticFilterPredicate) {
     try {

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -20,57 +20,40 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
-import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.ql.exec.mr.ExecMapper;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.PartitionKey;
-import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.exceptions.NoSuchTableException;
-import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.hive.MetastoreUtil;
-import org.apache.iceberg.mr.Catalogs;
-import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -211,1239 +194,1239 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     ExecMapper.setDone(false);
   }
 
-  @Test
-  public void testScanTable() throws IOException {
-    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Adding the ORDER BY clause will cause Hive to spawn a local MR job this time.
-    List<Object[]> descRows =
-        shell.executeStatement("SELECT first_name, customer_id FROM default.customers ORDER BY customer_id DESC");
-
-    Assert.assertEquals(3, descRows.size());
-    Assert.assertArrayEquals(new Object[] {"Trudy", 2L}, descRows.get(0));
-    Assert.assertArrayEquals(new Object[] {"Bob", 1L}, descRows.get(1));
-    Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
-  }
-
-  @Test
-  public void testMigrateHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl";
-    String createQuery = "CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName));
-    shell.executeStatement(createQuery);
-    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
-    validateMigration(tableName);
-  }
-
-  @Test
-  public void testMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_part";
-    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
-        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-    validateMigration(tableName);
-  }
-
-  @Test
-  public void testMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_part_bucketed";
-    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
-        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-    validateMigration(tableName);
-  }
-
-  @Test
-  public void testRollbackMigrateHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_rollback";
-    shell.executeStatement("CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
-    validateMigrationRollback(tableName);
-  }
-
-  @Test
-  public void testRollbackMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_rollback";
-    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
-        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-    validateMigrationRollback(tableName);
-  }
-
-  @Test
-  public void testRollbackMultiPartitionedHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_rollback";
-    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string, c int) " +
-        "STORED AS " + fileFormat.name() + " " +
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='111') VALUES (1), (2), (3)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb', c='111') VALUES (4), (5)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='222') VALUES (6)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc', c='333') VALUES (7), (8), (9), (10)");
-    validateMigrationRollback(tableName);
-  }
-
-  @Test
-  public void testRollbackMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
-    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-    String tableName = "tbl_part_bucketed";
-    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
-        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-    validateMigrationRollback(tableName);
-  }
-
-  @Test
-  public void testAnalyzeTableComputeStatistics() throws IOException, TException, InterruptedException {
-    String dbName = "default";
-    String tableName = "customers";
-    Table table = testTables
-        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
-    validateBasicStats(table, dbName, tableName);
-  }
-
-  @Test
-  public void testAnalyzeTableComputeStatisticsForColumns() throws IOException, TException, InterruptedException {
-    String dbName = "default";
-    String tableName = "orders";
-    Table table = testTables.createTable(shell, tableName, ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS FOR COLUMNS");
-    validateBasicStats(table, dbName, tableName);
-  }
-
-  @Test
-  public void testAnalyzeTableComputeStatisticsEmptyTable() throws IOException, TException, InterruptedException {
-    String dbName = "default";
-    String tableName = "customers";
-    Table table = testTables
-        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-            new ArrayList<>());
-    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
-    validateBasicStats(table, dbName, tableName);
-  }
-
-  @Test
-  public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
-    shell.setHiveSessionValue("hive.cbo.enable", true);
-
-    testTables.createTable(shell, "products", PRODUCT_SCHEMA, fileFormat, PRODUCT_RECORDS);
-    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-
-    List<Object[]> rows = shell.executeStatement(
-            "SELECT o.order_id, o.customer_id, o.total, p.name " +
-                    "FROM default.orders o JOIN default.products p ON o.product_id = p.id ORDER BY o.order_id"
-    );
-
-    Assert.assertEquals(3, rows.size());
-    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d, "skirt"}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d, "tee"}, rows.get(1));
-    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
-  }
-
-  @Test
-  public void testDescribeTable() throws IOException {
-    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    List<Object[]> rows = shell.executeStatement("DESCRIBE default.customers");
-    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(), rows.size());
-    for (int i = 0; i < HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(); i++) {
-      Types.NestedField field = HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().get(i);
-      String comment = field.doc() == null ? "from deserializer" : field.doc();
-      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
-          comment}, rows.get(i));
-    }
-  }
-
-  @Test
-  public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
-    shell.setHiveSessionValue("hive.cbo.enable", true);
-    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-
-    List<Object[]> rows = shell.executeStatement(
-            "SELECT c.first_name, o.order_id " +
-                    "FROM default.orders o JOIN default.customers c ON o.customer_id = c.customer_id " +
-                    "ORDER BY o.order_id DESC"
-    );
-
-    Assert.assertEquals(3, rows.size());
-    Assert.assertArrayEquals(new Object[] {"Bob", 102L}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {"Alice", 101L}, rows.get(1));
-    Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
-  }
-
-  @Test
-  public void testCBOWithSelfJoin() throws IOException {
-    shell.setHiveSessionValue("hive.cbo.enable", true);
-
-    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-
-    List<Object[]> rows = shell.executeStatement(
-            "SELECT o1.order_id, o1.customer_id, o1.total " +
-                    "FROM default.orders o1 JOIN default.orders o2 ON o1.order_id = o2.order_id ORDER BY o1.order_id"
-    );
-
-    Assert.assertEquals(3, rows.size());
-    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d}, rows.get(1));
-    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
-  }
-
-  @Test
-  public void testJoinTablesSupportedTypes() throws IOException {
-    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-      Type type = SUPPORTED_TYPES.get(i);
-      if (type == Types.TimestampType.withZone() && isVectorized) {
-        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
-        continue;
-      }
-      // TODO: remove this filter when issue #1881 is resolved
-      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-        continue;
-      }
-      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
-      String columnName = type.typeId().toString().toLowerCase() + "_column";
-
-      Schema schema = new Schema(required(1, columnName, type));
-      List<Record> records = TestHelper.generateRandomRecords(schema, 1, 0L);
-
-      testTables.createTable(shell, tableName, schema, fileFormat, records);
-      List<Object[]> queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
-              " from default." + tableName + " s join default." + tableName + " h on h." + columnName + "=s." +
-              columnName);
-      Assert.assertEquals("Non matching record count for table " + tableName + " with type " + type,
-              1, queryResult.size());
-    }
-  }
-
-  @Test
-  public void testSelectDistinctFromTable() throws IOException {
-    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-      Type type = SUPPORTED_TYPES.get(i);
-      if (type == Types.TimestampType.withZone() && isVectorized) {
-        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
-        continue;
-      }
-      // TODO: remove this filter when issue #1881 is resolved
-      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-        continue;
-      }
-      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
-      String columnName = type.typeId().toString().toLowerCase() + "_column";
-
-      Schema schema = new Schema(required(1, columnName, type));
-      List<Record> records = TestHelper.generateRandomRecords(schema, 4, 0L);
-      int size = records.stream().map(r -> r.getField(columnName)).collect(Collectors.toSet()).size();
-      testTables.createTable(shell, tableName, schema, fileFormat, records);
-      List<Object[]> queryResult = shell.executeStatement("select count(distinct(" + columnName +
-              ")) from default." + tableName);
-      int distinctIds = ((Long) queryResult.get(0)[0]).intValue();
-      Assert.assertEquals(tableName, size, distinctIds);
-    }
-  }
-
-  @Test
-  public void testPartitionPruning() throws IOException {
-    Schema salesSchema = new Schema(
-        required(1, "ss_item_sk", Types.IntegerType.get()),
-        required(2, "ss_sold_date_sk", Types.IntegerType.get()));
-
-    PartitionSpec salesSpec =
-        PartitionSpec.builderFor(salesSchema).identity("ss_sold_date_sk").build();
-
-    Schema dimSchema = new Schema(
-        required(1, "d_date_sk", Types.IntegerType.get()),
-        required(2, "d_moy", Types.IntegerType.get()));
-
-    List<Record> salesRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
-                                    .add(51, 5)
-                                    .add(61, 6)
-                                    .add(71, 7)
-                                    .add(81, 8)
-                                    .add(91, 9)
-                                    .build();
-    List<Record> dimRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
-                                    .add(1, 10)
-                                    .add(2, 20)
-                                    .add(3, 30)
-                                    .add(4, 40)
-                                    .add(5, 50)
-                                    .build();
-
-    Table salesTable = testTables.createTable(shell, "x1_store_sales", salesSchema, salesSpec, fileFormat, null);
-
-    PartitionKey partitionKey = new PartitionKey(salesSpec, salesSchema);
-    for (Record r : salesRecords) {
-      partitionKey.partition(r);
-      testTables.appendIcebergTable(shell.getHiveConf(), salesTable, fileFormat, partitionKey, ImmutableList.of(r));
-    }
-    testTables.createTable(shell, "x1_date_dim", dimSchema, fileFormat, dimRecords);
-
-    String query = "select s.ss_item_sk from x1_store_sales s, x1_date_dim d " +
-                       "where s.ss_sold_date_sk=d.d_date_sk*2 and d.d_moy=30";
-
-    // Check the query results
-    List<Object[]> rows = shell.executeStatement(query);
-
-    Assert.assertEquals(1, rows.size());
-    Assert.assertArrayEquals(new Object[] {61}, rows.get(0));
-
-    // Check if Dynamic Partitioning is used
-    Assert.assertTrue(shell.executeStatement("explain " + query).stream()
-                          .filter(a -> ((String) a[0]).contains("Dynamic Partitioning Event Operator"))
-                          .findAny()
-                          .isPresent());
-  }
-
-  @Test
-  public void testInsert() throws IOException {
-    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, ImmutableList.of());
-
-    // The expected query is like
-    // INSERT INTO customers VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Trudy')
-    StringBuilder query = new StringBuilder().append("INSERT INTO customers VALUES ");
-    HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.forEach(record -> query.append("(")
-        .append(record.get(0)).append(",'")
-        .append(record.get(1)).append("','")
-        .append(record.get(2)).append("'),"));
-    query.setLength(query.length() - 1);
-
-    shell.executeStatement(query.toString());
-
-    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-  }
-
-  @Test
-  public void testInsertSupportedTypes() throws IOException {
-    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-      Type type = SUPPORTED_TYPES.get(i);
-      // TODO: remove this filter when issue #1881 is resolved
-      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-        continue;
-      }
-      // TODO: remove this filter when we figure out how we could test binary types
-      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
-        continue;
-      }
-      String columnName = type.typeId().toString().toLowerCase() + "_column";
-
-      Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));
-      List<Record> expected = TestHelper.generateRandomRecords(schema, 5, 0L);
-
-      Table table = testTables.createTable(shell, type.typeId().toString().toLowerCase() + "_table_" + i,
-          schema, PartitionSpec.unpartitioned(), fileFormat, expected);
-
-      HiveIcebergTestUtils.validateData(table, expected, 0);
-    }
-  }
-
-  /**
-   * Testing map only inserts.
-   * @throws IOException If there is an underlying IOException
-   */
-  @Test
-  public void testInsertFromSelect() throws IOException {
-    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    shell.executeStatement("INSERT INTO customers SELECT * FROM customers");
-
-    // Check that everything is duplicated as expected
-    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-  }
-
-  @Test
-  public void testAlterChangeColumn() throws IOException {
-    // TODO: remove once vectorized execution can handle column reorders/renames
-    Assume.assumeTrue(!isVectorized);
-
-    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN last_name family_name string AFTER customer_id");
-
-    List<Object[]> result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
-    Assert.assertEquals(3, result.size());
-    Assert.assertArrayEquals(new Object[]{0L, "Brown", "Alice"}, result.get(0));
-    Assert.assertArrayEquals(new Object[]{1L, "Green", "Bob"}, result.get(1));
-    Assert.assertArrayEquals(new Object[]{2L, "Pink", "Trudy"}, result.get(2));
-
-    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN family_name family_name string FIRST");
-
-    result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
-    Assert.assertEquals(3, result.size());
-    Assert.assertArrayEquals(new Object[]{"Brown", 0L, "Alice"}, result.get(0));
-    Assert.assertArrayEquals(new Object[]{"Green", 1L, "Bob"}, result.get(1));
-    Assert.assertArrayEquals(new Object[]{"Pink", 2L, "Trudy"}, result.get(2));
-
-    result = shell.executeStatement("SELECT customer_id, family_name FROM customers ORDER BY customer_id");
-    Assert.assertEquals(3, result.size());
-    Assert.assertArrayEquals(new Object[]{0L, "Brown"}, result.get(0));
-    Assert.assertArrayEquals(new Object[]{1L, "Green"}, result.get(1));
-    Assert.assertArrayEquals(new Object[]{2L, "Pink"}, result.get(2));
-  }
-
-  @Test
-  public void testInsertOverwriteNonPartitionedTable() throws IOException {
-    TableIdentifier target = TableIdentifier.of("default", "target");
-    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, ImmutableList.of());
-
-    // IOW overwrites the whole table (empty target table)
-    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source");
-
-    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-
-    // IOW overwrites the whole table (non-empty target table)
-    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(0L, "Mike", "Taylor")
-        .add(1L, "Christy", "Hubert")
-        .build();
-    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
-
-    HiveIcebergTestUtils.validateData(table, newRecords, 0);
-
-    // IOW empty result set -> clears the target table
-    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source WHERE FALSE");
-
-    HiveIcebergTestUtils.validateData(table, ImmutableList.of(), 0);
-  }
-
-
-  @Test
-  public void testSpecialCharacters() {
-    TableIdentifier table = TableIdentifier.of("default", "tar,! ,get");
-    // note: the Chinese character seems to be accepted in the column name, but not
-    // in the table name - this is the case for both Iceberg and standard Hive tables.
-    shell.executeStatement(String.format(
-        "CREATE TABLE `%s` (id bigint, `dep,! 是,t` string) STORED BY ICEBERG STORED AS %s %s TBLPROPERTIES ('%s'='%s')",
-        table.name(), fileFormat, testTables.locationForCreateTableSQL(table),
-        InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME));
-    shell.executeStatement(String.format("INSERT INTO `%s` VALUES (1, 'moon'), (2, 'star')", table.name()));
-
-    List<Object[]> result = shell.executeStatement(String.format(
-        "SELECT `dep,! 是,t`, id FROM `%s` ORDER BY id", table.name()));
-
-    Assert.assertEquals(2, result.size());
-    Assert.assertArrayEquals(new Object[]{"moon", 1L}, result.get(0));
-    Assert.assertArrayEquals(new Object[]{"star", 2L}, result.get(1));
-  }
-
-  @Test
-  public void testInsertOverwritePartitionedTable() throws IOException {
-    TableIdentifier target = TableIdentifier.of("default", "target");
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .identity("last_name").build();
-    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        spec, fileFormat, ImmutableList.of());
-
-    // IOW into empty target table -> whole source result set is inserted
-    List<Record> expected = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    expected.add(TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
-    shell.executeStatement(testTables.getInsertQuery(expected, target, true));
-
-    HiveIcebergTestUtils.validateData(table, expected, 0);
-
-    // IOW into non-empty target table -> only the affected partitions are overwritten
-    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(0L, "Mike", "Brown") // overwritten
-        .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
-        .add(3L, "Bill", "Purple") // appended (new partition)
-        .build();
-    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
-
-    expected = new ArrayList<>(newRecords);
-    expected.add(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2)); // existing, untouched partition ('Pink')
-    HiveIcebergTestUtils.validateData(table, expected, 0);
-
-    // IOW empty source result set -> has no effect on partitioned table
-    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM target WHERE FALSE");
-
-    HiveIcebergTestUtils.validateData(table, expected, 0);
-  }
-
-  @Test
-  public void testCTASFromHiveTable() {
-    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-
-    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
-    shell.executeStatement(testTables.getInsertQuery(
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
-
-    shell.executeStatement(String.format(
-        "CREATE TABLE target STORED BY ICEBERG %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
-        testTables.locationForCreateTableSQL(TableIdentifier.of("default", "target")),
-        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
-
-    List<Object[]> objects = shell.executeStatement("SELECT * FROM target ORDER BY id");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
-  }
-
-  @Test
-  public void testCTASPartitionedFromHiveTable() throws TException, InterruptedException {
-    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-
-    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
-    shell.executeStatement(testTables.getInsertQuery(
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
-
-    shell.executeStatement(String.format(
-        "CREATE TABLE target PARTITIONED BY (dept, name) " +
-        "STORED BY ICEBERG TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
-        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
-
-    // check table can be read back correctly
-    List<Object[]> objects = shell.executeStatement("SELECT id, name, dept FROM target ORDER BY id");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
-
-    // check HMS table has been created correctly (no partition cols, props pushed down)
-    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "target");
-    Assert.assertEquals(3, hmsTable.getSd().getColsSize());
-    Assert.assertTrue(hmsTable.getPartitionKeys().isEmpty());
-    Assert.assertEquals(fileFormat.toString(), hmsTable.getParameters().get(TableProperties.DEFAULT_FILE_FORMAT));
-
-    // check Iceberg table has correct partition spec
-    Table table = testTables.loadTable(TableIdentifier.of("default", "target"));
-    Assert.assertEquals(2, table.spec().fields().size());
-    Assert.assertEquals("dept", table.spec().fields().get(0).name());
-    Assert.assertEquals("name", table.spec().fields().get(1).name());
-  }
-
-  @Test
-  public void testCTASFailureRollback() throws IOException {
-    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-
-    // force an execution error by passing in a committer class that Tez won't be able to load
-    shell.setHiveSessionValue("hive.tez.mapreduce.output.committer.class", "org.apache.NotExistingClass");
-
-    TableIdentifier target = TableIdentifier.of("default", "target");
-    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    String[] partitioningSchemes = {"", "PARTITIONED BY (last_name)", "PARTITIONED BY (customer_id, last_name)"};
-    for (String partitioning : partitioningSchemes) {
-      AssertHelpers.assertThrows("Should fail while loading non-existent output committer class.",
-          IllegalArgumentException.class, "org.apache.NotExistingClass",
-          () -> shell.executeStatement(String.format(
-              "CREATE TABLE target %s STORED BY ICEBERG AS SELECT * FROM source", partitioning)));
-      // CTAS table should have been dropped by the lifecycle hook
-      Assert.assertThrows(NoSuchTableException.class, () -> testTables.loadTable(target));
-    }
-  }
-
-  /**
-   * Testing map-reduce inserts.
-   * @throws IOException If there is an underlying IOException
-   */
-  @Test
-  public void testInsertFromSelectWithOrderBy() throws IOException {
-    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // We expect that there will be Mappers and Reducers here
-    shell.executeStatement("INSERT INTO customers SELECT * FROM customers ORDER BY customer_id");
-
-    // Check that everything is duplicated as expected
-    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-  }
-
-  @Test
-  public void testInsertFromSelectWithProjection() throws IOException {
-    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, ImmutableList.of());
-    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-
-    shell.executeStatement(
-        "INSERT INTO customers (customer_id, last_name) SELECT distinct(customer_id), 'test' FROM orders");
-
-    List<Record> expected = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(0L, null, "test")
-        .add(1L, null, "test")
-        .build();
-
-    HiveIcebergTestUtils.validateData(table, expected, 0);
-  }
-
-  @Test
-  public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
-    List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .identity("last_name").build();
-    testTables.createTable(shell, "source_customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        spec, fileFormat, records);
-    Table table = testTables.createTable(shell, "target_customers",
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
-
-    // Below select from source table should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
-    // Inserting into the target table should not fail because first_name is not selected from the source table
-    shell.executeStatement("INSERT INTO target_customers SELECT customer_id, 'Sam', last_name FROM source_customers");
-
-    List<Record> expected = Lists.newArrayListWithExpectedSize(records.size());
-    records.forEach(r -> {
-      Record copy = r.copy();
-      copy.setField("first_name", "Sam");
-      expected.add(copy);
-    });
-    HiveIcebergTestUtils.validateData(table, expected, 0);
-  }
-
-  @Test
-  public void testInsertFromJoiningTwoIcebergTables() throws IOException {
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-            .identity("last_name").build();
-    testTables.createTable(shell, "source_customers_1", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    testTables.createTable(shell, "source_customers_2", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    Table table = testTables.createTable(shell, "target_customers",
-            HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
-
-    shell.executeStatement("INSERT INTO target_customers SELECT a.customer_id, b.first_name, a.last_name FROM " +
-            "source_customers_1 a JOIN source_customers_2 b ON a.last_name = b.last_name");
-
-    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-  }
-
-  @Test
-  public void testWriteArrayOfPrimitivesInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "arrayofprimitives",
-            Types.ListType.ofRequired(3, Types.StringType.get())));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteArrayOfArraysInTable() throws IOException {
-    Schema schema =
-        new Schema(
-            required(1, "id", Types.LongType.get()),
-            required(2, "arrayofarrays",
-                Types.ListType.ofRequired(3, Types.ListType.ofRequired(4, Types.StringType.get()))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 3, 1L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteArrayOfMapsInTable() throws IOException {
-    Schema schema =
-        new Schema(required(1, "id", Types.LongType.get()),
-            required(2, "arrayofmaps", Types.ListType
-                .ofRequired(3, Types.MapType.ofRequired(4, 5, Types.StringType.get(),
-                    Types.StringType.get()))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteArrayOfStructsInTable() throws IOException {
-    Schema schema =
-        new Schema(required(1, "id", Types.LongType.get()),
-            required(2, "arrayofstructs", Types.ListType.ofRequired(3, Types.StructType
-                .of(required(4, "something", Types.StringType.get()), required(5, "someone",
-                    Types.StringType.get()), required(6, "somewhere", Types.StringType.get())))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteMapOfPrimitivesInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "mapofprimitives", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-            Types.StringType.get())));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteMapOfArraysInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "mapofarrays",
-            Types.MapType.ofRequired(3, 4, Types.StringType.get(), Types.ListType.ofRequired(5,
-                Types.StringType.get()))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteMapOfMapsInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "mapofmaps", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-            Types.MapType.ofRequired(5, 6, Types.StringType.get(), Types.StringType.get()))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteMapOfStructsInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "mapofstructs", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-            Types.StructType.of(required(5, "something", Types.StringType.get()),
-                required(6, "someone", Types.StringType.get()),
-                required(7, "somewhere", Types.StringType.get())))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteStructOfPrimitivesInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "structofprimitives",
-            Types.StructType.of(required(3, "key", Types.StringType.get()), required(4, "value",
-                Types.StringType.get()))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteStructOfArraysInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "structofarrays", Types.StructType
-            .of(required(3, "names", Types.ListType.ofRequired(4, Types.StringType.get())),
-                required(5, "birthdays", Types.ListType.ofRequired(6,
-                    Types.StringType.get())))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteStructOfMapsInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "structofmaps", Types.StructType
-            .of(required(3, "map1", Types.MapType.ofRequired(4, 5,
-                Types.StringType.get(), Types.StringType.get())), required(6, "map2",
-                Types.MapType.ofRequired(7, 8, Types.StringType.get(),
-                    Types.StringType.get())))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testWriteStructOfStructsInTable() throws IOException {
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "structofstructs", Types.StructType.of(required(3, "struct1", Types.StructType
-            .of(required(4, "key", Types.StringType.get()), required(5, "value",
-                Types.StringType.get()))))));
-    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-    testComplexTypeWrite(schema, records);
-  }
-
-  @Test
-  public void testPartitionedWrite() throws IOException {
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .bucket("customer_id", 3)
-        .build();
-
-    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-
-    Table table = testTables.createTable(shell, "partitioned_customers",
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-
-    HiveIcebergTestUtils.validateData(table, records, 0);
-  }
-
-  @Test
-  public void testIdentityPartitionedWrite() throws IOException {
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .identity("customer_id")
-        .build();
-
-    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-
-    Table table = testTables.createTable(shell, "partitioned_customers",
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-
-    HiveIcebergTestUtils.validateData(table, records, 0);
-  }
-
-  @Test
-  public void testMultilevelIdentityPartitionedWrite() throws IOException {
-    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .identity("customer_id")
-        .identity("last_name")
-        .build();
-
-    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-
-    Table table = testTables.createTable(shell, "partitioned_customers",
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-
-    HiveIcebergTestUtils.validateData(table, records, 0);
-  }
-
-  @Test
-  public void testYearTransform() throws IOException {
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.DateType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).year("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, LocalDate.of(2020, 1, 21))
-        .add(2L, LocalDate.of(2020, 1, 22))
-        .add(3L, LocalDate.of(2019, 1, 21))
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testMonthTransform() throws IOException {
-    Assume.assumeTrue("ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive", isVectorized);
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.TimestampType.withZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).month("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
-        .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
-        .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testDayTransform() throws IOException {
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.TimestampType.withoutZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).day("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testHourTransform() throws IOException {
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.TimestampType.withoutZone()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).hour("part_field").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testBucketTransform() throws IOException {
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.StringType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("part_field", 2).build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, "Part1")
-        .add(2L, "Part2")
-        .add(3L, "Art3")
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testTruncateTransform() throws IOException {
-    Schema schema = new Schema(
-        optional(1, "id", Types.LongType.get()),
-        optional(2, "part_field", Types.StringType.get()));
-    PartitionSpec spec = PartitionSpec.builderFor(schema).truncate("part_field", 2).build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(1L, "Part1")
-        .add(2L, "Part2")
-        .add(3L, "Art3")
-        .build();
-    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-    HiveIcebergTestUtils.validateData(table, records, 0);
-
-    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-  }
-
-  @Test
-  public void testMultiTableInsert() throws IOException {
-    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    Schema target1Schema = new Schema(
-        optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "first_name", Types.StringType.get())
-    );
-
-    Schema target2Schema = new Schema(
-        optional(1, "last_name", Types.StringType.get()),
-        optional(2, "customer_id", Types.LongType.get())
-    );
-
-    List<Record> target1Records = TestHelper.RecordsBuilder.newInstance(target1Schema)
-                                      .add(0L, "Alice")
-                                      .add(1L, "Bob")
-                                      .add(2L, "Trudy")
-                                      .build();
-
-    List<Record> target2Records = TestHelper.RecordsBuilder.newInstance(target2Schema)
-                                      .add("Brown", 0L)
-                                      .add("Green", 1L)
-                                      .add("Pink", 2L)
-                                      .build();
-
-    Table target1 = testTables.createTable(shell, "target1", target1Schema, fileFormat, ImmutableList.of());
-    Table target2 = testTables.createTable(shell, "target2", target2Schema, fileFormat, ImmutableList.of());
-
-    // simple insert: should create a single vertex writing to both target tables
-    shell.executeStatement("FROM customers " +
-        "INSERT INTO target1 SELECT customer_id, first_name " +
-        "INSERT INTO target2 SELECT last_name, customer_id");
-
-    // Check that everything is as expected
-    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
-    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
-
-    // truncate the target tables
-    testTables.truncateIcebergTable(target1);
-    testTables.truncateIcebergTable(target2);
-
-    // complex insert: should use a different vertex for each target table
-    shell.executeStatement("FROM customers " +
-        "INSERT INTO target1 SELECT customer_id, first_name ORDER BY first_name " +
-        "INSERT INTO target2 SELECT last_name, customer_id ORDER BY last_name");
-
-    // Check that everything is as expected
-    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
-    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
-  }
-
-  @Test
-  public void testWriteWithDefaultWriteFormat() {
-    Assume.assumeTrue("Testing the default file format is enough for a single scenario.",
-        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
-
-    TableIdentifier identifier = TableIdentifier.of("default", "customers");
-
-    // create Iceberg table without specifying a write format in the tbl properties
-    // it should fall back to using the default file format
-    shell.executeStatement(String.format("CREATE EXTERNAL TABLE %s (id bigint, name string) STORED BY '%s' %s",
-        identifier,
-        HiveIcebergStorageHandler.class.getName(),
-        testTables.locationForCreateTableSQL(identifier)));
-
-    shell.executeStatement(String.format("INSERT INTO %s VALUES (10, 'Linda')", identifier));
-    List<Object[]> results = shell.executeStatement(String.format("SELECT * FROM %s", identifier));
-
-    Assert.assertEquals(1, results.size());
-    Assert.assertEquals(10L, results.get(0)[0]);
-    Assert.assertEquals("Linda", results.get(0)[1]);
-  }
-
-  @Test
-  public void testInsertEmptyResultSet() throws IOException {
-    Table source = testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, ImmutableList.of());
-    Table target = testTables.createTable(shell, "target", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, ImmutableList.of());
-
-    shell.executeStatement("INSERT INTO target SELECT * FROM source");
-    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
-
-    testTables.appendIcebergTable(shell.getHiveConf(), source, fileFormat, null,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
-    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
-  }
-
-  @Test
-  public void testDecimalTableWithPredicateLiterals() throws IOException {
-    Schema schema = new Schema(required(1, "decimal_field", Types.DecimalType.of(7, 2)));
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-        .add(new BigDecimal("85.00"))
-        .add(new BigDecimal("100.56"))
-        .add(new BigDecimal("100.57"))
-        .build();
-    testTables.createTable(shell, "dec_test", schema, fileFormat, records);
-
-    // Use integer literal in predicate
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field >= 85");
-    Assert.assertEquals(3, rows.size());
-    Assert.assertArrayEquals(new Object[] {"85.00"}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(1));
-    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(2));
-
-    // Use decimal literal in predicate with smaller scale than schema type definition
-    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 99.1");
-    Assert.assertEquals(2, rows.size());
-    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(1));
-
-    // Use decimal literal in predicate with higher scale than schema type definition
-    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 100.565");
-    Assert.assertEquals(1, rows.size());
-    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(0));
-
-    // Use decimal literal in predicate with the same scale as schema type definition
-    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 640.34");
-    Assert.assertEquals(0, rows.size());
-  }
-
-  @Test
-  public void testStructOfMapsInTable() throws IOException {
-    Schema schema = new Schema(
-        required(1, "structofmaps", Types.StructType
-            .of(required(2, "map1", Types.MapType.ofRequired(3, 4,
-                Types.StringType.get(), Types.StringType.get())), required(5, "map2",
-                Types.MapType.ofRequired(6, 7, Types.StringType.get(),
-                    Types.IntegerType.get())))));
-    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-    // access a map entry inside a struct
-    for (int i = 0; i < records.size(); i++) {
-      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofmaps");
-      Map<?, ?> expectedMap = (Map<?, ?>) expectedStruct.getField("map1");
-      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
-        List<Object[]> queryResult = shell.executeStatement(String
-            .format("SELECT structofmaps.map1[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
-                i));
-        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
-      }
-      expectedMap = (Map<?, ?>) expectedStruct.getField("map2");
-      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
-        List<Object[]> queryResult = shell.executeStatement(String
-            .format("SELECT structofmaps.map2[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
-                i));
-        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
-      }
-    }
-  }
-
-  @Test
-  public void testStructOfArraysInTable() throws IOException {
-    Schema schema = new Schema(
-        required(1, "structofarrays", Types.StructType
-            .of(required(2, "names", Types.ListType.ofRequired(3, Types.StringType.get())),
-                required(4, "birthdays", Types.ListType.ofRequired(5,
-                    Types.DateType.get())))));
-    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-    // access an element of an array inside a struct
-    for (int i = 0; i < records.size(); i++) {
-      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofarrays");
-      List<?> expectedList = (List<?>) expectedStruct.getField("names");
-      for (int j = 0; j < expectedList.size(); j++) {
-        List<Object[]> queryResult = shell.executeStatement(
-            String.format("SELECT structofarrays.names[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
-        Assert.assertEquals(expectedList.get(j), queryResult.get(0)[0]);
-      }
-      expectedList = (List<?>) expectedStruct.getField("birthdays");
-      for (int j = 0; j < expectedList.size(); j++) {
-        List<Object[]> queryResult = shell.executeStatement(
-            String.format("SELECT structofarrays.birthdays[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
-        Assert.assertEquals(expectedList.get(j).toString(), queryResult.get(0)[0]);
-      }
-    }
-  }
-
-  @Test
-  public void testStructOfPrimitivesInTable() throws IOException {
-    Schema schema = new Schema(required(1, "structofprimitives",
-        Types.StructType.of(required(2, "key", Types.StringType.get()), required(3, "value",
-            Types.IntegerType.get()))));
-    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-    // access a single value in a struct
-    for (int i = 0; i < records.size(); i++) {
-      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofprimitives");
-      List<Object[]> queryResult = shell.executeStatement(String.format(
-          "SELECT structofprimitives.key, structofprimitives.value FROM default.structtable LIMIT 1 OFFSET %d", i));
-      Assert.assertEquals(expectedStruct.getField("key"), queryResult.get(0)[0]);
-      Assert.assertEquals(expectedStruct.getField("value"), queryResult.get(0)[1]);
-    }
-  }
-
-  @Test
-  public void testStructOfStructsInTable() throws IOException {
-    Schema schema = new Schema(
-        required(1, "structofstructs", Types.StructType.of(required(2, "struct1", Types.StructType
-            .of(required(3, "key", Types.StringType.get()), required(4, "value",
-                Types.IntegerType.get()))))));
-    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-    // access a struct element inside a struct
-    for (int i = 0; i < records.size(); i++) {
-      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofstructs");
-      GenericRecord expectedInnerStruct = (GenericRecord) expectedStruct.getField("struct1");
-      List<Object[]> queryResult = shell.executeStatement(String.format(
-          "SELECT structofstructs.struct1.key, structofstructs.struct1.value FROM default.structtable " +
-              "LIMIT 1 OFFSET %d", i));
-      Assert.assertEquals(expectedInnerStruct.getField("key"), queryResult.get(0)[0]);
-      Assert.assertEquals(expectedInnerStruct.getField("value"), queryResult.get(0)[1]);
-    }
-  }
-
-  @Test
-  public void testScanTableCaseInsensitive() throws IOException {
-    testTables.createTable(shell, "customers",
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA_WITH_UPPERCASE, fileFormat,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-
-    Assert.assertEquals(3, rows.size());
-    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
-    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, rows.get(2));
-
-    rows = shell.executeStatement("SELECT * FROM default.customers where CustomER_Id < 2 " +
-        "and first_name in ('Alice', 'Bob')");
-
-    Assert.assertEquals(2, rows.size());
-    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
-    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
-  }
-
-  @Test
-  public void testTruncateTable() throws IOException, TException, InterruptedException {
-    // Create an Iceberg table with some records in it then execute a truncate table command.
-    // Then check if the data is deleted and the table statistics are reset to 0.
-    String databaseName = "default";
-    String tableName = "customers";
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-  }
-
-  @Test
-  public void testTruncateEmptyTable() throws IOException, TException, InterruptedException {
-    // Create an empty Iceberg table and execute a truncate table command on it.
-    String databaseName = "default";
-    String tableName = "customers";
-    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, null);
-    // Set the 'external.table.purge' table property on the table
-    String alterTableCommand =
-        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')";
-    shell.executeStatement(alterTableCommand);
-
-    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-
-    shell.executeStatement("TRUNCATE " + identifier);
-
-    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-    Map<String, String> summary = icebergTable.currentSnapshot().summary();
-    for (String key : STATS_MAPPING.values()) {
-      Assert.assertEquals("0", summary.get(key));
-    }
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-    Assert.assertEquals(0, rows.size());
-    validateBasicStats(icebergTable, databaseName, tableName);
-  }
-
-  @Test
-  public void testMultipleTruncateTable() throws IOException, TException, InterruptedException {
-    // Create an Iceberg table with come records in it, then execute a truncate table command
-    // and check the result. Then insert some new data and run an other truncate table command.
-    // The purpose of this test is to make sure that multiple truncate table commands can
-    // run after each other without any issue (like issues with locking).
-    String databaseName = "default";
-    String tableName = "customers";
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-
-    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(3L, "Jane", "Purple").add(4L, "Tim", "Grey").add(5L, "Eva", "Yellow").add(6L, "James", "White")
-        .add(7L, "Jack", "Black").build();
-    shell.executeStatement("INSERT INTO default.customers values (3, 'Jane', 'Purple'), (4, 'Tim', 'Grey')," +
-        "(5, 'Eva', 'Yellow'), (6, 'James', 'White'), (7, 'Jack', 'Black')");
-
-    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-    testTruncateTable(databaseName, tableName, icebergTable, newRecords,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-  }
-
-  @Test
-  public void testTruncateTableExternalPurgeFalse() throws IOException, TException, InterruptedException {
-    // Create an Iceberg table with some records in it and set the 'external.table.purge' table property
-    // to false and try to run a truncate table command on it. The command should fail with a SemanticException.
-    // Then check if the data is not deleted from the table and also the statistics are not changed.
-    String databaseName = "default";
-    String tableName = "customers";
-    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='false')");
-    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-
-    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-        "Cannot truncate non-managed table", () -> {
-          shell.executeStatement("TRUNCATE " + identifier);
-        });
-
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-    validateBasicStats(icebergTable, databaseName, tableName);
-  }
-
-  @Test
-  public void testTruncateTableForceExternalPurgeFalse() throws IOException, TException, InterruptedException {
-    // Create an Iceberg table with some records and set the 'external.table.purge' table parameter to false.
-    // Then execute a truncate table force command which should run without any error.
-    // Then check if the data is deleted from the table and the statistics are reset.
-    String databaseName = "default";
-    String tableName = "customers";
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, false, true);
-  }
+//  @Test
+//  public void testScanTable() throws IOException {
+//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Adding the ORDER BY clause will cause Hive to spawn a local MR job this time.
+//    List<Object[]> descRows =
+//        shell.executeStatement("SELECT first_name, customer_id FROM default.customers ORDER BY customer_id DESC");
+//
+//    Assert.assertEquals(3, descRows.size());
+//    Assert.assertArrayEquals(new Object[] {"Trudy", 2L}, descRows.get(0));
+//    Assert.assertArrayEquals(new Object[] {"Bob", 1L}, descRows.get(1));
+//    Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
+//  }
+//
+//  @Test
+//  public void testMigrateHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl";
+//    String createQuery = "CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName));
+//    shell.executeStatement(createQuery);
+//    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
+//    validateMigration(tableName);
+//  }
+//
+//  @Test
+//  public void testMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_part";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
+//        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+//    validateMigration(tableName);
+//  }
+//
+//  @Test
+//  public void testMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_part_bucketed";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
+//        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+//    validateMigration(tableName);
+//  }
+//
+//  @Test
+//  public void testRollbackMigrateHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_rollback";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
+//    validateMigrationRollback(tableName);
+//  }
+//
+//  @Test
+//  public void testRollbackMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_rollback";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
+//        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+//    validateMigrationRollback(tableName);
+//  }
+//
+//  @Test
+//  public void testRollbackMultiPartitionedHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_rollback";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string, c int) " +
+//        "STORED AS " + fileFormat.name() + " " +
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='111') VALUES (1), (2), (3)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb', c='111') VALUES (4), (5)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='222') VALUES (6)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc', c='333') VALUES (7), (8), (9), (10)");
+//    validateMigrationRollback(tableName);
+//  }
+//
+//  @Test
+//  public void testRollbackMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
+//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+//    String tableName = "tbl_part_bucketed";
+//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
+//        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+//    validateMigrationRollback(tableName);
+//  }
+//
+//  @Test
+//  public void testAnalyzeTableComputeStatistics() throws IOException, TException, InterruptedException {
+//    String dbName = "default";
+//    String tableName = "customers";
+//    Table table = testTables
+//        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
+//    validateBasicStats(table, dbName, tableName);
+//  }
+//
+//  @Test
+//  public void testAnalyzeTableComputeStatisticsForColumns() throws IOException, TException, InterruptedException {
+//    String dbName = "default";
+//    String tableName = "orders";
+//    Table table = testTables.createTable(shell, tableName, ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS FOR COLUMNS");
+//    validateBasicStats(table, dbName, tableName);
+//  }
+//
+//  @Test
+//  public void testAnalyzeTableComputeStatisticsEmptyTable() throws IOException, TException, InterruptedException {
+//    String dbName = "default";
+//    String tableName = "customers";
+//    Table table = testTables
+//        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+//            new ArrayList<>());
+//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
+//    validateBasicStats(table, dbName, tableName);
+//  }
+//
+//  @Test
+//  public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
+//    shell.setHiveSessionValue("hive.cbo.enable", true);
+//
+//    testTables.createTable(shell, "products", PRODUCT_SCHEMA, fileFormat, PRODUCT_RECORDS);
+//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+//
+//    List<Object[]> rows = shell.executeStatement(
+//            "SELECT o.order_id, o.customer_id, o.total, p.name " +
+//                    "FROM default.orders o JOIN default.products p ON o.product_id = p.id ORDER BY o.order_id"
+//    );
+//
+//    Assert.assertEquals(3, rows.size());
+//    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d, "skirt"}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d, "tee"}, rows.get(1));
+//    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
+//  }
+//
+//  @Test
+//  public void testDescribeTable() throws IOException {
+//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    List<Object[]> rows = shell.executeStatement("DESCRIBE default.customers");
+//    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(), rows.size());
+//    for (int i = 0; i < HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(); i++) {
+//      Types.NestedField field = HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().get(i);
+//      String comment = field.doc() == null ? "from deserializer" : field.doc();
+//      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
+//          comment}, rows.get(i));
+//    }
+//  }
+//
+//  @Test
+//  public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
+//    shell.setHiveSessionValue("hive.cbo.enable", true);
+//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+//
+//    List<Object[]> rows = shell.executeStatement(
+//            "SELECT c.first_name, o.order_id " +
+//                    "FROM default.orders o JOIN default.customers c ON o.customer_id = c.customer_id " +
+//                    "ORDER BY o.order_id DESC"
+//    );
+//
+//    Assert.assertEquals(3, rows.size());
+//    Assert.assertArrayEquals(new Object[] {"Bob", 102L}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {"Alice", 101L}, rows.get(1));
+//    Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
+//  }
+//
+//  @Test
+//  public void testCBOWithSelfJoin() throws IOException {
+//    shell.setHiveSessionValue("hive.cbo.enable", true);
+//
+//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+//
+//    List<Object[]> rows = shell.executeStatement(
+//            "SELECT o1.order_id, o1.customer_id, o1.total " +
+//                    "FROM default.orders o1 JOIN default.orders o2 ON o1.order_id = o2.order_id ORDER BY o1.order_id"
+//    );
+//
+//    Assert.assertEquals(3, rows.size());
+//    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d}, rows.get(1));
+//    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
+//  }
+//
+//  @Test
+//  public void testJoinTablesSupportedTypes() throws IOException {
+//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+//      Type type = SUPPORTED_TYPES.get(i);
+//      if (type == Types.TimestampType.withZone() && isVectorized) {
+//        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+//        continue;
+//      }
+//      // TODO: remove this filter when issue #1881 is resolved
+//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+//        continue;
+//      }
+//      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+//      String columnName = type.typeId().toString().toLowerCase() + "_column";
+//
+//      Schema schema = new Schema(required(1, columnName, type));
+//      List<Record> records = TestHelper.generateRandomRecords(schema, 1, 0L);
+//
+//      testTables.createTable(shell, tableName, schema, fileFormat, records);
+//      List<Object[]> queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
+//              " from default." + tableName + " s join default." + tableName + " h on h." + columnName + "=s." +
+//              columnName);
+//      Assert.assertEquals("Non matching record count for table " + tableName + " with type " + type,
+//              1, queryResult.size());
+//    }
+//  }
+//
+//  @Test
+//  public void testSelectDistinctFromTable() throws IOException {
+//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+//      Type type = SUPPORTED_TYPES.get(i);
+//      if (type == Types.TimestampType.withZone() && isVectorized) {
+//        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+//        continue;
+//      }
+//      // TODO: remove this filter when issue #1881 is resolved
+//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+//        continue;
+//      }
+//      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+//      String columnName = type.typeId().toString().toLowerCase() + "_column";
+//
+//      Schema schema = new Schema(required(1, columnName, type));
+//      List<Record> records = TestHelper.generateRandomRecords(schema, 4, 0L);
+//      int size = records.stream().map(r -> r.getField(columnName)).collect(Collectors.toSet()).size();
+//      testTables.createTable(shell, tableName, schema, fileFormat, records);
+//      List<Object[]> queryResult = shell.executeStatement("select count(distinct(" + columnName +
+//              ")) from default." + tableName);
+//      int distinctIds = ((Long) queryResult.get(0)[0]).intValue();
+//      Assert.assertEquals(tableName, size, distinctIds);
+//    }
+//  }
+//
+//  @Test
+//  public void testPartitionPruning() throws IOException {
+//    Schema salesSchema = new Schema(
+//        required(1, "ss_item_sk", Types.IntegerType.get()),
+//        required(2, "ss_sold_date_sk", Types.IntegerType.get()));
+//
+//    PartitionSpec salesSpec =
+//        PartitionSpec.builderFor(salesSchema).identity("ss_sold_date_sk").build();
+//
+//    Schema dimSchema = new Schema(
+//        required(1, "d_date_sk", Types.IntegerType.get()),
+//        required(2, "d_moy", Types.IntegerType.get()));
+//
+//    List<Record> salesRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
+//                                    .add(51, 5)
+//                                    .add(61, 6)
+//                                    .add(71, 7)
+//                                    .add(81, 8)
+//                                    .add(91, 9)
+//                                    .build();
+//    List<Record> dimRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
+//                                    .add(1, 10)
+//                                    .add(2, 20)
+//                                    .add(3, 30)
+//                                    .add(4, 40)
+//                                    .add(5, 50)
+//                                    .build();
+//
+//    Table salesTable = testTables.createTable(shell, "x1_store_sales", salesSchema, salesSpec, fileFormat, null);
+//
+//    PartitionKey partitionKey = new PartitionKey(salesSpec, salesSchema);
+//    for (Record r : salesRecords) {
+//      partitionKey.partition(r);
+//      testTables.appendIcebergTable(shell.getHiveConf(), salesTable, fileFormat, partitionKey, ImmutableList.of(r));
+//    }
+//    testTables.createTable(shell, "x1_date_dim", dimSchema, fileFormat, dimRecords);
+//
+//    String query = "select s.ss_item_sk from x1_store_sales s, x1_date_dim d " +
+//                       "where s.ss_sold_date_sk=d.d_date_sk*2 and d.d_moy=30";
+//
+//    // Check the query results
+//    List<Object[]> rows = shell.executeStatement(query);
+//
+//    Assert.assertEquals(1, rows.size());
+//    Assert.assertArrayEquals(new Object[] {61}, rows.get(0));
+//
+//    // Check if Dynamic Partitioning is used
+//    Assert.assertTrue(shell.executeStatement("explain " + query).stream()
+//                          .filter(a -> ((String) a[0]).contains("Dynamic Partitioning Event Operator"))
+//                          .findAny()
+//                          .isPresent());
+//  }
+//
+//  @Test
+//  public void testInsert() throws IOException {
+//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, ImmutableList.of());
+//
+//    // The expected query is like
+//    // INSERT INTO customers VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Trudy')
+//    StringBuilder query = new StringBuilder().append("INSERT INTO customers VALUES ");
+//    HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.forEach(record -> query.append("(")
+//        .append(record.get(0)).append(",'")
+//        .append(record.get(1)).append("','")
+//        .append(record.get(2)).append("'),"));
+//    query.setLength(query.length() - 1);
+//
+//    shell.executeStatement(query.toString());
+//
+//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+//  }
+//
+//  @Test
+//  public void testInsertSupportedTypes() throws IOException {
+//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+//      Type type = SUPPORTED_TYPES.get(i);
+//      // TODO: remove this filter when issue #1881 is resolved
+//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+//        continue;
+//      }
+//      // TODO: remove this filter when we figure out how we could test binary types
+//      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
+//        continue;
+//      }
+//      String columnName = type.typeId().toString().toLowerCase() + "_column";
+//
+//      Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));
+//      List<Record> expected = TestHelper.generateRandomRecords(schema, 5, 0L);
+//
+//      Table table = testTables.createTable(shell, type.typeId().toString().toLowerCase() + "_table_" + i,
+//          schema, PartitionSpec.unpartitioned(), fileFormat, expected);
+//
+//      HiveIcebergTestUtils.validateData(table, expected, 0);
+//    }
+//  }
+//
+//  /**
+//   * Testing map only inserts.
+//   * @throws IOException If there is an underlying IOException
+//   */
+//  @Test
+//  public void testInsertFromSelect() throws IOException {
+//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    shell.executeStatement("INSERT INTO customers SELECT * FROM customers");
+//
+//    // Check that everything is duplicated as expected
+//    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//  }
+//
+//  @Test
+//  public void testAlterChangeColumn() throws IOException {
+//    // TODO: remove once vectorized execution can handle column reorders/renames
+//    Assume.assumeTrue(!isVectorized);
+//
+//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN last_name family_name string AFTER customer_id");
+//
+//    List<Object[]> result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+//    Assert.assertEquals(3, result.size());
+//    Assert.assertArrayEquals(new Object[]{0L, "Brown", "Alice"}, result.get(0));
+//    Assert.assertArrayEquals(new Object[]{1L, "Green", "Bob"}, result.get(1));
+//    Assert.assertArrayEquals(new Object[]{2L, "Pink", "Trudy"}, result.get(2));
+//
+//    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN family_name family_name string FIRST");
+//
+//    result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+//    Assert.assertEquals(3, result.size());
+//    Assert.assertArrayEquals(new Object[]{"Brown", 0L, "Alice"}, result.get(0));
+//    Assert.assertArrayEquals(new Object[]{"Green", 1L, "Bob"}, result.get(1));
+//    Assert.assertArrayEquals(new Object[]{"Pink", 2L, "Trudy"}, result.get(2));
+//
+//    result = shell.executeStatement("SELECT customer_id, family_name FROM customers ORDER BY customer_id");
+//    Assert.assertEquals(3, result.size());
+//    Assert.assertArrayEquals(new Object[]{0L, "Brown"}, result.get(0));
+//    Assert.assertArrayEquals(new Object[]{1L, "Green"}, result.get(1));
+//    Assert.assertArrayEquals(new Object[]{2L, "Pink"}, result.get(2));
+//  }
+//
+//  @Test
+//  public void testInsertOverwriteNonPartitionedTable() throws IOException {
+//    TableIdentifier target = TableIdentifier.of("default", "target");
+//    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, ImmutableList.of());
+//
+//    // IOW overwrites the whole table (empty target table)
+//    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source");
+//
+//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+//
+//    // IOW overwrites the whole table (non-empty target table)
+//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(0L, "Mike", "Taylor")
+//        .add(1L, "Christy", "Hubert")
+//        .build();
+//    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
+//
+//    HiveIcebergTestUtils.validateData(table, newRecords, 0);
+//
+//    // IOW empty result set -> clears the target table
+//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source WHERE FALSE");
+//
+//    HiveIcebergTestUtils.validateData(table, ImmutableList.of(), 0);
+//  }
+//
+//
+//  @Test
+//  public void testSpecialCharacters() {
+//    TableIdentifier table = TableIdentifier.of("default", "tar,! ,get");
+//    // note: the Chinese character seems to be accepted in the column name, but not
+//    // in the table name - this is the case for both Iceberg and standard Hive tables.
+//    shell.executeStatement(String.format(
+//        "CREATE TABLE `%s` (id bigint, `dep,! 是,t` string) STORED BY ICEBERG STORED AS %s %s TBLPROPERTIES ('%s'='%s')",
+//        table.name(), fileFormat, testTables.locationForCreateTableSQL(table),
+//        InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME));
+//    shell.executeStatement(String.format("INSERT INTO `%s` VALUES (1, 'moon'), (2, 'star')", table.name()));
+//
+//    List<Object[]> result = shell.executeStatement(String.format(
+//        "SELECT `dep,! 是,t`, id FROM `%s` ORDER BY id", table.name()));
+//
+//    Assert.assertEquals(2, result.size());
+//    Assert.assertArrayEquals(new Object[]{"moon", 1L}, result.get(0));
+//    Assert.assertArrayEquals(new Object[]{"star", 2L}, result.get(1));
+//  }
+//
+//  @Test
+//  public void testInsertOverwritePartitionedTable() throws IOException {
+//    TableIdentifier target = TableIdentifier.of("default", "target");
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .identity("last_name").build();
+//    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        spec, fileFormat, ImmutableList.of());
+//
+//    // IOW into empty target table -> whole source result set is inserted
+//    List<Record> expected = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    expected.add(TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
+//    shell.executeStatement(testTables.getInsertQuery(expected, target, true));
+//
+//    HiveIcebergTestUtils.validateData(table, expected, 0);
+//
+//    // IOW into non-empty target table -> only the affected partitions are overwritten
+//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(0L, "Mike", "Brown") // overwritten
+//        .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
+//        .add(3L, "Bill", "Purple") // appended (new partition)
+//        .build();
+//    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
+//
+//    expected = new ArrayList<>(newRecords);
+//    expected.add(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2)); // existing, untouched partition ('Pink')
+//    HiveIcebergTestUtils.validateData(table, expected, 0);
+//
+//    // IOW empty source result set -> has no effect on partitioned table
+//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM target WHERE FALSE");
+//
+//    HiveIcebergTestUtils.validateData(table, expected, 0);
+//  }
+//
+//  @Test
+//  public void testCTASFromHiveTable() {
+//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+//
+//    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
+//    shell.executeStatement(testTables.getInsertQuery(
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
+//
+//    shell.executeStatement(String.format(
+//        "CREATE TABLE target STORED BY ICEBERG %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
+//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", "target")),
+//        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
+//
+//    List<Object[]> objects = shell.executeStatement("SELECT * FROM target ORDER BY id");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
+//  }
+//
+//  @Test
+//  public void testCTASPartitionedFromHiveTable() throws TException, InterruptedException {
+//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+//
+//    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
+//    shell.executeStatement(testTables.getInsertQuery(
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
+//
+//    shell.executeStatement(String.format(
+//        "CREATE TABLE target PARTITIONED BY (dept, name) " +
+//        "STORED BY ICEBERG TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
+//        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
+//
+//    // check table can be read back correctly
+//    List<Object[]> objects = shell.executeStatement("SELECT id, name, dept FROM target ORDER BY id");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
+//
+//    // check HMS table has been created correctly (no partition cols, props pushed down)
+//    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "target");
+//    Assert.assertEquals(3, hmsTable.getSd().getColsSize());
+//    Assert.assertTrue(hmsTable.getPartitionKeys().isEmpty());
+//    Assert.assertEquals(fileFormat.toString(), hmsTable.getParameters().get(TableProperties.DEFAULT_FILE_FORMAT));
+//
+//    // check Iceberg table has correct partition spec
+//    Table table = testTables.loadTable(TableIdentifier.of("default", "target"));
+//    Assert.assertEquals(2, table.spec().fields().size());
+//    Assert.assertEquals("dept", table.spec().fields().get(0).name());
+//    Assert.assertEquals("name", table.spec().fields().get(1).name());
+//  }
+//
+//  @Test
+//  public void testCTASFailureRollback() throws IOException {
+//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+//
+//    // force an execution error by passing in a committer class that Tez won't be able to load
+//    shell.setHiveSessionValue("hive.tez.mapreduce.output.committer.class", "org.apache.NotExistingClass");
+//
+//    TableIdentifier target = TableIdentifier.of("default", "target");
+//    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    String[] partitioningSchemes = {"", "PARTITIONED BY (last_name)", "PARTITIONED BY (customer_id, last_name)"};
+//    for (String partitioning : partitioningSchemes) {
+//      AssertHelpers.assertThrows("Should fail while loading non-existent output committer class.",
+//          IllegalArgumentException.class, "org.apache.NotExistingClass",
+//          () -> shell.executeStatement(String.format(
+//              "CREATE TABLE target %s STORED BY ICEBERG AS SELECT * FROM source", partitioning)));
+//      // CTAS table should have been dropped by the lifecycle hook
+//      Assert.assertThrows(NoSuchTableException.class, () -> testTables.loadTable(target));
+//    }
+//  }
+//
+//  /**
+//   * Testing map-reduce inserts.
+//   * @throws IOException If there is an underlying IOException
+//   */
+//  @Test
+//  public void testInsertFromSelectWithOrderBy() throws IOException {
+//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // We expect that there will be Mappers and Reducers here
+//    shell.executeStatement("INSERT INTO customers SELECT * FROM customers ORDER BY customer_id");
+//
+//    // Check that everything is duplicated as expected
+//    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//  }
+//
+//  @Test
+//  public void testInsertFromSelectWithProjection() throws IOException {
+//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, ImmutableList.of());
+//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+//
+//    shell.executeStatement(
+//        "INSERT INTO customers (customer_id, last_name) SELECT distinct(customer_id), 'test' FROM orders");
+//
+//    List<Record> expected = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(0L, null, "test")
+//        .add(1L, null, "test")
+//        .build();
+//
+//    HiveIcebergTestUtils.validateData(table, expected, 0);
+//  }
+//
+//  @Test
+//  public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
+//    List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .identity("last_name").build();
+//    testTables.createTable(shell, "source_customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        spec, fileFormat, records);
+//    Table table = testTables.createTable(shell, "target_customers",
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
+//
+//    // Below select from source table should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
+//    // Inserting into the target table should not fail because first_name is not selected from the source table
+//    shell.executeStatement("INSERT INTO target_customers SELECT customer_id, 'Sam', last_name FROM source_customers");
+//
+//    List<Record> expected = Lists.newArrayListWithExpectedSize(records.size());
+//    records.forEach(r -> {
+//      Record copy = r.copy();
+//      copy.setField("first_name", "Sam");
+//      expected.add(copy);
+//    });
+//    HiveIcebergTestUtils.validateData(table, expected, 0);
+//  }
+//
+//  @Test
+//  public void testInsertFromJoiningTwoIcebergTables() throws IOException {
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//            .identity("last_name").build();
+//    testTables.createTable(shell, "source_customers_1", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    testTables.createTable(shell, "source_customers_2", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    Table table = testTables.createTable(shell, "target_customers",
+//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
+//
+//    shell.executeStatement("INSERT INTO target_customers SELECT a.customer_id, b.first_name, a.last_name FROM " +
+//            "source_customers_1 a JOIN source_customers_2 b ON a.last_name = b.last_name");
+//
+//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+//  }
+//
+//  @Test
+//  public void testWriteArrayOfPrimitivesInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "arrayofprimitives",
+//            Types.ListType.ofRequired(3, Types.StringType.get())));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteArrayOfArraysInTable() throws IOException {
+//    Schema schema =
+//        new Schema(
+//            required(1, "id", Types.LongType.get()),
+//            required(2, "arrayofarrays",
+//                Types.ListType.ofRequired(3, Types.ListType.ofRequired(4, Types.StringType.get()))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 3, 1L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteArrayOfMapsInTable() throws IOException {
+//    Schema schema =
+//        new Schema(required(1, "id", Types.LongType.get()),
+//            required(2, "arrayofmaps", Types.ListType
+//                .ofRequired(3, Types.MapType.ofRequired(4, 5, Types.StringType.get(),
+//                    Types.StringType.get()))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteArrayOfStructsInTable() throws IOException {
+//    Schema schema =
+//        new Schema(required(1, "id", Types.LongType.get()),
+//            required(2, "arrayofstructs", Types.ListType.ofRequired(3, Types.StructType
+//                .of(required(4, "something", Types.StringType.get()), required(5, "someone",
+//                    Types.StringType.get()), required(6, "somewhere", Types.StringType.get())))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteMapOfPrimitivesInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "mapofprimitives", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+//            Types.StringType.get())));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteMapOfArraysInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "mapofarrays",
+//            Types.MapType.ofRequired(3, 4, Types.StringType.get(), Types.ListType.ofRequired(5,
+//                Types.StringType.get()))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteMapOfMapsInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "mapofmaps", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+//            Types.MapType.ofRequired(5, 6, Types.StringType.get(), Types.StringType.get()))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteMapOfStructsInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "mapofstructs", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+//            Types.StructType.of(required(5, "something", Types.StringType.get()),
+//                required(6, "someone", Types.StringType.get()),
+//                required(7, "somewhere", Types.StringType.get())))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteStructOfPrimitivesInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "structofprimitives",
+//            Types.StructType.of(required(3, "key", Types.StringType.get()), required(4, "value",
+//                Types.StringType.get()))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteStructOfArraysInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "structofarrays", Types.StructType
+//            .of(required(3, "names", Types.ListType.ofRequired(4, Types.StringType.get())),
+//                required(5, "birthdays", Types.ListType.ofRequired(6,
+//                    Types.StringType.get())))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteStructOfMapsInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "structofmaps", Types.StructType
+//            .of(required(3, "map1", Types.MapType.ofRequired(4, 5,
+//                Types.StringType.get(), Types.StringType.get())), required(6, "map2",
+//                Types.MapType.ofRequired(7, 8, Types.StringType.get(),
+//                    Types.StringType.get())))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testWriteStructOfStructsInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "structofstructs", Types.StructType.of(required(3, "struct1", Types.StructType
+//            .of(required(4, "key", Types.StringType.get()), required(5, "value",
+//                Types.StringType.get()))))));
+//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+//    testComplexTypeWrite(schema, records);
+//  }
+//
+//  @Test
+//  public void testPartitionedWrite() throws IOException {
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .bucket("customer_id", 3)
+//        .build();
+//
+//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+//
+//    Table table = testTables.createTable(shell, "partitioned_customers",
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+//
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//  }
+//
+//  @Test
+//  public void testIdentityPartitionedWrite() throws IOException {
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .identity("customer_id")
+//        .build();
+//
+//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+//
+//    Table table = testTables.createTable(shell, "partitioned_customers",
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+//
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//  }
+//
+//  @Test
+//  public void testMultilevelIdentityPartitionedWrite() throws IOException {
+//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .identity("customer_id")
+//        .identity("last_name")
+//        .build();
+//
+//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+//
+//    Table table = testTables.createTable(shell, "partitioned_customers",
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+//
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//  }
+//
+//  @Test
+//  public void testYearTransform() throws IOException {
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.DateType.get()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).year("part_field").build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, LocalDate.of(2020, 1, 21))
+//        .add(2L, LocalDate.of(2020, 1, 22))
+//        .add(3L, LocalDate.of(2019, 1, 21))
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testMonthTransform() throws IOException {
+//    Assume.assumeTrue("ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive", isVectorized);
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.TimestampType.withZone()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).month("part_field").build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
+//        .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
+//        .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testDayTransform() throws IOException {
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.TimestampType.withoutZone()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).day("part_field").build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+//        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+//        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testHourTransform() throws IOException {
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.TimestampType.withoutZone()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).hour("part_field").build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+//        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+//        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testBucketTransform() throws IOException {
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.StringType.get()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("part_field", 2).build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, "Part1")
+//        .add(2L, "Part2")
+//        .add(3L, "Art3")
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testTruncateTransform() throws IOException {
+//    Schema schema = new Schema(
+//        optional(1, "id", Types.LongType.get()),
+//        optional(2, "part_field", Types.StringType.get()));
+//    PartitionSpec spec = PartitionSpec.builderFor(schema).truncate("part_field", 2).build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(1L, "Part1")
+//        .add(2L, "Part2")
+//        .add(3L, "Art3")
+//        .build();
+//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+//    HiveIcebergTestUtils.validateData(table, records, 0);
+//
+//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+//  }
+//
+//  @Test
+//  public void testMultiTableInsert() throws IOException {
+//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    Schema target1Schema = new Schema(
+//        optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "first_name", Types.StringType.get())
+//    );
+//
+//    Schema target2Schema = new Schema(
+//        optional(1, "last_name", Types.StringType.get()),
+//        optional(2, "customer_id", Types.LongType.get())
+//    );
+//
+//    List<Record> target1Records = TestHelper.RecordsBuilder.newInstance(target1Schema)
+//                                      .add(0L, "Alice")
+//                                      .add(1L, "Bob")
+//                                      .add(2L, "Trudy")
+//                                      .build();
+//
+//    List<Record> target2Records = TestHelper.RecordsBuilder.newInstance(target2Schema)
+//                                      .add("Brown", 0L)
+//                                      .add("Green", 1L)
+//                                      .add("Pink", 2L)
+//                                      .build();
+//
+//    Table target1 = testTables.createTable(shell, "target1", target1Schema, fileFormat, ImmutableList.of());
+//    Table target2 = testTables.createTable(shell, "target2", target2Schema, fileFormat, ImmutableList.of());
+//
+//    // simple insert: should create a single vertex writing to both target tables
+//    shell.executeStatement("FROM customers " +
+//        "INSERT INTO target1 SELECT customer_id, first_name " +
+//        "INSERT INTO target2 SELECT last_name, customer_id");
+//
+//    // Check that everything is as expected
+//    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
+//    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
+//
+//    // truncate the target tables
+//    testTables.truncateIcebergTable(target1);
+//    testTables.truncateIcebergTable(target2);
+//
+//    // complex insert: should use a different vertex for each target table
+//    shell.executeStatement("FROM customers " +
+//        "INSERT INTO target1 SELECT customer_id, first_name ORDER BY first_name " +
+//        "INSERT INTO target2 SELECT last_name, customer_id ORDER BY last_name");
+//
+//    // Check that everything is as expected
+//    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
+//    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
+//  }
+//
+//  @Test
+//  public void testWriteWithDefaultWriteFormat() {
+//    Assume.assumeTrue("Testing the default file format is enough for a single scenario.",
+//        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
+//
+//    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+//
+//    // create Iceberg table without specifying a write format in the tbl properties
+//    // it should fall back to using the default file format
+//    shell.executeStatement(String.format("CREATE EXTERNAL TABLE %s (id bigint, name string) STORED BY '%s' %s",
+//        identifier,
+//        HiveIcebergStorageHandler.class.getName(),
+//        testTables.locationForCreateTableSQL(identifier)));
+//
+//    shell.executeStatement(String.format("INSERT INTO %s VALUES (10, 'Linda')", identifier));
+//    List<Object[]> results = shell.executeStatement(String.format("SELECT * FROM %s", identifier));
+//
+//    Assert.assertEquals(1, results.size());
+//    Assert.assertEquals(10L, results.get(0)[0]);
+//    Assert.assertEquals("Linda", results.get(0)[1]);
+//  }
+//
+//  @Test
+//  public void testInsertEmptyResultSet() throws IOException {
+//    Table source = testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, ImmutableList.of());
+//    Table target = testTables.createTable(shell, "target", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, ImmutableList.of());
+//
+//    shell.executeStatement("INSERT INTO target SELECT * FROM source");
+//    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+//
+//    testTables.appendIcebergTable(shell.getHiveConf(), source, fileFormat, null,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
+//    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+//  }
+//
+//  @Test
+//  public void testDecimalTableWithPredicateLiterals() throws IOException {
+//    Schema schema = new Schema(required(1, "decimal_field", Types.DecimalType.of(7, 2)));
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+//        .add(new BigDecimal("85.00"))
+//        .add(new BigDecimal("100.56"))
+//        .add(new BigDecimal("100.57"))
+//        .build();
+//    testTables.createTable(shell, "dec_test", schema, fileFormat, records);
+//
+//    // Use integer literal in predicate
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field >= 85");
+//    Assert.assertEquals(3, rows.size());
+//    Assert.assertArrayEquals(new Object[] {"85.00"}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(1));
+//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(2));
+//
+//    // Use decimal literal in predicate with smaller scale than schema type definition
+//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 99.1");
+//    Assert.assertEquals(2, rows.size());
+//    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(1));
+//
+//    // Use decimal literal in predicate with higher scale than schema type definition
+//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 100.565");
+//    Assert.assertEquals(1, rows.size());
+//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(0));
+//
+//    // Use decimal literal in predicate with the same scale as schema type definition
+//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 640.34");
+//    Assert.assertEquals(0, rows.size());
+//  }
+//
+//  @Test
+//  public void testStructOfMapsInTable() throws IOException {
+//    Schema schema = new Schema(
+//        required(1, "structofmaps", Types.StructType
+//            .of(required(2, "map1", Types.MapType.ofRequired(3, 4,
+//                Types.StringType.get(), Types.StringType.get())), required(5, "map2",
+//                Types.MapType.ofRequired(6, 7, Types.StringType.get(),
+//                    Types.IntegerType.get())))));
+//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+//    // access a map entry inside a struct
+//    for (int i = 0; i < records.size(); i++) {
+//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofmaps");
+//      Map<?, ?> expectedMap = (Map<?, ?>) expectedStruct.getField("map1");
+//      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
+//        List<Object[]> queryResult = shell.executeStatement(String
+//            .format("SELECT structofmaps.map1[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
+//                i));
+//        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
+//      }
+//      expectedMap = (Map<?, ?>) expectedStruct.getField("map2");
+//      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
+//        List<Object[]> queryResult = shell.executeStatement(String
+//            .format("SELECT structofmaps.map2[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
+//                i));
+//        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
+//      }
+//    }
+//  }
+//
+//  @Test
+//  public void testStructOfArraysInTable() throws IOException {
+//    Schema schema = new Schema(
+//        required(1, "structofarrays", Types.StructType
+//            .of(required(2, "names", Types.ListType.ofRequired(3, Types.StringType.get())),
+//                required(4, "birthdays", Types.ListType.ofRequired(5,
+//                    Types.DateType.get())))));
+//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+//    // access an element of an array inside a struct
+//    for (int i = 0; i < records.size(); i++) {
+//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofarrays");
+//      List<?> expectedList = (List<?>) expectedStruct.getField("names");
+//      for (int j = 0; j < expectedList.size(); j++) {
+//        List<Object[]> queryResult = shell.executeStatement(
+//            String.format("SELECT structofarrays.names[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
+//        Assert.assertEquals(expectedList.get(j), queryResult.get(0)[0]);
+//      }
+//      expectedList = (List<?>) expectedStruct.getField("birthdays");
+//      for (int j = 0; j < expectedList.size(); j++) {
+//        List<Object[]> queryResult = shell.executeStatement(
+//            String.format("SELECT structofarrays.birthdays[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
+//        Assert.assertEquals(expectedList.get(j).toString(), queryResult.get(0)[0]);
+//      }
+//    }
+//  }
+//
+//  @Test
+//  public void testStructOfPrimitivesInTable() throws IOException {
+//    Schema schema = new Schema(required(1, "structofprimitives",
+//        Types.StructType.of(required(2, "key", Types.StringType.get()), required(3, "value",
+//            Types.IntegerType.get()))));
+//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+//    // access a single value in a struct
+//    for (int i = 0; i < records.size(); i++) {
+//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofprimitives");
+//      List<Object[]> queryResult = shell.executeStatement(String.format(
+//          "SELECT structofprimitives.key, structofprimitives.value FROM default.structtable LIMIT 1 OFFSET %d", i));
+//      Assert.assertEquals(expectedStruct.getField("key"), queryResult.get(0)[0]);
+//      Assert.assertEquals(expectedStruct.getField("value"), queryResult.get(0)[1]);
+//    }
+//  }
+//
+//  @Test
+//  public void testStructOfStructsInTable() throws IOException {
+//    Schema schema = new Schema(
+//        required(1, "structofstructs", Types.StructType.of(required(2, "struct1", Types.StructType
+//            .of(required(3, "key", Types.StringType.get()), required(4, "value",
+//                Types.IntegerType.get()))))));
+//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+//    // access a struct element inside a struct
+//    for (int i = 0; i < records.size(); i++) {
+//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofstructs");
+//      GenericRecord expectedInnerStruct = (GenericRecord) expectedStruct.getField("struct1");
+//      List<Object[]> queryResult = shell.executeStatement(String.format(
+//          "SELECT structofstructs.struct1.key, structofstructs.struct1.value FROM default.structtable " +
+//              "LIMIT 1 OFFSET %d", i));
+//      Assert.assertEquals(expectedInnerStruct.getField("key"), queryResult.get(0)[0]);
+//      Assert.assertEquals(expectedInnerStruct.getField("value"), queryResult.get(0)[1]);
+//    }
+//  }
+//
+//  @Test
+//  public void testScanTableCaseInsensitive() throws IOException {
+//    testTables.createTable(shell, "customers",
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA_WITH_UPPERCASE, fileFormat,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//
+//    Assert.assertEquals(3, rows.size());
+//    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
+//    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, rows.get(2));
+//
+//    rows = shell.executeStatement("SELECT * FROM default.customers where CustomER_Id < 2 " +
+//        "and first_name in ('Alice', 'Bob')");
+//
+//    Assert.assertEquals(2, rows.size());
+//    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
+//    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
+//  }
+//
+//  @Test
+//  public void testTruncateTable() throws IOException, TException, InterruptedException {
+//    // Create an Iceberg table with some records in it then execute a truncate table command.
+//    // Then check if the data is deleted and the table statistics are reset to 0.
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+//  }
+//
+//  @Test
+//  public void testTruncateEmptyTable() throws IOException, TException, InterruptedException {
+//    // Create an empty Iceberg table and execute a truncate table command on it.
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, null);
+//    // Set the 'external.table.purge' table property on the table
+//    String alterTableCommand =
+//        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')";
+//    shell.executeStatement(alterTableCommand);
+//
+//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+//
+//    shell.executeStatement("TRUNCATE " + identifier);
+//
+//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+//    Map<String, String> summary = icebergTable.currentSnapshot().summary();
+//    for (String key : STATS_MAPPING.values()) {
+//      Assert.assertEquals("0", summary.get(key));
+//    }
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+//    Assert.assertEquals(0, rows.size());
+//    validateBasicStats(icebergTable, databaseName, tableName);
+//  }
+//
+//  @Test
+//  public void testMultipleTruncateTable() throws IOException, TException, InterruptedException {
+//    // Create an Iceberg table with come records in it, then execute a truncate table command
+//    // and check the result. Then insert some new data and run an other truncate table command.
+//    // The purpose of this test is to make sure that multiple truncate table commands can
+//    // run after each other without any issue (like issues with locking).
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+//
+//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(3L, "Jane", "Purple").add(4L, "Tim", "Grey").add(5L, "Eva", "Yellow").add(6L, "James", "White")
+//        .add(7L, "Jack", "Black").build();
+//    shell.executeStatement("INSERT INTO default.customers values (3, 'Jane', 'Purple'), (4, 'Tim', 'Grey')," +
+//        "(5, 'Eva', 'Yellow'), (6, 'James', 'White'), (7, 'Jack', 'Black')");
+//
+//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+//    testTruncateTable(databaseName, tableName, icebergTable, newRecords,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+//  }
+//
+//  @Test
+//  public void testTruncateTableExternalPurgeFalse() throws IOException, TException, InterruptedException {
+//    // Create an Iceberg table with some records in it and set the 'external.table.purge' table property
+//    // to false and try to run a truncate table command on it. The command should fail with a SemanticException.
+//    // Then check if the data is not deleted from the table and also the statistics are not changed.
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='false')");
+//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+//
+//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+//        "Cannot truncate non-managed table", () -> {
+//          shell.executeStatement("TRUNCATE " + identifier);
+//        });
+//
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+//    validateBasicStats(icebergTable, databaseName, tableName);
+//  }
+//
+//  @Test
+//  public void testTruncateTableForceExternalPurgeFalse() throws IOException, TException, InterruptedException {
+//    // Create an Iceberg table with some records and set the 'external.table.purge' table parameter to false.
+//    // Then execute a truncate table force command which should run without any error.
+//    // Then check if the data is deleted from the table and the statistics are reset.
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, false, true);
+//  }
 
   @Test
   public void testTruncateTableWithPartitionSpec() throws IOException, TException, InterruptedException {
@@ -1458,7 +1441,7 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')");
     shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
 
-    AssertHelpers.assertThrows("should throw exception", UnsupportedOperationException.class,
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
         "Using partition spec in query is unsupported for non-native table backed by: " +
             "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler",
         () -> {
@@ -1472,590 +1455,590 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     validateBasicStats(icebergTable, databaseName, tableName);
   }
 
-  @Test
-  public void testTruncateTablePartitionedIcebergTable() throws IOException, TException, InterruptedException {
-    // Create a partitioned Iceberg table with some initial data and run a truncate table command on this table.
-    // Then check if the data is deleted and the table statistics are reset to 0.
-    String databaseName = "default";
-    String tableName = "customers";
-    PartitionSpec spec =
-        PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-        .add(0L, "Alice", "Brown")
-        .add(1L, "Bob", "Brown")
-        .add(2L, "Trudy", "Green")
-        .add(3L, "John", "Pink")
-        .add(4L, "Jane", "Pink")
-        .build();
-    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        spec, fileFormat, records);
-    testTruncateTable(databaseName, tableName, icebergTable, records,
-        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-  }
-
-  private void testTruncateTable(String databaseName, String tableName, Table icebergTable, List<Record> records,
-      Schema schema, boolean externalTablePurge, boolean force) throws TException, InterruptedException {
-    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-    // Set the 'external.table.purge' table property on the table
-    String alterTableCommand =
-        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='" + externalTablePurge + "')";
-    shell.executeStatement(alterTableCommand);
-
-    // Validate the initial data and the table statistics
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-    HiveIcebergTestUtils.validateData(records, HiveIcebergTestUtils.valueForRow(schema, rows), 0);
-    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-    validateBasicStats(icebergTable, databaseName, tableName);
-
-    // Run a 'truncate table' or 'truncate table force' command
-    String truncateCommand = "TRUNCATE " + identifier;
-    if (force) {
-      truncateCommand = truncateCommand + " FORCE";
-    }
-    shell.executeStatement(truncateCommand);
-
-    // Validate if the data is deleted from the table and also that the table
-    // statistics are reset to 0.
-    Table table = testTables.loadTable(identifier);
-    Map<String, String> summary = table.currentSnapshot().summary();
-    for (String key : STATS_MAPPING.values()) {
-      Assert.assertEquals("0", summary.get(key));
-    }
-    rows = shell.executeStatement("SELECT * FROM " + identifier);
-    Assert.assertEquals(0, rows.size());
-    validateBasicStats(table, databaseName, tableName);
-  }
-
-  @Test
-  public void testAddColumnToIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Add a new column (age long) to the Iceberg table.
-    icebergTable.updateSchema().addColumn("age", Types.LongType.get()).commit();
-
-    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-        optional(3, "last_name", Types.StringType.get(), "This is last name"),
-        optional(4, "age", Types.LongType.get()));
-
-    // Also add a new entry to the table where the age column is set.
-    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
-    List<Record> newCustomerWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null).build();
-    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomerWithAge);
-
-    // Do a 'select *' from Hive and check if the age column appears in the result.
-    // It should be null for the old data and should be filled for the data added after the column addition.
-    TestHelper.RecordsBuilder customersWithAgeBuilder = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-        .add(0L, "Alice", "Brown", null).add(1L, "Bob", "Green", null).add(2L, "Trudy", "Pink", null)
-        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null);
-    List<Record> customersWithAge = customersWithAgeBuilder.build();
-
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-        0);
-
-    // Do a 'select customer_id, age' from Hive to check if the new column can be queried from Hive.
-    // The customer_id is needed because of the result sorting.
-    Schema customerSchemaWithAgeOnly =
-        new Schema(optional(1, "customer_id", Types.LongType.get()), optional(4, "age", Types.LongType.get()));
-    TestHelper.RecordsBuilder customerWithAgeOnlyBuilder = TestHelper.RecordsBuilder
-        .newInstance(customerSchemaWithAgeOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, 34L).add(4L, null);
-    List<Record> customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
-
-    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
-
-    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
-    shell.executeStatement(
-        "INSERT INTO default.customers values (5L, 'Lily', 'Magenta', NULL), (6L, 'Roni', 'Purple', 23L)");
-
-    customersWithAgeBuilder.add(5L, "Lily", "Magenta", null).add(6L, "Roni", "Purple", 23L);
-    customersWithAge = customersWithAgeBuilder.build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-        0);
-
-    customerWithAgeOnlyBuilder.add(5L, null).add(6L, 23L);
-    customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
-    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
-  }
-
-  @Test
-  public void testAddRequiredColumnToIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name without initial data.
-    // The reason why not to add initial data is that adding a required column is an incompatible change in Iceberg.
-    // So there is no contract on what happens when trying to read the old data back. It behaves differently depending
-    // on the underlying file format. So there is no point creating a test for that as there is no expected behaviour.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, null);
-
-    // Add a new required column (age long) to the Iceberg table.
-    icebergTable.updateSchema().allowIncompatibleChanges().addRequiredColumn("age", Types.LongType.get()).commit();
-
-    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-        optional(3, "last_name", Types.StringType.get(), "This is last name"),
-        required(4, "age", Types.LongType.get()));
-
-    // Insert some data with age column from Hive.
-    shell.executeStatement(
-        "INSERT INTO default.customers values (0L, 'Lily', 'Magenta', 28L), (1L, 'Roni', 'Purple', 33L)");
-
-    // Do a 'select *' from Hive and check if the age column appears in the result.
-    List<Record> customersWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-        .add(0L, "Lily", "Magenta", 28L).add(1L, "Roni", "Purple", 33L).build();
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-        0);
-
-    // Should add test step to insert NULL value into the new required column. But at the moment it
-    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
-  }
-
-  @Test
-  public void testAddColumnIntoStructToIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns id and person, where person is a struct, consists of the
-    // columns first_name and last_name.
-    Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, "person", Types.StructType
-        .of(required(3, "first_name", Types.StringType.get()), required(4, "last_name", Types.StringType.get()))));
-    List<Record> people = TestHelper.generateRandomRecords(schema, 3, 0L);
-    Table icebergTable = testTables.createTable(shell, "people", schema, fileFormat, people);
-
-    // Add a new column (age long) to the Iceberg table into the person struct
-    icebergTable.updateSchema().addColumn("person", "age", Types.LongType.get()).commit();
-
-    Schema schemaWithAge = new Schema(required(1, "id", Types.LongType.get()),
-        required(2, "person", Types.StructType.of(required(3, "first_name", Types.StringType.get()),
-            required(4, "last_name", Types.StringType.get()), optional(5, "age", Types.LongType.get()))));
-    List<Record> newPeople = TestHelper.generateRandomRecords(schemaWithAge, 2, 10L);
-
-    // Also add a new entry to the table where the age column is set.
-    icebergTable = testTables.loadTable(TableIdentifier.of("default", "people"));
-    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newPeople);
-
-    List<Record> sortedExpected = new ArrayList<>(people);
-    sortedExpected.addAll(newPeople);
-    sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(0)));
-    List<Object[]> rows = shell
-        .executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people order by id");
-    Assert.assertEquals(sortedExpected.size(), rows.size());
-    for (int i = 0; i < sortedExpected.size(); i++) {
-      Object[] row = rows.get(i);
-      Long id = (Long) sortedExpected.get(i).get(0);
-      Record person = (Record) sortedExpected.get(i).getField("person");
-      String lastName = (String) person.getField("last_name");
-      String firstName = (String) person.getField("first_name");
-      Long age = null;
-      if (person.getField("age") != null) {
-        age = (Long) person.getField("age");
-      }
-      Assert.assertEquals(id, (Long) row[0]);
-      Assert.assertEquals(firstName, (String) row[1]);
-      Assert.assertEquals(lastName, (String) row[2]);
-      Assert.assertEquals(age, row[3]);
-    }
-
-    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
-    shell.executeStatement("CREATE TABLE dummy_tbl (id bigint, first_name string, last_name string, age bigint)");
-    shell.executeStatement("INSERT INTO dummy_tbl VALUES (1, 'Lily', 'Blue', 34), (2, 'Roni', 'Grey', NULL)");
-    shell.executeStatement("INSERT INTO default.people SELECT id, named_struct('first_name', first_name, " +
-        "'last_name', last_name, 'age', age) from dummy_tbl");
-
-    rows = shell.executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people " +
-        "where id in (1, 2) order by id");
-    Assert.assertEquals(2, rows.size());
-    Assert.assertEquals((Long) 1L, (Long) rows.get(0)[0]);
-    Assert.assertEquals("Lily", (String) rows.get(0)[1]);
-    Assert.assertEquals("Blue", (String) rows.get(0)[2]);
-    Assert.assertEquals((Long) 34L, (Long) rows.get(0)[3]);
-    Assert.assertEquals((Long) 2L, (Long) rows.get(1)[0]);
-    Assert.assertEquals("Roni", (String) rows.get(1)[1]);
-    Assert.assertEquals("Grey", (String) rows.get(1)[2]);
-    Assert.assertNull(rows.get(1)[3]);
-  }
-
-  @Test
-  public void testMakeColumnRequiredInIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Add a new required column (age long) to the Iceberg table.
-    icebergTable.updateSchema().allowIncompatibleChanges().requireColumn("last_name").commit();
-
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-
-    // Insert some data with last_name no NULL.
-    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', 'Purple')");
-
-    List<Record> customerRecords = TestHelper.RecordsBuilder
-        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(0L, "Alice", "Brown")
-        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", "Purple").build();
-
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customerRecords,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-
-    // Should add test step to insert NULL value into the new required column. But at the moment it
-    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
-  }
-
-  @Test
-  public void testRemoveColumnFromIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Remove the first_name column from the table.
-    icebergTable.updateSchema().deleteColumn("first_name").commit();
-
-    Schema customerSchemaWithoutFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "last_name", Types.StringType.get(), "This is last name"));
-
-    TestHelper.RecordsBuilder customersWithoutFirstNameBuilder = TestHelper.RecordsBuilder
-        .newInstance(customerSchemaWithoutFirstName).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
-    List<Record> customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
-
-    // Run a 'select *' from Hive to see if the result doesn't contain the first_name column any more.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
-
-    // Run a 'select first_name' and check if an exception is thrown.
-    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-        "Invalid table alias or column reference 'first_name'", () -> {
-          shell.executeStatement("SELECT first_name FROM default.customers");
-        });
-
-    // Insert an entry from Hive to check if it can be inserted without the first_name column.
-    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta')");
-
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    customersWithoutFirstNameBuilder.add(4L, "Magenta");
-    customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
-    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
-  }
-
-  @Test
-  public void testRemoveAndAddBackColumnFromIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Remove the first_name column
-    icebergTable.updateSchema().deleteColumn("first_name").commit();
-    // Add a new column with the name first_name
-    icebergTable.updateSchema().addColumn("first_name", Types.StringType.get(), "This is new first name").commit();
-
-    // Add new data to the table with the new first_name column filled.
-    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
-    Schema customerSchemaWithNewFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "last_name", Types.StringType.get(), "This is last name"),
-        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
-    List<Record> newCustomersWithNewFirstName =
-        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(3L, "Red", "James").build();
-    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomersWithNewFirstName);
-
-    TestHelper.RecordsBuilder customersWithNewFirstNameBuilder =
-        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(0L, "Brown", null)
-            .add(1L, "Green", null).add(2L, "Pink", null).add(3L, "Red", "James");
-    List<Record> customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
-
-    // Run a 'select *' from Hive and check if the first_name column is returned.
-    // It should be null for the old data and should be filled in the entry added after the column addition.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
-
-    Schema customerSchemaWithNewFirstNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
-
-    TestHelper.RecordsBuilder customersWithNewFirstNameOnlyBuilder = TestHelper.RecordsBuilder
-        .newInstance(customerSchemaWithNewFirstNameOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, "James");
-    List<Record> customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
-
-    // Run a 'select first_name' from Hive to check if the new first-name column can be queried.
-    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
-
-    // Insert data from Hive with first_name filled and with null first_name value.
-    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta', 'Lily'), (5L, 'Purple', NULL)");
-
-    // Check if the newly inserted data is returned correctly by select statements.
-    customersWithNewFirstNameBuilder.add(4L, "Magenta", "Lily").add(5L, "Purple", null);
-    customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
-
-    customersWithNewFirstNameOnlyBuilder.add(4L, "Lily").add(5L, null);
-    customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
-    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
-        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
-  }
-
-  @Test
-  public void testRenameColumnInIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Rename the last_name column to family_name
-    icebergTable.updateSchema().renameColumn("last_name", "family_name").commit();
-
-    Schema schemaWithFamilyName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-        optional(3, "family_name", Types.StringType.get(), "This is last name"));
-
-    // Run a 'select *' from Hive to check if the same records are returned in the same order as before the rename.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
-
-    Schema shemaWithFamilyNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
-        optional(2, "family_name", Types.StringType.get(), "This is family name"));
-    TestHelper.RecordsBuilder customersWithFamilyNameOnlyBuilder = TestHelper.RecordsBuilder
-        .newInstance(shemaWithFamilyNameOnly).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
-    List<Record> customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
-
-    // Run a 'select family_name' from Hive to check if the column can be queried with the new name.
-    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
-        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
-
-    // Run a 'select last_name' to check if an exception is thrown.
-    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-        "Invalid table alias or column reference 'last_name'", () -> {
-          shell.executeStatement("SELECT last_name FROM default.customers");
-        });
-
-    // Insert some data from Hive to check if the last_name column is still can be filled.
-    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', NULL)");
-
-    List<Record> newCustomers = TestHelper.RecordsBuilder.newInstance(schemaWithFamilyName).add(0L, "Alice", "Brown")
-        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", null).build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(newCustomers, HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
-
-    customersWithFamilyNameOnlyBuilder.add(3L, "Magenta").add(4L, null);
-    customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
-    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
-        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
-  }
-
-  @Test
-  public void testMoveLastNameToFirstInIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Move the last_name column in the table schema as first_column
-    icebergTable.updateSchema().moveFirst("last_name").commit();
-
-    Schema customerSchemaLastNameFirst =
-        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
-            optional(2, "customer_id", Types.LongType.get()),
-            optional(3, "first_name", Types.StringType.get(), "This is first name"));
-
-    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
-            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
-    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-
-    // Run a 'select *' to check if the order of the column in the result has been changed.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-
-    // Query the data with names and check if the result is the same as when the table was created.
-    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-
-    // Insert data from Hive to check if the last_name column has to be first in the values list.
-    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
-
-    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
-    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-  }
-
-  @Test
-  public void testMoveLastNameBeforeCustomerIdInIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Move the last_name column before the customer_id in the table schema.
-    icebergTable.updateSchema().moveBefore("last_name", "customer_id").commit();
-
-    Schema customerSchemaLastNameFirst =
-        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
-            optional(2, "customer_id", Types.LongType.get()),
-            optional(3, "first_name", Types.StringType.get(), "This is first name"));
-
-    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
-            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
-    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-
-    // Run a 'select *' to check if the order of the column in the result has been changed.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-
-    // Query the data with names and check if the result is the same as when the table was created.
-    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-
-    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
-    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
-
-    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
-    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-  }
-
-  @Test
-  public void testMoveCustomerIdAfterFirstNameInIcebergTable() throws IOException {
-    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-
-    // Move the last_name column before the customer_id in the table schema.
-    icebergTable.updateSchema().moveAfter("customer_id", "first_name").commit();
-
-    Schema customerSchemaLastNameFirst =
-        new Schema(optional(1, "first_name", Types.StringType.get(), "This is first name"),
-            optional(2, "customer_id", Types.LongType.get()),
-            optional(3, "last_name", Types.StringType.get(), "This is last name"));
-
-    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Alice", 0L, "Brown")
-            .add("Bob", 1L, "Green").add("Trudy", 2L, "Pink");
-    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-
-    // Run a 'select *' to check if the order of the column in the result has been changed.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-
-    // Query the data with names and check if the result is the same as when the table was created.
-    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-
-    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
-    shell.executeStatement("INSERT INTO default.customers values ('Lily', 3L, 'Magenta')");
-
-    customersWithLastNameFirstBuilder.add("Lily", 3L, "Magenta");
-    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-    rows = shell.executeStatement("SELECT * FROM default.customers");
-    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-  }
-
-  @Test
-  public void testUpdateColumnTypeInIcebergTable() throws IOException, TException, InterruptedException {
-    // Create an Iceberg table with int, float and decimal(2,1) types with some initial records
-    Schema schema = new Schema(optional(1, "id", Types.LongType.get()),
-        optional(2, "int_col", Types.IntegerType.get(), "This is an integer type"),
-        optional(3, "float_col", Types.FloatType.get(), "This is a float type"),
-        optional(4, "decimal_col", Types.DecimalType.of(2, 1), "This is a decimal type"));
-
-    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22F, BigDecimal.valueOf(13L, 1))
-        .add(1L, 223344, 555.22F, BigDecimal.valueOf(22L, 1)).add(2L, -234, -342F, BigDecimal.valueOf(-12L, 1)).build();
-
-    Table icebergTable = testTables.createTable(shell, "types_table", schema, fileFormat, records);
-
-    // In the result set a float column is returned as double and a decimal is returned as string,
-    // even though Hive has the columns with the right types.
-    // Probably this conversation happens when fetching the result set after calling the select through the shell.
-    // Because of this, a separate schema and record list has to be used when validating the returned values.
-    Schema schemaForResultSet =
-        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.IntegerType.get()),
-            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
-
-    List<Record> expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22d, "1.3")
-        .add(1L, 223344, 555.22d, "2.2").add(2L, -234, -342d, "-1.2").build();
-
-    // Check the select result and the column types of the table.
-    List<Object[]> rows = shell.executeStatement("SELECT * FROM types_table");
-    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-
-    org.apache.hadoop.hive.metastore.api.Table table = shell.metastore().getTable("default", "types_table");
-    Assert.assertNotNull(table);
-    Assert.assertNotNull(table.getSd());
-    List<FieldSchema> columns = table.getSd().getCols();
-    Assert.assertEquals("id", columns.get(0).getName());
-    Assert.assertEquals("bigint", columns.get(0).getType());
-    Assert.assertEquals("int_col", columns.get(1).getName());
-    Assert.assertEquals("int", columns.get(1).getType());
-    Assert.assertEquals("float_col", columns.get(2).getName());
-    Assert.assertEquals("float", columns.get(2).getType());
-    Assert.assertEquals("decimal_col", columns.get(3).getName());
-    Assert.assertEquals("decimal(2,1)", columns.get(3).getType());
-
-    // Change the column types on the table to long, double and decimal(6,1)
-    icebergTable.updateSchema().updateColumn("int_col", Types.LongType.get())
-        .updateColumn("float_col", Types.DoubleType.get()).updateColumn("decimal_col", Types.DecimalType.of(6, 1))
-        .commit();
-
-    schemaForResultSet =
-        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.LongType.get()),
-            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
-
-    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35L, 22d, "1.3")
-        .add(1L, 223344L, 555.219970703125d, "2.2").add(2L, -234L, -342d, "-1.2").build();
-
-    rows = shell.executeStatement("SELECT * FROM types_table");
-    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-
-    // Check if the column types in Hive have also changed to big_int, double an decimal(6,1)
-    // Do this check only for Hive catalog, as this is the only case when the column types are updated
-    // in the metastore. In case of other catalog types, the table is not updated in the metastore,
-    // so no point in checking the column types.
-    if (TestTables.TestTableType.HIVE_CATALOG.equals(this.testTableType)) {
-      table = shell.metastore().getTable("default", "types_table");
-      Assert.assertNotNull(table);
-      Assert.assertNotNull(table.getSd());
-      columns = table.getSd().getCols();
-      Assert.assertEquals("id", columns.get(0).getName());
-      Assert.assertEquals("bigint", columns.get(0).getType());
-      Assert.assertEquals("int_col", columns.get(1).getName());
-      Assert.assertEquals("bigint", columns.get(1).getType());
-      Assert.assertEquals("float_col", columns.get(2).getName());
-      Assert.assertEquals("double", columns.get(2).getType());
-      Assert.assertEquals("decimal_col", columns.get(3).getName());
-      Assert.assertEquals("decimal(6,1)", columns.get(3).getType());
-    }
-
-    // Insert some data which fit to the new column types and check if they are saved and can be queried correctly.
-    // This should work for all catalog types.
-    shell.executeStatement(
-        "INSERT INTO types_table values (3, 3147483647, 111.333, 12345.5), (4, -3147483648, 55, -2234.5)");
-    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(3L, 3147483647L, 111.333d, "12345.5")
-        .add(4L, -3147483648L, 55d, "-2234.5").build();
-    rows = shell.executeStatement("SELECT * FROM types_table where id in(3, 4)");
-    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-  }
+//  @Test
+//  public void testTruncateTablePartitionedIcebergTable() throws IOException, TException, InterruptedException {
+//    // Create a partitioned Iceberg table with some initial data and run a truncate table command on this table.
+//    // Then check if the data is deleted and the table statistics are reset to 0.
+//    String databaseName = "default";
+//    String tableName = "customers";
+//    PartitionSpec spec =
+//        PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+//        .add(0L, "Alice", "Brown")
+//        .add(1L, "Bob", "Brown")
+//        .add(2L, "Trudy", "Green")
+//        .add(3L, "John", "Pink")
+//        .add(4L, "Jane", "Pink")
+//        .build();
+//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        spec, fileFormat, records);
+//    testTruncateTable(databaseName, tableName, icebergTable, records,
+//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+//  }
+//
+//  private void testTruncateTable(String databaseName, String tableName, Table icebergTable, List<Record> records,
+//      Schema schema, boolean externalTablePurge, boolean force) throws TException, InterruptedException {
+//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+//    // Set the 'external.table.purge' table property on the table
+//    String alterTableCommand =
+//        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='" + externalTablePurge + "')";
+//    shell.executeStatement(alterTableCommand);
+//
+//    // Validate the initial data and the table statistics
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+//    HiveIcebergTestUtils.validateData(records, HiveIcebergTestUtils.valueForRow(schema, rows), 0);
+//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+//    validateBasicStats(icebergTable, databaseName, tableName);
+//
+//    // Run a 'truncate table' or 'truncate table force' command
+//    String truncateCommand = "TRUNCATE " + identifier;
+//    if (force) {
+//      truncateCommand = truncateCommand + " FORCE";
+//    }
+//    shell.executeStatement(truncateCommand);
+//
+//    // Validate if the data is deleted from the table and also that the table
+//    // statistics are reset to 0.
+//    Table table = testTables.loadTable(identifier);
+//    Map<String, String> summary = table.currentSnapshot().summary();
+//    for (String key : STATS_MAPPING.values()) {
+//      Assert.assertEquals("0", summary.get(key));
+//    }
+//    rows = shell.executeStatement("SELECT * FROM " + identifier);
+//    Assert.assertEquals(0, rows.size());
+//    validateBasicStats(table, databaseName, tableName);
+//  }
+//
+//  @Test
+//  public void testAddColumnToIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Add a new column (age long) to the Iceberg table.
+//    icebergTable.updateSchema().addColumn("age", Types.LongType.get()).commit();
+//
+//    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+//        optional(3, "last_name", Types.StringType.get(), "This is last name"),
+//        optional(4, "age", Types.LongType.get()));
+//
+//    // Also add a new entry to the table where the age column is set.
+//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
+//    List<Record> newCustomerWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+//        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null).build();
+//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomerWithAge);
+//
+//    // Do a 'select *' from Hive and check if the age column appears in the result.
+//    // It should be null for the old data and should be filled for the data added after the column addition.
+//    TestHelper.RecordsBuilder customersWithAgeBuilder = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+//        .add(0L, "Alice", "Brown", null).add(1L, "Bob", "Green", null).add(2L, "Trudy", "Pink", null)
+//        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null);
+//    List<Record> customersWithAge = customersWithAgeBuilder.build();
+//
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+//        0);
+//
+//    // Do a 'select customer_id, age' from Hive to check if the new column can be queried from Hive.
+//    // The customer_id is needed because of the result sorting.
+//    Schema customerSchemaWithAgeOnly =
+//        new Schema(optional(1, "customer_id", Types.LongType.get()), optional(4, "age", Types.LongType.get()));
+//    TestHelper.RecordsBuilder customerWithAgeOnlyBuilder = TestHelper.RecordsBuilder
+//        .newInstance(customerSchemaWithAgeOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, 34L).add(4L, null);
+//    List<Record> customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
+//
+//    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
+//
+//    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
+//    shell.executeStatement(
+//        "INSERT INTO default.customers values (5L, 'Lily', 'Magenta', NULL), (6L, 'Roni', 'Purple', 23L)");
+//
+//    customersWithAgeBuilder.add(5L, "Lily", "Magenta", null).add(6L, "Roni", "Purple", 23L);
+//    customersWithAge = customersWithAgeBuilder.build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+//        0);
+//
+//    customerWithAgeOnlyBuilder.add(5L, null).add(6L, 23L);
+//    customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
+//    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
+//  }
+//
+//  @Test
+//  public void testAddRequiredColumnToIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name without initial data.
+//    // The reason why not to add initial data is that adding a required column is an incompatible change in Iceberg.
+//    // So there is no contract on what happens when trying to read the old data back. It behaves differently depending
+//    // on the underlying file format. So there is no point creating a test for that as there is no expected behaviour.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, null);
+//
+//    // Add a new required column (age long) to the Iceberg table.
+//    icebergTable.updateSchema().allowIncompatibleChanges().addRequiredColumn("age", Types.LongType.get()).commit();
+//
+//    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+//        optional(3, "last_name", Types.StringType.get(), "This is last name"),
+//        required(4, "age", Types.LongType.get()));
+//
+//    // Insert some data with age column from Hive.
+//    shell.executeStatement(
+//        "INSERT INTO default.customers values (0L, 'Lily', 'Magenta', 28L), (1L, 'Roni', 'Purple', 33L)");
+//
+//    // Do a 'select *' from Hive and check if the age column appears in the result.
+//    List<Record> customersWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+//        .add(0L, "Lily", "Magenta", 28L).add(1L, "Roni", "Purple", 33L).build();
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+//        0);
+//
+//    // Should add test step to insert NULL value into the new required column. But at the moment it
+//    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
+//  }
+//
+//  @Test
+//  public void testAddColumnIntoStructToIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns id and person, where person is a struct, consists of the
+//    // columns first_name and last_name.
+//    Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, "person", Types.StructType
+//        .of(required(3, "first_name", Types.StringType.get()), required(4, "last_name", Types.StringType.get()))));
+//    List<Record> people = TestHelper.generateRandomRecords(schema, 3, 0L);
+//    Table icebergTable = testTables.createTable(shell, "people", schema, fileFormat, people);
+//
+//    // Add a new column (age long) to the Iceberg table into the person struct
+//    icebergTable.updateSchema().addColumn("person", "age", Types.LongType.get()).commit();
+//
+//    Schema schemaWithAge = new Schema(required(1, "id", Types.LongType.get()),
+//        required(2, "person", Types.StructType.of(required(3, "first_name", Types.StringType.get()),
+//            required(4, "last_name", Types.StringType.get()), optional(5, "age", Types.LongType.get()))));
+//    List<Record> newPeople = TestHelper.generateRandomRecords(schemaWithAge, 2, 10L);
+//
+//    // Also add a new entry to the table where the age column is set.
+//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "people"));
+//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newPeople);
+//
+//    List<Record> sortedExpected = new ArrayList<>(people);
+//    sortedExpected.addAll(newPeople);
+//    sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(0)));
+//    List<Object[]> rows = shell
+//        .executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people order by id");
+//    Assert.assertEquals(sortedExpected.size(), rows.size());
+//    for (int i = 0; i < sortedExpected.size(); i++) {
+//      Object[] row = rows.get(i);
+//      Long id = (Long) sortedExpected.get(i).get(0);
+//      Record person = (Record) sortedExpected.get(i).getField("person");
+//      String lastName = (String) person.getField("last_name");
+//      String firstName = (String) person.getField("first_name");
+//      Long age = null;
+//      if (person.getField("age") != null) {
+//        age = (Long) person.getField("age");
+//      }
+//      Assert.assertEquals(id, (Long) row[0]);
+//      Assert.assertEquals(firstName, (String) row[1]);
+//      Assert.assertEquals(lastName, (String) row[2]);
+//      Assert.assertEquals(age, row[3]);
+//    }
+//
+//    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
+//    shell.executeStatement("CREATE TABLE dummy_tbl (id bigint, first_name string, last_name string, age bigint)");
+//    shell.executeStatement("INSERT INTO dummy_tbl VALUES (1, 'Lily', 'Blue', 34), (2, 'Roni', 'Grey', NULL)");
+//    shell.executeStatement("INSERT INTO default.people SELECT id, named_struct('first_name', first_name, " +
+//        "'last_name', last_name, 'age', age) from dummy_tbl");
+//
+//    rows = shell.executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people " +
+//        "where id in (1, 2) order by id");
+//    Assert.assertEquals(2, rows.size());
+//    Assert.assertEquals((Long) 1L, (Long) rows.get(0)[0]);
+//    Assert.assertEquals("Lily", (String) rows.get(0)[1]);
+//    Assert.assertEquals("Blue", (String) rows.get(0)[2]);
+//    Assert.assertEquals((Long) 34L, (Long) rows.get(0)[3]);
+//    Assert.assertEquals((Long) 2L, (Long) rows.get(1)[0]);
+//    Assert.assertEquals("Roni", (String) rows.get(1)[1]);
+//    Assert.assertEquals("Grey", (String) rows.get(1)[2]);
+//    Assert.assertNull(rows.get(1)[3]);
+//  }
+//
+//  @Test
+//  public void testMakeColumnRequiredInIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Add a new required column (age long) to the Iceberg table.
+//    icebergTable.updateSchema().allowIncompatibleChanges().requireColumn("last_name").commit();
+//
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//
+//    // Insert some data with last_name no NULL.
+//    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', 'Purple')");
+//
+//    List<Record> customerRecords = TestHelper.RecordsBuilder
+//        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(0L, "Alice", "Brown")
+//        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", "Purple").build();
+//
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customerRecords,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//
+//    // Should add test step to insert NULL value into the new required column. But at the moment it
+//    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
+//  }
+//
+//  @Test
+//  public void testRemoveColumnFromIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Remove the first_name column from the table.
+//    icebergTable.updateSchema().deleteColumn("first_name").commit();
+//
+//    Schema customerSchemaWithoutFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "last_name", Types.StringType.get(), "This is last name"));
+//
+//    TestHelper.RecordsBuilder customersWithoutFirstNameBuilder = TestHelper.RecordsBuilder
+//        .newInstance(customerSchemaWithoutFirstName).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
+//    List<Record> customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
+//
+//    // Run a 'select *' from Hive to see if the result doesn't contain the first_name column any more.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
+//
+//    // Run a 'select first_name' and check if an exception is thrown.
+//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+//        "Invalid table alias or column reference 'first_name'", () -> {
+//          shell.executeStatement("SELECT first_name FROM default.customers");
+//        });
+//
+//    // Insert an entry from Hive to check if it can be inserted without the first_name column.
+//    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta')");
+//
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    customersWithoutFirstNameBuilder.add(4L, "Magenta");
+//    customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
+//    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
+//  }
+//
+//  @Test
+//  public void testRemoveAndAddBackColumnFromIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Remove the first_name column
+//    icebergTable.updateSchema().deleteColumn("first_name").commit();
+//    // Add a new column with the name first_name
+//    icebergTable.updateSchema().addColumn("first_name", Types.StringType.get(), "This is new first name").commit();
+//
+//    // Add new data to the table with the new first_name column filled.
+//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
+//    Schema customerSchemaWithNewFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "last_name", Types.StringType.get(), "This is last name"),
+//        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
+//    List<Record> newCustomersWithNewFirstName =
+//        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(3L, "Red", "James").build();
+//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomersWithNewFirstName);
+//
+//    TestHelper.RecordsBuilder customersWithNewFirstNameBuilder =
+//        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(0L, "Brown", null)
+//            .add(1L, "Green", null).add(2L, "Pink", null).add(3L, "Red", "James");
+//    List<Record> customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
+//
+//    // Run a 'select *' from Hive and check if the first_name column is returned.
+//    // It should be null for the old data and should be filled in the entry added after the column addition.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
+//
+//    Schema customerSchemaWithNewFirstNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
+//
+//    TestHelper.RecordsBuilder customersWithNewFirstNameOnlyBuilder = TestHelper.RecordsBuilder
+//        .newInstance(customerSchemaWithNewFirstNameOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, "James");
+//    List<Record> customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
+//
+//    // Run a 'select first_name' from Hive to check if the new first-name column can be queried.
+//    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
+//
+//    // Insert data from Hive with first_name filled and with null first_name value.
+//    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta', 'Lily'), (5L, 'Purple', NULL)");
+//
+//    // Check if the newly inserted data is returned correctly by select statements.
+//    customersWithNewFirstNameBuilder.add(4L, "Magenta", "Lily").add(5L, "Purple", null);
+//    customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
+//
+//    customersWithNewFirstNameOnlyBuilder.add(4L, "Lily").add(5L, null);
+//    customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
+//    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
+//  }
+//
+//  @Test
+//  public void testRenameColumnInIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Rename the last_name column to family_name
+//    icebergTable.updateSchema().renameColumn("last_name", "family_name").commit();
+//
+//    Schema schemaWithFamilyName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+//        optional(3, "family_name", Types.StringType.get(), "This is last name"));
+//
+//    // Run a 'select *' from Hive to check if the same records are returned in the same order as before the rename.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
+//
+//    Schema shemaWithFamilyNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
+//        optional(2, "family_name", Types.StringType.get(), "This is family name"));
+//    TestHelper.RecordsBuilder customersWithFamilyNameOnlyBuilder = TestHelper.RecordsBuilder
+//        .newInstance(shemaWithFamilyNameOnly).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
+//    List<Record> customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
+//
+//    // Run a 'select family_name' from Hive to check if the column can be queried with the new name.
+//    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
+//        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
+//
+//    // Run a 'select last_name' to check if an exception is thrown.
+//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+//        "Invalid table alias or column reference 'last_name'", () -> {
+//          shell.executeStatement("SELECT last_name FROM default.customers");
+//        });
+//
+//    // Insert some data from Hive to check if the last_name column is still can be filled.
+//    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', NULL)");
+//
+//    List<Record> newCustomers = TestHelper.RecordsBuilder.newInstance(schemaWithFamilyName).add(0L, "Alice", "Brown")
+//        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", null).build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(newCustomers, HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
+//
+//    customersWithFamilyNameOnlyBuilder.add(3L, "Magenta").add(4L, null);
+//    customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
+//    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
+//        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
+//  }
+//
+//  @Test
+//  public void testMoveLastNameToFirstInIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Move the last_name column in the table schema as first_column
+//    icebergTable.updateSchema().moveFirst("last_name").commit();
+//
+//    Schema customerSchemaLastNameFirst =
+//        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
+//            optional(2, "customer_id", Types.LongType.get()),
+//            optional(3, "first_name", Types.StringType.get(), "This is first name"));
+//
+//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
+//            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
+//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//
+//    // Run a 'select *' to check if the order of the column in the result has been changed.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//
+//    // Query the data with names and check if the result is the same as when the table was created.
+//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//
+//    // Insert data from Hive to check if the last_name column has to be first in the values list.
+//    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
+//
+//    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
+//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//  }
+//
+//  @Test
+//  public void testMoveLastNameBeforeCustomerIdInIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Move the last_name column before the customer_id in the table schema.
+//    icebergTable.updateSchema().moveBefore("last_name", "customer_id").commit();
+//
+//    Schema customerSchemaLastNameFirst =
+//        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
+//            optional(2, "customer_id", Types.LongType.get()),
+//            optional(3, "first_name", Types.StringType.get(), "This is first name"));
+//
+//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
+//            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
+//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//
+//    // Run a 'select *' to check if the order of the column in the result has been changed.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//
+//    // Query the data with names and check if the result is the same as when the table was created.
+//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//
+//    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
+//    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
+//
+//    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
+//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//  }
+//
+//  @Test
+//  public void testMoveCustomerIdAfterFirstNameInIcebergTable() throws IOException {
+//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+//
+//    // Move the last_name column before the customer_id in the table schema.
+//    icebergTable.updateSchema().moveAfter("customer_id", "first_name").commit();
+//
+//    Schema customerSchemaLastNameFirst =
+//        new Schema(optional(1, "first_name", Types.StringType.get(), "This is first name"),
+//            optional(2, "customer_id", Types.LongType.get()),
+//            optional(3, "last_name", Types.StringType.get(), "This is last name"));
+//
+//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Alice", 0L, "Brown")
+//            .add("Bob", 1L, "Green").add("Trudy", 2L, "Pink");
+//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//
+//    // Run a 'select *' to check if the order of the column in the result has been changed.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//
+//    // Query the data with names and check if the result is the same as when the table was created.
+//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+//
+//    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
+//    shell.executeStatement("INSERT INTO default.customers values ('Lily', 3L, 'Magenta')");
+//
+//    customersWithLastNameFirstBuilder.add("Lily", 3L, "Magenta");
+//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+//    rows = shell.executeStatement("SELECT * FROM default.customers");
+//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+//  }
+//
+//  @Test
+//  public void testUpdateColumnTypeInIcebergTable() throws IOException, TException, InterruptedException {
+//    // Create an Iceberg table with int, float and decimal(2,1) types with some initial records
+//    Schema schema = new Schema(optional(1, "id", Types.LongType.get()),
+//        optional(2, "int_col", Types.IntegerType.get(), "This is an integer type"),
+//        optional(3, "float_col", Types.FloatType.get(), "This is a float type"),
+//        optional(4, "decimal_col", Types.DecimalType.of(2, 1), "This is a decimal type"));
+//
+//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22F, BigDecimal.valueOf(13L, 1))
+//        .add(1L, 223344, 555.22F, BigDecimal.valueOf(22L, 1)).add(2L, -234, -342F, BigDecimal.valueOf(-12L, 1)).build();
+//
+//    Table icebergTable = testTables.createTable(shell, "types_table", schema, fileFormat, records);
+//
+//    // In the result set a float column is returned as double and a decimal is returned as string,
+//    // even though Hive has the columns with the right types.
+//    // Probably this conversation happens when fetching the result set after calling the select through the shell.
+//    // Because of this, a separate schema and record list has to be used when validating the returned values.
+//    Schema schemaForResultSet =
+//        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.IntegerType.get()),
+//            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
+//
+//    List<Record> expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22d, "1.3")
+//        .add(1L, 223344, 555.22d, "2.2").add(2L, -234, -342d, "-1.2").build();
+//
+//    // Check the select result and the column types of the table.
+//    List<Object[]> rows = shell.executeStatement("SELECT * FROM types_table");
+//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+//
+//    org.apache.hadoop.hive.metastore.api.Table table = shell.metastore().getTable("default", "types_table");
+//    Assert.assertNotNull(table);
+//    Assert.assertNotNull(table.getSd());
+//    List<FieldSchema> columns = table.getSd().getCols();
+//    Assert.assertEquals("id", columns.get(0).getName());
+//    Assert.assertEquals("bigint", columns.get(0).getType());
+//    Assert.assertEquals("int_col", columns.get(1).getName());
+//    Assert.assertEquals("int", columns.get(1).getType());
+//    Assert.assertEquals("float_col", columns.get(2).getName());
+//    Assert.assertEquals("float", columns.get(2).getType());
+//    Assert.assertEquals("decimal_col", columns.get(3).getName());
+//    Assert.assertEquals("decimal(2,1)", columns.get(3).getType());
+//
+//    // Change the column types on the table to long, double and decimal(6,1)
+//    icebergTable.updateSchema().updateColumn("int_col", Types.LongType.get())
+//        .updateColumn("float_col", Types.DoubleType.get()).updateColumn("decimal_col", Types.DecimalType.of(6, 1))
+//        .commit();
+//
+//    schemaForResultSet =
+//        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.LongType.get()),
+//            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
+//
+//    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35L, 22d, "1.3")
+//        .add(1L, 223344L, 555.219970703125d, "2.2").add(2L, -234L, -342d, "-1.2").build();
+//
+//    rows = shell.executeStatement("SELECT * FROM types_table");
+//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+//
+//    // Check if the column types in Hive have also changed to big_int, double an decimal(6,1)
+//    // Do this check only for Hive catalog, as this is the only case when the column types are updated
+//    // in the metastore. In case of other catalog types, the table is not updated in the metastore,
+//    // so no point in checking the column types.
+//    if (TestTables.TestTableType.HIVE_CATALOG.equals(this.testTableType)) {
+//      table = shell.metastore().getTable("default", "types_table");
+//      Assert.assertNotNull(table);
+//      Assert.assertNotNull(table.getSd());
+//      columns = table.getSd().getCols();
+//      Assert.assertEquals("id", columns.get(0).getName());
+//      Assert.assertEquals("bigint", columns.get(0).getType());
+//      Assert.assertEquals("int_col", columns.get(1).getName());
+//      Assert.assertEquals("bigint", columns.get(1).getType());
+//      Assert.assertEquals("float_col", columns.get(2).getName());
+//      Assert.assertEquals("double", columns.get(2).getType());
+//      Assert.assertEquals("decimal_col", columns.get(3).getName());
+//      Assert.assertEquals("decimal(6,1)", columns.get(3).getType());
+//    }
+//
+//    // Insert some data which fit to the new column types and check if they are saved and can be queried correctly.
+//    // This should work for all catalog types.
+//    shell.executeStatement(
+//        "INSERT INTO types_table values (3, 3147483647, 111.333, 12345.5), (4, -3147483648, 55, -2234.5)");
+//    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(3L, 3147483647L, 111.333d, "12345.5")
+//        .add(4L, -3147483648L, 55d, "-2234.5").build();
+//    rows = shell.executeStatement("SELECT * FROM types_table where id in(3, 4)");
+//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+//  }
 
   private void testComplexTypeWrite(Schema schema, List<Record> records) throws IOException {
     String tableName = "complex_table";

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -1458,8 +1458,10 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')");
     shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
 
-    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-        "Partition spec for non partitioned table", () -> {
+    AssertHelpers.assertThrows("should throw exception", UnsupportedOperationException.class,
+        "Using partition spec in query is unsupported for non-native table backed by: " +
+            "org.apache.iceberg.mr.hive.HiveIcebergStorageHandler",
+        () -> {
           shell.executeStatement("TRUNCATE " + identifier + " PARTITION (customer_id=1)");
         });
 

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -1345,6 +1345,186 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   }
 
   @Test
+  public void testTruncateTable() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records in it then execute a truncate table command.
+    // Then check if the data is deleted and the table statistics are reset to 0.
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  @Test
+  public void testTruncateEmptyTable() throws IOException, TException, InterruptedException {
+    // Create an empty Iceberg table and execute a truncate table command on it.
+    String databaseName = "default";
+    String tableName = "customers";
+    String fullTableName = databaseName + "." + tableName;
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, null);
+    // Set the 'external.table.purge' table property on the table
+    String alterTableCommand =
+        "ALTER TABLE " + fullTableName + " SET TBLPROPERTIES('external.table.purge'='true')";
+    shell.executeStatement(alterTableCommand);
+
+    shell.executeStatement("ANALYZE TABLE " + fullTableName + " COMPUTE STATISTICS");
+
+    shell.executeStatement("TRUNCATE " + fullTableName);
+
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    Map<String, String> summary = icebergTable.currentSnapshot().summary();
+    for (String key : STATS_MAPPING.values()) {
+      Assert.assertEquals("0", summary.get(key));
+    }
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + fullTableName);
+    Assert.assertEquals(0, rows.size());
+    validateBasicStats(icebergTable, databaseName, tableName);
+  }
+
+  @Test
+  public void testMultipleTruncateTable() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with come records in it, then execute a truncate table command
+    // and check the result. Then insert some new data and run an other truncate table command.
+    // The purpose of this test is to make sure that multiple truncate table commands can
+    // run after each other without any issue (like issues with locking).
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(3L, "Jane", "Purple").add(4L, "Tim", "Grey").add(5L, "Eva", "Yellow").add(6L, "James", "White")
+        .add(7L, "Jack", "Black").build();
+    shell.executeStatement("INSERT INTO default.customers values (3, 'Jane', 'Purple'), (4, 'Tim', 'Grey')," +
+        "(5, 'Eva', 'Yellow'), (6, 'James', 'White'), (7, 'Jack', 'Black')");
+
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    testTruncateTable(databaseName, tableName, icebergTable, newRecords,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  @Test
+  public void testTruncateTableExternalPurgeFalse() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records in it and set the 'external.table.purge' table property
+    // to false and try to run a truncate table command on it. The command should fail with a SemanticException.
+    // Then check if the data is not deleted from the table and also the statistics are not changed.
+    String databaseName = "default";
+    String tableName = "customers";
+    String fullTableName = databaseName + "." + tableName;
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("ALTER TABLE " + fullTableName + " SET TBLPROPERTIES('external.table.purge'='false')");
+    shell.executeStatement("ANALYZE TABLE " + fullTableName + " COMPUTE STATISTICS");
+
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "Cannot truncate non-managed table", () -> {
+          shell.executeStatement("TRUNCATE " + fullTableName);
+        });
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + fullTableName);
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    validateBasicStats(icebergTable, databaseName, tableName);
+  }
+
+  @Test
+  public void testTruncateTableForceExternalPurgeFalse() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records and set the 'external.table.purge' table parameter to false.
+    // Then execute a truncate table force command which should run without any error.
+    // Then check if the data is deleted from the table and the statistics are reset.
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, false, true);
+  }
+
+  @Test
+  public void testTruncateTableWithPartitionSpec() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some record and try to run a truncate table command with partition
+    // spec. The command should fail as the table is unpartitioned in Hive. Then check if the
+    // initial data and the table statistics are not changed.
+    String databaseName = "default";
+    String tableName = "customers";
+    String fullTableName = databaseName + "." + tableName;
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("ALTER TABLE " + fullTableName + " SET TBLPROPERTIES('external.table.purge'='true')");
+    shell.executeStatement("ANALYZE TABLE " + fullTableName + " COMPUTE STATISTICS");
+
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "Partition spec for non partitioned table", () -> {
+          shell.executeStatement("TRUNCATE " + fullTableName + " PARTITION (customer_id=1)");
+        });
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + fullTableName);
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    validateBasicStats(icebergTable, databaseName, tableName);
+  }
+
+  @Test
+  public void testTruncateTablePartitionedIcebergTable() throws IOException, TException, InterruptedException {
+    // Create a partitioned Iceberg table with some initial data and run a truncate table command on this table.
+    // Then check if the data is deleted and the table statistics are reset to 0.
+    String databaseName = "default";
+    String tableName = "customers";
+    PartitionSpec spec =
+        PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Alice", "Brown")
+        .add(1L, "Bob", "Brown")
+        .add(2L, "Trudy", "Green")
+        .add(3L, "John", "Pink")
+        .add(4L, "Jane", "Pink")
+        .build();
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, records);
+    testTruncateTable(databaseName, tableName, icebergTable, records,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  private void testTruncateTable(String databaseName, String tableName, Table icebergTable, List<Record> records,
+      Schema schema, boolean externalTablePurge, boolean force) throws TException, InterruptedException {
+    String fullTableName = databaseName + "." + tableName;
+    // Set the 'external.table.purge' table property on the table
+    String alterTableCommand =
+        "ALTER TABLE " + fullTableName + " SET TBLPROPERTIES('external.table.purge'='" + externalTablePurge + "')";
+    shell.executeStatement(alterTableCommand);
+
+    // Validate the initial data and the table statistics
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + fullTableName);
+    HiveIcebergTestUtils.validateData(records, HiveIcebergTestUtils.valueForRow(schema, rows), 0);
+    shell.executeStatement("ANALYZE TABLE " + fullTableName + " COMPUTE STATISTICS");
+    validateBasicStats(icebergTable, databaseName, tableName);
+
+    // Run a 'truncate table' or 'truncate table force' command
+    String truncateCommand = "TRUNCATE " + fullTableName;
+    if (force) {
+      truncateCommand = truncateCommand + " FORCE";
+    }
+    shell.executeStatement(truncateCommand);
+
+    // Validate if the data is deleted from the table and also that the table
+    // statistics are reset to 0.
+    Table table = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    Map<String, String> summary = table.currentSnapshot().summary();
+    for (String key : STATS_MAPPING.values()) {
+      Assert.assertEquals("0", summary.get(key));
+    }
+    rows = shell.executeStatement("SELECT * FROM " + fullTableName);
+    Assert.assertEquals(0, rows.size());
+    validateBasicStats(table, databaseName, tableName);
+  }
+
+  @Test
   public void testAddColumnToIcebergTable() throws IOException {
     // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
     Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -20,40 +20,57 @@
 package org.apache.iceberg.mr.hive;
 
 import java.io.IOException;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.common.StatsSetupConst;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.partition.spec.PartitionSpecProxy;
 import org.apache.hadoop.hive.ql.exec.mr.ExecMapper;
 import org.apache.iceberg.AssertHelpers;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.hive.HiveSchemaUtil;
 import org.apache.iceberg.hive.MetastoreUtil;
+import org.apache.iceberg.mr.Catalogs;
+import org.apache.iceberg.mr.InputFormatConfig;
 import org.apache.iceberg.mr.TestHelper;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.thrift.TException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
+import org.junit.Assume;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
@@ -194,1239 +211,1239 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     ExecMapper.setDone(false);
   }
 
-//  @Test
-//  public void testScanTable() throws IOException {
-//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Adding the ORDER BY clause will cause Hive to spawn a local MR job this time.
-//    List<Object[]> descRows =
-//        shell.executeStatement("SELECT first_name, customer_id FROM default.customers ORDER BY customer_id DESC");
-//
-//    Assert.assertEquals(3, descRows.size());
-//    Assert.assertArrayEquals(new Object[] {"Trudy", 2L}, descRows.get(0));
-//    Assert.assertArrayEquals(new Object[] {"Bob", 1L}, descRows.get(1));
-//    Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
-//  }
-//
-//  @Test
-//  public void testMigrateHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl";
-//    String createQuery = "CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName));
-//    shell.executeStatement(createQuery);
-//    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
-//    validateMigration(tableName);
-//  }
-//
-//  @Test
-//  public void testMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_part";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
-//        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-//    validateMigration(tableName);
-//  }
-//
-//  @Test
-//  public void testMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_part_bucketed";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
-//        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-//    validateMigration(tableName);
-//  }
-//
-//  @Test
-//  public void testRollbackMigrateHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_rollback";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
-//    validateMigrationRollback(tableName);
-//  }
-//
-//  @Test
-//  public void testRollbackMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_rollback";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
-//        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-//    validateMigrationRollback(tableName);
-//  }
-//
-//  @Test
-//  public void testRollbackMultiPartitionedHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_rollback";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string, c int) " +
-//        "STORED AS " + fileFormat.name() + " " +
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='111') VALUES (1), (2), (3)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb', c='111') VALUES (4), (5)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='222') VALUES (6)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc', c='333') VALUES (7), (8), (9), (10)");
-//    validateMigrationRollback(tableName);
-//  }
-//
-//  @Test
-//  public void testRollbackMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
-//    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
-//    String tableName = "tbl_part_bucketed";
-//    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
-//        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
-//    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
-//    validateMigrationRollback(tableName);
-//  }
-//
-//  @Test
-//  public void testAnalyzeTableComputeStatistics() throws IOException, TException, InterruptedException {
-//    String dbName = "default";
-//    String tableName = "customers";
-//    Table table = testTables
-//        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
-//    validateBasicStats(table, dbName, tableName);
-//  }
-//
-//  @Test
-//  public void testAnalyzeTableComputeStatisticsForColumns() throws IOException, TException, InterruptedException {
-//    String dbName = "default";
-//    String tableName = "orders";
-//    Table table = testTables.createTable(shell, tableName, ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS FOR COLUMNS");
-//    validateBasicStats(table, dbName, tableName);
-//  }
-//
-//  @Test
-//  public void testAnalyzeTableComputeStatisticsEmptyTable() throws IOException, TException, InterruptedException {
-//    String dbName = "default";
-//    String tableName = "customers";
-//    Table table = testTables
-//        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-//            new ArrayList<>());
-//    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
-//    validateBasicStats(table, dbName, tableName);
-//  }
-//
-//  @Test
-//  public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
-//    shell.setHiveSessionValue("hive.cbo.enable", true);
-//
-//    testTables.createTable(shell, "products", PRODUCT_SCHEMA, fileFormat, PRODUCT_RECORDS);
-//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-//
-//    List<Object[]> rows = shell.executeStatement(
-//            "SELECT o.order_id, o.customer_id, o.total, p.name " +
-//                    "FROM default.orders o JOIN default.products p ON o.product_id = p.id ORDER BY o.order_id"
-//    );
-//
-//    Assert.assertEquals(3, rows.size());
-//    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d, "skirt"}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d, "tee"}, rows.get(1));
-//    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
-//  }
-//
-//  @Test
-//  public void testDescribeTable() throws IOException {
-//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    List<Object[]> rows = shell.executeStatement("DESCRIBE default.customers");
-//    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(), rows.size());
-//    for (int i = 0; i < HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(); i++) {
-//      Types.NestedField field = HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().get(i);
-//      String comment = field.doc() == null ? "from deserializer" : field.doc();
-//      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
-//          comment}, rows.get(i));
-//    }
-//  }
-//
-//  @Test
-//  public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
-//    shell.setHiveSessionValue("hive.cbo.enable", true);
-//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
-//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-//
-//    List<Object[]> rows = shell.executeStatement(
-//            "SELECT c.first_name, o.order_id " +
-//                    "FROM default.orders o JOIN default.customers c ON o.customer_id = c.customer_id " +
-//                    "ORDER BY o.order_id DESC"
-//    );
-//
-//    Assert.assertEquals(3, rows.size());
-//    Assert.assertArrayEquals(new Object[] {"Bob", 102L}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {"Alice", 101L}, rows.get(1));
-//    Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
-//  }
-//
-//  @Test
-//  public void testCBOWithSelfJoin() throws IOException {
-//    shell.setHiveSessionValue("hive.cbo.enable", true);
-//
-//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-//
-//    List<Object[]> rows = shell.executeStatement(
-//            "SELECT o1.order_id, o1.customer_id, o1.total " +
-//                    "FROM default.orders o1 JOIN default.orders o2 ON o1.order_id = o2.order_id ORDER BY o1.order_id"
-//    );
-//
-//    Assert.assertEquals(3, rows.size());
-//    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d}, rows.get(1));
-//    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
-//  }
-//
-//  @Test
-//  public void testJoinTablesSupportedTypes() throws IOException {
-//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-//      Type type = SUPPORTED_TYPES.get(i);
-//      if (type == Types.TimestampType.withZone() && isVectorized) {
-//        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
-//        continue;
-//      }
-//      // TODO: remove this filter when issue #1881 is resolved
-//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-//        continue;
-//      }
-//      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
-//      String columnName = type.typeId().toString().toLowerCase() + "_column";
-//
-//      Schema schema = new Schema(required(1, columnName, type));
-//      List<Record> records = TestHelper.generateRandomRecords(schema, 1, 0L);
-//
-//      testTables.createTable(shell, tableName, schema, fileFormat, records);
-//      List<Object[]> queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
-//              " from default." + tableName + " s join default." + tableName + " h on h." + columnName + "=s." +
-//              columnName);
-//      Assert.assertEquals("Non matching record count for table " + tableName + " with type " + type,
-//              1, queryResult.size());
-//    }
-//  }
-//
-//  @Test
-//  public void testSelectDistinctFromTable() throws IOException {
-//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-//      Type type = SUPPORTED_TYPES.get(i);
-//      if (type == Types.TimestampType.withZone() && isVectorized) {
-//        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
-//        continue;
-//      }
-//      // TODO: remove this filter when issue #1881 is resolved
-//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-//        continue;
-//      }
-//      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
-//      String columnName = type.typeId().toString().toLowerCase() + "_column";
-//
-//      Schema schema = new Schema(required(1, columnName, type));
-//      List<Record> records = TestHelper.generateRandomRecords(schema, 4, 0L);
-//      int size = records.stream().map(r -> r.getField(columnName)).collect(Collectors.toSet()).size();
-//      testTables.createTable(shell, tableName, schema, fileFormat, records);
-//      List<Object[]> queryResult = shell.executeStatement("select count(distinct(" + columnName +
-//              ")) from default." + tableName);
-//      int distinctIds = ((Long) queryResult.get(0)[0]).intValue();
-//      Assert.assertEquals(tableName, size, distinctIds);
-//    }
-//  }
-//
-//  @Test
-//  public void testPartitionPruning() throws IOException {
-//    Schema salesSchema = new Schema(
-//        required(1, "ss_item_sk", Types.IntegerType.get()),
-//        required(2, "ss_sold_date_sk", Types.IntegerType.get()));
-//
-//    PartitionSpec salesSpec =
-//        PartitionSpec.builderFor(salesSchema).identity("ss_sold_date_sk").build();
-//
-//    Schema dimSchema = new Schema(
-//        required(1, "d_date_sk", Types.IntegerType.get()),
-//        required(2, "d_moy", Types.IntegerType.get()));
-//
-//    List<Record> salesRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
-//                                    .add(51, 5)
-//                                    .add(61, 6)
-//                                    .add(71, 7)
-//                                    .add(81, 8)
-//                                    .add(91, 9)
-//                                    .build();
-//    List<Record> dimRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
-//                                    .add(1, 10)
-//                                    .add(2, 20)
-//                                    .add(3, 30)
-//                                    .add(4, 40)
-//                                    .add(5, 50)
-//                                    .build();
-//
-//    Table salesTable = testTables.createTable(shell, "x1_store_sales", salesSchema, salesSpec, fileFormat, null);
-//
-//    PartitionKey partitionKey = new PartitionKey(salesSpec, salesSchema);
-//    for (Record r : salesRecords) {
-//      partitionKey.partition(r);
-//      testTables.appendIcebergTable(shell.getHiveConf(), salesTable, fileFormat, partitionKey, ImmutableList.of(r));
-//    }
-//    testTables.createTable(shell, "x1_date_dim", dimSchema, fileFormat, dimRecords);
-//
-//    String query = "select s.ss_item_sk from x1_store_sales s, x1_date_dim d " +
-//                       "where s.ss_sold_date_sk=d.d_date_sk*2 and d.d_moy=30";
-//
-//    // Check the query results
-//    List<Object[]> rows = shell.executeStatement(query);
-//
-//    Assert.assertEquals(1, rows.size());
-//    Assert.assertArrayEquals(new Object[] {61}, rows.get(0));
-//
-//    // Check if Dynamic Partitioning is used
-//    Assert.assertTrue(shell.executeStatement("explain " + query).stream()
-//                          .filter(a -> ((String) a[0]).contains("Dynamic Partitioning Event Operator"))
-//                          .findAny()
-//                          .isPresent());
-//  }
-//
-//  @Test
-//  public void testInsert() throws IOException {
-//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, ImmutableList.of());
-//
-//    // The expected query is like
-//    // INSERT INTO customers VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Trudy')
-//    StringBuilder query = new StringBuilder().append("INSERT INTO customers VALUES ");
-//    HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.forEach(record -> query.append("(")
-//        .append(record.get(0)).append(",'")
-//        .append(record.get(1)).append("','")
-//        .append(record.get(2)).append("'),"));
-//    query.setLength(query.length() - 1);
-//
-//    shell.executeStatement(query.toString());
-//
-//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-//  }
-//
-//  @Test
-//  public void testInsertSupportedTypes() throws IOException {
-//    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
-//      Type type = SUPPORTED_TYPES.get(i);
-//      // TODO: remove this filter when issue #1881 is resolved
-//      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
-//        continue;
-//      }
-//      // TODO: remove this filter when we figure out how we could test binary types
-//      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
-//        continue;
-//      }
-//      String columnName = type.typeId().toString().toLowerCase() + "_column";
-//
-//      Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));
-//      List<Record> expected = TestHelper.generateRandomRecords(schema, 5, 0L);
-//
-//      Table table = testTables.createTable(shell, type.typeId().toString().toLowerCase() + "_table_" + i,
-//          schema, PartitionSpec.unpartitioned(), fileFormat, expected);
-//
-//      HiveIcebergTestUtils.validateData(table, expected, 0);
-//    }
-//  }
-//
-//  /**
-//   * Testing map only inserts.
-//   * @throws IOException If there is an underlying IOException
-//   */
-//  @Test
-//  public void testInsertFromSelect() throws IOException {
-//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    shell.executeStatement("INSERT INTO customers SELECT * FROM customers");
-//
-//    // Check that everything is duplicated as expected
-//    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//  }
-//
-//  @Test
-//  public void testAlterChangeColumn() throws IOException {
-//    // TODO: remove once vectorized execution can handle column reorders/renames
-//    Assume.assumeTrue(!isVectorized);
-//
-//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN last_name family_name string AFTER customer_id");
-//
-//    List<Object[]> result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
-//    Assert.assertEquals(3, result.size());
-//    Assert.assertArrayEquals(new Object[]{0L, "Brown", "Alice"}, result.get(0));
-//    Assert.assertArrayEquals(new Object[]{1L, "Green", "Bob"}, result.get(1));
-//    Assert.assertArrayEquals(new Object[]{2L, "Pink", "Trudy"}, result.get(2));
-//
-//    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN family_name family_name string FIRST");
-//
-//    result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
-//    Assert.assertEquals(3, result.size());
-//    Assert.assertArrayEquals(new Object[]{"Brown", 0L, "Alice"}, result.get(0));
-//    Assert.assertArrayEquals(new Object[]{"Green", 1L, "Bob"}, result.get(1));
-//    Assert.assertArrayEquals(new Object[]{"Pink", 2L, "Trudy"}, result.get(2));
-//
-//    result = shell.executeStatement("SELECT customer_id, family_name FROM customers ORDER BY customer_id");
-//    Assert.assertEquals(3, result.size());
-//    Assert.assertArrayEquals(new Object[]{0L, "Brown"}, result.get(0));
-//    Assert.assertArrayEquals(new Object[]{1L, "Green"}, result.get(1));
-//    Assert.assertArrayEquals(new Object[]{2L, "Pink"}, result.get(2));
-//  }
-//
-//  @Test
-//  public void testInsertOverwriteNonPartitionedTable() throws IOException {
-//    TableIdentifier target = TableIdentifier.of("default", "target");
-//    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, ImmutableList.of());
-//
-//    // IOW overwrites the whole table (empty target table)
-//    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source");
-//
-//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-//
-//    // IOW overwrites the whole table (non-empty target table)
-//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(0L, "Mike", "Taylor")
-//        .add(1L, "Christy", "Hubert")
-//        .build();
-//    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
-//
-//    HiveIcebergTestUtils.validateData(table, newRecords, 0);
-//
-//    // IOW empty result set -> clears the target table
-//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source WHERE FALSE");
-//
-//    HiveIcebergTestUtils.validateData(table, ImmutableList.of(), 0);
-//  }
-//
-//
-//  @Test
-//  public void testSpecialCharacters() {
-//    TableIdentifier table = TableIdentifier.of("default", "tar,! ,get");
-//    // note: the Chinese character seems to be accepted in the column name, but not
-//    // in the table name - this is the case for both Iceberg and standard Hive tables.
-//    shell.executeStatement(String.format(
-//        "CREATE TABLE `%s` (id bigint, `dep,! 是,t` string) STORED BY ICEBERG STORED AS %s %s TBLPROPERTIES ('%s'='%s')",
-//        table.name(), fileFormat, testTables.locationForCreateTableSQL(table),
-//        InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME));
-//    shell.executeStatement(String.format("INSERT INTO `%s` VALUES (1, 'moon'), (2, 'star')", table.name()));
-//
-//    List<Object[]> result = shell.executeStatement(String.format(
-//        "SELECT `dep,! 是,t`, id FROM `%s` ORDER BY id", table.name()));
-//
-//    Assert.assertEquals(2, result.size());
-//    Assert.assertArrayEquals(new Object[]{"moon", 1L}, result.get(0));
-//    Assert.assertArrayEquals(new Object[]{"star", 2L}, result.get(1));
-//  }
-//
-//  @Test
-//  public void testInsertOverwritePartitionedTable() throws IOException {
-//    TableIdentifier target = TableIdentifier.of("default", "target");
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .identity("last_name").build();
-//    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        spec, fileFormat, ImmutableList.of());
-//
-//    // IOW into empty target table -> whole source result set is inserted
-//    List<Record> expected = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    expected.add(TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
-//    shell.executeStatement(testTables.getInsertQuery(expected, target, true));
-//
-//    HiveIcebergTestUtils.validateData(table, expected, 0);
-//
-//    // IOW into non-empty target table -> only the affected partitions are overwritten
-//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(0L, "Mike", "Brown") // overwritten
-//        .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
-//        .add(3L, "Bill", "Purple") // appended (new partition)
-//        .build();
-//    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
-//
-//    expected = new ArrayList<>(newRecords);
-//    expected.add(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2)); // existing, untouched partition ('Pink')
-//    HiveIcebergTestUtils.validateData(table, expected, 0);
-//
-//    // IOW empty source result set -> has no effect on partitioned table
-//    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM target WHERE FALSE");
-//
-//    HiveIcebergTestUtils.validateData(table, expected, 0);
-//  }
-//
-//  @Test
-//  public void testCTASFromHiveTable() {
-//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-//
-//    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
-//    shell.executeStatement(testTables.getInsertQuery(
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
-//
-//    shell.executeStatement(String.format(
-//        "CREATE TABLE target STORED BY ICEBERG %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
-//        testTables.locationForCreateTableSQL(TableIdentifier.of("default", "target")),
-//        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
-//
-//    List<Object[]> objects = shell.executeStatement("SELECT * FROM target ORDER BY id");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
-//  }
-//
-//  @Test
-//  public void testCTASPartitionedFromHiveTable() throws TException, InterruptedException {
-//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-//
-//    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
-//    shell.executeStatement(testTables.getInsertQuery(
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
-//
-//    shell.executeStatement(String.format(
-//        "CREATE TABLE target PARTITIONED BY (dept, name) " +
-//        "STORED BY ICEBERG TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
-//        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
-//
-//    // check table can be read back correctly
-//    List<Object[]> objects = shell.executeStatement("SELECT id, name, dept FROM target ORDER BY id");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
-//
-//    // check HMS table has been created correctly (no partition cols, props pushed down)
-//    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "target");
-//    Assert.assertEquals(3, hmsTable.getSd().getColsSize());
-//    Assert.assertTrue(hmsTable.getPartitionKeys().isEmpty());
-//    Assert.assertEquals(fileFormat.toString(), hmsTable.getParameters().get(TableProperties.DEFAULT_FILE_FORMAT));
-//
-//    // check Iceberg table has correct partition spec
-//    Table table = testTables.loadTable(TableIdentifier.of("default", "target"));
-//    Assert.assertEquals(2, table.spec().fields().size());
-//    Assert.assertEquals("dept", table.spec().fields().get(0).name());
-//    Assert.assertEquals("name", table.spec().fields().get(1).name());
-//  }
-//
-//  @Test
-//  public void testCTASFailureRollback() throws IOException {
-//    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
-//
-//    // force an execution error by passing in a committer class that Tez won't be able to load
-//    shell.setHiveSessionValue("hive.tez.mapreduce.output.committer.class", "org.apache.NotExistingClass");
-//
-//    TableIdentifier target = TableIdentifier.of("default", "target");
-//    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    String[] partitioningSchemes = {"", "PARTITIONED BY (last_name)", "PARTITIONED BY (customer_id, last_name)"};
-//    for (String partitioning : partitioningSchemes) {
-//      AssertHelpers.assertThrows("Should fail while loading non-existent output committer class.",
-//          IllegalArgumentException.class, "org.apache.NotExistingClass",
-//          () -> shell.executeStatement(String.format(
-//              "CREATE TABLE target %s STORED BY ICEBERG AS SELECT * FROM source", partitioning)));
-//      // CTAS table should have been dropped by the lifecycle hook
-//      Assert.assertThrows(NoSuchTableException.class, () -> testTables.loadTable(target));
-//    }
-//  }
-//
-//  /**
-//   * Testing map-reduce inserts.
-//   * @throws IOException If there is an underlying IOException
-//   */
-//  @Test
-//  public void testInsertFromSelectWithOrderBy() throws IOException {
-//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // We expect that there will be Mappers and Reducers here
-//    shell.executeStatement("INSERT INTO customers SELECT * FROM customers ORDER BY customer_id");
-//
-//    // Check that everything is duplicated as expected
-//    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//  }
-//
-//  @Test
-//  public void testInsertFromSelectWithProjection() throws IOException {
-//    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, ImmutableList.of());
-//    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
-//
-//    shell.executeStatement(
-//        "INSERT INTO customers (customer_id, last_name) SELECT distinct(customer_id), 'test' FROM orders");
-//
-//    List<Record> expected = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(0L, null, "test")
-//        .add(1L, null, "test")
-//        .build();
-//
-//    HiveIcebergTestUtils.validateData(table, expected, 0);
-//  }
-//
-//  @Test
-//  public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
-//    List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .identity("last_name").build();
-//    testTables.createTable(shell, "source_customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        spec, fileFormat, records);
-//    Table table = testTables.createTable(shell, "target_customers",
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
-//
-//    // Below select from source table should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
-//    // Inserting into the target table should not fail because first_name is not selected from the source table
-//    shell.executeStatement("INSERT INTO target_customers SELECT customer_id, 'Sam', last_name FROM source_customers");
-//
-//    List<Record> expected = Lists.newArrayListWithExpectedSize(records.size());
-//    records.forEach(r -> {
-//      Record copy = r.copy();
-//      copy.setField("first_name", "Sam");
-//      expected.add(copy);
-//    });
-//    HiveIcebergTestUtils.validateData(table, expected, 0);
-//  }
-//
-//  @Test
-//  public void testInsertFromJoiningTwoIcebergTables() throws IOException {
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//            .identity("last_name").build();
-//    testTables.createTable(shell, "source_customers_1", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    testTables.createTable(shell, "source_customers_2", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    Table table = testTables.createTable(shell, "target_customers",
-//            HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
-//
-//    shell.executeStatement("INSERT INTO target_customers SELECT a.customer_id, b.first_name, a.last_name FROM " +
-//            "source_customers_1 a JOIN source_customers_2 b ON a.last_name = b.last_name");
-//
-//    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
-//  }
-//
-//  @Test
-//  public void testWriteArrayOfPrimitivesInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "arrayofprimitives",
-//            Types.ListType.ofRequired(3, Types.StringType.get())));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteArrayOfArraysInTable() throws IOException {
-//    Schema schema =
-//        new Schema(
-//            required(1, "id", Types.LongType.get()),
-//            required(2, "arrayofarrays",
-//                Types.ListType.ofRequired(3, Types.ListType.ofRequired(4, Types.StringType.get()))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 3, 1L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteArrayOfMapsInTable() throws IOException {
-//    Schema schema =
-//        new Schema(required(1, "id", Types.LongType.get()),
-//            required(2, "arrayofmaps", Types.ListType
-//                .ofRequired(3, Types.MapType.ofRequired(4, 5, Types.StringType.get(),
-//                    Types.StringType.get()))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteArrayOfStructsInTable() throws IOException {
-//    Schema schema =
-//        new Schema(required(1, "id", Types.LongType.get()),
-//            required(2, "arrayofstructs", Types.ListType.ofRequired(3, Types.StructType
-//                .of(required(4, "something", Types.StringType.get()), required(5, "someone",
-//                    Types.StringType.get()), required(6, "somewhere", Types.StringType.get())))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteMapOfPrimitivesInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "mapofprimitives", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-//            Types.StringType.get())));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteMapOfArraysInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "mapofarrays",
-//            Types.MapType.ofRequired(3, 4, Types.StringType.get(), Types.ListType.ofRequired(5,
-//                Types.StringType.get()))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteMapOfMapsInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "mapofmaps", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-//            Types.MapType.ofRequired(5, 6, Types.StringType.get(), Types.StringType.get()))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteMapOfStructsInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "mapofstructs", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
-//            Types.StructType.of(required(5, "something", Types.StringType.get()),
-//                required(6, "someone", Types.StringType.get()),
-//                required(7, "somewhere", Types.StringType.get())))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteStructOfPrimitivesInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "structofprimitives",
-//            Types.StructType.of(required(3, "key", Types.StringType.get()), required(4, "value",
-//                Types.StringType.get()))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteStructOfArraysInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "structofarrays", Types.StructType
-//            .of(required(3, "names", Types.ListType.ofRequired(4, Types.StringType.get())),
-//                required(5, "birthdays", Types.ListType.ofRequired(6,
-//                    Types.StringType.get())))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteStructOfMapsInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "structofmaps", Types.StructType
-//            .of(required(3, "map1", Types.MapType.ofRequired(4, 5,
-//                Types.StringType.get(), Types.StringType.get())), required(6, "map2",
-//                Types.MapType.ofRequired(7, 8, Types.StringType.get(),
-//                    Types.StringType.get())))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testWriteStructOfStructsInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "structofstructs", Types.StructType.of(required(3, "struct1", Types.StructType
-//            .of(required(4, "key", Types.StringType.get()), required(5, "value",
-//                Types.StringType.get()))))));
-//    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
-//    testComplexTypeWrite(schema, records);
-//  }
-//
-//  @Test
-//  public void testPartitionedWrite() throws IOException {
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .bucket("customer_id", 3)
-//        .build();
-//
-//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-//
-//    Table table = testTables.createTable(shell, "partitioned_customers",
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-//
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//  }
-//
-//  @Test
-//  public void testIdentityPartitionedWrite() throws IOException {
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .identity("customer_id")
-//        .build();
-//
-//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-//
-//    Table table = testTables.createTable(shell, "partitioned_customers",
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-//
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//  }
-//
-//  @Test
-//  public void testMultilevelIdentityPartitionedWrite() throws IOException {
-//    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .identity("customer_id")
-//        .identity("last_name")
-//        .build();
-//
-//    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
-//
-//    Table table = testTables.createTable(shell, "partitioned_customers",
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
-//
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//  }
-//
-//  @Test
-//  public void testYearTransform() throws IOException {
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.DateType.get()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).year("part_field").build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, LocalDate.of(2020, 1, 21))
-//        .add(2L, LocalDate.of(2020, 1, 22))
-//        .add(3L, LocalDate.of(2019, 1, 21))
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testMonthTransform() throws IOException {
-//    Assume.assumeTrue("ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive", isVectorized);
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.TimestampType.withZone()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).month("part_field").build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
-//        .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
-//        .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testDayTransform() throws IOException {
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.TimestampType.withoutZone()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).day("part_field").build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-//        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-//        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testHourTransform() throws IOException {
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.TimestampType.withoutZone()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).hour("part_field").build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
-//        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
-//        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testBucketTransform() throws IOException {
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.StringType.get()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("part_field", 2).build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, "Part1")
-//        .add(2L, "Part2")
-//        .add(3L, "Art3")
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testTruncateTransform() throws IOException {
-//    Schema schema = new Schema(
-//        optional(1, "id", Types.LongType.get()),
-//        optional(2, "part_field", Types.StringType.get()));
-//    PartitionSpec spec = PartitionSpec.builderFor(schema).truncate("part_field", 2).build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(1L, "Part1")
-//        .add(2L, "Part2")
-//        .add(3L, "Art3")
-//        .build();
-//    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
-//    HiveIcebergTestUtils.validateData(table, records, 0);
-//
-//    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
-//  }
-//
-//  @Test
-//  public void testMultiTableInsert() throws IOException {
-//    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    Schema target1Schema = new Schema(
-//        optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "first_name", Types.StringType.get())
-//    );
-//
-//    Schema target2Schema = new Schema(
-//        optional(1, "last_name", Types.StringType.get()),
-//        optional(2, "customer_id", Types.LongType.get())
-//    );
-//
-//    List<Record> target1Records = TestHelper.RecordsBuilder.newInstance(target1Schema)
-//                                      .add(0L, "Alice")
-//                                      .add(1L, "Bob")
-//                                      .add(2L, "Trudy")
-//                                      .build();
-//
-//    List<Record> target2Records = TestHelper.RecordsBuilder.newInstance(target2Schema)
-//                                      .add("Brown", 0L)
-//                                      .add("Green", 1L)
-//                                      .add("Pink", 2L)
-//                                      .build();
-//
-//    Table target1 = testTables.createTable(shell, "target1", target1Schema, fileFormat, ImmutableList.of());
-//    Table target2 = testTables.createTable(shell, "target2", target2Schema, fileFormat, ImmutableList.of());
-//
-//    // simple insert: should create a single vertex writing to both target tables
-//    shell.executeStatement("FROM customers " +
-//        "INSERT INTO target1 SELECT customer_id, first_name " +
-//        "INSERT INTO target2 SELECT last_name, customer_id");
-//
-//    // Check that everything is as expected
-//    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
-//    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
-//
-//    // truncate the target tables
-//    testTables.truncateIcebergTable(target1);
-//    testTables.truncateIcebergTable(target2);
-//
-//    // complex insert: should use a different vertex for each target table
-//    shell.executeStatement("FROM customers " +
-//        "INSERT INTO target1 SELECT customer_id, first_name ORDER BY first_name " +
-//        "INSERT INTO target2 SELECT last_name, customer_id ORDER BY last_name");
-//
-//    // Check that everything is as expected
-//    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
-//    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
-//  }
-//
-//  @Test
-//  public void testWriteWithDefaultWriteFormat() {
-//    Assume.assumeTrue("Testing the default file format is enough for a single scenario.",
-//        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
-//
-//    TableIdentifier identifier = TableIdentifier.of("default", "customers");
-//
-//    // create Iceberg table without specifying a write format in the tbl properties
-//    // it should fall back to using the default file format
-//    shell.executeStatement(String.format("CREATE EXTERNAL TABLE %s (id bigint, name string) STORED BY '%s' %s",
-//        identifier,
-//        HiveIcebergStorageHandler.class.getName(),
-//        testTables.locationForCreateTableSQL(identifier)));
-//
-//    shell.executeStatement(String.format("INSERT INTO %s VALUES (10, 'Linda')", identifier));
-//    List<Object[]> results = shell.executeStatement(String.format("SELECT * FROM %s", identifier));
-//
-//    Assert.assertEquals(1, results.size());
-//    Assert.assertEquals(10L, results.get(0)[0]);
-//    Assert.assertEquals("Linda", results.get(0)[1]);
-//  }
-//
-//  @Test
-//  public void testInsertEmptyResultSet() throws IOException {
-//    Table source = testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, ImmutableList.of());
-//    Table target = testTables.createTable(shell, "target", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, ImmutableList.of());
-//
-//    shell.executeStatement("INSERT INTO target SELECT * FROM source");
-//    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
-//
-//    testTables.appendIcebergTable(shell.getHiveConf(), source, fileFormat, null,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
-//    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
-//  }
-//
-//  @Test
-//  public void testDecimalTableWithPredicateLiterals() throws IOException {
-//    Schema schema = new Schema(required(1, "decimal_field", Types.DecimalType.of(7, 2)));
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
-//        .add(new BigDecimal("85.00"))
-//        .add(new BigDecimal("100.56"))
-//        .add(new BigDecimal("100.57"))
-//        .build();
-//    testTables.createTable(shell, "dec_test", schema, fileFormat, records);
-//
-//    // Use integer literal in predicate
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field >= 85");
-//    Assert.assertEquals(3, rows.size());
-//    Assert.assertArrayEquals(new Object[] {"85.00"}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(1));
-//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(2));
-//
-//    // Use decimal literal in predicate with smaller scale than schema type definition
-//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 99.1");
-//    Assert.assertEquals(2, rows.size());
-//    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(1));
-//
-//    // Use decimal literal in predicate with higher scale than schema type definition
-//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 100.565");
-//    Assert.assertEquals(1, rows.size());
-//    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(0));
-//
-//    // Use decimal literal in predicate with the same scale as schema type definition
-//    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 640.34");
-//    Assert.assertEquals(0, rows.size());
-//  }
-//
-//  @Test
-//  public void testStructOfMapsInTable() throws IOException {
-//    Schema schema = new Schema(
-//        required(1, "structofmaps", Types.StructType
-//            .of(required(2, "map1", Types.MapType.ofRequired(3, 4,
-//                Types.StringType.get(), Types.StringType.get())), required(5, "map2",
-//                Types.MapType.ofRequired(6, 7, Types.StringType.get(),
-//                    Types.IntegerType.get())))));
-//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-//    // access a map entry inside a struct
-//    for (int i = 0; i < records.size(); i++) {
-//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofmaps");
-//      Map<?, ?> expectedMap = (Map<?, ?>) expectedStruct.getField("map1");
-//      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
-//        List<Object[]> queryResult = shell.executeStatement(String
-//            .format("SELECT structofmaps.map1[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
-//                i));
-//        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
-//      }
-//      expectedMap = (Map<?, ?>) expectedStruct.getField("map2");
-//      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
-//        List<Object[]> queryResult = shell.executeStatement(String
-//            .format("SELECT structofmaps.map2[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
-//                i));
-//        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
-//      }
-//    }
-//  }
-//
-//  @Test
-//  public void testStructOfArraysInTable() throws IOException {
-//    Schema schema = new Schema(
-//        required(1, "structofarrays", Types.StructType
-//            .of(required(2, "names", Types.ListType.ofRequired(3, Types.StringType.get())),
-//                required(4, "birthdays", Types.ListType.ofRequired(5,
-//                    Types.DateType.get())))));
-//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-//    // access an element of an array inside a struct
-//    for (int i = 0; i < records.size(); i++) {
-//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofarrays");
-//      List<?> expectedList = (List<?>) expectedStruct.getField("names");
-//      for (int j = 0; j < expectedList.size(); j++) {
-//        List<Object[]> queryResult = shell.executeStatement(
-//            String.format("SELECT structofarrays.names[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
-//        Assert.assertEquals(expectedList.get(j), queryResult.get(0)[0]);
-//      }
-//      expectedList = (List<?>) expectedStruct.getField("birthdays");
-//      for (int j = 0; j < expectedList.size(); j++) {
-//        List<Object[]> queryResult = shell.executeStatement(
-//            String.format("SELECT structofarrays.birthdays[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
-//        Assert.assertEquals(expectedList.get(j).toString(), queryResult.get(0)[0]);
-//      }
-//    }
-//  }
-//
-//  @Test
-//  public void testStructOfPrimitivesInTable() throws IOException {
-//    Schema schema = new Schema(required(1, "structofprimitives",
-//        Types.StructType.of(required(2, "key", Types.StringType.get()), required(3, "value",
-//            Types.IntegerType.get()))));
-//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-//    // access a single value in a struct
-//    for (int i = 0; i < records.size(); i++) {
-//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofprimitives");
-//      List<Object[]> queryResult = shell.executeStatement(String.format(
-//          "SELECT structofprimitives.key, structofprimitives.value FROM default.structtable LIMIT 1 OFFSET %d", i));
-//      Assert.assertEquals(expectedStruct.getField("key"), queryResult.get(0)[0]);
-//      Assert.assertEquals(expectedStruct.getField("value"), queryResult.get(0)[1]);
-//    }
-//  }
-//
-//  @Test
-//  public void testStructOfStructsInTable() throws IOException {
-//    Schema schema = new Schema(
-//        required(1, "structofstructs", Types.StructType.of(required(2, "struct1", Types.StructType
-//            .of(required(3, "key", Types.StringType.get()), required(4, "value",
-//                Types.IntegerType.get()))))));
-//    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
-//    // access a struct element inside a struct
-//    for (int i = 0; i < records.size(); i++) {
-//      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofstructs");
-//      GenericRecord expectedInnerStruct = (GenericRecord) expectedStruct.getField("struct1");
-//      List<Object[]> queryResult = shell.executeStatement(String.format(
-//          "SELECT structofstructs.struct1.key, structofstructs.struct1.value FROM default.structtable " +
-//              "LIMIT 1 OFFSET %d", i));
-//      Assert.assertEquals(expectedInnerStruct.getField("key"), queryResult.get(0)[0]);
-//      Assert.assertEquals(expectedInnerStruct.getField("value"), queryResult.get(0)[1]);
-//    }
-//  }
-//
-//  @Test
-//  public void testScanTableCaseInsensitive() throws IOException {
-//    testTables.createTable(shell, "customers",
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA_WITH_UPPERCASE, fileFormat,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//
-//    Assert.assertEquals(3, rows.size());
-//    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
-//    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, rows.get(2));
-//
-//    rows = shell.executeStatement("SELECT * FROM default.customers where CustomER_Id < 2 " +
-//        "and first_name in ('Alice', 'Bob')");
-//
-//    Assert.assertEquals(2, rows.size());
-//    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
-//    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
-//  }
-//
-//  @Test
-//  public void testTruncateTable() throws IOException, TException, InterruptedException {
-//    // Create an Iceberg table with some records in it then execute a truncate table command.
-//    // Then check if the data is deleted and the table statistics are reset to 0.
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-//  }
-//
-//  @Test
-//  public void testTruncateEmptyTable() throws IOException, TException, InterruptedException {
-//    // Create an empty Iceberg table and execute a truncate table command on it.
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, null);
-//    // Set the 'external.table.purge' table property on the table
-//    String alterTableCommand =
-//        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')";
-//    shell.executeStatement(alterTableCommand);
-//
-//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-//
-//    shell.executeStatement("TRUNCATE " + identifier);
-//
-//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-//    Map<String, String> summary = icebergTable.currentSnapshot().summary();
-//    for (String key : STATS_MAPPING.values()) {
-//      Assert.assertEquals("0", summary.get(key));
-//    }
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-//    Assert.assertEquals(0, rows.size());
-//    validateBasicStats(icebergTable, databaseName, tableName);
-//  }
-//
-//  @Test
-//  public void testMultipleTruncateTable() throws IOException, TException, InterruptedException {
-//    // Create an Iceberg table with come records in it, then execute a truncate table command
-//    // and check the result. Then insert some new data and run an other truncate table command.
-//    // The purpose of this test is to make sure that multiple truncate table commands can
-//    // run after each other without any issue (like issues with locking).
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-//
-//    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(3L, "Jane", "Purple").add(4L, "Tim", "Grey").add(5L, "Eva", "Yellow").add(6L, "James", "White")
-//        .add(7L, "Jack", "Black").build();
-//    shell.executeStatement("INSERT INTO default.customers values (3, 'Jane', 'Purple'), (4, 'Tim', 'Grey')," +
-//        "(5, 'Eva', 'Yellow'), (6, 'James', 'White'), (7, 'Jack', 'Black')");
-//
-//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-//    testTruncateTable(databaseName, tableName, icebergTable, newRecords,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-//  }
-//
-//  @Test
-//  public void testTruncateTableExternalPurgeFalse() throws IOException, TException, InterruptedException {
-//    // Create an Iceberg table with some records in it and set the 'external.table.purge' table property
-//    // to false and try to run a truncate table command on it. The command should fail with a SemanticException.
-//    // Then check if the data is not deleted from the table and also the statistics are not changed.
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='false')");
-//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-//
-//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-//        "Cannot truncate non-managed table", () -> {
-//          shell.executeStatement("TRUNCATE " + identifier);
-//        });
-//
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
-//    validateBasicStats(icebergTable, databaseName, tableName);
-//  }
-//
-//  @Test
-//  public void testTruncateTableForceExternalPurgeFalse() throws IOException, TException, InterruptedException {
-//    // Create an Iceberg table with some records and set the 'external.table.purge' table parameter to false.
-//    // Then execute a truncate table force command which should run without any error.
-//    // Then check if the data is deleted from the table and the statistics are reset.
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, false, true);
-//  }
+  @Test
+  public void testScanTable() throws IOException {
+    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Adding the ORDER BY clause will cause Hive to spawn a local MR job this time.
+    List<Object[]> descRows =
+        shell.executeStatement("SELECT first_name, customer_id FROM default.customers ORDER BY customer_id DESC");
+
+    Assert.assertEquals(3, descRows.size());
+    Assert.assertArrayEquals(new Object[] {"Trudy", 2L}, descRows.get(0));
+    Assert.assertArrayEquals(new Object[] {"Bob", 1L}, descRows.get(1));
+    Assert.assertArrayEquals(new Object[] {"Alice", 0L}, descRows.get(2));
+  }
+
+  @Test
+  public void testMigrateHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl";
+    String createQuery = "CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName));
+    shell.executeStatement(createQuery);
+    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
+    validateMigration(tableName);
+  }
+
+  @Test
+  public void testMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_part";
+    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
+        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+    validateMigration(tableName);
+  }
+
+  @Test
+  public void testMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_part_bucketed";
+    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
+        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+    validateMigration(tableName);
+  }
+
+  @Test
+  public void testRollbackMigrateHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_rollback";
+    shell.executeStatement("CREATE EXTERNAL TABLE " +  tableName + " (a int) STORED AS " + fileFormat.name() + " " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " VALUES (1), (2), (3)");
+    validateMigrationRollback(tableName);
+  }
+
+  @Test
+  public void testRollbackMigratePartitionedHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_rollback";
+    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) STORED AS " +
+        fileFormat.name() + " " + testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+    validateMigrationRollback(tableName);
+  }
+
+  @Test
+  public void testRollbackMultiPartitionedHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_rollback";
+    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string, c int) " +
+        "STORED AS " + fileFormat.name() + " " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='111') VALUES (1), (2), (3)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb', c='111') VALUES (4), (5)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa', c='222') VALUES (6)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc', c='333') VALUES (7), (8), (9), (10)");
+    validateMigrationRollback(tableName);
+  }
+
+  @Test
+  public void testRollbackMigratePartitionedBucketedHiveTableToIceberg() throws TException, InterruptedException {
+    Assume.assumeTrue(fileFormat == FileFormat.AVRO || fileFormat == FileFormat.PARQUET);
+    String tableName = "tbl_part_bucketed";
+    shell.executeStatement("CREATE EXTERNAL TABLE " + tableName + " (a int) PARTITIONED BY (b string) clustered by " +
+        "(a) INTO 2 BUCKETS STORED AS " + fileFormat.name() + " " +
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", tableName)));
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='aaa') VALUES (1), (2), (3)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='bbb') VALUES (4), (5)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ccc') VALUES (6)");
+    shell.executeStatement("INSERT INTO " + tableName + " PARTITION (b='ddd') VALUES (7), (8), (9), (10)");
+    validateMigrationRollback(tableName);
+  }
+
+  @Test
+  public void testAnalyzeTableComputeStatistics() throws IOException, TException, InterruptedException {
+    String dbName = "default";
+    String tableName = "customers";
+    Table table = testTables
+        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
+    validateBasicStats(table, dbName, tableName);
+  }
+
+  @Test
+  public void testAnalyzeTableComputeStatisticsForColumns() throws IOException, TException, InterruptedException {
+    String dbName = "default";
+    String tableName = "orders";
+    Table table = testTables.createTable(shell, tableName, ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS FOR COLUMNS");
+    validateBasicStats(table, dbName, tableName);
+  }
+
+  @Test
+  public void testAnalyzeTableComputeStatisticsEmptyTable() throws IOException, TException, InterruptedException {
+    String dbName = "default";
+    String tableName = "customers";
+    Table table = testTables
+        .createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+            new ArrayList<>());
+    shell.executeStatement("ANALYZE TABLE " + dbName + "." + tableName + " COMPUTE STATISTICS");
+    validateBasicStats(table, dbName, tableName);
+  }
+
+  @Test
+  public void testCBOWithSelectedColumnsNonOverlapJoin() throws IOException {
+    shell.setHiveSessionValue("hive.cbo.enable", true);
+
+    testTables.createTable(shell, "products", PRODUCT_SCHEMA, fileFormat, PRODUCT_RECORDS);
+    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+
+    List<Object[]> rows = shell.executeStatement(
+            "SELECT o.order_id, o.customer_id, o.total, p.name " +
+                    "FROM default.orders o JOIN default.products p ON o.product_id = p.id ORDER BY o.order_id"
+    );
+
+    Assert.assertEquals(3, rows.size());
+    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d, "skirt"}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d, "tee"}, rows.get(1));
+    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d, "watch"}, rows.get(2));
+  }
+
+  @Test
+  public void testDescribeTable() throws IOException {
+    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    List<Object[]> rows = shell.executeStatement("DESCRIBE default.customers");
+    Assert.assertEquals(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(), rows.size());
+    for (int i = 0; i < HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().size(); i++) {
+      Types.NestedField field = HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA.columns().get(i);
+      String comment = field.doc() == null ? "from deserializer" : field.doc();
+      Assert.assertArrayEquals(new Object[] {field.name(), HiveSchemaUtil.convert(field.type()).getTypeName(),
+          comment}, rows.get(i));
+    }
+  }
+
+  @Test
+  public void testCBOWithSelectedColumnsOverlapJoin() throws IOException {
+    shell.setHiveSessionValue("hive.cbo.enable", true);
+    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, fileFormat,
+            HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+
+    List<Object[]> rows = shell.executeStatement(
+            "SELECT c.first_name, o.order_id " +
+                    "FROM default.orders o JOIN default.customers c ON o.customer_id = c.customer_id " +
+                    "ORDER BY o.order_id DESC"
+    );
+
+    Assert.assertEquals(3, rows.size());
+    Assert.assertArrayEquals(new Object[] {"Bob", 102L}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {"Alice", 101L}, rows.get(1));
+    Assert.assertArrayEquals(new Object[] {"Alice", 100L}, rows.get(2));
+  }
+
+  @Test
+  public void testCBOWithSelfJoin() throws IOException {
+    shell.setHiveSessionValue("hive.cbo.enable", true);
+
+    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+
+    List<Object[]> rows = shell.executeStatement(
+            "SELECT o1.order_id, o1.customer_id, o1.total " +
+                    "FROM default.orders o1 JOIN default.orders o2 ON o1.order_id = o2.order_id ORDER BY o1.order_id"
+    );
+
+    Assert.assertEquals(3, rows.size());
+    Assert.assertArrayEquals(new Object[] {100L, 0L, 11.11d}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {101L, 0L, 22.22d}, rows.get(1));
+    Assert.assertArrayEquals(new Object[] {102L, 1L, 33.33d}, rows.get(2));
+  }
+
+  @Test
+  public void testJoinTablesSupportedTypes() throws IOException {
+    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+      Type type = SUPPORTED_TYPES.get(i);
+      if (type == Types.TimestampType.withZone() && isVectorized) {
+        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+        continue;
+      }
+      // TODO: remove this filter when issue #1881 is resolved
+      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+        continue;
+      }
+      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+      String columnName = type.typeId().toString().toLowerCase() + "_column";
+
+      Schema schema = new Schema(required(1, columnName, type));
+      List<Record> records = TestHelper.generateRandomRecords(schema, 1, 0L);
+
+      testTables.createTable(shell, tableName, schema, fileFormat, records);
+      List<Object[]> queryResult = shell.executeStatement("select s." + columnName + ", h." + columnName +
+              " from default." + tableName + " s join default." + tableName + " h on h." + columnName + "=s." +
+              columnName);
+      Assert.assertEquals("Non matching record count for table " + tableName + " with type " + type,
+              1, queryResult.size());
+    }
+  }
+
+  @Test
+  public void testSelectDistinctFromTable() throws IOException {
+    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+      Type type = SUPPORTED_TYPES.get(i);
+      if (type == Types.TimestampType.withZone() && isVectorized) {
+        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+        continue;
+      }
+      // TODO: remove this filter when issue #1881 is resolved
+      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+        continue;
+      }
+      String tableName = type.typeId().toString().toLowerCase() + "_table_" + i;
+      String columnName = type.typeId().toString().toLowerCase() + "_column";
+
+      Schema schema = new Schema(required(1, columnName, type));
+      List<Record> records = TestHelper.generateRandomRecords(schema, 4, 0L);
+      int size = records.stream().map(r -> r.getField(columnName)).collect(Collectors.toSet()).size();
+      testTables.createTable(shell, tableName, schema, fileFormat, records);
+      List<Object[]> queryResult = shell.executeStatement("select count(distinct(" + columnName +
+              ")) from default." + tableName);
+      int distinctIds = ((Long) queryResult.get(0)[0]).intValue();
+      Assert.assertEquals(tableName, size, distinctIds);
+    }
+  }
+
+  @Test
+  public void testPartitionPruning() throws IOException {
+    Schema salesSchema = new Schema(
+        required(1, "ss_item_sk", Types.IntegerType.get()),
+        required(2, "ss_sold_date_sk", Types.IntegerType.get()));
+
+    PartitionSpec salesSpec =
+        PartitionSpec.builderFor(salesSchema).identity("ss_sold_date_sk").build();
+
+    Schema dimSchema = new Schema(
+        required(1, "d_date_sk", Types.IntegerType.get()),
+        required(2, "d_moy", Types.IntegerType.get()));
+
+    List<Record> salesRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
+                                    .add(51, 5)
+                                    .add(61, 6)
+                                    .add(71, 7)
+                                    .add(81, 8)
+                                    .add(91, 9)
+                                    .build();
+    List<Record> dimRecords = TestHelper.RecordsBuilder.newInstance(salesSchema)
+                                    .add(1, 10)
+                                    .add(2, 20)
+                                    .add(3, 30)
+                                    .add(4, 40)
+                                    .add(5, 50)
+                                    .build();
+
+    Table salesTable = testTables.createTable(shell, "x1_store_sales", salesSchema, salesSpec, fileFormat, null);
+
+    PartitionKey partitionKey = new PartitionKey(salesSpec, salesSchema);
+    for (Record r : salesRecords) {
+      partitionKey.partition(r);
+      testTables.appendIcebergTable(shell.getHiveConf(), salesTable, fileFormat, partitionKey, ImmutableList.of(r));
+    }
+    testTables.createTable(shell, "x1_date_dim", dimSchema, fileFormat, dimRecords);
+
+    String query = "select s.ss_item_sk from x1_store_sales s, x1_date_dim d " +
+                       "where s.ss_sold_date_sk=d.d_date_sk*2 and d.d_moy=30";
+
+    // Check the query results
+    List<Object[]> rows = shell.executeStatement(query);
+
+    Assert.assertEquals(1, rows.size());
+    Assert.assertArrayEquals(new Object[] {61}, rows.get(0));
+
+    // Check if Dynamic Partitioning is used
+    Assert.assertTrue(shell.executeStatement("explain " + query).stream()
+                          .filter(a -> ((String) a[0]).contains("Dynamic Partitioning Event Operator"))
+                          .findAny()
+                          .isPresent());
+  }
+
+  @Test
+  public void testInsert() throws IOException {
+    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, ImmutableList.of());
+
+    // The expected query is like
+    // INSERT INTO customers VALUES (0, 'Alice'), (1, 'Bob'), (2, 'Trudy')
+    StringBuilder query = new StringBuilder().append("INSERT INTO customers VALUES ");
+    HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.forEach(record -> query.append("(")
+        .append(record.get(0)).append(",'")
+        .append(record.get(1)).append("','")
+        .append(record.get(2)).append("'),"));
+    query.setLength(query.length() - 1);
+
+    shell.executeStatement(query.toString());
+
+    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+  }
+
+  @Test
+  public void testInsertSupportedTypes() throws IOException {
+    for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
+      Type type = SUPPORTED_TYPES.get(i);
+      // TODO: remove this filter when issue #1881 is resolved
+      if (type == Types.UUIDType.get() && fileFormat == FileFormat.PARQUET) {
+        continue;
+      }
+      // TODO: remove this filter when we figure out how we could test binary types
+      if (type.equals(Types.BinaryType.get()) || type.equals(Types.FixedType.ofLength(5))) {
+        continue;
+      }
+      String columnName = type.typeId().toString().toLowerCase() + "_column";
+
+      Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, columnName, type));
+      List<Record> expected = TestHelper.generateRandomRecords(schema, 5, 0L);
+
+      Table table = testTables.createTable(shell, type.typeId().toString().toLowerCase() + "_table_" + i,
+          schema, PartitionSpec.unpartitioned(), fileFormat, expected);
+
+      HiveIcebergTestUtils.validateData(table, expected, 0);
+    }
+  }
+
+  /**
+   * Testing map only inserts.
+   * @throws IOException If there is an underlying IOException
+   */
+  @Test
+  public void testInsertFromSelect() throws IOException {
+    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    shell.executeStatement("INSERT INTO customers SELECT * FROM customers");
+
+    // Check that everything is duplicated as expected
+    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testAlterChangeColumn() throws IOException {
+    // TODO: remove once vectorized execution can handle column reorders/renames
+    Assume.assumeTrue(!isVectorized);
+
+    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN last_name family_name string AFTER customer_id");
+
+    List<Object[]> result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+    Assert.assertEquals(3, result.size());
+    Assert.assertArrayEquals(new Object[]{0L, "Brown", "Alice"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{1L, "Green", "Bob"}, result.get(1));
+    Assert.assertArrayEquals(new Object[]{2L, "Pink", "Trudy"}, result.get(2));
+
+    shell.executeStatement("ALTER TABLE customers CHANGE COLUMN family_name family_name string FIRST");
+
+    result = shell.executeStatement("SELECT * FROM customers ORDER BY customer_id");
+    Assert.assertEquals(3, result.size());
+    Assert.assertArrayEquals(new Object[]{"Brown", 0L, "Alice"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{"Green", 1L, "Bob"}, result.get(1));
+    Assert.assertArrayEquals(new Object[]{"Pink", 2L, "Trudy"}, result.get(2));
+
+    result = shell.executeStatement("SELECT customer_id, family_name FROM customers ORDER BY customer_id");
+    Assert.assertEquals(3, result.size());
+    Assert.assertArrayEquals(new Object[]{0L, "Brown"}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{1L, "Green"}, result.get(1));
+    Assert.assertArrayEquals(new Object[]{2L, "Pink"}, result.get(2));
+  }
+
+  @Test
+  public void testInsertOverwriteNonPartitionedTable() throws IOException {
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, ImmutableList.of());
+
+    // IOW overwrites the whole table (empty target table)
+    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source");
+
+    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+
+    // IOW overwrites the whole table (non-empty target table)
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Mike", "Taylor")
+        .add(1L, "Christy", "Hubert")
+        .build();
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
+
+    HiveIcebergTestUtils.validateData(table, newRecords, 0);
+
+    // IOW empty result set -> clears the target table
+    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM source WHERE FALSE");
+
+    HiveIcebergTestUtils.validateData(table, ImmutableList.of(), 0);
+  }
+
+
+  @Test
+  public void testSpecialCharacters() {
+    TableIdentifier table = TableIdentifier.of("default", "tar,! ,get");
+    // note: the Chinese character seems to be accepted in the column name, but not
+    // in the table name - this is the case for both Iceberg and standard Hive tables.
+    shell.executeStatement(String.format(
+        "CREATE TABLE `%s` (id bigint, `dep,! 是,t` string) STORED BY ICEBERG STORED AS %s %s TBLPROPERTIES ('%s'='%s')",
+        table.name(), fileFormat, testTables.locationForCreateTableSQL(table),
+        InputFormatConfig.CATALOG_NAME, Catalogs.ICEBERG_DEFAULT_CATALOG_NAME));
+    shell.executeStatement(String.format("INSERT INTO `%s` VALUES (1, 'moon'), (2, 'star')", table.name()));
+
+    List<Object[]> result = shell.executeStatement(String.format(
+        "SELECT `dep,! 是,t`, id FROM `%s` ORDER BY id", table.name()));
+
+    Assert.assertEquals(2, result.size());
+    Assert.assertArrayEquals(new Object[]{"moon", 1L}, result.get(0));
+    Assert.assertArrayEquals(new Object[]{"star", 2L}, result.get(1));
+  }
+
+  @Test
+  public void testInsertOverwritePartitionedTable() throws IOException {
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("last_name").build();
+    Table table = testTables.createTable(shell, target.name(), HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, ImmutableList.of());
+
+    // IOW into empty target table -> whole source result set is inserted
+    List<Record> expected = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    expected.add(TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(8L, "Sue", "Green").build().get(0)); // add one more to 'Green' so we have a partition w/ multiple records
+    shell.executeStatement(testTables.getInsertQuery(expected, target, true));
+
+    HiveIcebergTestUtils.validateData(table, expected, 0);
+
+    // IOW into non-empty target table -> only the affected partitions are overwritten
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Mike", "Brown") // overwritten
+        .add(1L, "Christy", "Green") // overwritten (partition has this single record now)
+        .add(3L, "Bill", "Purple") // appended (new partition)
+        .build();
+    shell.executeStatement(testTables.getInsertQuery(newRecords, target, true));
+
+    expected = new ArrayList<>(newRecords);
+    expected.add(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS.get(2)); // existing, untouched partition ('Pink')
+    HiveIcebergTestUtils.validateData(table, expected, 0);
+
+    // IOW empty source result set -> has no effect on partitioned table
+    shell.executeStatement("INSERT OVERWRITE TABLE target SELECT * FROM target WHERE FALSE");
+
+    HiveIcebergTestUtils.validateData(table, expected, 0);
+  }
+
+  @Test
+  public void testCTASFromHiveTable() {
+    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+
+    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
+    shell.executeStatement(testTables.getInsertQuery(
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
+
+    shell.executeStatement(String.format(
+        "CREATE TABLE target STORED BY ICEBERG %s TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
+        testTables.locationForCreateTableSQL(TableIdentifier.of("default", "target")),
+        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
+
+    List<Object[]> objects = shell.executeStatement("SELECT * FROM target ORDER BY id");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
+  }
+
+  @Test
+  public void testCTASPartitionedFromHiveTable() throws TException, InterruptedException {
+    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+
+    shell.executeStatement("CREATE TABLE source (id bigint, name string) PARTITIONED BY (dept string) STORED AS ORC");
+    shell.executeStatement(testTables.getInsertQuery(
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, TableIdentifier.of("default", "source"), false));
+
+    shell.executeStatement(String.format(
+        "CREATE TABLE target PARTITIONED BY (dept, name) " +
+        "STORED BY ICEBERG TBLPROPERTIES ('%s'='%s') AS SELECT * FROM source",
+        TableProperties.DEFAULT_FILE_FORMAT, fileFormat));
+
+    // check table can be read back correctly
+    List<Object[]> objects = shell.executeStatement("SELECT id, name, dept FROM target ORDER BY id");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, objects), 0);
+
+    // check HMS table has been created correctly (no partition cols, props pushed down)
+    org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "target");
+    Assert.assertEquals(3, hmsTable.getSd().getColsSize());
+    Assert.assertTrue(hmsTable.getPartitionKeys().isEmpty());
+    Assert.assertEquals(fileFormat.toString(), hmsTable.getParameters().get(TableProperties.DEFAULT_FILE_FORMAT));
+
+    // check Iceberg table has correct partition spec
+    Table table = testTables.loadTable(TableIdentifier.of("default", "target"));
+    Assert.assertEquals(2, table.spec().fields().size());
+    Assert.assertEquals("dept", table.spec().fields().get(0).name());
+    Assert.assertEquals("name", table.spec().fields().get(1).name());
+  }
+
+  @Test
+  public void testCTASFailureRollback() throws IOException {
+    Assume.assumeTrue(HiveIcebergSerDe.CTAS_EXCEPTION_MSG, testTableType == TestTables.TestTableType.HIVE_CATALOG);
+
+    // force an execution error by passing in a committer class that Tez won't be able to load
+    shell.setHiveSessionValue("hive.tez.mapreduce.output.committer.class", "org.apache.NotExistingClass");
+
+    TableIdentifier target = TableIdentifier.of("default", "target");
+    testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    String[] partitioningSchemes = {"", "PARTITIONED BY (last_name)", "PARTITIONED BY (customer_id, last_name)"};
+    for (String partitioning : partitioningSchemes) {
+      AssertHelpers.assertThrows("Should fail while loading non-existent output committer class.",
+          IllegalArgumentException.class, "org.apache.NotExistingClass",
+          () -> shell.executeStatement(String.format(
+              "CREATE TABLE target %s STORED BY ICEBERG AS SELECT * FROM source", partitioning)));
+      // CTAS table should have been dropped by the lifecycle hook
+      Assert.assertThrows(NoSuchTableException.class, () -> testTables.loadTable(target));
+    }
+  }
+
+  /**
+   * Testing map-reduce inserts.
+   * @throws IOException If there is an underlying IOException
+   */
+  @Test
+  public void testInsertFromSelectWithOrderBy() throws IOException {
+    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // We expect that there will be Mappers and Reducers here
+    shell.executeStatement("INSERT INTO customers SELECT * FROM customers ORDER BY customer_id");
+
+    // Check that everything is duplicated as expected
+    List<Record> records = new ArrayList<>(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    records.addAll(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testInsertFromSelectWithProjection() throws IOException {
+    Table table = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, ImmutableList.of());
+    testTables.createTable(shell, "orders", ORDER_SCHEMA, fileFormat, ORDER_RECORDS);
+
+    shell.executeStatement(
+        "INSERT INTO customers (customer_id, last_name) SELECT distinct(customer_id), 'test' FROM orders");
+
+    List<Record> expected = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, null, "test")
+        .add(1L, null, "test")
+        .build();
+
+    HiveIcebergTestUtils.validateData(table, expected, 0);
+  }
+
+  @Test
+  public void testInsertUsingSourceTableWithSharedColumnsNames() throws IOException {
+    List<Record> records = HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS;
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("last_name").build();
+    testTables.createTable(shell, "source_customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, records);
+    Table table = testTables.createTable(shell, "target_customers",
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
+
+    // Below select from source table should produce: "hive.io.file.readcolumn.names=customer_id,last_name".
+    // Inserting into the target table should not fail because first_name is not selected from the source table
+    shell.executeStatement("INSERT INTO target_customers SELECT customer_id, 'Sam', last_name FROM source_customers");
+
+    List<Record> expected = Lists.newArrayListWithExpectedSize(records.size());
+    records.forEach(r -> {
+      Record copy = r.copy();
+      copy.setField("first_name", "Sam");
+      expected.add(copy);
+    });
+    HiveIcebergTestUtils.validateData(table, expected, 0);
+  }
+
+  @Test
+  public void testInsertFromJoiningTwoIcebergTables() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+            .identity("last_name").build();
+    testTables.createTable(shell, "source_customers_1", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTables.createTable(shell, "source_customers_2", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+            spec, fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    Table table = testTables.createTable(shell, "target_customers",
+            HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, ImmutableList.of());
+
+    shell.executeStatement("INSERT INTO target_customers SELECT a.customer_id, b.first_name, a.last_name FROM " +
+            "source_customers_1 a JOIN source_customers_2 b ON a.last_name = b.last_name");
+
+    HiveIcebergTestUtils.validateData(table, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS, 0);
+  }
+
+  @Test
+  public void testWriteArrayOfPrimitivesInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "arrayofprimitives",
+            Types.ListType.ofRequired(3, Types.StringType.get())));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteArrayOfArraysInTable() throws IOException {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "arrayofarrays",
+                Types.ListType.ofRequired(3, Types.ListType.ofRequired(4, Types.StringType.get()))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 3, 1L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteArrayOfMapsInTable() throws IOException {
+    Schema schema =
+        new Schema(required(1, "id", Types.LongType.get()),
+            required(2, "arrayofmaps", Types.ListType
+                .ofRequired(3, Types.MapType.ofRequired(4, 5, Types.StringType.get(),
+                    Types.StringType.get()))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteArrayOfStructsInTable() throws IOException {
+    Schema schema =
+        new Schema(required(1, "id", Types.LongType.get()),
+            required(2, "arrayofstructs", Types.ListType.ofRequired(3, Types.StructType
+                .of(required(4, "something", Types.StringType.get()), required(5, "someone",
+                    Types.StringType.get()), required(6, "somewhere", Types.StringType.get())))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteMapOfPrimitivesInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "mapofprimitives", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+            Types.StringType.get())));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteMapOfArraysInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "mapofarrays",
+            Types.MapType.ofRequired(3, 4, Types.StringType.get(), Types.ListType.ofRequired(5,
+                Types.StringType.get()))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteMapOfMapsInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "mapofmaps", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+            Types.MapType.ofRequired(5, 6, Types.StringType.get(), Types.StringType.get()))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteMapOfStructsInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "mapofstructs", Types.MapType.ofRequired(3, 4, Types.StringType.get(),
+            Types.StructType.of(required(5, "something", Types.StringType.get()),
+                required(6, "someone", Types.StringType.get()),
+                required(7, "somewhere", Types.StringType.get())))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteStructOfPrimitivesInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "structofprimitives",
+            Types.StructType.of(required(3, "key", Types.StringType.get()), required(4, "value",
+                Types.StringType.get()))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteStructOfArraysInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "structofarrays", Types.StructType
+            .of(required(3, "names", Types.ListType.ofRequired(4, Types.StringType.get())),
+                required(5, "birthdays", Types.ListType.ofRequired(6,
+                    Types.StringType.get())))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 1L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteStructOfMapsInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "structofmaps", Types.StructType
+            .of(required(3, "map1", Types.MapType.ofRequired(4, 5,
+                Types.StringType.get(), Types.StringType.get())), required(6, "map2",
+                Types.MapType.ofRequired(7, 8, Types.StringType.get(),
+                    Types.StringType.get())))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testWriteStructOfStructsInTable() throws IOException {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "structofstructs", Types.StructType.of(required(3, "struct1", Types.StructType
+            .of(required(4, "key", Types.StringType.get()), required(5, "value",
+                Types.StringType.get()))))));
+    List<Record> records = TestHelper.generateRandomRecords(schema, 5, 0L);
+    testComplexTypeWrite(schema, records);
+  }
+
+  @Test
+  public void testPartitionedWrite() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .bucket("customer_id", 3)
+        .build();
+
+    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+
+    Table table = testTables.createTable(shell, "partitioned_customers",
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+
+    HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testIdentityPartitionedWrite() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("customer_id")
+        .build();
+
+    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+
+    Table table = testTables.createTable(shell, "partitioned_customers",
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+
+    HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testMultilevelIdentityPartitionedWrite() throws IOException {
+    PartitionSpec spec = PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .identity("customer_id")
+        .identity("last_name")
+        .build();
+
+    List<Record> records = TestHelper.generateRandomRecords(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, 4, 0L);
+
+    Table table = testTables.createTable(shell, "partitioned_customers",
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, spec, fileFormat, records);
+
+    HiveIcebergTestUtils.validateData(table, records, 0);
+  }
+
+  @Test
+  public void testYearTransform() throws IOException {
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.DateType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).year("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, LocalDate.of(2020, 1, 21))
+        .add(2L, LocalDate.of(2020, 1, 22))
+        .add(3L, LocalDate.of(2019, 1, 21))
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testMonthTransform() throws IOException {
+    Assume.assumeTrue("ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive", isVectorized);
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.TimestampType.withZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).month("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(1)))
+        .add(2L, OffsetDateTime.of(2017, 11, 22, 11, 30, 7, 0, ZoneOffset.ofHours(2)))
+        .add(3L, OffsetDateTime.of(2017, 11, 23, 11, 30, 7, 0, ZoneOffset.ofHours(3)))
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testDayTransform() throws IOException {
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.TimestampType.withoutZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).day("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testHourTransform() throws IOException {
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.TimestampType.withoutZone()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).hour("part_field").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, LocalDateTime.of(2019, 2, 22, 9, 44, 54))
+        .add(2L, LocalDateTime.of(2019, 2, 22, 10, 44, 54))
+        .add(3L, LocalDateTime.of(2019, 2, 23, 9, 44, 54))
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testBucketTransform() throws IOException {
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).bucket("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, "Part1")
+        .add(2L, "Part2")
+        .add(3L, "Art3")
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testTruncateTransform() throws IOException {
+    Schema schema = new Schema(
+        optional(1, "id", Types.LongType.get()),
+        optional(2, "part_field", Types.StringType.get()));
+    PartitionSpec spec = PartitionSpec.builderFor(schema).truncate("part_field", 2).build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(1L, "Part1")
+        .add(2L, "Part2")
+        .add(3L, "Art3")
+        .build();
+    Table table = testTables.createTable(shell, "part_test", schema, spec, fileFormat, records);
+    HiveIcebergTestUtils.validateData(table, records, 0);
+
+    HiveIcebergTestUtils.validateDataWithSQL(shell, "part_test", records, "id");
+  }
+
+  @Test
+  public void testMultiTableInsert() throws IOException {
+    testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    Schema target1Schema = new Schema(
+        optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "first_name", Types.StringType.get())
+    );
+
+    Schema target2Schema = new Schema(
+        optional(1, "last_name", Types.StringType.get()),
+        optional(2, "customer_id", Types.LongType.get())
+    );
+
+    List<Record> target1Records = TestHelper.RecordsBuilder.newInstance(target1Schema)
+                                      .add(0L, "Alice")
+                                      .add(1L, "Bob")
+                                      .add(2L, "Trudy")
+                                      .build();
+
+    List<Record> target2Records = TestHelper.RecordsBuilder.newInstance(target2Schema)
+                                      .add("Brown", 0L)
+                                      .add("Green", 1L)
+                                      .add("Pink", 2L)
+                                      .build();
+
+    Table target1 = testTables.createTable(shell, "target1", target1Schema, fileFormat, ImmutableList.of());
+    Table target2 = testTables.createTable(shell, "target2", target2Schema, fileFormat, ImmutableList.of());
+
+    // simple insert: should create a single vertex writing to both target tables
+    shell.executeStatement("FROM customers " +
+        "INSERT INTO target1 SELECT customer_id, first_name " +
+        "INSERT INTO target2 SELECT last_name, customer_id");
+
+    // Check that everything is as expected
+    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
+    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
+
+    // truncate the target tables
+    testTables.truncateIcebergTable(target1);
+    testTables.truncateIcebergTable(target2);
+
+    // complex insert: should use a different vertex for each target table
+    shell.executeStatement("FROM customers " +
+        "INSERT INTO target1 SELECT customer_id, first_name ORDER BY first_name " +
+        "INSERT INTO target2 SELECT last_name, customer_id ORDER BY last_name");
+
+    // Check that everything is as expected
+    HiveIcebergTestUtils.validateData(target1, target1Records, 0);
+    HiveIcebergTestUtils.validateData(target2, target2Records, 1);
+  }
+
+  @Test
+  public void testWriteWithDefaultWriteFormat() {
+    Assume.assumeTrue("Testing the default file format is enough for a single scenario.",
+        testTableType == TestTables.TestTableType.HIVE_CATALOG && fileFormat == FileFormat.ORC);
+
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+
+    // create Iceberg table without specifying a write format in the tbl properties
+    // it should fall back to using the default file format
+    shell.executeStatement(String.format("CREATE EXTERNAL TABLE %s (id bigint, name string) STORED BY '%s' %s",
+        identifier,
+        HiveIcebergStorageHandler.class.getName(),
+        testTables.locationForCreateTableSQL(identifier)));
+
+    shell.executeStatement(String.format("INSERT INTO %s VALUES (10, 'Linda')", identifier));
+    List<Object[]> results = shell.executeStatement(String.format("SELECT * FROM %s", identifier));
+
+    Assert.assertEquals(1, results.size());
+    Assert.assertEquals(10L, results.get(0)[0]);
+    Assert.assertEquals("Linda", results.get(0)[1]);
+  }
+
+  @Test
+  public void testInsertEmptyResultSet() throws IOException {
+    Table source = testTables.createTable(shell, "source", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, ImmutableList.of());
+    Table target = testTables.createTable(shell, "target", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, ImmutableList.of());
+
+    shell.executeStatement("INSERT INTO target SELECT * FROM source");
+    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+
+    testTables.appendIcebergTable(shell.getHiveConf(), source, fileFormat, null,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("INSERT INTO target SELECT * FROM source WHERE first_name = 'Nobody'");
+    HiveIcebergTestUtils.validateData(target, ImmutableList.of(), 0);
+  }
+
+  @Test
+  public void testDecimalTableWithPredicateLiterals() throws IOException {
+    Schema schema = new Schema(required(1, "decimal_field", Types.DecimalType.of(7, 2)));
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema)
+        .add(new BigDecimal("85.00"))
+        .add(new BigDecimal("100.56"))
+        .add(new BigDecimal("100.57"))
+        .build();
+    testTables.createTable(shell, "dec_test", schema, fileFormat, records);
+
+    // Use integer literal in predicate
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field >= 85");
+    Assert.assertEquals(3, rows.size());
+    Assert.assertArrayEquals(new Object[] {"85.00"}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(1));
+    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(2));
+
+    // Use decimal literal in predicate with smaller scale than schema type definition
+    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 99.1");
+    Assert.assertEquals(2, rows.size());
+    Assert.assertArrayEquals(new Object[] {"100.56"}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(1));
+
+    // Use decimal literal in predicate with higher scale than schema type definition
+    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 100.565");
+    Assert.assertEquals(1, rows.size());
+    Assert.assertArrayEquals(new Object[] {"100.57"}, rows.get(0));
+
+    // Use decimal literal in predicate with the same scale as schema type definition
+    rows = shell.executeStatement("SELECT * FROM default.dec_test where decimal_field > 640.34");
+    Assert.assertEquals(0, rows.size());
+  }
+
+  @Test
+  public void testStructOfMapsInTable() throws IOException {
+    Schema schema = new Schema(
+        required(1, "structofmaps", Types.StructType
+            .of(required(2, "map1", Types.MapType.ofRequired(3, 4,
+                Types.StringType.get(), Types.StringType.get())), required(5, "map2",
+                Types.MapType.ofRequired(6, 7, Types.StringType.get(),
+                    Types.IntegerType.get())))));
+    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+    // access a map entry inside a struct
+    for (int i = 0; i < records.size(); i++) {
+      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofmaps");
+      Map<?, ?> expectedMap = (Map<?, ?>) expectedStruct.getField("map1");
+      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
+        List<Object[]> queryResult = shell.executeStatement(String
+            .format("SELECT structofmaps.map1[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
+                i));
+        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
+      }
+      expectedMap = (Map<?, ?>) expectedStruct.getField("map2");
+      for (Map.Entry<?, ?> entry : expectedMap.entrySet()) {
+        List<Object[]> queryResult = shell.executeStatement(String
+            .format("SELECT structofmaps.map2[\"%s\"] from default.structtable LIMIT 1 OFFSET %d", entry.getKey(),
+                i));
+        Assert.assertEquals(entry.getValue(), queryResult.get(0)[0]);
+      }
+    }
+  }
+
+  @Test
+  public void testStructOfArraysInTable() throws IOException {
+    Schema schema = new Schema(
+        required(1, "structofarrays", Types.StructType
+            .of(required(2, "names", Types.ListType.ofRequired(3, Types.StringType.get())),
+                required(4, "birthdays", Types.ListType.ofRequired(5,
+                    Types.DateType.get())))));
+    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+    // access an element of an array inside a struct
+    for (int i = 0; i < records.size(); i++) {
+      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofarrays");
+      List<?> expectedList = (List<?>) expectedStruct.getField("names");
+      for (int j = 0; j < expectedList.size(); j++) {
+        List<Object[]> queryResult = shell.executeStatement(
+            String.format("SELECT structofarrays.names[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
+        Assert.assertEquals(expectedList.get(j), queryResult.get(0)[0]);
+      }
+      expectedList = (List<?>) expectedStruct.getField("birthdays");
+      for (int j = 0; j < expectedList.size(); j++) {
+        List<Object[]> queryResult = shell.executeStatement(
+            String.format("SELECT structofarrays.birthdays[%d] FROM default.structtable LIMIT 1 OFFSET %d", j, i));
+        Assert.assertEquals(expectedList.get(j).toString(), queryResult.get(0)[0]);
+      }
+    }
+  }
+
+  @Test
+  public void testStructOfPrimitivesInTable() throws IOException {
+    Schema schema = new Schema(required(1, "structofprimitives",
+        Types.StructType.of(required(2, "key", Types.StringType.get()), required(3, "value",
+            Types.IntegerType.get()))));
+    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+    // access a single value in a struct
+    for (int i = 0; i < records.size(); i++) {
+      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofprimitives");
+      List<Object[]> queryResult = shell.executeStatement(String.format(
+          "SELECT structofprimitives.key, structofprimitives.value FROM default.structtable LIMIT 1 OFFSET %d", i));
+      Assert.assertEquals(expectedStruct.getField("key"), queryResult.get(0)[0]);
+      Assert.assertEquals(expectedStruct.getField("value"), queryResult.get(0)[1]);
+    }
+  }
+
+  @Test
+  public void testStructOfStructsInTable() throws IOException {
+    Schema schema = new Schema(
+        required(1, "structofstructs", Types.StructType.of(required(2, "struct1", Types.StructType
+            .of(required(3, "key", Types.StringType.get()), required(4, "value",
+                Types.IntegerType.get()))))));
+    List<Record> records = testTables.createTableWithGeneratedRecords(shell, "structtable", schema, fileFormat, 1);
+    // access a struct element inside a struct
+    for (int i = 0; i < records.size(); i++) {
+      GenericRecord expectedStruct = (GenericRecord) records.get(i).getField("structofstructs");
+      GenericRecord expectedInnerStruct = (GenericRecord) expectedStruct.getField("struct1");
+      List<Object[]> queryResult = shell.executeStatement(String.format(
+          "SELECT structofstructs.struct1.key, structofstructs.struct1.value FROM default.structtable " +
+              "LIMIT 1 OFFSET %d", i));
+      Assert.assertEquals(expectedInnerStruct.getField("key"), queryResult.get(0)[0]);
+      Assert.assertEquals(expectedInnerStruct.getField("value"), queryResult.get(0)[1]);
+    }
+  }
+
+  @Test
+  public void testScanTableCaseInsensitive() throws IOException {
+    testTables.createTable(shell, "customers",
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA_WITH_UPPERCASE, fileFormat,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+
+    Assert.assertEquals(3, rows.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
+    Assert.assertArrayEquals(new Object[] {2L, "Trudy", "Pink"}, rows.get(2));
+
+    rows = shell.executeStatement("SELECT * FROM default.customers where CustomER_Id < 2 " +
+        "and first_name in ('Alice', 'Bob')");
+
+    Assert.assertEquals(2, rows.size());
+    Assert.assertArrayEquals(new Object[] {0L, "Alice", "Brown"}, rows.get(0));
+    Assert.assertArrayEquals(new Object[] {1L, "Bob", "Green"}, rows.get(1));
+  }
+
+  @Test
+  public void testTruncateTable() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records in it then execute a truncate table command.
+    // Then check if the data is deleted and the table statistics are reset to 0.
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  @Test
+  public void testTruncateEmptyTable() throws IOException, TException, InterruptedException {
+    // Create an empty Iceberg table and execute a truncate table command on it.
+    String databaseName = "default";
+    String tableName = "customers";
+    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, null);
+    // Set the 'external.table.purge' table property on the table
+    String alterTableCommand =
+        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='true')";
+    shell.executeStatement(alterTableCommand);
+
+    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+
+    shell.executeStatement("TRUNCATE " + identifier);
+
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    Map<String, String> summary = icebergTable.currentSnapshot().summary();
+    for (String key : STATS_MAPPING.values()) {
+      Assert.assertEquals("0", summary.get(key));
+    }
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+    Assert.assertEquals(0, rows.size());
+    validateBasicStats(icebergTable, databaseName, tableName);
+  }
+
+  @Test
+  public void testMultipleTruncateTable() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with come records in it, then execute a truncate table command
+    // and check the result. Then insert some new data and run an other truncate table command.
+    // The purpose of this test is to make sure that multiple truncate table commands can
+    // run after each other without any issue (like issues with locking).
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+
+    List<Record> newRecords = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(3L, "Jane", "Purple").add(4L, "Tim", "Grey").add(5L, "Eva", "Yellow").add(6L, "James", "White")
+        .add(7L, "Jack", "Black").build();
+    shell.executeStatement("INSERT INTO default.customers values (3, 'Jane', 'Purple'), (4, 'Tim', 'Grey')," +
+        "(5, 'Eva', 'Yellow'), (6, 'James', 'White'), (7, 'Jack', 'Black')");
+
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    testTruncateTable(databaseName, tableName, icebergTable, newRecords,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  @Test
+  public void testTruncateTableExternalPurgeFalse() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records in it and set the 'external.table.purge' table property
+    // to false and try to run a truncate table command on it. The command should fail with a SemanticException.
+    // Then check if the data is not deleted from the table and also the statistics are not changed.
+    String databaseName = "default";
+    String tableName = "customers";
+    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    shell.executeStatement("ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='false')");
+    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "Cannot truncate non-managed table", () -> {
+          shell.executeStatement("TRUNCATE " + identifier);
+        });
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+    icebergTable = testTables.loadTable(TableIdentifier.of(databaseName, tableName));
+    validateBasicStats(icebergTable, databaseName, tableName);
+  }
+
+  @Test
+  public void testTruncateTableForceExternalPurgeFalse() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with some records and set the 'external.table.purge' table parameter to false.
+    // Then execute a truncate table force command which should run without any error.
+    // Then check if the data is deleted from the table and the statistics are reset.
+    String databaseName = "default";
+    String tableName = "customers";
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+    testTruncateTable(databaseName, tableName, icebergTable, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, false, true);
+  }
 
   @Test
   public void testTruncateTableWithPartitionSpec() throws IOException, TException, InterruptedException {
@@ -1455,590 +1472,590 @@ public class TestHiveIcebergStorageHandlerWithEngine {
     validateBasicStats(icebergTable, databaseName, tableName);
   }
 
-//  @Test
-//  public void testTruncateTablePartitionedIcebergTable() throws IOException, TException, InterruptedException {
-//    // Create a partitioned Iceberg table with some initial data and run a truncate table command on this table.
-//    // Then check if the data is deleted and the table statistics are reset to 0.
-//    String databaseName = "default";
-//    String tableName = "customers";
-//    PartitionSpec spec =
-//        PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
-//        .add(0L, "Alice", "Brown")
-//        .add(1L, "Bob", "Brown")
-//        .add(2L, "Trudy", "Green")
-//        .add(3L, "John", "Pink")
-//        .add(4L, "Jane", "Pink")
-//        .build();
-//    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        spec, fileFormat, records);
-//    testTruncateTable(databaseName, tableName, icebergTable, records,
-//        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
-//  }
-//
-//  private void testTruncateTable(String databaseName, String tableName, Table icebergTable, List<Record> records,
-//      Schema schema, boolean externalTablePurge, boolean force) throws TException, InterruptedException {
-//    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
-//    // Set the 'external.table.purge' table property on the table
-//    String alterTableCommand =
-//        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='" + externalTablePurge + "')";
-//    shell.executeStatement(alterTableCommand);
-//
-//    // Validate the initial data and the table statistics
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
-//    HiveIcebergTestUtils.validateData(records, HiveIcebergTestUtils.valueForRow(schema, rows), 0);
-//    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
-//    validateBasicStats(icebergTable, databaseName, tableName);
-//
-//    // Run a 'truncate table' or 'truncate table force' command
-//    String truncateCommand = "TRUNCATE " + identifier;
-//    if (force) {
-//      truncateCommand = truncateCommand + " FORCE";
-//    }
-//    shell.executeStatement(truncateCommand);
-//
-//    // Validate if the data is deleted from the table and also that the table
-//    // statistics are reset to 0.
-//    Table table = testTables.loadTable(identifier);
-//    Map<String, String> summary = table.currentSnapshot().summary();
-//    for (String key : STATS_MAPPING.values()) {
-//      Assert.assertEquals("0", summary.get(key));
-//    }
-//    rows = shell.executeStatement("SELECT * FROM " + identifier);
-//    Assert.assertEquals(0, rows.size());
-//    validateBasicStats(table, databaseName, tableName);
-//  }
-//
-//  @Test
-//  public void testAddColumnToIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Add a new column (age long) to the Iceberg table.
-//    icebergTable.updateSchema().addColumn("age", Types.LongType.get()).commit();
-//
-//    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-//        optional(3, "last_name", Types.StringType.get(), "This is last name"),
-//        optional(4, "age", Types.LongType.get()));
-//
-//    // Also add a new entry to the table where the age column is set.
-//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
-//    List<Record> newCustomerWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-//        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null).build();
-//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomerWithAge);
-//
-//    // Do a 'select *' from Hive and check if the age column appears in the result.
-//    // It should be null for the old data and should be filled for the data added after the column addition.
-//    TestHelper.RecordsBuilder customersWithAgeBuilder = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-//        .add(0L, "Alice", "Brown", null).add(1L, "Bob", "Green", null).add(2L, "Trudy", "Pink", null)
-//        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null);
-//    List<Record> customersWithAge = customersWithAgeBuilder.build();
-//
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-//        0);
-//
-//    // Do a 'select customer_id, age' from Hive to check if the new column can be queried from Hive.
-//    // The customer_id is needed because of the result sorting.
-//    Schema customerSchemaWithAgeOnly =
-//        new Schema(optional(1, "customer_id", Types.LongType.get()), optional(4, "age", Types.LongType.get()));
-//    TestHelper.RecordsBuilder customerWithAgeOnlyBuilder = TestHelper.RecordsBuilder
-//        .newInstance(customerSchemaWithAgeOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, 34L).add(4L, null);
-//    List<Record> customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
-//
-//    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
-//
-//    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
-//    shell.executeStatement(
-//        "INSERT INTO default.customers values (5L, 'Lily', 'Magenta', NULL), (6L, 'Roni', 'Purple', 23L)");
-//
-//    customersWithAgeBuilder.add(5L, "Lily", "Magenta", null).add(6L, "Roni", "Purple", 23L);
-//    customersWithAge = customersWithAgeBuilder.build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-//        0);
-//
-//    customerWithAgeOnlyBuilder.add(5L, null).add(6L, 23L);
-//    customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
-//    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
-//  }
-//
-//  @Test
-//  public void testAddRequiredColumnToIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name without initial data.
-//    // The reason why not to add initial data is that adding a required column is an incompatible change in Iceberg.
-//    // So there is no contract on what happens when trying to read the old data back. It behaves differently depending
-//    // on the underlying file format. So there is no point creating a test for that as there is no expected behaviour.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, null);
-//
-//    // Add a new required column (age long) to the Iceberg table.
-//    icebergTable.updateSchema().allowIncompatibleChanges().addRequiredColumn("age", Types.LongType.get()).commit();
-//
-//    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-//        optional(3, "last_name", Types.StringType.get(), "This is last name"),
-//        required(4, "age", Types.LongType.get()));
-//
-//    // Insert some data with age column from Hive.
-//    shell.executeStatement(
-//        "INSERT INTO default.customers values (0L, 'Lily', 'Magenta', 28L), (1L, 'Roni', 'Purple', 33L)");
-//
-//    // Do a 'select *' from Hive and check if the age column appears in the result.
-//    List<Record> customersWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
-//        .add(0L, "Lily", "Magenta", 28L).add(1L, "Roni", "Purple", 33L).build();
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
-//        0);
-//
-//    // Should add test step to insert NULL value into the new required column. But at the moment it
-//    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
-//  }
-//
-//  @Test
-//  public void testAddColumnIntoStructToIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns id and person, where person is a struct, consists of the
-//    // columns first_name and last_name.
-//    Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, "person", Types.StructType
-//        .of(required(3, "first_name", Types.StringType.get()), required(4, "last_name", Types.StringType.get()))));
-//    List<Record> people = TestHelper.generateRandomRecords(schema, 3, 0L);
-//    Table icebergTable = testTables.createTable(shell, "people", schema, fileFormat, people);
-//
-//    // Add a new column (age long) to the Iceberg table into the person struct
-//    icebergTable.updateSchema().addColumn("person", "age", Types.LongType.get()).commit();
-//
-//    Schema schemaWithAge = new Schema(required(1, "id", Types.LongType.get()),
-//        required(2, "person", Types.StructType.of(required(3, "first_name", Types.StringType.get()),
-//            required(4, "last_name", Types.StringType.get()), optional(5, "age", Types.LongType.get()))));
-//    List<Record> newPeople = TestHelper.generateRandomRecords(schemaWithAge, 2, 10L);
-//
-//    // Also add a new entry to the table where the age column is set.
-//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "people"));
-//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newPeople);
-//
-//    List<Record> sortedExpected = new ArrayList<>(people);
-//    sortedExpected.addAll(newPeople);
-//    sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(0)));
-//    List<Object[]> rows = shell
-//        .executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people order by id");
-//    Assert.assertEquals(sortedExpected.size(), rows.size());
-//    for (int i = 0; i < sortedExpected.size(); i++) {
-//      Object[] row = rows.get(i);
-//      Long id = (Long) sortedExpected.get(i).get(0);
-//      Record person = (Record) sortedExpected.get(i).getField("person");
-//      String lastName = (String) person.getField("last_name");
-//      String firstName = (String) person.getField("first_name");
-//      Long age = null;
-//      if (person.getField("age") != null) {
-//        age = (Long) person.getField("age");
-//      }
-//      Assert.assertEquals(id, (Long) row[0]);
-//      Assert.assertEquals(firstName, (String) row[1]);
-//      Assert.assertEquals(lastName, (String) row[2]);
-//      Assert.assertEquals(age, row[3]);
-//    }
-//
-//    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
-//    shell.executeStatement("CREATE TABLE dummy_tbl (id bigint, first_name string, last_name string, age bigint)");
-//    shell.executeStatement("INSERT INTO dummy_tbl VALUES (1, 'Lily', 'Blue', 34), (2, 'Roni', 'Grey', NULL)");
-//    shell.executeStatement("INSERT INTO default.people SELECT id, named_struct('first_name', first_name, " +
-//        "'last_name', last_name, 'age', age) from dummy_tbl");
-//
-//    rows = shell.executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people " +
-//        "where id in (1, 2) order by id");
-//    Assert.assertEquals(2, rows.size());
-//    Assert.assertEquals((Long) 1L, (Long) rows.get(0)[0]);
-//    Assert.assertEquals("Lily", (String) rows.get(0)[1]);
-//    Assert.assertEquals("Blue", (String) rows.get(0)[2]);
-//    Assert.assertEquals((Long) 34L, (Long) rows.get(0)[3]);
-//    Assert.assertEquals((Long) 2L, (Long) rows.get(1)[0]);
-//    Assert.assertEquals("Roni", (String) rows.get(1)[1]);
-//    Assert.assertEquals("Grey", (String) rows.get(1)[2]);
-//    Assert.assertNull(rows.get(1)[3]);
-//  }
-//
-//  @Test
-//  public void testMakeColumnRequiredInIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Add a new required column (age long) to the Iceberg table.
-//    icebergTable.updateSchema().allowIncompatibleChanges().requireColumn("last_name").commit();
-//
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//
-//    // Insert some data with last_name no NULL.
-//    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', 'Purple')");
-//
-//    List<Record> customerRecords = TestHelper.RecordsBuilder
-//        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(0L, "Alice", "Brown")
-//        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", "Purple").build();
-//
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customerRecords,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//
-//    // Should add test step to insert NULL value into the new required column. But at the moment it
-//    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
-//  }
-//
-//  @Test
-//  public void testRemoveColumnFromIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Remove the first_name column from the table.
-//    icebergTable.updateSchema().deleteColumn("first_name").commit();
-//
-//    Schema customerSchemaWithoutFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "last_name", Types.StringType.get(), "This is last name"));
-//
-//    TestHelper.RecordsBuilder customersWithoutFirstNameBuilder = TestHelper.RecordsBuilder
-//        .newInstance(customerSchemaWithoutFirstName).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
-//    List<Record> customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
-//
-//    // Run a 'select *' from Hive to see if the result doesn't contain the first_name column any more.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
-//
-//    // Run a 'select first_name' and check if an exception is thrown.
-//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-//        "Invalid table alias or column reference 'first_name'", () -> {
-//          shell.executeStatement("SELECT first_name FROM default.customers");
-//        });
-//
-//    // Insert an entry from Hive to check if it can be inserted without the first_name column.
-//    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta')");
-//
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    customersWithoutFirstNameBuilder.add(4L, "Magenta");
-//    customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
-//    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
-//  }
-//
-//  @Test
-//  public void testRemoveAndAddBackColumnFromIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Remove the first_name column
-//    icebergTable.updateSchema().deleteColumn("first_name").commit();
-//    // Add a new column with the name first_name
-//    icebergTable.updateSchema().addColumn("first_name", Types.StringType.get(), "This is new first name").commit();
-//
-//    // Add new data to the table with the new first_name column filled.
-//    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
-//    Schema customerSchemaWithNewFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "last_name", Types.StringType.get(), "This is last name"),
-//        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
-//    List<Record> newCustomersWithNewFirstName =
-//        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(3L, "Red", "James").build();
-//    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomersWithNewFirstName);
-//
-//    TestHelper.RecordsBuilder customersWithNewFirstNameBuilder =
-//        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(0L, "Brown", null)
-//            .add(1L, "Green", null).add(2L, "Pink", null).add(3L, "Red", "James");
-//    List<Record> customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
-//
-//    // Run a 'select *' from Hive and check if the first_name column is returned.
-//    // It should be null for the old data and should be filled in the entry added after the column addition.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
-//
-//    Schema customerSchemaWithNewFirstNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
-//
-//    TestHelper.RecordsBuilder customersWithNewFirstNameOnlyBuilder = TestHelper.RecordsBuilder
-//        .newInstance(customerSchemaWithNewFirstNameOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, "James");
-//    List<Record> customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
-//
-//    // Run a 'select first_name' from Hive to check if the new first-name column can be queried.
-//    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
-//
-//    // Insert data from Hive with first_name filled and with null first_name value.
-//    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta', 'Lily'), (5L, 'Purple', NULL)");
-//
-//    // Check if the newly inserted data is returned correctly by select statements.
-//    customersWithNewFirstNameBuilder.add(4L, "Magenta", "Lily").add(5L, "Purple", null);
-//    customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
-//
-//    customersWithNewFirstNameOnlyBuilder.add(4L, "Lily").add(5L, null);
-//    customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
-//    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
-//  }
-//
-//  @Test
-//  public void testRenameColumnInIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Rename the last_name column to family_name
-//    icebergTable.updateSchema().renameColumn("last_name", "family_name").commit();
-//
-//    Schema schemaWithFamilyName = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "first_name", Types.StringType.get(), "This is first name"),
-//        optional(3, "family_name", Types.StringType.get(), "This is last name"));
-//
-//    // Run a 'select *' from Hive to check if the same records are returned in the same order as before the rename.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
-//
-//    Schema shemaWithFamilyNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
-//        optional(2, "family_name", Types.StringType.get(), "This is family name"));
-//    TestHelper.RecordsBuilder customersWithFamilyNameOnlyBuilder = TestHelper.RecordsBuilder
-//        .newInstance(shemaWithFamilyNameOnly).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
-//    List<Record> customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
-//
-//    // Run a 'select family_name' from Hive to check if the column can be queried with the new name.
-//    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
-//        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
-//
-//    // Run a 'select last_name' to check if an exception is thrown.
-//    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
-//        "Invalid table alias or column reference 'last_name'", () -> {
-//          shell.executeStatement("SELECT last_name FROM default.customers");
-//        });
-//
-//    // Insert some data from Hive to check if the last_name column is still can be filled.
-//    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', NULL)");
-//
-//    List<Record> newCustomers = TestHelper.RecordsBuilder.newInstance(schemaWithFamilyName).add(0L, "Alice", "Brown")
-//        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", null).build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(newCustomers, HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
-//
-//    customersWithFamilyNameOnlyBuilder.add(3L, "Magenta").add(4L, null);
-//    customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
-//    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
-//        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
-//  }
-//
-//  @Test
-//  public void testMoveLastNameToFirstInIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Move the last_name column in the table schema as first_column
-//    icebergTable.updateSchema().moveFirst("last_name").commit();
-//
-//    Schema customerSchemaLastNameFirst =
-//        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
-//            optional(2, "customer_id", Types.LongType.get()),
-//            optional(3, "first_name", Types.StringType.get(), "This is first name"));
-//
-//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
-//            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
-//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//
-//    // Run a 'select *' to check if the order of the column in the result has been changed.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//
-//    // Query the data with names and check if the result is the same as when the table was created.
-//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//
-//    // Insert data from Hive to check if the last_name column has to be first in the values list.
-//    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
-//
-//    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
-//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//  }
-//
-//  @Test
-//  public void testMoveLastNameBeforeCustomerIdInIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Move the last_name column before the customer_id in the table schema.
-//    icebergTable.updateSchema().moveBefore("last_name", "customer_id").commit();
-//
-//    Schema customerSchemaLastNameFirst =
-//        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
-//            optional(2, "customer_id", Types.LongType.get()),
-//            optional(3, "first_name", Types.StringType.get(), "This is first name"));
-//
-//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
-//            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
-//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//
-//    // Run a 'select *' to check if the order of the column in the result has been changed.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//
-//    // Query the data with names and check if the result is the same as when the table was created.
-//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//
-//    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
-//    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
-//
-//    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
-//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//  }
-//
-//  @Test
-//  public void testMoveCustomerIdAfterFirstNameInIcebergTable() throws IOException {
-//    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
-//    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
-//        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
-//
-//    // Move the last_name column before the customer_id in the table schema.
-//    icebergTable.updateSchema().moveAfter("customer_id", "first_name").commit();
-//
-//    Schema customerSchemaLastNameFirst =
-//        new Schema(optional(1, "first_name", Types.StringType.get(), "This is first name"),
-//            optional(2, "customer_id", Types.LongType.get()),
-//            optional(3, "last_name", Types.StringType.get(), "This is last name"));
-//
-//    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
-//        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Alice", 0L, "Brown")
-//            .add("Bob", 1L, "Green").add("Trudy", 2L, "Pink");
-//    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//
-//    // Run a 'select *' to check if the order of the column in the result has been changed.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//
-//    // Query the data with names and check if the result is the same as when the table was created.
-//    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
-//    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
-//        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
-//
-//    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
-//    shell.executeStatement("INSERT INTO default.customers values ('Lily', 3L, 'Magenta')");
-//
-//    customersWithLastNameFirstBuilder.add("Lily", 3L, "Magenta");
-//    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
-//    rows = shell.executeStatement("SELECT * FROM default.customers");
-//    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
-//        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
-//  }
-//
-//  @Test
-//  public void testUpdateColumnTypeInIcebergTable() throws IOException, TException, InterruptedException {
-//    // Create an Iceberg table with int, float and decimal(2,1) types with some initial records
-//    Schema schema = new Schema(optional(1, "id", Types.LongType.get()),
-//        optional(2, "int_col", Types.IntegerType.get(), "This is an integer type"),
-//        optional(3, "float_col", Types.FloatType.get(), "This is a float type"),
-//        optional(4, "decimal_col", Types.DecimalType.of(2, 1), "This is a decimal type"));
-//
-//    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22F, BigDecimal.valueOf(13L, 1))
-//        .add(1L, 223344, 555.22F, BigDecimal.valueOf(22L, 1)).add(2L, -234, -342F, BigDecimal.valueOf(-12L, 1)).build();
-//
-//    Table icebergTable = testTables.createTable(shell, "types_table", schema, fileFormat, records);
-//
-//    // In the result set a float column is returned as double and a decimal is returned as string,
-//    // even though Hive has the columns with the right types.
-//    // Probably this conversation happens when fetching the result set after calling the select through the shell.
-//    // Because of this, a separate schema and record list has to be used when validating the returned values.
-//    Schema schemaForResultSet =
-//        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.IntegerType.get()),
-//            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
-//
-//    List<Record> expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22d, "1.3")
-//        .add(1L, 223344, 555.22d, "2.2").add(2L, -234, -342d, "-1.2").build();
-//
-//    // Check the select result and the column types of the table.
-//    List<Object[]> rows = shell.executeStatement("SELECT * FROM types_table");
-//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-//
-//    org.apache.hadoop.hive.metastore.api.Table table = shell.metastore().getTable("default", "types_table");
-//    Assert.assertNotNull(table);
-//    Assert.assertNotNull(table.getSd());
-//    List<FieldSchema> columns = table.getSd().getCols();
-//    Assert.assertEquals("id", columns.get(0).getName());
-//    Assert.assertEquals("bigint", columns.get(0).getType());
-//    Assert.assertEquals("int_col", columns.get(1).getName());
-//    Assert.assertEquals("int", columns.get(1).getType());
-//    Assert.assertEquals("float_col", columns.get(2).getName());
-//    Assert.assertEquals("float", columns.get(2).getType());
-//    Assert.assertEquals("decimal_col", columns.get(3).getName());
-//    Assert.assertEquals("decimal(2,1)", columns.get(3).getType());
-//
-//    // Change the column types on the table to long, double and decimal(6,1)
-//    icebergTable.updateSchema().updateColumn("int_col", Types.LongType.get())
-//        .updateColumn("float_col", Types.DoubleType.get()).updateColumn("decimal_col", Types.DecimalType.of(6, 1))
-//        .commit();
-//
-//    schemaForResultSet =
-//        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.LongType.get()),
-//            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
-//
-//    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35L, 22d, "1.3")
-//        .add(1L, 223344L, 555.219970703125d, "2.2").add(2L, -234L, -342d, "-1.2").build();
-//
-//    rows = shell.executeStatement("SELECT * FROM types_table");
-//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-//
-//    // Check if the column types in Hive have also changed to big_int, double an decimal(6,1)
-//    // Do this check only for Hive catalog, as this is the only case when the column types are updated
-//    // in the metastore. In case of other catalog types, the table is not updated in the metastore,
-//    // so no point in checking the column types.
-//    if (TestTables.TestTableType.HIVE_CATALOG.equals(this.testTableType)) {
-//      table = shell.metastore().getTable("default", "types_table");
-//      Assert.assertNotNull(table);
-//      Assert.assertNotNull(table.getSd());
-//      columns = table.getSd().getCols();
-//      Assert.assertEquals("id", columns.get(0).getName());
-//      Assert.assertEquals("bigint", columns.get(0).getType());
-//      Assert.assertEquals("int_col", columns.get(1).getName());
-//      Assert.assertEquals("bigint", columns.get(1).getType());
-//      Assert.assertEquals("float_col", columns.get(2).getName());
-//      Assert.assertEquals("double", columns.get(2).getType());
-//      Assert.assertEquals("decimal_col", columns.get(3).getName());
-//      Assert.assertEquals("decimal(6,1)", columns.get(3).getType());
-//    }
-//
-//    // Insert some data which fit to the new column types and check if they are saved and can be queried correctly.
-//    // This should work for all catalog types.
-//    shell.executeStatement(
-//        "INSERT INTO types_table values (3, 3147483647, 111.333, 12345.5), (4, -3147483648, 55, -2234.5)");
-//    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(3L, 3147483647L, 111.333d, "12345.5")
-//        .add(4L, -3147483648L, 55d, "-2234.5").build();
-//    rows = shell.executeStatement("SELECT * FROM types_table where id in(3, 4)");
-//    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
-//  }
+  @Test
+  public void testTruncateTablePartitionedIcebergTable() throws IOException, TException, InterruptedException {
+    // Create a partitioned Iceberg table with some initial data and run a truncate table command on this table.
+    // Then check if the data is deleted and the table statistics are reset to 0.
+    String databaseName = "default";
+    String tableName = "customers";
+    PartitionSpec spec =
+        PartitionSpec.builderFor(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).identity("last_name").build();
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA)
+        .add(0L, "Alice", "Brown")
+        .add(1L, "Bob", "Brown")
+        .add(2L, "Trudy", "Green")
+        .add(3L, "John", "Pink")
+        .add(4L, "Jane", "Pink")
+        .build();
+    Table icebergTable = testTables.createTable(shell, tableName, HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        spec, fileFormat, records);
+    testTruncateTable(databaseName, tableName, icebergTable, records,
+        HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, true, false);
+  }
+
+  private void testTruncateTable(String databaseName, String tableName, Table icebergTable, List<Record> records,
+      Schema schema, boolean externalTablePurge, boolean force) throws TException, InterruptedException {
+    TableIdentifier identifier = TableIdentifier.of(databaseName, tableName);
+    // Set the 'external.table.purge' table property on the table
+    String alterTableCommand =
+        "ALTER TABLE " + identifier + " SET TBLPROPERTIES('external.table.purge'='" + externalTablePurge + "')";
+    shell.executeStatement(alterTableCommand);
+
+    // Validate the initial data and the table statistics
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM " + identifier);
+    HiveIcebergTestUtils.validateData(records, HiveIcebergTestUtils.valueForRow(schema, rows), 0);
+    shell.executeStatement("ANALYZE TABLE " + identifier + " COMPUTE STATISTICS");
+    validateBasicStats(icebergTable, databaseName, tableName);
+
+    // Run a 'truncate table' or 'truncate table force' command
+    String truncateCommand = "TRUNCATE " + identifier;
+    if (force) {
+      truncateCommand = truncateCommand + " FORCE";
+    }
+    shell.executeStatement(truncateCommand);
+
+    // Validate if the data is deleted from the table and also that the table
+    // statistics are reset to 0.
+    Table table = testTables.loadTable(identifier);
+    Map<String, String> summary = table.currentSnapshot().summary();
+    for (String key : STATS_MAPPING.values()) {
+      Assert.assertEquals("0", summary.get(key));
+    }
+    rows = shell.executeStatement("SELECT * FROM " + identifier);
+    Assert.assertEquals(0, rows.size());
+    validateBasicStats(table, databaseName, tableName);
+  }
+
+  @Test
+  public void testAddColumnToIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Add a new column (age long) to the Iceberg table.
+    icebergTable.updateSchema().addColumn("age", Types.LongType.get()).commit();
+
+    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+        optional(3, "last_name", Types.StringType.get(), "This is last name"),
+        optional(4, "age", Types.LongType.get()));
+
+    // Also add a new entry to the table where the age column is set.
+    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
+    List<Record> newCustomerWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null).build();
+    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomerWithAge);
+
+    // Do a 'select *' from Hive and check if the age column appears in the result.
+    // It should be null for the old data and should be filled for the data added after the column addition.
+    TestHelper.RecordsBuilder customersWithAgeBuilder = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+        .add(0L, "Alice", "Brown", null).add(1L, "Bob", "Green", null).add(2L, "Trudy", "Pink", null)
+        .add(3L, "James", "Red", 34L).add(4L, "Lily", "Blue", null);
+    List<Record> customersWithAge = customersWithAgeBuilder.build();
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+        0);
+
+    // Do a 'select customer_id, age' from Hive to check if the new column can be queried from Hive.
+    // The customer_id is needed because of the result sorting.
+    Schema customerSchemaWithAgeOnly =
+        new Schema(optional(1, "customer_id", Types.LongType.get()), optional(4, "age", Types.LongType.get()));
+    TestHelper.RecordsBuilder customerWithAgeOnlyBuilder = TestHelper.RecordsBuilder
+        .newInstance(customerSchemaWithAgeOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, 34L).add(4L, null);
+    List<Record> customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
+
+    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
+
+    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
+    shell.executeStatement(
+        "INSERT INTO default.customers values (5L, 'Lily', 'Magenta', NULL), (6L, 'Roni', 'Purple', 23L)");
+
+    customersWithAgeBuilder.add(5L, "Lily", "Magenta", null).add(6L, "Roni", "Purple", 23L);
+    customersWithAge = customersWithAgeBuilder.build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+        0);
+
+    customerWithAgeOnlyBuilder.add(5L, null).add(6L, 23L);
+    customersWithAgeOnly = customerWithAgeOnlyBuilder.build();
+    rows = shell.executeStatement("SELECT customer_id, age FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithAgeOnly,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithAgeOnly, rows), 0);
+  }
+
+  @Test
+  public void testAddRequiredColumnToIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name without initial data.
+    // The reason why not to add initial data is that adding a required column is an incompatible change in Iceberg.
+    // So there is no contract on what happens when trying to read the old data back. It behaves differently depending
+    // on the underlying file format. So there is no point creating a test for that as there is no expected behaviour.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, null);
+
+    // Add a new required column (age long) to the Iceberg table.
+    icebergTable.updateSchema().allowIncompatibleChanges().addRequiredColumn("age", Types.LongType.get()).commit();
+
+    Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+        optional(3, "last_name", Types.StringType.get(), "This is last name"),
+        required(4, "age", Types.LongType.get()));
+
+    // Insert some data with age column from Hive.
+    shell.executeStatement(
+        "INSERT INTO default.customers values (0L, 'Lily', 'Magenta', 28L), (1L, 'Roni', 'Purple', 33L)");
+
+    // Do a 'select *' from Hive and check if the age column appears in the result.
+    List<Record> customersWithAge = TestHelper.RecordsBuilder.newInstance(customerSchemaWithAge)
+        .add(0L, "Lily", "Magenta", 28L).add(1L, "Roni", "Purple", 33L).build();
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithAge, HiveIcebergTestUtils.valueForRow(customerSchemaWithAge, rows),
+        0);
+
+    // Should add test step to insert NULL value into the new required column. But at the moment it
+    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
+  }
+
+  @Test
+  public void testAddColumnIntoStructToIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns id and person, where person is a struct, consists of the
+    // columns first_name and last_name.
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()), required(2, "person", Types.StructType
+        .of(required(3, "first_name", Types.StringType.get()), required(4, "last_name", Types.StringType.get()))));
+    List<Record> people = TestHelper.generateRandomRecords(schema, 3, 0L);
+    Table icebergTable = testTables.createTable(shell, "people", schema, fileFormat, people);
+
+    // Add a new column (age long) to the Iceberg table into the person struct
+    icebergTable.updateSchema().addColumn("person", "age", Types.LongType.get()).commit();
+
+    Schema schemaWithAge = new Schema(required(1, "id", Types.LongType.get()),
+        required(2, "person", Types.StructType.of(required(3, "first_name", Types.StringType.get()),
+            required(4, "last_name", Types.StringType.get()), optional(5, "age", Types.LongType.get()))));
+    List<Record> newPeople = TestHelper.generateRandomRecords(schemaWithAge, 2, 10L);
+
+    // Also add a new entry to the table where the age column is set.
+    icebergTable = testTables.loadTable(TableIdentifier.of("default", "people"));
+    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newPeople);
+
+    List<Record> sortedExpected = new ArrayList<>(people);
+    sortedExpected.addAll(newPeople);
+    sortedExpected.sort(Comparator.comparingLong(record -> (Long) record.get(0)));
+    List<Object[]> rows = shell
+        .executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people order by id");
+    Assert.assertEquals(sortedExpected.size(), rows.size());
+    for (int i = 0; i < sortedExpected.size(); i++) {
+      Object[] row = rows.get(i);
+      Long id = (Long) sortedExpected.get(i).get(0);
+      Record person = (Record) sortedExpected.get(i).getField("person");
+      String lastName = (String) person.getField("last_name");
+      String firstName = (String) person.getField("first_name");
+      Long age = null;
+      if (person.getField("age") != null) {
+        age = (Long) person.getField("age");
+      }
+      Assert.assertEquals(id, (Long) row[0]);
+      Assert.assertEquals(firstName, (String) row[1]);
+      Assert.assertEquals(lastName, (String) row[2]);
+      Assert.assertEquals(age, row[3]);
+    }
+
+    // Insert some data with age column from Hive. Insert an entry with null age and an entry with filled age.
+    shell.executeStatement("CREATE TABLE dummy_tbl (id bigint, first_name string, last_name string, age bigint)");
+    shell.executeStatement("INSERT INTO dummy_tbl VALUES (1, 'Lily', 'Blue', 34), (2, 'Roni', 'Grey', NULL)");
+    shell.executeStatement("INSERT INTO default.people SELECT id, named_struct('first_name', first_name, " +
+        "'last_name', last_name, 'age', age) from dummy_tbl");
+
+    rows = shell.executeStatement("SELECT id, person.first_name, person.last_name, person.age FROM default.people " +
+        "where id in (1, 2) order by id");
+    Assert.assertEquals(2, rows.size());
+    Assert.assertEquals((Long) 1L, (Long) rows.get(0)[0]);
+    Assert.assertEquals("Lily", (String) rows.get(0)[1]);
+    Assert.assertEquals("Blue", (String) rows.get(0)[2]);
+    Assert.assertEquals((Long) 34L, (Long) rows.get(0)[3]);
+    Assert.assertEquals((Long) 2L, (Long) rows.get(1)[0]);
+    Assert.assertEquals("Roni", (String) rows.get(1)[1]);
+    Assert.assertEquals("Grey", (String) rows.get(1)[2]);
+    Assert.assertNull(rows.get(1)[3]);
+  }
+
+  @Test
+  public void testMakeColumnRequiredInIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Add a new required column (age long) to the Iceberg table.
+    icebergTable.updateSchema().allowIncompatibleChanges().requireColumn("last_name").commit();
+
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+
+    // Insert some data with last_name no NULL.
+    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', 'Purple')");
+
+    List<Record> customerRecords = TestHelper.RecordsBuilder
+        .newInstance(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA).add(0L, "Alice", "Brown")
+        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", "Purple").build();
+
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customerRecords,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+
+    // Should add test step to insert NULL value into the new required column. But at the moment it
+    // works inconsistently for different file types, so leave it for later when this behaviour is cleaned up.
+  }
+
+  @Test
+  public void testRemoveColumnFromIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Remove the first_name column from the table.
+    icebergTable.updateSchema().deleteColumn("first_name").commit();
+
+    Schema customerSchemaWithoutFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "last_name", Types.StringType.get(), "This is last name"));
+
+    TestHelper.RecordsBuilder customersWithoutFirstNameBuilder = TestHelper.RecordsBuilder
+        .newInstance(customerSchemaWithoutFirstName).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
+    List<Record> customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
+
+    // Run a 'select *' from Hive to see if the result doesn't contain the first_name column any more.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
+
+    // Run a 'select first_name' and check if an exception is thrown.
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "Invalid table alias or column reference 'first_name'", () -> {
+          shell.executeStatement("SELECT first_name FROM default.customers");
+        });
+
+    // Insert an entry from Hive to check if it can be inserted without the first_name column.
+    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta')");
+
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    customersWithoutFirstNameBuilder.add(4L, "Magenta");
+    customersWithoutFirstName = customersWithoutFirstNameBuilder.build();
+    HiveIcebergTestUtils.validateData(customersWithoutFirstName,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithoutFirstName, rows), 0);
+  }
+
+  @Test
+  public void testRemoveAndAddBackColumnFromIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Remove the first_name column
+    icebergTable.updateSchema().deleteColumn("first_name").commit();
+    // Add a new column with the name first_name
+    icebergTable.updateSchema().addColumn("first_name", Types.StringType.get(), "This is new first name").commit();
+
+    // Add new data to the table with the new first_name column filled.
+    icebergTable = testTables.loadTable(TableIdentifier.of("default", "customers"));
+    Schema customerSchemaWithNewFirstName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "last_name", Types.StringType.get(), "This is last name"),
+        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
+    List<Record> newCustomersWithNewFirstName =
+        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(3L, "Red", "James").build();
+    testTables.appendIcebergTable(shell.getHiveConf(), icebergTable, fileFormat, null, newCustomersWithNewFirstName);
+
+    TestHelper.RecordsBuilder customersWithNewFirstNameBuilder =
+        TestHelper.RecordsBuilder.newInstance(customerSchemaWithNewFirstName).add(0L, "Brown", null)
+            .add(1L, "Green", null).add(2L, "Pink", null).add(3L, "Red", "James");
+    List<Record> customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
+
+    // Run a 'select *' from Hive and check if the first_name column is returned.
+    // It should be null for the old data and should be filled in the entry added after the column addition.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
+
+    Schema customerSchemaWithNewFirstNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(3, "first_name", Types.StringType.get(), "This is the newly added first name"));
+
+    TestHelper.RecordsBuilder customersWithNewFirstNameOnlyBuilder = TestHelper.RecordsBuilder
+        .newInstance(customerSchemaWithNewFirstNameOnly).add(0L, null).add(1L, null).add(2L, null).add(3L, "James");
+    List<Record> customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
+
+    // Run a 'select first_name' from Hive to check if the new first-name column can be queried.
+    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
+
+    // Insert data from Hive with first_name filled and with null first_name value.
+    shell.executeStatement("INSERT INTO default.customers values (4L, 'Magenta', 'Lily'), (5L, 'Purple', NULL)");
+
+    // Check if the newly inserted data is returned correctly by select statements.
+    customersWithNewFirstNameBuilder.add(4L, "Magenta", "Lily").add(5L, "Purple", null);
+    customersWithNewFirstName = customersWithNewFirstNameBuilder.build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithNewFirstName,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstName, rows), 0);
+
+    customersWithNewFirstNameOnlyBuilder.add(4L, "Lily").add(5L, null);
+    customersWithNewFirstNameOnly = customersWithNewFirstNameOnlyBuilder.build();
+    rows = shell.executeStatement("SELECT customer_id, first_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithNewFirstNameOnly,
+        HiveIcebergTestUtils.valueForRow(customerSchemaWithNewFirstNameOnly, rows), 0);
+  }
+
+  @Test
+  public void testRenameColumnInIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Rename the last_name column to family_name
+    icebergTable.updateSchema().renameColumn("last_name", "family_name").commit();
+
+    Schema schemaWithFamilyName = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+        optional(3, "family_name", Types.StringType.get(), "This is last name"));
+
+    // Run a 'select *' from Hive to check if the same records are returned in the same order as before the rename.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
+
+    Schema shemaWithFamilyNameOnly = new Schema(optional(1, "customer_id", Types.LongType.get()),
+        optional(2, "family_name", Types.StringType.get(), "This is family name"));
+    TestHelper.RecordsBuilder customersWithFamilyNameOnlyBuilder = TestHelper.RecordsBuilder
+        .newInstance(shemaWithFamilyNameOnly).add(0L, "Brown").add(1L, "Green").add(2L, "Pink");
+    List<Record> customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
+
+    // Run a 'select family_name' from Hive to check if the column can be queried with the new name.
+    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
+        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
+
+    // Run a 'select last_name' to check if an exception is thrown.
+    AssertHelpers.assertThrows("should throw exception", IllegalArgumentException.class,
+        "Invalid table alias or column reference 'last_name'", () -> {
+          shell.executeStatement("SELECT last_name FROM default.customers");
+        });
+
+    // Insert some data from Hive to check if the last_name column is still can be filled.
+    shell.executeStatement("INSERT INTO default.customers values (3L, 'Lily', 'Magenta'), (4L, 'Roni', NULL)");
+
+    List<Record> newCustomers = TestHelper.RecordsBuilder.newInstance(schemaWithFamilyName).add(0L, "Alice", "Brown")
+        .add(1L, "Bob", "Green").add(2L, "Trudy", "Pink").add(3L, "Lily", "Magenta").add(4L, "Roni", null).build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(newCustomers, HiveIcebergTestUtils.valueForRow(schemaWithFamilyName, rows), 0);
+
+    customersWithFamilyNameOnlyBuilder.add(3L, "Magenta").add(4L, null);
+    customersWithFamilyNameOnly = customersWithFamilyNameOnlyBuilder.build();
+    rows = shell.executeStatement("SELECT customer_id, family_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithFamilyNameOnly,
+        HiveIcebergTestUtils.valueForRow(shemaWithFamilyNameOnly, rows), 0);
+  }
+
+  @Test
+  public void testMoveLastNameToFirstInIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Move the last_name column in the table schema as first_column
+    icebergTable.updateSchema().moveFirst("last_name").commit();
+
+    Schema customerSchemaLastNameFirst =
+        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
+            optional(2, "customer_id", Types.LongType.get()),
+            optional(3, "first_name", Types.StringType.get(), "This is first name"));
+
+    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
+            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
+    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+
+    // Run a 'select *' to check if the order of the column in the result has been changed.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+
+    // Query the data with names and check if the result is the same as when the table was created.
+    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+
+    // Insert data from Hive to check if the last_name column has to be first in the values list.
+    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
+
+    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
+    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+  }
+
+  @Test
+  public void testMoveLastNameBeforeCustomerIdInIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Move the last_name column before the customer_id in the table schema.
+    icebergTable.updateSchema().moveBefore("last_name", "customer_id").commit();
+
+    Schema customerSchemaLastNameFirst =
+        new Schema(optional(1, "last_name", Types.StringType.get(), "This is last name"),
+            optional(2, "customer_id", Types.LongType.get()),
+            optional(3, "first_name", Types.StringType.get(), "This is first name"));
+
+    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Brown", 0L, "Alice")
+            .add("Green", 1L, "Bob").add("Pink", 2L, "Trudy");
+    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+
+    // Run a 'select *' to check if the order of the column in the result has been changed.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+
+    // Query the data with names and check if the result is the same as when the table was created.
+    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+
+    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
+    shell.executeStatement("INSERT INTO default.customers values ('Magenta', 3L, 'Lily')");
+
+    customersWithLastNameFirstBuilder.add("Magenta", 3L, "Lily");
+    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+  }
+
+  @Test
+  public void testMoveCustomerIdAfterFirstNameInIcebergTable() throws IOException {
+    // Create an Iceberg table with the columns customer_id, first_name and last_name with some initial data.
+    Table icebergTable = testTables.createTable(shell, "customers", HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA,
+        fileFormat, HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS);
+
+    // Move the last_name column before the customer_id in the table schema.
+    icebergTable.updateSchema().moveAfter("customer_id", "first_name").commit();
+
+    Schema customerSchemaLastNameFirst =
+        new Schema(optional(1, "first_name", Types.StringType.get(), "This is first name"),
+            optional(2, "customer_id", Types.LongType.get()),
+            optional(3, "last_name", Types.StringType.get(), "This is last name"));
+
+    TestHelper.RecordsBuilder customersWithLastNameFirstBuilder =
+        TestHelper.RecordsBuilder.newInstance(customerSchemaLastNameFirst).add("Alice", 0L, "Brown")
+            .add("Bob", 1L, "Green").add("Trudy", 2L, "Pink");
+    List<Record> customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+
+    // Run a 'select *' to check if the order of the column in the result has been changed.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+
+    // Query the data with names and check if the result is the same as when the table was created.
+    rows = shell.executeStatement("SELECT customer_id, first_name, last_name FROM default.customers");
+    HiveIcebergTestUtils.validateData(HiveIcebergStorageHandlerTestUtils.CUSTOMER_RECORDS,
+        HiveIcebergTestUtils.valueForRow(HiveIcebergStorageHandlerTestUtils.CUSTOMER_SCHEMA, rows), 0);
+
+    // Insert data from Hive to check if the last_name column has to be before the customer_id in the values list.
+    shell.executeStatement("INSERT INTO default.customers values ('Lily', 3L, 'Magenta')");
+
+    customersWithLastNameFirstBuilder.add("Lily", 3L, "Magenta");
+    customersWithLastNameFirst = customersWithLastNameFirstBuilder.build();
+    rows = shell.executeStatement("SELECT * FROM default.customers");
+    HiveIcebergTestUtils.validateData(customersWithLastNameFirst,
+        HiveIcebergTestUtils.valueForRow(customerSchemaLastNameFirst, rows), 1);
+  }
+
+  @Test
+  public void testUpdateColumnTypeInIcebergTable() throws IOException, TException, InterruptedException {
+    // Create an Iceberg table with int, float and decimal(2,1) types with some initial records
+    Schema schema = new Schema(optional(1, "id", Types.LongType.get()),
+        optional(2, "int_col", Types.IntegerType.get(), "This is an integer type"),
+        optional(3, "float_col", Types.FloatType.get(), "This is a float type"),
+        optional(4, "decimal_col", Types.DecimalType.of(2, 1), "This is a decimal type"));
+
+    List<Record> records = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22F, BigDecimal.valueOf(13L, 1))
+        .add(1L, 223344, 555.22F, BigDecimal.valueOf(22L, 1)).add(2L, -234, -342F, BigDecimal.valueOf(-12L, 1)).build();
+
+    Table icebergTable = testTables.createTable(shell, "types_table", schema, fileFormat, records);
+
+    // In the result set a float column is returned as double and a decimal is returned as string,
+    // even though Hive has the columns with the right types.
+    // Probably this conversation happens when fetching the result set after calling the select through the shell.
+    // Because of this, a separate schema and record list has to be used when validating the returned values.
+    Schema schemaForResultSet =
+        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.IntegerType.get()),
+            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
+
+    List<Record> expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35, 22d, "1.3")
+        .add(1L, 223344, 555.22d, "2.2").add(2L, -234, -342d, "-1.2").build();
+
+    // Check the select result and the column types of the table.
+    List<Object[]> rows = shell.executeStatement("SELECT * FROM types_table");
+    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+
+    org.apache.hadoop.hive.metastore.api.Table table = shell.metastore().getTable("default", "types_table");
+    Assert.assertNotNull(table);
+    Assert.assertNotNull(table.getSd());
+    List<FieldSchema> columns = table.getSd().getCols();
+    Assert.assertEquals("id", columns.get(0).getName());
+    Assert.assertEquals("bigint", columns.get(0).getType());
+    Assert.assertEquals("int_col", columns.get(1).getName());
+    Assert.assertEquals("int", columns.get(1).getType());
+    Assert.assertEquals("float_col", columns.get(2).getName());
+    Assert.assertEquals("float", columns.get(2).getType());
+    Assert.assertEquals("decimal_col", columns.get(3).getName());
+    Assert.assertEquals("decimal(2,1)", columns.get(3).getType());
+
+    // Change the column types on the table to long, double and decimal(6,1)
+    icebergTable.updateSchema().updateColumn("int_col", Types.LongType.get())
+        .updateColumn("float_col", Types.DoubleType.get()).updateColumn("decimal_col", Types.DecimalType.of(6, 1))
+        .commit();
+
+    schemaForResultSet =
+        new Schema(optional(1, "id", Types.LongType.get()), optional(2, "int_col", Types.LongType.get()),
+            optional(3, "float_col", Types.DoubleType.get()), optional(4, "decimal_col", Types.StringType.get()));
+
+    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(0L, 35L, 22d, "1.3")
+        .add(1L, 223344L, 555.219970703125d, "2.2").add(2L, -234L, -342d, "-1.2").build();
+
+    rows = shell.executeStatement("SELECT * FROM types_table");
+    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+
+    // Check if the column types in Hive have also changed to big_int, double an decimal(6,1)
+    // Do this check only for Hive catalog, as this is the only case when the column types are updated
+    // in the metastore. In case of other catalog types, the table is not updated in the metastore,
+    // so no point in checking the column types.
+    if (TestTables.TestTableType.HIVE_CATALOG.equals(this.testTableType)) {
+      table = shell.metastore().getTable("default", "types_table");
+      Assert.assertNotNull(table);
+      Assert.assertNotNull(table.getSd());
+      columns = table.getSd().getCols();
+      Assert.assertEquals("id", columns.get(0).getName());
+      Assert.assertEquals("bigint", columns.get(0).getType());
+      Assert.assertEquals("int_col", columns.get(1).getName());
+      Assert.assertEquals("bigint", columns.get(1).getType());
+      Assert.assertEquals("float_col", columns.get(2).getName());
+      Assert.assertEquals("double", columns.get(2).getType());
+      Assert.assertEquals("decimal_col", columns.get(3).getName());
+      Assert.assertEquals("decimal(6,1)", columns.get(3).getType());
+    }
+
+    // Insert some data which fit to the new column types and check if they are saved and can be queried correctly.
+    // This should work for all catalog types.
+    shell.executeStatement(
+        "INSERT INTO types_table values (3, 3147483647, 111.333, 12345.5), (4, -3147483648, 55, -2234.5)");
+    expectedResults = TestHelper.RecordsBuilder.newInstance(schema).add(3L, 3147483647L, 111.333d, "12345.5")
+        .add(4L, -3147483648L, 55d, "-2234.5").build();
+    rows = shell.executeStatement("SELECT * FROM types_table where id in(3, 4)");
+    HiveIcebergTestUtils.validateData(expectedResults, HiveIcebergTestUtils.valueForRow(schemaForResultSet, rows), 0);
+  }
 
   private void testComplexTypeWrite(Schema schema, List<Record> records) throws IOException {
     String tableName = "complex_table";

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestTables.java
@@ -132,7 +132,7 @@ abstract class TestTables {
   public String createHiveTableSQL(TableIdentifier identifier, Map<String, String> tableProps) {
     Preconditions.checkArgument(!identifier.namespace().isEmpty(), "Namespace should not be empty");
     Preconditions.checkArgument(identifier.namespace().levels().length == 1, "Namespace should be single level");
-    return String.format("CREATE TABLE %s.%s STORED BY '%s' %s %s", identifier.namespace(), identifier.name(),
+    return String.format("CREATE EXTERNAL TABLE %s.%s STORED BY '%s' %s %s", identifier.namespace(), identifier.name(),
         HiveIcebergStorageHandler.class.getName(), locationForCreateTableSQL(identifier),
             propertiesForCreateTableSQL(tableProps));
   }

--- a/iceberg/iceberg-handler/src/test/queries/negative/truncate_iceberg_table_external_purge_false.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/truncate_iceberg_table_external_purge_false.q
@@ -1,0 +1,8 @@
+set hive.vectorized.execution.enabled=false;
+
+drop table if exists test_truncate_neg1;
+create external table test_truncate_neg1 (id int, value string) stored by iceberg stored as orc;
+alter table test_truncate_neg1 set tblproperties('external.table.purge'='false');
+insert into test_truncate_neg1 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
+
+truncate test_truncate_neg1;

--- a/iceberg/iceberg-handler/src/test/queries/negative/truncate_iceberg_table_with_partition_spec.q
+++ b/iceberg/iceberg-handler/src/test/queries/negative/truncate_iceberg_table_with_partition_spec.q
@@ -1,0 +1,8 @@
+set hive.vectorized.execution.enabled=false;
+
+drop table if exists test_truncate_neg2;
+create external table test_truncate_neg2 (id int, value string) stored by iceberg stored as orc;
+alter table test_truncate_neg2 set tblproperties('external.table.purge'='true');
+insert into test_truncate_neg2 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
+
+truncate test_truncate_neg2 partition(id=1);

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
@@ -1,3 +1,5 @@
+-- SORT_QUERY_RESULTS
+
 set hive.vectorized.execution.enabled=false;
 
 drop table if exists test_truncate;
@@ -8,13 +10,13 @@ insert into test_truncate values (6, 'six'), (7, 'seven');
 insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten');
 analyze table test_truncate compute statistics;
 
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 truncate test_truncate force;
 
 select count(*) from test_truncate;
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_force_iceberg_table.q
@@ -1,0 +1,20 @@
+set hive.vectorized.execution.enabled=false;
+
+drop table if exists test_truncate;
+create external table test_truncate (id int, value string) stored by iceberg stored as parquet;
+alter table test_truncate set tblproperties('external.table.purge'='false');
+insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
+insert into test_truncate values (6, 'six'), (7, 'seven');
+insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten');
+analyze table test_truncate compute statistics;
+
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+truncate test_truncate force;
+
+select count(*) from test_truncate;
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
@@ -1,3 +1,5 @@
+-- SORT_QUERY_RESULTS
+
 set hive.vectorized.execution.enabled=false;
 
 drop table if exists test_truncate;
@@ -8,23 +10,23 @@ insert into test_truncate values (6, 'six'), (7, 'seven');
 insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten');
 analyze table test_truncate compute statistics;
 
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 truncate test_truncate;
 
 select count(*) from test_truncate;
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 truncate test_truncate;
 
 select count(*) from test_truncate;
-select * from test_truncate order by id;
+select * from test_truncate;
 describe formatted test_truncate;
 
 drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_iceberg_table.q
@@ -1,0 +1,30 @@
+set hive.vectorized.execution.enabled=false;
+
+drop table if exists test_truncate;
+create external table test_truncate (id int, value string) stored by iceberg stored as orc;
+alter table test_truncate set tblproperties('external.table.purge'='true');
+insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
+insert into test_truncate values (6, 'six'), (7, 'seven');
+insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten');
+analyze table test_truncate compute statistics;
+
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+truncate test_truncate;
+
+select count(*) from test_truncate;
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five'); 
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+truncate test_truncate;
+
+select count(*) from test_truncate;
+select * from test_truncate order by id;
+describe formatted test_truncate;
+
+drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
@@ -1,3 +1,5 @@
+-- SORT_QUERY_RESULTS
+
 set hive.vectorized.execution.enabled=false;
 
 drop table if exists test_truncate;
@@ -11,11 +13,11 @@ alter table test_truncate set tblproperties ('storage_handler'='org.apache.icebe
 
 analyze table test_truncate compute statistics;
 describe formatted test_truncate;
-select * from test_truncate order by a;
+select * from test_truncate;
 
 truncate test_truncate;
 select count(*) from test_truncate;
-select * from test_truncate order by a;
+select * from test_truncate;
 describe formatted test_truncate;
 
 drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
+++ b/iceberg/iceberg-handler/src/test/queries/positive/truncate_partitioned_iceberg_table.q
@@ -1,0 +1,21 @@
+set hive.vectorized.execution.enabled=false;
+
+drop table if exists test_truncate;
+create external table test_truncate(a int) partitioned by (b string) stored as avro;
+alter table test_truncate set tblproperties('external.table.purge'='true');
+insert into table test_truncate partition (b='one') values (1), (2), (3);
+insert into table test_truncate partition (b='two') values (4), (5);
+insert into table test_truncate partition (b='three') values (6), (7), (8);
+insert into table test_truncate partition (b='four') values (9);
+alter table test_truncate set tblproperties ('storage_handler'='org.apache.iceberg.mr.hive.HiveIcebergStorageHandler');
+
+analyze table test_truncate compute statistics;
+describe formatted test_truncate;
+select * from test_truncate order by a;
+
+truncate test_truncate;
+select count(*) from test_truncate;
+select * from test_truncate order by a;
+describe formatted test_truncate;
+
+drop table if exists test_truncate;

--- a/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_external_purge_false.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_external_purge_false.q.out
@@ -1,0 +1,29 @@
+PREHOOK: query: drop table if exists test_truncate_neg1
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_truncate_neg1
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_truncate_neg1 (id int, value string) stored by iceberg stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_truncate_neg1
+POSTHOOK: query: create external table test_truncate_neg1 (id int, value string) stored by iceberg stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_truncate_neg1
+PREHOOK: query: alter table test_truncate_neg1 set tblproperties('external.table.purge'='false')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate_neg1
+PREHOOK: Output: default@test_truncate_neg1
+POSTHOOK: query: alter table test_truncate_neg1 set tblproperties('external.table.purge'='false')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate_neg1
+POSTHOOK: Output: default@test_truncate_neg1
+PREHOOK: query: insert into test_truncate_neg1 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate_neg1
+POSTHOOK: query: insert into test_truncate_neg1 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate_neg1
+FAILED: SemanticException [Error 10146]: Cannot truncate non-managed table test_truncate_neg1.

--- a/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_with_partition_spec.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_with_partition_spec.q.out
@@ -26,4 +26,4 @@ POSTHOOK: query: insert into test_truncate_neg2 values (1, 'one'),(2,'two'),(3,'
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@test_truncate_neg2
-FAILED: SemanticException [Error 10148]: Partition spec for non partitioned table test_truncate_neg2.
+FAILED: UnsupportedOperationException Using partition spec in query is unsupported for non-native table backed by: org.apache.iceberg.mr.hive.HiveIcebergStorageHandler

--- a/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_with_partition_spec.q.out
+++ b/iceberg/iceberg-handler/src/test/results/negative/truncate_iceberg_table_with_partition_spec.q.out
@@ -1,0 +1,29 @@
+PREHOOK: query: drop table if exists test_truncate_neg2
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_truncate_neg2
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_truncate_neg2 (id int, value string) stored by iceberg stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_truncate_neg2
+POSTHOOK: query: create external table test_truncate_neg2 (id int, value string) stored by iceberg stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_truncate_neg2
+PREHOOK: query: alter table test_truncate_neg2 set tblproperties('external.table.purge'='true')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate_neg2
+PREHOOK: Output: default@test_truncate_neg2
+POSTHOOK: query: alter table test_truncate_neg2 set tblproperties('external.table.purge'='true')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate_neg2
+POSTHOOK: Output: default@test_truncate_neg2
+PREHOOK: query: insert into test_truncate_neg2 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate_neg2
+POSTHOOK: query: insert into test_truncate_neg2 values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate_neg2
+FAILED: SemanticException [Error 10148]: Partition spec for non partitioned table test_truncate_neg2.

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
@@ -1,0 +1,187 @@
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_truncate (id int, value string) stored by iceberg stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: create external table test_truncate (id int, value string) stored by iceberg stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='false')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='false')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (6, 'six'), (7, 'seven')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (6, 'six'), (7, 'seven')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: analyze table test_truncate compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: analyze table test_truncate compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one
+2	two
+3	three
+4	four
+5	five
+6	six
+7	seven
+8	eight
+9	nine
+10	ten
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	false               
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	3                   
+	numRows             	10                  
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1935                
+#### A masked pattern was here ####
+	write.format.default	parquet             
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: truncate test_truncate force
+PREHOOK: type: TRUNCATETABLE
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: truncate test_truncate force
+POSTHOOK: type: TRUNCATETABLE
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select count(*) from test_truncate
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from test_truncate
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	false               
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	parquet             
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_force_iceberg_table.q.out
@@ -50,15 +50,16 @@ POSTHOOK: query: analyze table test_truncate compute statistics
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: default@test_truncate
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	one
+10	ten
 2	two
 3	three
 4	four
@@ -67,7 +68,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 7	seven
 8	eight
 9	nine
-10	ten
 PREHOOK: query: describe formatted test_truncate
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test_truncate
@@ -126,11 +126,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
@@ -50,15 +50,16 @@ POSTHOOK: query: analyze table test_truncate compute statistics
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: default@test_truncate
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 1	one
+10	ten
 2	two
 3	three
 4	four
@@ -67,7 +68,6 @@ POSTHOOK: Output: hdfs://### HDFS PATH ###
 7	seven
 8	eight
 9	nine
-10	ten
 PREHOOK: query: describe formatted test_truncate
 PREHOOK: type: DESCTABLE
 PREHOOK: Input: default@test_truncate
@@ -126,11 +126,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
@@ -185,11 +185,11 @@ POSTHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@test_truncate
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
@@ -256,11 +256,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-PREHOOK: query: select * from test_truncate order by id
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_iceberg_table.q.out
@@ -1,0 +1,317 @@
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_truncate (id int, value string) stored by iceberg stored as orc
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: create external table test_truncate (id int, value string) stored by iceberg stored as orc
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='true')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='true')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (6, 'six'), (7, 'seven')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (6, 'six'), (7, 'seven')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (8, 'eight'), (9, 'nine'), (10, 'ten')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: analyze table test_truncate compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: analyze table test_truncate compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one
+2	two
+3	three
+4	four
+5	five
+6	six
+7	seven
+8	eight
+9	nine
+10	ten
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	3                   
+	numRows             	10                  
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1096                
+#### A masked pattern was here ####
+	write.format.default	orc                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: truncate test_truncate
+PREHOOK: type: TRUNCATETABLE
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: truncate test_truncate
+POSTHOOK: type: TRUNCATETABLE
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select count(*) from test_truncate
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from test_truncate
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	orc                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: insert into test_truncate values (1, 'one'),(2,'two'),(3,'three'),(4,'four'),(5,'five')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one
+2	two
+3	three
+4	four
+5	five
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	1                   
+	numRows             	5                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	371                 
+#### A masked pattern was here ####
+	write.format.default	orc                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: truncate test_truncate
+PREHOOK: type: TRUNCATETABLE
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: truncate test_truncate
+POSTHOOK: type: TRUNCATETABLE
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select count(*) from test_truncate
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from test_truncate
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: select * from test_truncate order by id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+id                  	int                 	from deserializer   
+value               	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	rawDataSize         	0                   
+	serialization.format	1                   
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	orc                 
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
@@ -1,0 +1,202 @@
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: create external table test_truncate(a int) partitioned by (b string) stored as avro
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: create external table test_truncate(a int) partitioned by (b string) stored as avro
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='true')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: alter table test_truncate set tblproperties('external.table.purge'='true')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: insert into table test_truncate partition (b='one') values (1), (2), (3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate@b=one
+POSTHOOK: query: insert into table test_truncate partition (b='one') values (1), (2), (3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate@b=one
+POSTHOOK: Lineage: test_truncate PARTITION(b=one).a SCRIPT []
+PREHOOK: query: insert into table test_truncate partition (b='two') values (4), (5)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate@b=two
+POSTHOOK: query: insert into table test_truncate partition (b='two') values (4), (5)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate@b=two
+POSTHOOK: Lineage: test_truncate PARTITION(b=two).a SCRIPT []
+PREHOOK: query: insert into table test_truncate partition (b='three') values (6), (7), (8)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate@b=three
+POSTHOOK: query: insert into table test_truncate partition (b='three') values (6), (7), (8)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate@b=three
+POSTHOOK: Lineage: test_truncate PARTITION(b=three).a SCRIPT []
+PREHOOK: query: insert into table test_truncate partition (b='four') values (9)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_truncate@b=four
+POSTHOOK: query: insert into table test_truncate partition (b='four') values (9)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_truncate@b=four
+POSTHOOK: Lineage: test_truncate PARTITION(b=four).a SCRIPT []
+PREHOOK: query: alter table test_truncate set tblproperties ('storage_handler'='org.apache.iceberg.mr.hive.HiveIcebergStorageHandler')
+PREHOOK: type: ALTERTABLE_PROPERTIES
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: alter table test_truncate set tblproperties ('storage_handler'='org.apache.iceberg.mr.hive.HiveIcebergStorageHandler')
+POSTHOOK: type: ALTERTABLE_PROPERTIES
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: analyze table test_truncate compute statistics
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: analyze table test_truncate compute statistics
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+a                   	int                 	from deserializer   
+b                   	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	4                   
+	numRows             	0                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	1074                
+#### A masked pattern was here ####
+	write.format.default	avro                
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: select * from test_truncate order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+1	one
+2	one
+3	one
+4	two
+5	two
+6	three
+7	three
+8	three
+9	four
+PREHOOK: query: truncate test_truncate
+PREHOOK: type: TRUNCATETABLE
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: truncate test_truncate
+POSTHOOK: type: TRUNCATETABLE
+POSTHOOK: Output: default@test_truncate
+PREHOOK: query: select count(*) from test_truncate
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select count(*) from test_truncate
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+PREHOOK: query: select * from test_truncate order by a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select * from test_truncate order by a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+PREHOOK: query: describe formatted test_truncate
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@test_truncate
+POSTHOOK: query: describe formatted test_truncate
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@test_truncate
+# col_name            	data_type           	comment             
+a                   	int                 	from deserializer   
+b                   	string              	from deserializer   
+	 	 
+# Detailed Table Information	 	 
+Database:           	default             	 
+#### A masked pattern was here ####
+Retention:          	0                   	 
+#### A masked pattern was here ####
+Table Type:         	EXTERNAL_TABLE      	 
+Table Parameters:	 	 
+	COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\"}
+	EXTERNAL            	TRUE                
+	bucketing_version   	2                   
+	engine.hive.enabled 	true                
+	external.table.purge	true                
+#### A masked pattern was here ####
+	metadata_location   	hdfs://### HDFS PATH ###
+	numFiles            	0                   
+	numRows             	0                   
+	previous_metadata_location	hdfs://### HDFS PATH ###
+	storage_handler     	org.apache.iceberg.mr.hive.HiveIcebergStorageHandler
+	table_type          	ICEBERG             
+	totalSize           	0                   
+#### A masked pattern was here ####
+	write.format.default	avro                
+	 	 
+# Storage Information	 	 
+SerDe Library:      	org.apache.iceberg.mr.hive.HiveIcebergSerDe	 
+InputFormat:        	org.apache.iceberg.mr.hive.HiveIcebergInputFormat	 
+OutputFormat:       	org.apache.iceberg.mr.hive.HiveIcebergOutputFormat	 
+Compressed:         	No                  	 
+Num Buckets:        	0                   	 
+Bucket Columns:     	[]                  	 
+Sort Columns:       	[]                  	 
+PREHOOK: query: drop table if exists test_truncate
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test_truncate
+PREHOOK: Output: default@test_truncate
+POSTHOOK: query: drop table if exists test_truncate
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test_truncate
+POSTHOOK: Output: default@test_truncate

--- a/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
+++ b/iceberg/iceberg-handler/src/test/results/positive/truncate_partitioned_iceberg_table.q.out
@@ -80,6 +80,10 @@ POSTHOOK: Input: default@test_truncate
 a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
 	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	IDENTITY            	 
+	 	 
 # Detailed Table Information	 	 
 Database:           	default             	 
 #### A masked pattern was here ####
@@ -111,11 +115,11 @@ Compressed:         	No
 Num Buckets:        	0                   	 
 Bucket Columns:     	[]                  	 
 Sort Columns:       	[]                  	 
-PREHOOK: query: select * from test_truncate order by a
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by a
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
@@ -143,11 +147,11 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
 0
-PREHOOK: query: select * from test_truncate order by a
+PREHOOK: query: select * from test_truncate
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_truncate
 PREHOOK: Output: hdfs://### HDFS PATH ###
-POSTHOOK: query: select * from test_truncate order by a
+POSTHOOK: query: select * from test_truncate
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_truncate
 POSTHOOK: Output: hdfs://### HDFS PATH ###
@@ -160,6 +164,10 @@ POSTHOOK: Input: default@test_truncate
 # col_name            	data_type           	comment             
 a                   	int                 	from deserializer   
 b                   	string              	from deserializer   
+	 	 
+# Partition Transform Information	 	 
+# col_name            	transform_type      	 
+b                   	IDENTITY            	 
 	 	 
 # Detailed Table Information	 	 
 Database:           	default             	 

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/misc/truncate/TruncateTableAnalyzer.java
@@ -104,7 +104,8 @@ public class TruncateTableAnalyzer extends AbstractBaseAlterTableAnalyzer {
 
     validateUnsupportedPartitionClause(table, root.getChildCount() > 1);
 
-    if (table.isNonNative()) {
+    if (table.isNonNative()
+        && (table.getStorageHandler() == null || !table.getStorageHandler().supportsTruncateOnNonNativeTables())) {
       throw new SemanticException(ErrorMsg.TRUNCATE_FOR_NON_NATIVE_TABLE.format(tableName)); //TODO
     }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/HiveStorageHandler.java
@@ -312,4 +312,14 @@ public interface HiveStorageHandler extends Configurable {
   default boolean isAllowedAlterOperation(AlterTableType opType) {
     return DEFAULT_ALLOWED_ALTER_OPS.contains(opType);
   }
+
+  /**
+   * Check if the underlying storage handler implementation supports truncate operation
+   * for non native tables.
+   * @return true if the storage handler can support it
+   * @return
+   */
+  default boolean supportsTruncateOnNonNativeTables() {
+    return false;
+  }
 }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.cpp
@@ -4448,6 +4448,11 @@ void TruncateTableRequest::__set_validWriteIdList(const std::string& val) {
   this->validWriteIdList = val;
 __isset.validWriteIdList = true;
 }
+
+void TruncateTableRequest::__set_environmentContext(const EnvironmentContext& val) {
+  this->environmentContext = val;
+__isset.environmentContext = true;
+}
 std::ostream& operator<<(std::ostream& out, const TruncateTableRequest& obj)
 {
   obj.printTo(out);
@@ -4530,6 +4535,14 @@ uint32_t TruncateTableRequest::read(::apache::thrift::protocol::TProtocol* iprot
           xfer += iprot->skip(ftype);
         }
         break;
+      case 6:
+        if (ftype == ::apache::thrift::protocol::T_STRUCT) {
+          xfer += this->environmentContext.read(iprot);
+          this->__isset.environmentContext = true;
+        } else {
+          xfer += iprot->skip(ftype);
+        }
+        break;
       default:
         xfer += iprot->skip(ftype);
         break;
@@ -4582,6 +4595,11 @@ uint32_t TruncateTableRequest::write(::apache::thrift::protocol::TProtocol* opro
     xfer += oprot->writeString(this->validWriteIdList);
     xfer += oprot->writeFieldEnd();
   }
+  if (this->__isset.environmentContext) {
+    xfer += oprot->writeFieldBegin("environmentContext", ::apache::thrift::protocol::T_STRUCT, 6);
+    xfer += this->environmentContext.write(oprot);
+    xfer += oprot->writeFieldEnd();
+  }
   xfer += oprot->writeFieldStop();
   xfer += oprot->writeStructEnd();
   return xfer;
@@ -4594,6 +4612,7 @@ void swap(TruncateTableRequest &a, TruncateTableRequest &b) {
   swap(a.partNames, b.partNames);
   swap(a.writeId, b.writeId);
   swap(a.validWriteIdList, b.validWriteIdList);
+  swap(a.environmentContext, b.environmentContext);
   swap(a.__isset, b.__isset);
 }
 
@@ -4603,6 +4622,7 @@ TruncateTableRequest::TruncateTableRequest(const TruncateTableRequest& other140)
   partNames = other140.partNames;
   writeId = other140.writeId;
   validWriteIdList = other140.validWriteIdList;
+  environmentContext = other140.environmentContext;
   __isset = other140.__isset;
 }
 TruncateTableRequest& TruncateTableRequest::operator=(const TruncateTableRequest& other141) {
@@ -4611,6 +4631,7 @@ TruncateTableRequest& TruncateTableRequest::operator=(const TruncateTableRequest
   partNames = other141.partNames;
   writeId = other141.writeId;
   validWriteIdList = other141.validWriteIdList;
+  environmentContext = other141.environmentContext;
   __isset = other141.__isset;
   return *this;
 }
@@ -4622,6 +4643,7 @@ void TruncateTableRequest::printTo(std::ostream& out) const {
   out << ", " << "partNames="; (__isset.partNames ? (out << to_string(partNames)) : (out << "<null>"));
   out << ", " << "writeId="; (__isset.writeId ? (out << to_string(writeId)) : (out << "<null>"));
   out << ", " << "validWriteIdList="; (__isset.validWriteIdList ? (out << to_string(validWriteIdList)) : (out << "<null>"));
+  out << ", " << "environmentContext="; (__isset.environmentContext ? (out << to_string(environmentContext)) : (out << "<null>"));
   out << ")";
 }
 

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-cpp/hive_metastore_types.h
@@ -2265,10 +2265,11 @@ void swap(GrantRevokePrivilegeResponse &a, GrantRevokePrivilegeResponse &b);
 std::ostream& operator<<(std::ostream& out, const GrantRevokePrivilegeResponse& obj);
 
 typedef struct _TruncateTableRequest__isset {
-  _TruncateTableRequest__isset() : partNames(false), writeId(true), validWriteIdList(false) {}
+  _TruncateTableRequest__isset() : partNames(false), writeId(true), validWriteIdList(false), environmentContext(false) {}
   bool partNames :1;
   bool writeId :1;
   bool validWriteIdList :1;
+  bool environmentContext :1;
 } _TruncateTableRequest__isset;
 
 class TruncateTableRequest : public virtual ::apache::thrift::TBase {
@@ -2285,6 +2286,7 @@ class TruncateTableRequest : public virtual ::apache::thrift::TBase {
   std::vector<std::string>  partNames;
   int64_t writeId;
   std::string validWriteIdList;
+  EnvironmentContext environmentContext;
 
   _TruncateTableRequest__isset __isset;
 
@@ -2297,6 +2299,8 @@ class TruncateTableRequest : public virtual ::apache::thrift::TBase {
   void __set_writeId(const int64_t val);
 
   void __set_validWriteIdList(const std::string& val);
+
+  void __set_environmentContext(const EnvironmentContext& val);
 
   bool operator == (const TruncateTableRequest & rhs) const
   {
@@ -2315,6 +2319,10 @@ class TruncateTableRequest : public virtual ::apache::thrift::TBase {
     if (__isset.validWriteIdList != rhs.__isset.validWriteIdList)
       return false;
     else if (__isset.validWriteIdList && !(validWriteIdList == rhs.validWriteIdList))
+      return false;
+    if (__isset.environmentContext != rhs.__isset.environmentContext)
+      return false;
+    else if (__isset.environmentContext && !(environmentContext == rhs.environmentContext))
       return false;
     return true;
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TruncateTableRequest.java
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-javabean/org/apache/hadoop/hive/metastore/api/TruncateTableRequest.java
@@ -16,6 +16,7 @@ package org.apache.hadoop.hive.metastore.api;
   private static final org.apache.thrift.protocol.TField PART_NAMES_FIELD_DESC = new org.apache.thrift.protocol.TField("partNames", org.apache.thrift.protocol.TType.LIST, (short)3);
   private static final org.apache.thrift.protocol.TField WRITE_ID_FIELD_DESC = new org.apache.thrift.protocol.TField("writeId", org.apache.thrift.protocol.TType.I64, (short)4);
   private static final org.apache.thrift.protocol.TField VALID_WRITE_ID_LIST_FIELD_DESC = new org.apache.thrift.protocol.TField("validWriteIdList", org.apache.thrift.protocol.TType.STRING, (short)5);
+  private static final org.apache.thrift.protocol.TField ENVIRONMENT_CONTEXT_FIELD_DESC = new org.apache.thrift.protocol.TField("environmentContext", org.apache.thrift.protocol.TType.STRUCT, (short)6);
 
   private static final org.apache.thrift.scheme.SchemeFactory STANDARD_SCHEME_FACTORY = new TruncateTableRequestStandardSchemeFactory();
   private static final org.apache.thrift.scheme.SchemeFactory TUPLE_SCHEME_FACTORY = new TruncateTableRequestTupleSchemeFactory();
@@ -25,6 +26,7 @@ package org.apache.hadoop.hive.metastore.api;
   private @org.apache.thrift.annotation.Nullable java.util.List<java.lang.String> partNames; // optional
   private long writeId; // optional
   private @org.apache.thrift.annotation.Nullable java.lang.String validWriteIdList; // optional
+  private @org.apache.thrift.annotation.Nullable EnvironmentContext environmentContext; // optional
 
   /** The set of fields this struct contains, along with convenience methods for finding and manipulating them. */
   public enum _Fields implements org.apache.thrift.TFieldIdEnum {
@@ -32,7 +34,8 @@ package org.apache.hadoop.hive.metastore.api;
     TABLE_NAME((short)2, "tableName"),
     PART_NAMES((short)3, "partNames"),
     WRITE_ID((short)4, "writeId"),
-    VALID_WRITE_ID_LIST((short)5, "validWriteIdList");
+    VALID_WRITE_ID_LIST((short)5, "validWriteIdList"),
+    ENVIRONMENT_CONTEXT((short)6, "environmentContext");
 
     private static final java.util.Map<java.lang.String, _Fields> byName = new java.util.HashMap<java.lang.String, _Fields>();
 
@@ -58,6 +61,8 @@ package org.apache.hadoop.hive.metastore.api;
           return WRITE_ID;
         case 5: // VALID_WRITE_ID_LIST
           return VALID_WRITE_ID_LIST;
+        case 6: // ENVIRONMENT_CONTEXT
+          return ENVIRONMENT_CONTEXT;
         default:
           return null;
       }
@@ -101,7 +106,7 @@ package org.apache.hadoop.hive.metastore.api;
   // isset id assignments
   private static final int __WRITEID_ISSET_ID = 0;
   private byte __isset_bitfield = 0;
-  private static final _Fields optionals[] = {_Fields.PART_NAMES,_Fields.WRITE_ID,_Fields.VALID_WRITE_ID_LIST};
+  private static final _Fields optionals[] = {_Fields.PART_NAMES,_Fields.WRITE_ID,_Fields.VALID_WRITE_ID_LIST,_Fields.ENVIRONMENT_CONTEXT};
   public static final java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> metaDataMap;
   static {
     java.util.Map<_Fields, org.apache.thrift.meta_data.FieldMetaData> tmpMap = new java.util.EnumMap<_Fields, org.apache.thrift.meta_data.FieldMetaData>(_Fields.class);
@@ -116,6 +121,8 @@ package org.apache.hadoop.hive.metastore.api;
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.I64)));
     tmpMap.put(_Fields.VALID_WRITE_ID_LIST, new org.apache.thrift.meta_data.FieldMetaData("validWriteIdList", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
         new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRING)));
+    tmpMap.put(_Fields.ENVIRONMENT_CONTEXT, new org.apache.thrift.meta_data.FieldMetaData("environmentContext", org.apache.thrift.TFieldRequirementType.OPTIONAL, 
+        new org.apache.thrift.meta_data.FieldValueMetaData(org.apache.thrift.protocol.TType.STRUCT        , "EnvironmentContext")));
     metaDataMap = java.util.Collections.unmodifiableMap(tmpMap);
     org.apache.thrift.meta_data.FieldMetaData.addStructMetaDataMap(TruncateTableRequest.class, metaDataMap);
   }
@@ -153,6 +160,9 @@ package org.apache.hadoop.hive.metastore.api;
     if (other.isSetValidWriteIdList()) {
       this.validWriteIdList = other.validWriteIdList;
     }
+    if (other.isSetEnvironmentContext()) {
+      this.environmentContext = new EnvironmentContext(other.environmentContext);
+    }
   }
 
   public TruncateTableRequest deepCopy() {
@@ -167,6 +177,7 @@ package org.apache.hadoop.hive.metastore.api;
     this.writeId = -1L;
 
     this.validWriteIdList = null;
+    this.environmentContext = null;
   }
 
   @org.apache.thrift.annotation.Nullable
@@ -303,6 +314,30 @@ package org.apache.hadoop.hive.metastore.api;
     }
   }
 
+  @org.apache.thrift.annotation.Nullable
+  public EnvironmentContext getEnvironmentContext() {
+    return this.environmentContext;
+  }
+
+  public void setEnvironmentContext(@org.apache.thrift.annotation.Nullable EnvironmentContext environmentContext) {
+    this.environmentContext = environmentContext;
+  }
+
+  public void unsetEnvironmentContext() {
+    this.environmentContext = null;
+  }
+
+  /** Returns true if field environmentContext is set (has been assigned a value) and false otherwise */
+  public boolean isSetEnvironmentContext() {
+    return this.environmentContext != null;
+  }
+
+  public void setEnvironmentContextIsSet(boolean value) {
+    if (!value) {
+      this.environmentContext = null;
+    }
+  }
+
   public void setFieldValue(_Fields field, @org.apache.thrift.annotation.Nullable java.lang.Object value) {
     switch (field) {
     case DB_NAME:
@@ -345,6 +380,14 @@ package org.apache.hadoop.hive.metastore.api;
       }
       break;
 
+    case ENVIRONMENT_CONTEXT:
+      if (value == null) {
+        unsetEnvironmentContext();
+      } else {
+        setEnvironmentContext((EnvironmentContext)value);
+      }
+      break;
+
     }
   }
 
@@ -365,6 +408,9 @@ package org.apache.hadoop.hive.metastore.api;
 
     case VALID_WRITE_ID_LIST:
       return getValidWriteIdList();
+
+    case ENVIRONMENT_CONTEXT:
+      return getEnvironmentContext();
 
     }
     throw new java.lang.IllegalStateException();
@@ -387,6 +433,8 @@ package org.apache.hadoop.hive.metastore.api;
       return isSetWriteId();
     case VALID_WRITE_ID_LIST:
       return isSetValidWriteIdList();
+    case ENVIRONMENT_CONTEXT:
+      return isSetEnvironmentContext();
     }
     throw new java.lang.IllegalStateException();
   }
@@ -449,6 +497,15 @@ package org.apache.hadoop.hive.metastore.api;
         return false;
     }
 
+    boolean this_present_environmentContext = true && this.isSetEnvironmentContext();
+    boolean that_present_environmentContext = true && that.isSetEnvironmentContext();
+    if (this_present_environmentContext || that_present_environmentContext) {
+      if (!(this_present_environmentContext && that_present_environmentContext))
+        return false;
+      if (!this.environmentContext.equals(that.environmentContext))
+        return false;
+    }
+
     return true;
   }
 
@@ -475,6 +532,10 @@ package org.apache.hadoop.hive.metastore.api;
     hashCode = hashCode * 8191 + ((isSetValidWriteIdList()) ? 131071 : 524287);
     if (isSetValidWriteIdList())
       hashCode = hashCode * 8191 + validWriteIdList.hashCode();
+
+    hashCode = hashCode * 8191 + ((isSetEnvironmentContext()) ? 131071 : 524287);
+    if (isSetEnvironmentContext())
+      hashCode = hashCode * 8191 + environmentContext.hashCode();
 
     return hashCode;
   }
@@ -533,6 +594,16 @@ package org.apache.hadoop.hive.metastore.api;
     }
     if (isSetValidWriteIdList()) {
       lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.validWriteIdList, other.validWriteIdList);
+      if (lastComparison != 0) {
+        return lastComparison;
+      }
+    }
+    lastComparison = java.lang.Boolean.compare(isSetEnvironmentContext(), other.isSetEnvironmentContext());
+    if (lastComparison != 0) {
+      return lastComparison;
+    }
+    if (isSetEnvironmentContext()) {
+      lastComparison = org.apache.thrift.TBaseHelper.compareTo(this.environmentContext, other.environmentContext);
       if (lastComparison != 0) {
         return lastComparison;
       }
@@ -596,6 +667,16 @@ package org.apache.hadoop.hive.metastore.api;
         sb.append("null");
       } else {
         sb.append(this.validWriteIdList);
+      }
+      first = false;
+    }
+    if (isSetEnvironmentContext()) {
+      if (!first) sb.append(", ");
+      sb.append("environmentContext:");
+      if (this.environmentContext == null) {
+        sb.append("null");
+      } else {
+        sb.append(this.environmentContext);
       }
       first = false;
     }
@@ -702,6 +783,15 @@ package org.apache.hadoop.hive.metastore.api;
               org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
             }
             break;
+          case 6: // ENVIRONMENT_CONTEXT
+            if (schemeField.type == org.apache.thrift.protocol.TType.STRUCT) {
+              struct.environmentContext = new EnvironmentContext();
+              struct.environmentContext.read(iprot);
+              struct.setEnvironmentContextIsSet(true);
+            } else { 
+              org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
+            }
+            break;
           default:
             org.apache.thrift.protocol.TProtocolUtil.skip(iprot, schemeField.type);
         }
@@ -751,6 +841,13 @@ package org.apache.hadoop.hive.metastore.api;
           oprot.writeFieldEnd();
         }
       }
+      if (struct.environmentContext != null) {
+        if (struct.isSetEnvironmentContext()) {
+          oprot.writeFieldBegin(ENVIRONMENT_CONTEXT_FIELD_DESC);
+          struct.environmentContext.write(oprot);
+          oprot.writeFieldEnd();
+        }
+      }
       oprot.writeFieldStop();
       oprot.writeStructEnd();
     }
@@ -780,7 +877,10 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValidWriteIdList()) {
         optionals.set(2);
       }
-      oprot.writeBitSet(optionals, 3);
+      if (struct.isSetEnvironmentContext()) {
+        optionals.set(3);
+      }
+      oprot.writeBitSet(optionals, 4);
       if (struct.isSetPartNames()) {
         {
           oprot.writeI32(struct.partNames.size());
@@ -796,6 +896,9 @@ package org.apache.hadoop.hive.metastore.api;
       if (struct.isSetValidWriteIdList()) {
         oprot.writeString(struct.validWriteIdList);
       }
+      if (struct.isSetEnvironmentContext()) {
+        struct.environmentContext.write(oprot);
+      }
     }
 
     @Override
@@ -805,7 +908,7 @@ package org.apache.hadoop.hive.metastore.api;
       struct.setDbNameIsSet(true);
       struct.tableName = iprot.readString();
       struct.setTableNameIsSet(true);
-      java.util.BitSet incoming = iprot.readBitSet(3);
+      java.util.BitSet incoming = iprot.readBitSet(4);
       if (incoming.get(0)) {
         {
           org.apache.thrift.protocol.TList _list131 = iprot.readListBegin(org.apache.thrift.protocol.TType.STRING);
@@ -826,6 +929,11 @@ package org.apache.hadoop.hive.metastore.api;
       if (incoming.get(2)) {
         struct.validWriteIdList = iprot.readString();
         struct.setValidWriteIdListIsSet(true);
+      }
+      if (incoming.get(3)) {
+        struct.environmentContext = new EnvironmentContext();
+        struct.environmentContext.read(iprot);
+        struct.setEnvironmentContextIsSet(true);
       }
     }
   }

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TruncateTableRequest.php
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-php/metastore/TruncateTableRequest.php
@@ -50,6 +50,12 @@ class TruncateTableRequest
             'isRequired' => false,
             'type' => TType::STRING,
         ),
+        6 => array(
+            'var' => 'environmentContext',
+            'isRequired' => false,
+            'type' => TType::STRUCT,
+            'class' => '\metastore\EnvironmentContext',
+        ),
     );
 
     /**
@@ -72,6 +78,10 @@ class TruncateTableRequest
      * @var string
      */
     public $validWriteIdList = null;
+    /**
+     * @var \metastore\EnvironmentContext
+     */
+    public $environmentContext = null;
 
     public function __construct($vals = null)
     {
@@ -90,6 +100,9 @@ class TruncateTableRequest
             }
             if (isset($vals['validWriteIdList'])) {
                 $this->validWriteIdList = $vals['validWriteIdList'];
+            }
+            if (isset($vals['environmentContext'])) {
+                $this->environmentContext = $vals['environmentContext'];
             }
         }
     }
@@ -157,6 +170,14 @@ class TruncateTableRequest
                         $xfer += $input->skip($ftype);
                     }
                     break;
+                case 6:
+                    if ($ftype == TType::STRUCT) {
+                        $this->environmentContext = new \metastore\EnvironmentContext();
+                        $xfer += $this->environmentContext->read($input);
+                    } else {
+                        $xfer += $input->skip($ftype);
+                    }
+                    break;
                 default:
                     $xfer += $input->skip($ftype);
                     break;
@@ -201,6 +222,14 @@ class TruncateTableRequest
         if ($this->validWriteIdList !== null) {
             $xfer += $output->writeFieldBegin('validWriteIdList', TType::STRING, 5);
             $xfer += $output->writeString($this->validWriteIdList);
+            $xfer += $output->writeFieldEnd();
+        }
+        if ($this->environmentContext !== null) {
+            if (!is_object($this->environmentContext)) {
+                throw new TProtocolException('Bad type in structure.', TProtocolException::INVALID_DATA);
+            }
+            $xfer += $output->writeFieldBegin('environmentContext', TType::STRUCT, 6);
+            $xfer += $this->environmentContext->write($output);
             $xfer += $output->writeFieldEnd();
         }
         $xfer += $output->writeFieldStop();

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-py/hive_metastore/ttypes.py
@@ -2541,16 +2541,18 @@ class TruncateTableRequest(object):
      - partNames
      - writeId
      - validWriteIdList
+     - environmentContext
 
     """
 
 
-    def __init__(self, dbName=None, tableName=None, partNames=None, writeId=-1, validWriteIdList=None,):
+    def __init__(self, dbName=None, tableName=None, partNames=None, writeId=-1, validWriteIdList=None, environmentContext=None,):
         self.dbName = dbName
         self.tableName = tableName
         self.partNames = partNames
         self.writeId = writeId
         self.validWriteIdList = validWriteIdList
+        self.environmentContext = environmentContext
 
     def read(self, iprot):
         if iprot._fast_decode is not None and isinstance(iprot.trans, TTransport.CReadableTransport) and self.thrift_spec is not None:
@@ -2591,6 +2593,12 @@ class TruncateTableRequest(object):
                     self.validWriteIdList = iprot.readString().decode('utf-8', errors='replace') if sys.version_info[0] == 2 else iprot.readString()
                 else:
                     iprot.skip(ftype)
+            elif fid == 6:
+                if ftype == TType.STRUCT:
+                    self.environmentContext = EnvironmentContext()
+                    self.environmentContext.read(iprot)
+                else:
+                    iprot.skip(ftype)
             else:
                 iprot.skip(ftype)
             iprot.readFieldEnd()
@@ -2623,6 +2631,10 @@ class TruncateTableRequest(object):
         if self.validWriteIdList is not None:
             oprot.writeFieldBegin('validWriteIdList', TType.STRING, 5)
             oprot.writeString(self.validWriteIdList.encode('utf-8') if sys.version_info[0] == 2 else self.validWriteIdList)
+            oprot.writeFieldEnd()
+        if self.environmentContext is not None:
+            oprot.writeFieldBegin('environmentContext', TType.STRUCT, 6)
+            self.environmentContext.write(oprot)
             oprot.writeFieldEnd()
         oprot.writeFieldStop()
         oprot.writeStructEnd()
@@ -28616,6 +28628,7 @@ TruncateTableRequest.thrift_spec = (
     (3, TType.LIST, 'partNames', (TType.STRING, 'UTF8', False), None, ),  # 3
     (4, TType.I64, 'writeId', None, -1, ),  # 4
     (5, TType.STRING, 'validWriteIdList', 'UTF8', None, ),  # 5
+    (6, TType.STRUCT, 'environmentContext', [EnvironmentContext, None], None, ),  # 6
 )
 all_structs.append(TruncateTableResponse)
 TruncateTableResponse.thrift_spec = (

--- a/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
+++ b/standalone-metastore/metastore-common/src/gen/thrift/gen-rb/hive_metastore_types.rb
@@ -1291,13 +1291,15 @@ class TruncateTableRequest
   PARTNAMES = 3
   WRITEID = 4
   VALIDWRITEIDLIST = 5
+  ENVIRONMENTCONTEXT = 6
 
   FIELDS = {
     DBNAME => {:type => ::Thrift::Types::STRING, :name => 'dbName'},
     TABLENAME => {:type => ::Thrift::Types::STRING, :name => 'tableName'},
     PARTNAMES => {:type => ::Thrift::Types::LIST, :name => 'partNames', :element => {:type => ::Thrift::Types::STRING}, :optional => true},
     WRITEID => {:type => ::Thrift::Types::I64, :name => 'writeId', :default => -1, :optional => true},
-    VALIDWRITEIDLIST => {:type => ::Thrift::Types::STRING, :name => 'validWriteIdList', :optional => true}
+    VALIDWRITEIDLIST => {:type => ::Thrift::Types::STRING, :name => 'validWriteIdList', :optional => true},
+    ENVIRONMENTCONTEXT => {:type => ::Thrift::Types::STRUCT, :name => 'environmentContext', :class => ::EnvironmentContext, :optional => true}
   }
 
   def struct_fields; FIELDS; end

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaHook.java
@@ -160,4 +160,13 @@ public interface HiveMetaHook {
     // Do nothing
   }
 
+  /**
+   * Called before deleting the data and statistics from the table in the metastore during TRUNCATE TABLE.
+   * @param table table to be truncated
+   * @param context context of the truncate operation
+   * @throws MetaException
+   */
+  public default void preTruncateTable(Table table, EnvironmentContext context) throws MetaException {
+    // Do nothing
+  }
 }

--- a/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/standalone-metastore/metastore-common/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1849,11 +1849,18 @@ public class HiveMetaStoreClient implements IMetaStoreClient, AutoCloseable {
   private void truncateTableInternal(String catName, String dbName, String tableName,
       List<String> partNames, String validWriteIds, long writeId)
           throws MetaException, TException {
+    Table table = getTable(catName, dbName, tableName);
+    HiveMetaHook hook = getHook(table);
+    EnvironmentContext envContext = new EnvironmentContext();
+    if (hook != null) {
+      hook.preTruncateTable(table, envContext);
+    }
     TruncateTableRequest req = new TruncateTableRequest(
         prependCatalogToDbName(catName, dbName, conf), tableName);
     req.setPartNames(partNames);
     req.setValidWriteIdList(validWriteIds);
     req.setWriteId(writeId);
+    req.setEnvironmentContext(envContext);
     client.truncate_table_req(req);
   }
 

--- a/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
+++ b/standalone-metastore/metastore-common/src/main/thrift/hive_metastore.thrift
@@ -302,7 +302,8 @@ struct TruncateTableRequest {
   2: required string tableName,
   3: optional list<string> partNames,
   4: optional i64 writeId=-1,
-  5: optional string validWriteIdList
+  5: optional string validWriteIdList,
+  6: optional EnvironmentContext environmentContext
 }
 
 struct TruncateTableResponse {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -3362,42 +3362,50 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   public void truncate_table(final String dbName, final String tableName, List<String> partNames)
       throws NoSuchObjectException, MetaException {
     // Deprecated path, won't work for txn tables.
-    truncateTableInternal(dbName, tableName, partNames, null, -1);
+    truncateTableInternal(dbName, tableName, partNames, null, -1, null);
   }
 
   @Override
   public TruncateTableResponse truncate_table_req(TruncateTableRequest req)
       throws MetaException, TException {
     truncateTableInternal(req.getDbName(), req.getTableName(), req.getPartNames(),
-        req.getValidWriteIdList(), req.getWriteId());
+        req.getValidWriteIdList(), req.getWriteId(), req.getEnvironmentContext());
     return new TruncateTableResponse();
   }
 
   private void truncateTableInternal(String dbName, String tableName, List<String> partNames,
-                                     String validWriteIds, long writeId) throws MetaException, NoSuchObjectException {
+                                     String validWriteIds, long writeId, EnvironmentContext context) throws MetaException, NoSuchObjectException {
     boolean isSkipTrash = false, needCmRecycle = false;
     try {
       String[] parsedDbName = parseDbName(dbName, conf);
       Table tbl = get_table_core(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], tableName);
 
-      boolean truncateFiles = !TxnUtils.isTransactionalTable(tbl) ||
-          !MetastoreConf.getBoolVar(getConf(), MetastoreConf.ConfVars.TRUNCATE_ACID_USE_BASE);
-
-      if (truncateFiles) {
-        isSkipTrash = MetaStoreUtils.isSkipTrash(tbl.getParameters());
-        Database db = get_database_core(parsedDbName[CAT_NAME], parsedDbName[DB_NAME]);
-        needCmRecycle = ReplChangeManager.shouldEnableCm(db, tbl);
+      boolean skipDataDeletion = false;
+      if (context != null && context.getProperties() != null
+          && context.getProperties().get("truncateSkipDataDeletion") != null) {
+        skipDataDeletion = Boolean.parseBoolean(context.getProperties().get("truncateSkipDataDeletion"));
       }
-      // This is not transactional
-      for (Path location : getLocationsForTruncate(getMS(), parsedDbName[CAT_NAME],
-          parsedDbName[DB_NAME], tableName, tbl, partNames)) {
-        FileSystem fs = location.getFileSystem(getConf());
+
+      if (!skipDataDeletion) {
+        boolean truncateFiles = !TxnUtils.isTransactionalTable(tbl)
+            || !MetastoreConf.getBoolVar(getConf(), MetastoreConf.ConfVars.TRUNCATE_ACID_USE_BASE);
+
         if (truncateFiles) {
-          truncateDataFiles(location, fs, isSkipTrash, needCmRecycle);
-        } else {
-          // For Acid tables we don't need to delete the old files, only write an empty baseDir.
-          // Compaction and cleaner will take care of the rest
-          addTruncateBaseFile(location, writeId, fs);
+          isSkipTrash = MetaStoreUtils.isSkipTrash(tbl.getParameters());
+          Database db = get_database_core(parsedDbName[CAT_NAME], parsedDbName[DB_NAME]);
+          needCmRecycle = ReplChangeManager.shouldEnableCm(db, tbl);
+        }
+        // This is not transactional
+        for (Path location : getLocationsForTruncate(getMS(), parsedDbName[CAT_NAME], parsedDbName[DB_NAME], tableName,
+            tbl, partNames)) {
+          FileSystem fs = location.getFileSystem(getConf());
+          if (truncateFiles) {
+            truncateDataFiles(location, fs, isSkipTrash, needCmRecycle);
+          } else {
+            // For Acid tables we don't need to delete the old files, only write an empty baseDir.
+            // Compaction and cleaner will take care of the rest
+            addTruncateBaseFile(location, writeId, fs);
+          }
         }
       }
 

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -152,6 +152,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
   @VisibleForTesting
   static long testTimeoutValue = -1;
 
+  public static final String TRUNCATE_SKIP_DATA_DELETION = "truncateSkipDataDeletion";
   public static final String ADMIN = "admin";
   public static final String PUBLIC = "public";
 
@@ -3380,11 +3381,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       String[] parsedDbName = parseDbName(dbName, conf);
       Table tbl = get_table_core(parsedDbName[CAT_NAME], parsedDbName[DB_NAME], tableName);
 
-      boolean skipDataDeletion = false;
-      if (context != null && context.getProperties() != null
-          && context.getProperties().get("truncateSkipDataDeletion") != null) {
-        skipDataDeletion = Boolean.parseBoolean(context.getProperties().get("truncateSkipDataDeletion"));
-      }
+      boolean skipDataDeletion = Optional.ofNullable(context)
+          .map(EnvironmentContext::getProperties)
+          .map(prop -> prop.get(TRUNCATE_SKIP_DATA_DELETION))
+          .map(Boolean::parseBoolean)
+          .orElse(false);
 
       if (!skipDataDeletion) {
         boolean truncateFiles = !TxnUtils.isTransactionalTable(tbl)


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
Added support for TRUNCATE TABLE operation for Hive Iceberg tables. Since these tables are unpartitioned in Hive, only the TRUNCATE without partition spec is supported.
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?
Had to extend the thrift API: added the EnvironmentContext parameter to the TruncateTableRequest class. This is needed because for Iceberg tables the data deletion will happen through the Iceberg API in a MetastoreHook and not in the Metastore itself. It is because for Iceberg table we cannot delete the files manually from metastore since this way the table history would be lost.
<!--
Please clarify why the changes are needed. For instance,
  1. If you propose a new API, clarify the use case for a new API.
  2. If you fix a bug, you can clarify why it is a bug.
-->


### Does this PR introduce _any_ user-facing change?
The TRUNCATE operation will work for Iceberg tables.
<!--
Note that it means *any* user-facing change including all aspects such as the documentation fix.
If yes, please clarify the previous behavior and the change this PR proposes - provide the console output, description, screenshot and/or a reproducable example to show the behavior difference if possible.
If possible, please also clarify if this is a user-facing change compared to the released Hive versions or within the unreleased branches such as master.
If no, write 'No'.
-->


### How was this patch tested?
Added unit test and q test for the many use cases.
<!--
If tests were added, say they were added here. Please make sure to add some test cases that check the changes thoroughly including negative and positive cases if possible.
If it was tested in a way different from regular unit tests, please clarify how you tested step by step, ideally copy and paste-able, so that other reviewers can test and check, and descendants can verify in the future.
If tests were not added, please describe why they were not added and/or why it was difficult to add.
-->
