### PR TITLE
HIVE-25348: Skip metrics collection about writes to tables with tblproperty no_auto_compaction=true if CTAS

### DIFF
--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands3.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands3.java
@@ -606,7 +606,8 @@ public class TestTxnCommands3 extends TxnCommandsBaseForTests {
         TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from TXNS"));
   }
 
-  @Test public void testWritesToDisabledCompactionTableCtas() throws Exception {
+  @Test
+  public void testWritesToDisabledCompactionTableCtas() throws Exception {
     MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.METRICS_ENABLED, true);
     MetastoreConf.setVar(hiveConf, MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS,
         HMSMetricsListener.class.getName());

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands3.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands3.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.common.FileUtils;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HMSMetricsListener;
 import org.apache.hadoop.hive.metastore.api.GetOpenTxnsResponse;
 import org.apache.hadoop.hive.metastore.api.ShowCompactRequest;
 import org.apache.hadoop.hive.metastore.api.ShowCompactResponse;
@@ -603,5 +604,15 @@ public class TestTxnCommands3 extends TxnCommandsBaseForTests {
   private void assertOneTxn() throws Exception {
     Assert.assertEquals(TestTxnDbUtil.queryToString(hiveConf, "select * from TXNS"), 1,
         TestTxnDbUtil.countQueryAgent(hiveConf, "select count(*) from TXNS"));
+  }
+
+  @Test public void testWritesToDisabledCompactionTableCtas() throws Exception {
+    MetastoreConf.setBoolVar(hiveConf, MetastoreConf.ConfVars.METRICS_ENABLED, true);
+    MetastoreConf.setVar(hiveConf, MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS,
+        HMSMetricsListener.class.getName());
+
+    runStatementOnDriver("insert into " + Table.ACIDTBL + " values(1,1)");
+    runStatementOnDriver("create table mytable stored as orc tblproperties ('transactional'='true')"
+        + "as select * from " + Table.ACIDTBL);
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/txn/compactor/TestCompactionMetrics.java
@@ -811,6 +811,9 @@ public class TestCompactionMetrics  extends CompactorTest {
         2, Metrics.getOrCreateGauge(MetricsConstants.TABLES_WITH_X_ABORTED_TXNS).intValue());
   }
 
+  /**
+   * See also org.apache.hadoop.hive.ql.TestTxnCommands3#testWritesToDisabledCompactionTableCtas()
+   */
   @Test
   public void testWritesToDisabledCompactionTable() throws Exception {
     MetastoreConf.setVar(conf, MetastoreConf.ConfVars.TRANSACTIONAL_EVENT_LISTENERS, HMSMetricsListener.class.getName());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSMetricsListener.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSMetricsListener.java
@@ -100,7 +100,8 @@ public class HMSMetricsListener extends MetaStoreEventListener {
     if (MetastoreConf.getBoolVar(getConf(), MetastoreConf.ConfVars.METASTORE_ACIDMETRICS_EXT_ON)) {
       Table table = getTable(allocWriteIdEvent);
 
-      if (MetaStoreUtils.isNoAutoCompactSet(table.getParameters())) {
+      // In the case of CTAS, the table is created after write ids are allocated, so we'll skip metrics collection.
+      if (table != null && MetaStoreUtils.isNoAutoCompactSet(table.getParameters())) {
         Metrics.getOrCreateGauge(MetricsConstants.WRITES_TO_DISABLED_COMPACTION_TABLE).incrementAndGet();
       }
     }


### PR DESCRIPTION
### Why are the changes needed?
See HIVE-25348

### How was this patch tested?
Unit test
