### PR TITLE
HIVE-25328: Limit scope of REPLACE COLUMNS for Iceberg tables

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -75,7 +75,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -308,9 +308,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
   }
 
   @Override
-  public void rollbackAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context)
-      throws MetaException {
-    if (Boolean.valueOf(context.getProperties().getOrDefault(MIGRATE_HIVE_TO_ICEBERG, "false"))) {
+  public void rollbackAlterTable(org.apache.hadoop.hive.metastore.api.Table hmsTable, EnvironmentContext context) {
+    if (Boolean.parseBoolean(context.getProperties().getOrDefault(MIGRATE_HIVE_TO_ICEBERG, "false"))) {
       LOG.debug("Initiating rollback for table {} at location {}",
           hmsTable.getTableName(), hmsTable.getSd().getLocation());
       context.getProperties().put(INITIALIZE_ROLLBACK_MIGRATION, "true");
@@ -373,7 +372,7 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       if (SUPPORTED_ALTER_OPS.stream().noneMatch(op -> op.equals(currentAlterTableOp))) {
         throw new MetaException(
             "Unsupported ALTER TABLE operation type on Iceberg table " + tableName + ", must be one of: " +
-                SUPPORTED_ALTER_OPS.toString());
+                SUPPORTED_ALTER_OPS);
       }
     }
   }
@@ -602,6 +601,10 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
           field.getName(), newType));
     }
     return (Type.PrimitiveType) newType;
+  }
+
+  private boolean isOutOfOrder(HiveSchemaUtil.SchemaDifference diff, Pair<String, Optional<String>> outOfOrder) {
+    return diff.getMissingFromFirst().isEmpty() && diff.getMissingFromSecond().isEmpty() && outOfOrder != null;
   }
 
   private class PreAlterTableProperties {

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -963,9 +963,8 @@ public class TestHiveIcebergStorageHandlerNoScan {
     testTables.createTable(shell, identifier.name(), schema, SPEC, FileFormat.PARQUET, ImmutableList.of());
 
     shell.executeStatement("ALTER TABLE default.customers REPLACE COLUMNS " +
-        "(customer_id bigint, last_name string COMMENT 'This is last name', " +
-        "address struct<city:string,street:string> COMMENT 'Adding some comment', " +
-        "new_col string COMMENT 'This is a new column added')");
+        "(customer_id int, last_name string COMMENT 'This is last name', " +
+        "address struct<city:string,street:string>)");
 
     org.apache.iceberg.Table icebergTable = testTables.loadTable(identifier);
     org.apache.hadoop.hive.metastore.api.Table hmsTable = shell.metastore().getTable("default", "customers");
@@ -974,18 +973,55 @@ public class TestHiveIcebergStorageHandlerNoScan {
     List<FieldSchema> hmsSchema = hmsTable.getSd().getCols();
 
     List<FieldSchema> expectedSchema = Lists.newArrayList(
-        // customer_id: type promotion (int -> bigint), no change in comment
-        new FieldSchema("customer_id", "bigint", null),
+        new FieldSchema("customer_id", "int", null),
         // first_name column is dropped
-        // last_name: no changes
         new FieldSchema("last_name", "string", "This is last name"),
-        // address: comment added, no change in type
-        new FieldSchema("address", "struct<city:string,street:string>", "Adding some comment"),
-        // new_col: brand new column
-        new FieldSchema("new_col", "string", "This is a new column added"));
+        new FieldSchema("address", "struct<city:string,street:string>", null));
 
     Assert.assertEquals(expectedSchema, icebergSchema);
     Assert.assertEquals(expectedSchema, hmsSchema);
+  }
+
+  @Test
+  public void testAlterTableReplaceColumnsFailsWhenNotOnlyDropping() {
+    TableIdentifier identifier = TableIdentifier.of("default", "customers");
+
+    Schema schema = new Schema(
+        optional(1, "customer_id", Types.IntegerType.get()),
+        optional(2, "first_name", Types.StringType.get(), "This is first name"),
+        optional(3, "last_name", Types.StringType.get(), "This is last name"),
+        optional(4, "address",  Types.StructType.of(
+            optional(5, "city", Types.StringType.get()),
+            optional(6, "street", Types.StringType.get())), null)
+    );
+    testTables.createTable(shell, identifier.name(), schema, SPEC, FileFormat.PARQUET, ImmutableList.of());
+
+    String[] commands = {
+        // type promotion
+        "ALTER TABLE default.customers REPLACE COLUMNS (customer_id bigint, first_name string COMMENT 'This is " +
+            "first name', last_name string COMMENT 'This is last name', address struct<city:string,street:string>)",
+        // delete a comment
+        "ALTER TABLE default.customers REPLACE COLUMNS (customer_id int, first_name string, " +
+            "last_name string COMMENT 'This is last name', address struct<city:string,street:string>)",
+        // change a comment
+        "ALTER TABLE default.customers REPLACE COLUMNS (customer_id int, first_name string COMMENT 'New docs', " +
+            "last_name string COMMENT 'This is last name', address struct<city:string,street:string>)",
+        // reorder columns
+        "ALTER TABLE default.customers REPLACE COLUMNS (customer_id int, last_name string COMMENT 'This is " +
+            "last name', first_name string COMMENT 'This is first name', address struct<city:string,street:string>)",
+        // add new column
+        "ALTER TABLE default.customers REPLACE COLUMNS (customer_id int, first_name string COMMENT 'This is " +
+            "first name', last_name string COMMENT 'This is last name', address struct<city:string,street:string>, " +
+            "new_col timestamp)",
+        // dropping a column + reordering columns
+        "ALTER TABLE default.customers REPLACE COLUMNS (last_name string COMMENT 'This is " +
+            "last name', first_name string COMMENT 'This is first name', address struct<city:string,street:string>)"
+    };
+
+    for (String command : commands) {
+      AssertHelpers.assertThrows("", IllegalArgumentException.class,
+          "Unsupported operation to use REPLACE COLUMNS", () -> shell.executeStatement(command));
+    }
   }
 
   @Test

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -996,6 +996,7 @@ public class TestHiveIcebergStorageHandlerNoScan {
     );
     testTables.createTable(shell, identifier.name(), schema, SPEC, FileFormat.PARQUET, ImmutableList.of());
 
+    // check unsupported operations
     String[] commands = {
         // type promotion
         "ALTER TABLE default.customers REPLACE COLUMNS (customer_id bigint, first_name string COMMENT 'This is " +
@@ -1022,6 +1023,12 @@ public class TestHiveIcebergStorageHandlerNoScan {
       AssertHelpers.assertThrows("", IllegalArgumentException.class,
           "Unsupported operation to use REPLACE COLUMNS", () -> shell.executeStatement(command));
     }
+
+    // check no-op case too
+    String command = "ALTER TABLE default.customers REPLACE COLUMNS (customer_id int, first_name string COMMENT 'This" +
+        " is first name', last_name string COMMENT 'This is last name', address struct<city:string,street:string>)";
+    AssertHelpers.assertThrows("", IllegalArgumentException.class,
+        "No schema change detected", () -> shell.executeStatement(command));
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `REPLACE COLUMNS` only for dropping one or more columns. If there's any column reorder, column rename, adding columns, changing column type or changing column comment, we throw an exception.

### Why are the changes needed?
Limit the damage the user can do with this command :)

### Does this PR introduce _any_ user-facing change?
Yes, limitation of the REPLACE command (but only for Iceberg tables; Hive tables are unaffected).

### How was this patch tested?
unit tests