### PR TITLE
HIVE-25342 : Optimize set_aggr_stats_for for mergeColStats path.

### DIFF
--- a/ql/src/test/queries/clientpositive/autoColumnStats_2.q
+++ b/ql/src/test/queries/clientpositive/autoColumnStats_2.q
@@ -216,3 +216,6 @@ explain select key from b_n3;
 explain select value from c_n1;
 explain select key from c_n1;
 
+describe formatted a_n3 PARTITION (ds='2010-03-11', hr) key;
+describe formatted a_n3 PARTITION (ds='2010-03-11', hr) value;
+

--- a/ql/src/test/results/clientpositive/llap/autoColumnStats_2.q.out
+++ b/ql/src/test/results/clientpositive/llap/autoColumnStats_2.q.out
@@ -1625,3 +1625,41 @@ STAGE PLANS:
             outputColumnNames: _col0
             ListSink
 
+PREHOOK: query: describe formatted a_n3 PARTITION (ds='2010-03-11', hr) key
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@a_n3
+POSTHOOK: query: describe formatted a_n3 PARTITION (ds='2010-03-11', hr) key
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@a_n3
+col_name            	ds                  
+data_type           	string              
+min                 	                    
+max                 	                    
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	100.0               
+max_col_len         	100                 
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	                    
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"ds\":\"true\"}}
+PREHOOK: query: describe formatted a_n3 PARTITION (ds='2010-03-11', hr) value
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@a_n3
+POSTHOOK: query: describe formatted a_n3 PARTITION (ds='2010-03-11', hr) value
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@a_n3
+col_name            	ds                  
+data_type           	string              
+min                 	                    
+max                 	                    
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	100.0               
+max_col_len         	100                 
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	                    
+COLUMN_STATS_ACCURATE	{\"COLUMN_STATS\":{\"ds\":\"true\"}}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/DirectSqlUpdateStat.java
@@ -209,7 +209,7 @@ class DirectSqlUpdateStat {
       try {
         pst = dbConn.prepareStatement(update);
         StatObjectConverter.initUpdatedColumnStatement(mPartitionColumnStatistics, pst);
-        LOG.info("Going to execute update " + update);
+        LOG.debug("Going to execute update " + update);
         int numUpdate = pst.executeUpdate();
         if (numUpdate != 1) {
           throw new MetaException("Invalid state of  PART_COL_STATS for PART_ID " + partId);
@@ -590,6 +590,8 @@ class DirectSqlUpdateStat {
       Map<PartColNameInfo, MPartitionColumnStatistics> insertMap = new HashMap<>();
       Map<PartColNameInfo, MPartitionColumnStatistics> updateMap = new HashMap<>();
       populateInsertUpdateMap(partitionInfoMap, updateMap, insertMap, dbConn);
+
+      LOG.info("Number of stats to insert  " + insertMap.size() + " update " + updateMap.size());
 
       if (insertMap.size() != 0) {
         insertIntoPartColStatTable(insertMap, csId, dbConn);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -8961,6 +8961,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
       Table t = getTable(catName, dbName, tableName);
       Map<String, ColumnStatistics> statsMap =  new HashMap<>();
+      boolean useDirectSql = MetastoreConf.getBoolVar(getConf(), ConfVars.TRY_DIRECT_SQL);
       for (Map.Entry<String, ColumnStatistics> entry : newStatsMap.entrySet()) {
         ColumnStatistics csNew = entry.getValue();
         ColumnStatistics csOld = oldStatsMap.get(entry.getKey());
@@ -8981,7 +8982,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
         if (!csNew.getStatsObj().isEmpty()) {
           // We don't short-circuit on errors here anymore. That can leave acid stats invalid.
-          if (MetastoreConf.getBoolVar(getConf(), ConfVars.TRY_DIRECT_SQL)) {
+          if (useDirectSql) {
             statsMap.put(csNew.getStatsDesc().getPartName(), csNew);
           } else {
             result = updatePartitonColStatsInternal(t, csNew,

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java
@@ -6978,6 +6978,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
     String tableName = tbl.getTableName();
 
     startFunction("updatePartitionColStatsInBatch", ":  db=" + dbName + " table=" + tableName);
+    long start = System.currentTimeMillis();
 
     Map<String, ColumnStatistics> newStatsMap = new HashMap<>();
     long numStats = 0;
@@ -7003,6 +7004,9 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
     } finally {
       endFunction("updatePartitionColStatsInBatch", true, null, tableName);
+      long end = System.currentTimeMillis();
+      float sec = (end - start) / 1000F;
+      LOG.info("updatePartitionColStatsInBatch took " + sec + " seconds for " + statsMap.size() + " stats");
     }
     return true;
   }
@@ -8956,6 +8960,7 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
 
       Table t = getTable(catName, dbName, tableName);
+      Map<String, ColumnStatistics> statsMap =  new HashMap<>();
       for (Map.Entry<String, ColumnStatistics> entry : newStatsMap.entrySet()) {
         ColumnStatistics csNew = entry.getValue();
         ColumnStatistics csOld = oldStatsMap.get(entry.getKey());
@@ -8976,8 +8981,12 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
 
         if (!csNew.getStatsObj().isEmpty()) {
           // We don't short-circuit on errors here anymore. That can leave acid stats invalid.
-          result = updatePartitonColStatsInternal(t, csNew,
-              request.getValidWriteIdList(), request.getWriteId()) && result;
+          if (MetastoreConf.getBoolVar(getConf(), ConfVars.TRY_DIRECT_SQL)) {
+            statsMap.put(csNew.getStatsDesc().getPartName(), csNew);
+          } else {
+            result = updatePartitonColStatsInternal(t, csNew,
+                    request.getValidWriteIdList(), request.getWriteId()) && result;
+          }
         } else if (isInvalidTxnStats) {
           // For now because the stats state is such as it is, we will invalidate everything.
           // Overall the sematics here are not clear - we could invalide only some columns, but does
@@ -8996,6 +9005,11 @@ public class HMSHandler extends FacebookBase implements IHMSHandler {
       }
       ms.commitTransaction();
       isCommitted = true;
+      // updatePartitionColStatsInBatch starts/commit transaction internally. As there is no write or select for update
+      // operations is done in this transaction, it is safe to commit it before calling updatePartitionColStatsInBatch.
+      if (!statsMap.isEmpty()) {
+        updatePartitionColStatsInBatch(t, statsMap,  request.getValidWriteIdList(), request.getWriteId());
+      }
     } finally {
       if (!isCommitted) {
         ms.rollbackTransaction();


### PR DESCRIPTION
<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
For the path where stats merge is done, optimisation using direct sql was missing. Now if the direct sql mode is enabled, the stats are collected in a map and updated in a batch.


### Why are the changes needed?
perf improvement.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Ptest.
