### PR TITLE
HIVE-25329: CTAS creates a managed table as non-ACID table

### DIFF
--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -7,6 +7,7 @@ minimr.query.files=\
 # Queries ran by both MiniLlapLocal and MiniTez
 minitez.query.files.shared=\
   compressed_skip_header_footer_aggr.q,\
+  create_table.q,\
   dynpart_sort_optimization_distribute_by.q,\
   hybridgrace_hashjoin_1.q,\
   hybridgrace_hashjoin_2.q,\

--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/SemanticAnalyzer.java
@@ -13344,6 +13344,7 @@ public class SemanticAnalyzer extends BaseSemanticAnalyzer {
         break;
       case HiveParser.KW_MANAGED:
         isManaged = true;
+        isTransactional = true;
         break;
       case HiveParser.KW_TEMPORARY:
         isTemporary = true;

--- a/ql/src/test/queries/clientpositive/create_table.q
+++ b/ql/src/test/queries/clientpositive/create_table.q
@@ -1,0 +1,5 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.create.as.external.legacy=true;
+create managed table test as select 1;
+show create table test;

--- a/ql/src/test/results/clientpositive/tez/create_table.q.out
+++ b/ql/src/test/results/clientpositive/tez/create_table.q.out
@@ -1,0 +1,32 @@
+PREHOOK: query: create managed table test as select 1
+PREHOOK: type: CREATETABLE_AS_SELECT
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test
+POSTHOOK: query: create managed table test as select 1
+POSTHOOK: type: CREATETABLE_AS_SELECT
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test
+POSTHOOK: Lineage: test._c0 SIMPLE []
+PREHOOK: query: show create table test
+PREHOOK: type: SHOW_CREATETABLE
+PREHOOK: Input: default@test
+POSTHOOK: query: show create table test
+POSTHOOK: type: SHOW_CREATETABLE
+POSTHOOK: Input: default@test
+CREATE TABLE `test`(
+  `_c0` int)
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.mapred.TextInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat'
+LOCATION
+  'hdfs://### HDFS PATH ###'
+TBLPROPERTIES (
+  'bucketing_version'='2', 
+  'transactional'='true', 
+  'transactional_properties'='insert_only', 
+#### A masked pattern was here ####


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change makes "create managed table" query to create a managed table regardless of "hive.create.as.external.legacy=true".

### Why are the changes needed?
According to HIVE-22158,  MANAGED tables should be ACID tables only.


### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
mvn test -Dtest=TestMiniTezCliDriver -Dqfile=create_table.q