### PR TITLE
HIVE-21614: "Support" comparing Derby's table parameter CLOB by replacing `=` with `LIKE`

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/OperatorEqualsToLikeReplacer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/OperatorEqualsToLikeReplacer.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.metastore;
+
+import org.apache.hadoop.hive.metastore.api.MetaException;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
+import org.apache.hadoop.hive.metastore.parser.ExpressionTree.LeafNode;
+import org.apache.hadoop.hive.metastore.parser.ExpressionTree.Operator;
+import org.apache.hadoop.hive.metastore.parser.ExpressionTree.TreeVisitor;
+
+/**
+ * Replaces any {@link Operator.EQUALS} with {@link Operator.LIKE} for {@link LeafNode}
+ * representing an equality comparison on a table parameter.
+ * 
+ * This utility is effective for database products that do not support equality comparisons
+ * between values of the CLOB type.
+ */
+final class OperatorEqualsToLikeReplacer extends TreeVisitor {
+  @Override
+  protected void visit(LeafNode node) throws MetaException {
+    if (
+      node.keyName.startsWith(hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS)
+      && node.operator == Operator.EQUALS
+    ) {
+      node.operator = Operator.LIKE;
+    }
+  }
+}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/OperatorEqualsToLikeReplacer.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/OperatorEqualsToLikeReplacer.java
@@ -34,10 +34,8 @@ import org.apache.hadoop.hive.metastore.parser.ExpressionTree.TreeVisitor;
 final class OperatorEqualsToLikeReplacer extends TreeVisitor {
   @Override
   protected void visit(LeafNode node) throws MetaException {
-    if (
-      node.keyName.startsWith(hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS)
-      && node.operator == Operator.EQUALS
-    ) {
+    if (node.keyName.startsWith(hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS)
+        && node.operator == Operator.EQUALS) {
       node.operator = Operator.LIKE;
     }
   }

--- a/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/test/java/org/apache/hadoop/hive/metastore/TestHiveMetaStore.java
@@ -2692,6 +2692,15 @@ public abstract class TestHiveMetaStore {
       assert(tableNames.contains(table1.getTableName()));
       assert(tableNames.contains(table2.getTableName()));
 
+      // HIVE-21614: = is externally "supported" for CLOB:
+      filter = org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS +
+          "test_param_2 = \"50\"";
+
+      tableNames = client.listTableNamesByFilter(dbName, filter, (short)-1);
+      assertEquals(2, tableNames.size());
+      assert(tableNames.contains(table1.getTableName()));
+      assert(tableNames.contains(table2.getTableName()));
+
       //test_param_2 = "75"
       filter = org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS +
           "test_param_2 LIKE \"75\"";


### PR DESCRIPTION
### What changes were proposed in this pull request?

On the Hive MetaStore server's side of the `HiveMetaStoreClient#listTableNamesByFilter()` API, conditionally manipulate the string filter by replacing any `=` comparison on a table parameter with a `LIKE` operator.

This replacement is only performed if:

1. The database product backing the Hive MetaStore is Derby,
2. The `=` comparison is on a table parameter, i.e. the `"TABLE_PARAMS"."PARAM_VALUE"` column.

### Why are the changes needed?

HIVE-12274 changed the type of the `"TABLE_PARAMS"."PARAM_VALUE"` column to `CLOB` for Derby and Oracle, e.g.:

https://github.com/apache/hive/blob/7d4134e7fe9bfb8b8aa3344a9ae72f4f36c98b2c/metastore/scripts/upgrade/derby/039-HIVE-12274.derby.sql#L8-L12

With the type change, invoking `ObjectStore#listTableNamesByFilter()` given a `=` comparison -- on a table parameter stored in Derby -- fails with the following exception:

```
ERROR 42818: Comparisons between 'CLOB (UCS_BASIC)' and 'CLOB (UCS_BASIC)' are not supported. Types must be comparable. String types must also have matching collation. If collation does not match, a possible solution is to cast operands to force them to the default collation (e.g. SELECT tablename FROM sys.systables WHERE CAST(tablename AS VARCHAR(128)) = 'T1')
```

Without reverting the column type change, we add support for `=` comparison on table parameters in Derby. This addresses HIVE-21614.

### Does this PR introduce _any_ user-facing change?

Yes, invoking `HiveMetaStoreClient#listTableNamesByFilter()` with a `$param_key = '$param_value'` filter now succeeds for Derby databases.

### How was this patch tested?
