### PR TITLE
HIVE-25338: AIOBE in conv UDF if input is empty

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFConv.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/udf/UDFConv.java
@@ -157,6 +157,10 @@ public class UDFConv extends UDF {
     }
 
     byte[] num = n.getBytes();
+    if (num.length == 0) {
+      // return empty if input is empty
+      return n;
+    }
     boolean negative = (num[0] == '-');
     int first = 0;
     if (negative) {

--- a/ql/src/test/queries/clientpositive/udf_conv.q
+++ b/ql/src/test/queries/clientpositive/udf_conv.q
@@ -76,3 +76,8 @@ FROM src tablesample (1 rows);
 SELECT conv(key, 10, 16),
        conv(key, 16, 10)
 FROM src tablesample (3 rows);
+
+create table test (a string);
+insert into test values (""),(10),(NULL);
+select conv(a,16,10) from test;
+drop table test;

--- a/ql/src/test/results/clientpositive/llap/udf_conv.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_conv.q.out
@@ -181,3 +181,39 @@ POSTHOOK: Input: default@src
 EE	568
 56	134
 137	785
+PREHOOK: query: create table test (a string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test
+POSTHOOK: query: create table test (a string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test
+PREHOOK: query: insert into test values (""),(10),(NULL)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test
+POSTHOOK: query: insert into test values (""),(10),(NULL)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test
+POSTHOOK: Lineage: test.a SCRIPT []
+PREHOOK: query: select conv(a,16,10) from test
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test
+#### A masked pattern was here ####
+POSTHOOK: query: select conv(a,16,10) from test
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test
+#### A masked pattern was here ####
+
+16
+NULL
+PREHOOK: query: drop table test
+PREHOOK: type: DROPTABLE
+PREHOOK: Input: default@test
+PREHOOK: Output: default@test
+POSTHOOK: query: drop table test
+POSTHOOK: type: DROPTABLE
+POSTHOOK: Input: default@test
+POSTHOOK: Output: default@test


### PR DESCRIPTION
### What changes were proposed in this pull request?
If conv UDF has empty input, return the output as empty rather than throwing AIOBE.

### Why are the changes needed?
Query is failing 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Included Testcase in q file.