### PR TITLE
HIVE-25343. Replace existed view should clean the old table properties

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateViewOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateViewOperation.java
@@ -79,8 +79,8 @@ public class CreateViewOperation extends DDLOperation<CreateViewDesc> {
       if (desc.getComment() != null) {
         oldview.setProperty("comment", desc.getComment());
       }
+      oldview.getTTable().getParameters().clear();
       if (desc.getProperties() != null) {
-        oldview.getTTable().getParameters().clear();
         oldview.getTTable().getParameters().putAll(desc.getProperties());
       }
       oldview.setPartCols(desc.getPartitionColumns());

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateViewOperation.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/create/CreateViewOperation.java
@@ -80,6 +80,7 @@ public class CreateViewOperation extends DDLOperation<CreateViewDesc> {
         oldview.setProperty("comment", desc.getComment());
       }
       if (desc.getProperties() != null) {
+        oldview.getTTable().getParameters().clear();
         oldview.getTTable().getParameters().putAll(desc.getProperties());
       }
       oldview.setPartCols(desc.getPartitionColumns());


### PR DESCRIPTION
### What changes were proposed in this pull request?
In many cases, users use Spark and Hive together. When a user creates a view via Spark, the table output columns will store in table properties, such as
<img width="451" alt="Screen Shot 2021-07-19 at 15 36 29" src="https://user-images.githubusercontent.com/1853780/126135227-2bf88250-03f4-4e7e-ba0a-6ba3f3c43483.png">

After that, if the user runs the command "create or replace view" via Hive, to change the schema. The old table properties added by Spark are not cleaned by Hive. Then users read the table via Spark. The schema didn't change. It very confused users.


### Why are the changes needed?
Fix the problem mentioned above.
How to reproduce:
```
spark-sql>create table lajin_table (a int, b int) stored as parquet;
spark-sql>create view lajin_view as select * from lajin_table;
spark-sql> desc lajin_view;
a       int     NULL    NULL
b       int     NULL    NULL

hive>desc lajin_view;
a                       int                                         
b                       int
hive>create or replace view lajin_view as select a, b, 3 as c from lajin_table;
hive>desc lajin_view;
a                       int                                         
b                       int                                         
c                       int

spark-sql> desc lajin_view; -- not changed
a       int     NULL    NULL
b       int     NULL    NULL
```

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Exists UTs or a new test.