### PR TITLE
HIVE-23688: fix Vectorization IndexArrayOutOfBoundsException when read null values in map

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/parquet/vector/VectorizedListColumnReader.java
@@ -77,19 +77,64 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
       isFirstRow = false;
     }
 
-    int index = 0;
-    while (!eof && index < total) {
-      // add element to ListColumnVector one by one
-      addElement(lcv, valueList, category, index);
-      index++;
-    }
+    int index = collectDataFromParquetPage(total, lcv, valueList, category);
 
-    // Decode the value if necessary
-    if (isCurrentPageDictionaryEncoded) {
-      valueList = decodeDictionaryIds(category, valueList);
-    }
     // Convert valueList to array for the ListColumnVector.child
     convertValueListToListColumnVector(category, lcv, valueList, index);
+  }
+
+  /**
+   * Collects data from a parquet page and returns the final row index where it stopped.
+   * The returned index can be equal to or less than total.
+   * @param total maximum number of rows to collect
+   * @param lcv column vector to do initial setup in data collection time
+   * @param valueList collection of values that will be fed into the vector later
+   * @param category
+   * @return
+   * @throws IOException
+   */
+  private int collectDataFromParquetPage(int total, ListColumnVector lcv, List<Object> valueList,
+      PrimitiveObjectInspector.PrimitiveCategory category) throws IOException {
+    int index = 0;
+    /*
+     * Here is a nested loop for collecting all values from a parquet page.
+     * A column of array type can be considered as a list of lists, so the two loops are as below:
+     * 1. The outer loop iterates on rows (index is a row index, so points to a row in the batch), e.g.:
+     * [0, 2, 3]    <- index: 0
+     * [NULL, 3, 4] <- index: 1
+     *
+     * 2. The inner loop iterates on values within a row (sets all data from parquet data page
+     * for an element in ListColumnVector), so fetchNextValue returns values one-by-one:
+     * 0, 2, 3, NULL, 3, 4
+     *
+     * As described below, the repetition level (repetitionLevel != 0)
+     * can be used to decide when we'll start to read values for the next list.
+     */
+    while (!eof && index < total) {
+      // add element to ListColumnVector one by one
+      lcv.offsets[index] = valueList.size();
+      /*
+       * Let's collect all values for a single list.
+       * Repetition level = 0 means that a new list started there in the parquet page,
+       * in that case, let's exit from the loop, and start to collect value for a new list.
+       */
+      do {
+        /*
+         * Definition level = 0 when a NULL value was returned instead of a list
+         * (this is not the same as a NULL value in of a list).
+         */
+        if (definitionLevel == 0) {
+          lcv.isNull[index] = true;
+          lcv.noNulls = false;
+        }
+        valueList
+            .add(isCurrentPageDictionaryEncoded ? dictionaryDecodeValue(category, (Integer) lastValue) : lastValue);
+      } while (fetchNextValue(category) && (repetitionLevel != 0));
+
+      lcv.lengths[index] = valueList.size() - lcv.offsets[index];
+      index++;
+    }
+    return index;
   }
 
   private int readPageIfNeed() throws IOException {
@@ -103,6 +148,13 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     return leftInPage;
   }
 
+  /**
+   * Reads a single value from parquet page, puts it into lastValue.
+   * Returns a boolean indicating if there is more values to read (true).
+   * @param category
+   * @return
+   * @throws IOException
+   */
   private boolean fetchNextValue(PrimitiveObjectInspector.PrimitiveCategory category) throws IOException {
     int left = readPageIfNeed();
     if (left > 0) {
@@ -123,25 +175,6 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
       eof = true;
       return false;
     }
-  }
-
-  /**
-   * The function will set all data from parquet data page for an element in ListColumnVector
-   */
-  private void addElement(ListColumnVector lcv, List<Object> elements, PrimitiveObjectInspector.PrimitiveCategory category, int index) throws IOException {
-    lcv.offsets[index] = elements.size();
-
-    do {
-      // add all data for an element in ListColumnVector, get out the loop if there is no data or the data is for new element
-      if (definitionLevel < maxDefLevel) {
-        lcv.lengths[index] = 0;
-        lcv.isNull[index] = true;
-        lcv.noNulls = false;
-      }
-      elements.add(lastValue);
-    } while (fetchNextValue(category) && (repetitionLevel != 0));
-
-    lcv.lengths[index] = elements.size() - lcv.offsets[index];
   }
 
   // Need to be in consistent with that VectorizedPrimitiveColumnReader#readBatchHelper
