### PR TITLE
Hive-24467: ConditionalTask remove tasks that not selected exists thr…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/QueryState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/QueryState.java
@@ -20,6 +20,8 @@ package org.apache.hadoop.hive.ql;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.lockmgr.HiveTxnManager;
 import org.apache.hadoop.hive.ql.plan.HiveOperation;
@@ -64,6 +66,11 @@ public class QueryState {
    * map of resources involved in the query.
    */
   private final Map<String, Object> resourceMap = new HashMap<>();
+
+  /**
+   * query level lock for ConditionalTask#resolveTask.
+   */
+  private final ReentrantLock resolveConditionalTaskLock = new ReentrantLock(true);
 
   /**
    * Private constructor, use QueryState.Builder instead.
@@ -153,6 +160,10 @@ public class QueryState {
 
   public Object getResource(String resourceIdentifier) {
     return resourceMap.get(resourceIdentifier);
+  }
+
+  public ReentrantLock getResolveConditionalTaskLock() {
+    return resolveConditionalTaskLock;
   }
 
   /**

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ConditionalTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ConditionalTask.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hive.ql.exec;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.plan.ConditionalResolver;
@@ -32,6 +33,8 @@ import org.apache.hadoop.hive.ql.plan.api.StageType;
 public class ConditionalTask extends Task<ConditionalWork> implements Serializable {
 
   private static final long serialVersionUID = 1L;
+  private static final ReentrantLock RESOLVE_TASK_LOCK = new ReentrantLock();
+
   private List<Task<?>> listTasks;
 
   private boolean resolved = false;
@@ -79,10 +82,13 @@ public class ConditionalTask extends Task<ConditionalWork> implements Serializab
     resolved = true;
 
     try {
+      RESOLVE_TASK_LOCK.lock();
       resolveTask();
     } catch (Exception e) {
       setException(e);
       return 1;
+    } finally {
+      RESOLVE_TASK_LOCK.unlock();
     }
     return 0;
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/ConditionalTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/ConditionalTask.java
@@ -80,7 +80,7 @@ public class ConditionalTask extends Task<ConditionalWork> implements Serializab
     resTasks = resolver.getTasks(conf, resolverCtx);
     resolved = true;
 
-    ReentrantLock resolveTaskLock = SessionState.get().getResolveConditionalTaskLock();
+    ReentrantLock resolveTaskLock = queryState.getResolveConditionalTaskLock();
     try {
       resolveTaskLock.lock();
       resolveTask();

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -160,9 +160,6 @@ public class SessionState implements ISessionAuthState{
   // Session-scope compile lock.
   private final ReentrantLock compileLock = new ReentrantLock(true);
 
-  // Session-scope lock for ConditionalTask#resolveTask.
-  private final ReentrantLock resolveConditionalTaskLock = new ReentrantLock(true);
-
   /**
    * current configuration.
    */
@@ -433,10 +430,6 @@ public class SessionState implements ISessionAuthState{
 
   public ReentrantLock getCompileLock() {
     return compileLock;
-  }
-
-  public ReentrantLock getResolveConditionalTaskLock() {
-    return resolveConditionalTaskLock;
   }
 
   public boolean getIsVerbose() {

--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -160,6 +160,9 @@ public class SessionState implements ISessionAuthState{
   // Session-scope compile lock.
   private final ReentrantLock compileLock = new ReentrantLock(true);
 
+  // Session-scope lock for ConditionalTask#resolveTask.
+  private final ReentrantLock resolveConditionalTaskLock = new ReentrantLock(true);
+
   /**
    * current configuration.
    */
@@ -430,6 +433,10 @@ public class SessionState implements ISessionAuthState{
 
   public ReentrantLock getCompileLock() {
     return compileLock;
+  }
+
+  public ReentrantLock getResolveConditionalTaskLock() {
+    return resolveConditionalTaskLock;
   }
 
   public boolean getIsVerbose() {


### PR DESCRIPTION
…ead safety problem

### What changes were proposed in this pull request?
Add lock to org.apache.hadoop.hive.ql.exec.ConditionalTask#resolveTask to prevent race condition when parallel execution is enabled

### Why are the changes needed?
Otherwise some stages might not be executed because of the race condition, result in wrong result or partial result.
Please refer to the JIRA issue：https://issues.apache.org/jira/browse/HIVE-24467


### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Tested in version hive-1.1.0 in our hadoop cluster