@@ -178,79 +211,40 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     }
   }
 
-  private List decodeDictionaryIds(PrimitiveObjectInspector.PrimitiveCategory category, List
-      valueList) {
-    int total = valueList.size();
-    List resultList;
-    List<Integer> intList = (List<Integer>) valueList;
+  private Object dictionaryDecodeValue(PrimitiveObjectInspector.PrimitiveCategory category, Integer dictionaryValue) {
+    if (dictionaryValue == null) {
+      return null;
+    }
 
     switch (category) {
     case INT:
     case BYTE:
     case SHORT:
-      resultList = new ArrayList<Integer>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readInteger(intList.get(i)));
-      }
-      break;
+      return dictionary.readInteger(dictionaryValue);
     case DATE:
     case INTERVAL_YEAR_MONTH:
     case LONG:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readLong(intList.get(i)));
-      }
-      break;
+      return dictionary.readLong(dictionaryValue);
     case BOOLEAN:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readBoolean(intList.get(i)));
-      }
-      break;
+      return dictionary.readBoolean(dictionaryValue) ? 1 : 0;
     case DOUBLE:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readDouble(intList.get(i)));
-      }
-      break;
+      return dictionary.readDouble(dictionaryValue);
     case BINARY:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readBytes(intList.get(i)));
-      }
-      break;
+      return dictionary.readBytes(dictionaryValue);
     case STRING:
     case CHAR:
     case VARCHAR:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readString(intList.get(i)));
-      }
-      break;
+      return dictionary.readString(dictionaryValue);
     case FLOAT:
-      resultList = new ArrayList<Float>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readFloat(intList.get(i)));
-      }
-      break;
+      return dictionary.readFloat(dictionaryValue);
     case DECIMAL:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readDecimal(intList.get(i)));
-      }
-      break;
+      return dictionary.readDecimal(dictionaryValue);
     case TIMESTAMP:
-      resultList = new ArrayList<Long>(total);
-      for (int i = 0; i < total; ++i) {
-        resultList.add(intList.get(i) == null ? null : dictionary.readTimestamp(intList.get(i)));
-      }
-      break;
+      return dictionary.readTimestamp(dictionaryValue);
     case INTERVAL_DAY_TIME:
     default:
       throw new RuntimeException("Unsupported type in the list: " + type);
     }
-
-    return resultList;
   }
 
   /**
@@ -454,7 +448,10 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     int length2 = cv2.vector.length;
     if (length1 == length2) {
       for (int i = 0; i < length1; i++) {
-        if (cv1.vector[i] != cv2.vector[i]) {
+        if (columnVectorsDifferNullForSameIndex(cv1, cv2, i)) {
+          return false;
+        }
+        if (!cv1.isNull[i] && !cv2.isNull[i] && cv1.vector[i] != cv2.vector[i]) {
           return false;
         }
       }
@@ -469,7 +466,10 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     int length2 = cv2.vector.length;
     if (length1 == length2) {
       for (int i = 0; i < length1; i++) {
-        if (cv1.vector[i] != cv2.vector[i]) {
+        if (columnVectorsDifferNullForSameIndex(cv1, cv2, i)) {
+          return false;
+        }
+        if (!cv1.isNull[i] && !cv2.isNull[i] && cv1.vector[i] != cv2.vector[i]) {
           return false;
         }
       }
@@ -484,9 +484,10 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     int length2 = cv2.vector.length;
     if (length1 == length2 && cv1.scale == cv2.scale && cv1.precision == cv2.precision) {
       for (int i = 0; i < length1; i++) {
-        if (cv1.vector[i] != null && cv2.vector[i] == null
-            || cv1.vector[i] == null && cv2.vector[i] != null
-            || cv1.vector[i] != null && cv2.vector[i] != null && !cv1.vector[i].equals(cv2.vector[i])) {
+        if (columnVectorsDifferNullForSameIndex(cv1, cv2, i)) {
+          return false;
+        }
+        if (!cv1.isNull[i] && !cv2.isNull[i] && !cv1.vector[i].equals(cv2.vector[i])) {
           return false;
         }
       }
@@ -501,9 +502,6 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
     int length2 = cv2.vector.length;
     if (length1 == length2) {
       for (int i = 0; i < length1; i++) {
-        if (cv1.vector[i] == null && cv2.vector[i] == null) {
-          continue;
-        }
         int innerLen1 = cv1.vector[i].length;
         int innerLen2 = cv2.vector[i].length;
         if (innerLen1 == innerLen2) {
@@ -520,5 +518,10 @@ public class VectorizedListColumnReader extends BaseVectorizedColumnReader {
       return false;
     }
     return true;
+  }
+
+
+  private boolean columnVectorsDifferNullForSameIndex(ColumnVector cv1, ColumnVector cv2, int index) {
+    return (cv1.isNull[index] && !cv2.isNull[index]) || (!cv1.isNull[index] && cv2.isNull[index]);
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestVectorizedListColumnReader.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/parquet/TestVectorizedListColumnReader.java
@@ -280,7 +280,7 @@ public class TestVectorizedListColumnReader extends VectorizedColumnReaderTestBa
           long length = vector.lengths[i];
           boolean isNull = isNull(row);
           if (isNull) {
-            assertEquals(vector.isNull[i], true);
+            assertEquals("vector.isNull[" + i + "] is expected to be true", true, vector.isNull[i]);
           } else {
             for (long j = 0; j < length; j++) {
               assertValue(type, vector.child, isDictionaryEncoding, index, (int) (start + j));

--- a/ql/src/test/queries/clientpositive/parquet_map_null_vectorization.q
+++ b/ql/src/test/queries/clientpositive/parquet_map_null_vectorization.q
@@ -1,0 +1,20 @@
+set hive.mapred.mode=nonstrict;
+set hive.vectorized.execution.enabled=true;
+set hive.fetch.task.conversion=none;
+
+DROP TABLE parquet_map_type;
+
+
+CREATE TABLE parquet_map_type (
+id int,
+stringMap map<string, string>
+) stored as parquet;
+
+
+insert overwrite table parquet_map_type
+SELECT 1, MAP('k1', null, 'k2', 'v2');
+
+
+select id, stringMap from parquet_map_type;
+
+select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1'];

--- a/ql/src/test/queries/clientpositive/parquet_map_null_vectorization.q
+++ b/ql/src/test/queries/clientpositive/parquet_map_null_vectorization.q
@@ -2,19 +2,88 @@ set hive.mapred.mode=nonstrict;
 set hive.vectorized.execution.enabled=true;
 set hive.fetch.task.conversion=none;
 
-DROP TABLE parquet_map_type;
+-- *** BOOLEAN ***
+CREATE TABLE parquet_map_type_boolean (
+id int,
+booleanMap map<boolean, boolean>
+) stored as parquet;
+
+insert into parquet_map_type_boolean SELECT 1, MAP(true, null, false, true); -- NULL as value
+insert into parquet_map_type_boolean (id) VALUES (2);
+--insert into parquet_map_type_boolean SELECT 3, MAP(null, false, true, true); -- NULL as key, fails until HIVE-25484 is solved
+
+select id, booleanMap from parquet_map_type_boolean;
+select id, booleanMap[true] from parquet_map_type_boolean group by id, booleanMap[true];
 
 
-CREATE TABLE parquet_map_type (
+-- *** STRING ***
+CREATE TABLE parquet_map_type_string (
 id int,
 stringMap map<string, string>
 ) stored as parquet;
 
+insert into parquet_map_type_string SELECT 1, MAP('k1', null, 'k2', 'v2'); -- NULL as value
+--insert into parquet_map_type_string (id) VALUES (2);-- NULL as map, fails until HIVE-25484 is solved
+--insert into parquet_map_type_string SELECT 3, MAP(null, 'k3', 'k4', 'v4'); -- NULL as key, fails until HIVE-25484 is solved
 
-insert overwrite table parquet_map_type
-SELECT 1, MAP('k1', null, 'k2', 'v2');
+select id, stringMap from parquet_map_type_string;
+select id, stringMap['k1'] from parquet_map_type_string group by id, stringMap['k1'];
 
 
-select id, stringMap from parquet_map_type;
+-- *** INT ***
+CREATE TABLE parquet_map_type_int (
+id int,
+intMap map<int, int>
+) stored as parquet;
 
-select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1'];
+insert into parquet_map_type_int SELECT 1, MAP(1, null, 2, 3); -- NULL as value
+insert into parquet_map_type_int (id) VALUES (2); -- NULL as map
+--insert into parquet_map_type_int SELECT 3, MAP(null, 4, 5, 6); -- NULL as key, fails until HIVE-25484 is solved
+
+select id, intMap from parquet_map_type_int;
+select id, intMap[1] from parquet_map_type_int group by id, intMap[1];
+
+
+-- *** DOUBLE ***
+CREATE TABLE parquet_map_type_double (
+id int,
+doubleMap map<double, double>
+) stored as parquet;
+
+--insert into parquet_map_type_double SELECT 1, MAP(CAST(1.0 as DOUBLE), null, CAST(2.0 as DOUBLE), CAST(3.0 as DOUBLE)); -- NULL as value, fails until HIVE-25484 is solved
+insert into parquet_map_type_double (id) VALUES (2);
+--insert into parquet_map_type_double SELECT 3, MAP(null, CAST(4.0 as DOUBLE), CAST(5.0 as DOUBLE), CAST(6.0 as DOUBLE)); -- NULL as key, fails until HIVE-25484 is solved
+
+select id, doubleMap from parquet_map_type_double;
+select id, doubleMap[1.0] from parquet_map_type_double group by id, doubleMap[1.0];
+
+
+-- *** DECIMAL ***
+CREATE TABLE parquet_map_type_decimal (
+id int,
+decimalMap map<decimal(1,0), decimal(1,0)>
+) stored as parquet;
+
+insert into parquet_map_type_decimal SELECT 1, MAP(1.0, NULL, 2.0, 3.0);
+insert into parquet_map_type_decimal (id) VALUES (2);
+--insert into parquet_map_type_decimal SELECT 3, MAP(null, 4.0, 5.0, 6.0); -- NULL as key, fails until HIVE-25484 is solved
+
+select id, decimalMap from parquet_map_type_decimal;
+select id, decimalMap[1.0] from parquet_map_type_decimal group by id, decimalMap[1.0];
+
+
+-- *** DATE ***
+CREATE TABLE parquet_map_type_date (
+id int,
+dateMap map<date, date>
+) stored as parquet;
+
+insert into parquet_map_type_date SELECT 1, MAP(CAST('2015-11-29' AS DATE), NULL, CAST('2016-11-29' AS DATE), CAST('2017-11-29' AS DATE));
+insert into parquet_map_type_date (id) VALUES (2);
+--insert into parquet_map_type_date SELECT 3, MAP(null, CAST('2018-11-29' AS DATE), CAST('2019-11-29' AS DATE), CAST('2020-11-29' AS DATE)); -- NULL as key, fails until HIVE-25484 is solved
+
+select id, dateMap from parquet_map_type_date;
+select id, dateMap[CAST('2015-11-29' AS DATE)] from parquet_map_type_date group by id, dateMap[CAST('2015-11-29' AS DATE)];
+
+
+-- *** TIMESTAMP: currently not supported by VectorizedListColumnReader.fillColumnVector ***

--- a/ql/src/test/results/clientpositive/llap/parquet_map_null_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_map_null_vectorization.q.out
@@ -1,0 +1,48 @@
+PREHOOK: query: DROP TABLE parquet_map_type
+PREHOOK: type: DROPTABLE
+POSTHOOK: query: DROP TABLE parquet_map_type
+POSTHOOK: type: DROPTABLE
+PREHOOK: query: CREATE TABLE parquet_map_type (
+id int,
+stringMap map<string, string>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type
+POSTHOOK: query: CREATE TABLE parquet_map_type (
+id int,
+stringMap map<string, string>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type
+PREHOOK: query: insert overwrite table parquet_map_type
+SELECT 1, MAP('k1', null, 'k2', 'v2')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type
+POSTHOOK: query: insert overwrite table parquet_map_type
+SELECT 1, MAP('k1', null, 'k2', 'v2')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type
+POSTHOOK: Lineage: parquet_map_type.id SIMPLE []
+POSTHOOK: Lineage: parquet_map_type.stringmap EXPRESSION []
+PREHOOK: query: select id, stringMap from parquet_map_type
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type
+#### A masked pattern was here ####
+POSTHOOK: query: select id, stringMap from parquet_map_type
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type
+#### A masked pattern was here ####
+1	{"k1":null,"k2":"v2"}
+PREHOOK: query: select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1']
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type
+#### A masked pattern was here ####
+POSTHOOK: query: select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1']
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type
+#### A masked pattern was here ####
+1	NULL

--- a/ql/src/test/results/clientpositive/llap/parquet_map_null_vectorization.q.out
+++ b/ql/src/test/results/clientpositive/llap/parquet_map_null_vectorization.q.out
@@ -1,48 +1,318 @@
-PREHOOK: query: DROP TABLE parquet_map_type
-PREHOOK: type: DROPTABLE
-POSTHOOK: query: DROP TABLE parquet_map_type
-POSTHOOK: type: DROPTABLE
-PREHOOK: query: CREATE TABLE parquet_map_type (
+PREHOOK: query: CREATE TABLE parquet_map_type_boolean (
+id int,
+booleanMap map<boolean, boolean>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type_boolean
+POSTHOOK: query: CREATE TABLE parquet_map_type_boolean (
+id int,
+booleanMap map<boolean, boolean>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type_boolean
+PREHOOK: query: insert into parquet_map_type_boolean SELECT 1, MAP(true, null, false, true)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_boolean
+POSTHOOK: query: insert into parquet_map_type_boolean SELECT 1, MAP(true, null, false, true)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_boolean
+POSTHOOK: Lineage: parquet_map_type_boolean.booleanmap EXPRESSION []
+POSTHOOK: Lineage: parquet_map_type_boolean.id SIMPLE []
+PREHOOK: query: -- NULL as value
+insert into parquet_map_type_boolean (id) VALUES (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_boolean
+POSTHOOK: query: -- NULL as value
+insert into parquet_map_type_boolean (id) VALUES (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_boolean
+POSTHOOK: Lineage: parquet_map_type_boolean.booleanmap SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_boolean.id SCRIPT []
+PREHOOK: query: select id, booleanMap from parquet_map_type_boolean
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_boolean
+#### A masked pattern was here ####
+POSTHOOK: query: select id, booleanMap from parquet_map_type_boolean
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_boolean
+#### A masked pattern was here ####
+1	{true:false,false:true}
+2	{false:false}
+PREHOOK: query: select id, booleanMap[true] from parquet_map_type_boolean group by id, booleanMap[true]
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_boolean
+#### A masked pattern was here ####
+POSTHOOK: query: select id, booleanMap[true] from parquet_map_type_boolean group by id, booleanMap[true]
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_boolean
+#### A masked pattern was here ####
+2	NULL
+1	false
+PREHOOK: query: CREATE TABLE parquet_map_type_string (
 id int,
 stringMap map<string, string>
 ) stored as parquet
 PREHOOK: type: CREATETABLE
 PREHOOK: Output: database:default
-PREHOOK: Output: default@parquet_map_type
-POSTHOOK: query: CREATE TABLE parquet_map_type (
+PREHOOK: Output: default@parquet_map_type_string
+POSTHOOK: query: CREATE TABLE parquet_map_type_string (
 id int,
 stringMap map<string, string>
 ) stored as parquet
 POSTHOOK: type: CREATETABLE
 POSTHOOK: Output: database:default
-POSTHOOK: Output: default@parquet_map_type
-PREHOOK: query: insert overwrite table parquet_map_type
-SELECT 1, MAP('k1', null, 'k2', 'v2')
+POSTHOOK: Output: default@parquet_map_type_string
+PREHOOK: query: insert into parquet_map_type_string SELECT 1, MAP('k1', null, 'k2', 'v2')
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
-PREHOOK: Output: default@parquet_map_type
-POSTHOOK: query: insert overwrite table parquet_map_type
-SELECT 1, MAP('k1', null, 'k2', 'v2')
+PREHOOK: Output: default@parquet_map_type_string
+POSTHOOK: query: insert into parquet_map_type_string SELECT 1, MAP('k1', null, 'k2', 'v2')
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
-POSTHOOK: Output: default@parquet_map_type
-POSTHOOK: Lineage: parquet_map_type.id SIMPLE []
-POSTHOOK: Lineage: parquet_map_type.stringmap EXPRESSION []
-PREHOOK: query: select id, stringMap from parquet_map_type
+POSTHOOK: Output: default@parquet_map_type_string
+POSTHOOK: Lineage: parquet_map_type_string.id SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_string.stringmap EXPRESSION []
+PREHOOK: query: -- NULL as value
+
+
+
+select id, stringMap from parquet_map_type_string
 PREHOOK: type: QUERY
-PREHOOK: Input: default@parquet_map_type
+PREHOOK: Input: default@parquet_map_type_string
 #### A masked pattern was here ####
-POSTHOOK: query: select id, stringMap from parquet_map_type
+POSTHOOK: query: -- NULL as value
+
+
+
+select id, stringMap from parquet_map_type_string
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@parquet_map_type
+POSTHOOK: Input: default@parquet_map_type_string
 #### A masked pattern was here ####
 1	{"k1":null,"k2":"v2"}
-PREHOOK: query: select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1']
+PREHOOK: query: select id, stringMap['k1'] from parquet_map_type_string group by id, stringMap['k1']
 PREHOOK: type: QUERY
-PREHOOK: Input: default@parquet_map_type
+PREHOOK: Input: default@parquet_map_type_string
 #### A masked pattern was here ####
-POSTHOOK: query: select id, stringMap['k1'] from parquet_map_type group by id, stringMap['k1']
+POSTHOOK: query: select id, stringMap['k1'] from parquet_map_type_string group by id, stringMap['k1']
 POSTHOOK: type: QUERY
-POSTHOOK: Input: default@parquet_map_type
+POSTHOOK: Input: default@parquet_map_type_string
 #### A masked pattern was here ####
 1	NULL
+PREHOOK: query: CREATE TABLE parquet_map_type_int (
+id int,
+intMap map<int, int>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type_int
+POSTHOOK: query: CREATE TABLE parquet_map_type_int (
+id int,
+intMap map<int, int>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type_int
+PREHOOK: query: insert into parquet_map_type_int SELECT 1, MAP(1, null, 2, 3)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_int
+POSTHOOK: query: insert into parquet_map_type_int SELECT 1, MAP(1, null, 2, 3)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_int
+POSTHOOK: Lineage: parquet_map_type_int.id SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_int.intmap EXPRESSION []
+PREHOOK: query: -- NULL as value
+insert into parquet_map_type_int (id) VALUES (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_int
+POSTHOOK: query: -- NULL as value
+insert into parquet_map_type_int (id) VALUES (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_int
+POSTHOOK: Lineage: parquet_map_type_int.id SCRIPT []
+POSTHOOK: Lineage: parquet_map_type_int.intmap SIMPLE []
+PREHOOK: query: -- NULL as map
+
+
+select id, intMap from parquet_map_type_int
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_int
+#### A masked pattern was here ####
+POSTHOOK: query: -- NULL as map
+
+
+select id, intMap from parquet_map_type_int
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_int
+#### A masked pattern was here ####
+1	{1:0,2:3}
+2	{0:0}
+PREHOOK: query: select id, intMap[1] from parquet_map_type_int group by id, intMap[1]
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_int
+#### A masked pattern was here ####
+POSTHOOK: query: select id, intMap[1] from parquet_map_type_int group by id, intMap[1]
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_int
+#### A masked pattern was here ####
+1	0
+2	NULL
+PREHOOK: query: CREATE TABLE parquet_map_type_double (
+id int,
+doubleMap map<double, double>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type_double
+POSTHOOK: query: CREATE TABLE parquet_map_type_double (
+id int,
+doubleMap map<double, double>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type_double
+PREHOOK: query: insert into parquet_map_type_double (id) VALUES (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_double
+POSTHOOK: query: insert into parquet_map_type_double (id) VALUES (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_double
+POSTHOOK: Lineage: parquet_map_type_double.doublemap SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_double.id SCRIPT []
+PREHOOK: query: select id, doubleMap from parquet_map_type_double
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_double
+#### A masked pattern was here ####
+POSTHOOK: query: select id, doubleMap from parquet_map_type_double
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_double
+#### A masked pattern was here ####
+2	{0.0:0.0}
+PREHOOK: query: select id, doubleMap[1.0] from parquet_map_type_double group by id, doubleMap[1.0]
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_double
+#### A masked pattern was here ####
+POSTHOOK: query: select id, doubleMap[1.0] from parquet_map_type_double group by id, doubleMap[1.0]
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_double
+#### A masked pattern was here ####
+2	NULL
+PREHOOK: query: CREATE TABLE parquet_map_type_decimal (
+id int,
+decimalMap map<decimal(1,0), decimal(1,0)>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type_decimal
+POSTHOOK: query: CREATE TABLE parquet_map_type_decimal (
+id int,
+decimalMap map<decimal(1,0), decimal(1,0)>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type_decimal
+PREHOOK: query: insert into parquet_map_type_decimal SELECT 1, MAP(1.0, NULL, 2.0, 3.0)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_decimal
+POSTHOOK: query: insert into parquet_map_type_decimal SELECT 1, MAP(1.0, NULL, 2.0, 3.0)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_decimal
+POSTHOOK: Lineage: parquet_map_type_decimal.decimalmap EXPRESSION []
+POSTHOOK: Lineage: parquet_map_type_decimal.id SIMPLE []
+PREHOOK: query: insert into parquet_map_type_decimal (id) VALUES (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_decimal
+POSTHOOK: query: insert into parquet_map_type_decimal (id) VALUES (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_decimal
+POSTHOOK: Lineage: parquet_map_type_decimal.decimalmap SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_decimal.id SCRIPT []
+PREHOOK: query: select id, decimalMap from parquet_map_type_decimal
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: select id, decimalMap from parquet_map_type_decimal
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_decimal
+#### A masked pattern was here ####
+1	{1:0,2:3}
+2	{0:0}
+PREHOOK: query: select id, decimalMap[1.0] from parquet_map_type_decimal group by id, decimalMap[1.0]
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_decimal
+#### A masked pattern was here ####
+POSTHOOK: query: select id, decimalMap[1.0] from parquet_map_type_decimal group by id, decimalMap[1.0]
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_decimal
+#### A masked pattern was here ####
+1	0
+2	NULL
+PREHOOK: query: CREATE TABLE parquet_map_type_date (
+id int,
+dateMap map<date, date>
+) stored as parquet
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@parquet_map_type_date
+POSTHOOK: query: CREATE TABLE parquet_map_type_date (
+id int,
+dateMap map<date, date>
+) stored as parquet
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@parquet_map_type_date
+PREHOOK: query: insert into parquet_map_type_date SELECT 1, MAP(CAST('2015-11-29' AS DATE), NULL, CAST('2016-11-29' AS DATE), CAST('2017-11-29' AS DATE))
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_date
+POSTHOOK: query: insert into parquet_map_type_date SELECT 1, MAP(CAST('2015-11-29' AS DATE), NULL, CAST('2016-11-29' AS DATE), CAST('2017-11-29' AS DATE))
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_date
+POSTHOOK: Lineage: parquet_map_type_date.datemap EXPRESSION []
+POSTHOOK: Lineage: parquet_map_type_date.id SIMPLE []
+PREHOOK: query: insert into parquet_map_type_date (id) VALUES (2)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@parquet_map_type_date
+POSTHOOK: query: insert into parquet_map_type_date (id) VALUES (2)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@parquet_map_type_date
+POSTHOOK: Lineage: parquet_map_type_date.datemap SIMPLE []
+POSTHOOK: Lineage: parquet_map_type_date.id SCRIPT []
+PREHOOK: query: select id, dateMap from parquet_map_type_date
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_date
+#### A masked pattern was here ####
+POSTHOOK: query: select id, dateMap from parquet_map_type_date
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_date
+#### A masked pattern was here ####
+1	{"2015-11-29":"1970-01-01","2016-11-29":"2017-11-29"}
+2	{"1970-01-01":"1970-01-01"}
+PREHOOK: query: select id, dateMap[CAST('2015-11-29' AS DATE)] from parquet_map_type_date group by id, dateMap[CAST('2015-11-29' AS DATE)]
+PREHOOK: type: QUERY
+PREHOOK: Input: default@parquet_map_type_date
+#### A masked pattern was here ####
+POSTHOOK: query: select id, dateMap[CAST('2015-11-29' AS DATE)] from parquet_map_type_date group by id, dateMap[CAST('2015-11-29' AS DATE)]
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@parquet_map_type_date
+#### A masked pattern was here ####
+1	1970-01-01
+2	NULL

--- a/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
+++ b/storage-api/src/java/org/apache/hadoop/hive/ql/exec/vector/BytesColumnVector.java
@@ -115,6 +115,10 @@ public class BytesColumnVector extends ColumnVector {
    * @param length  length of source byte sequence
    */
   public void setRef(int elementNum, byte[] sourceBuf, int start, int length) {
+    if (sourceBuf == null) {
+      this.isNull[elementNum] = true;
+      this.noNulls = false;
+    }
     vector[elementNum] = sourceBuf;
     this.start[elementNum] = start;
     this.length[elementNum] = length;


### PR DESCRIPTION
### What changes were proposed in this pull request?
This change prepares parquet VectorizedListColumnReader to read null values properly.


### Why are the changes needed?
Customers were facing very similar exceptions in the case of null values, the exception was reproducible with qtest.

### Does this PR introduce _any_ user-facing change?
No.


### How was this patch tested?
1. new qtest (fails without the patch)
2. TestVectorizedListColumnReader and TestVectorizedMapColumnReader cover many cases, and helped fixing some issues with the original patch.