### PR TITLE
HIVE-25353: Incremental rebuild of partitioned insert only MV in presence of delete operations

### DIFF
--- a/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
+++ b/common/src/java/org/apache/hadoop/hive/conf/HiveConf.java
@@ -1926,6 +1926,11 @@ public class HiveConf extends Configuration {
         "tries to modify the original materialization contents to reflect the latest changes to the\n" +
         "materialized view source tables, instead of rebuilding the contents fully. Incremental rebuild\n" +
         "is based on the materialized view algebraic incremental rewriting."),
+    HIVE_MATERIALIZED_VIEW_REBUILD_INCREMENTAL_PARTITION("hive.materializedview.rebuild.incremental.partition", true,
+        "Whether to try to execute partition based incremental rebuild for the materialized views. " +
+        "Partition based incremental rebuild tries to rebuild the materialization partitions which are affected by latest changes of the\n" +
+        "materialized view source tables only, instead of rebuilding all partitions. " +
+        "hive.materializedview.rebuild.incremental must be enabled."),
     HIVE_MATERIALIZED_VIEW_REBUILD_INCREMENTAL_FACTOR("hive.materializedview.rebuild.incremental.factor", 0.1f,
         "The estimated cost of the resulting plan for incremental maintenance of materialization\n" +
         "with aggregations will be multiplied by this value. Reducing the value can be useful to\n" +

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/view/materialized/alter/rebuild/AlterMaterializedViewRebuildAnalyzer.java
@@ -389,6 +389,10 @@ public class AlterMaterializedViewRebuildAnalyzer extends CalcitePlanner {
             RelNode basePlan, RelMetadataProvider mdProvider, RexExecutor executorProvider,
             HiveRelOptMaterialization materialization, RelNode calcitePreMVRewritingPlan) {
 
+      if (!HiveConf.getBoolVar(conf, HiveConf.ConfVars.HIVE_MATERIALIZED_VIEW_REBUILD_INCREMENTAL_PARTITION)) {
+        return null;
+      }
+
       RelOptHiveTable hiveTable = (RelOptHiveTable) materialization.tableRel.getTable();
       if (!AcidUtils.isInsertOnlyTable(hiveTable.getHiveTableMD())) {
         // TODO: plan may contains TS on fully ACID table and aggregate functions which are not supported the

--- a/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionInsertDeleteIncrementalRewritingRule.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/optimizer/calcite/rules/views/HiveAggregatePartitionInsertDeleteIncrementalRewritingRule.java
@@ -1,5 +1,4 @@
-package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;
-/*
+package org.apache.hadoop.hive.ql.optimizer.calcite.rules.views;/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,6 +20,7 @@ import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.core.Union;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
@@ -30,19 +30,23 @@ import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.rex.RexTableInputRef;
 import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.hadoop.hive.ql.optimizer.calcite.HiveRelFactories;
 import org.apache.hadoop.hive.ql.optimizer.calcite.RelOptHiveTable;
+import org.apache.hadoop.hive.ql.optimizer.calcite.rules.HiveHepExtractRelNodeRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import static org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil.findRexTableInputRefs;
+import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveAggregateInsertDeleteIncrementalRewritingRule.createJoinRightInput;
+import static org.apache.hadoop.hive.ql.optimizer.calcite.rules.views.HiveAggregatePartitionIncrementalRewritingRule.findPartitionColumnIndexes;
 
 /**
  * Rule to prepare the plan for incremental view maintenance if the view is partitioned and insert only:
@@ -52,29 +56,37 @@ import static org.apache.hadoop.hive.ql.optimizer.calcite.HiveCalciteUtil.findRe
  * Assume that we have a materialized view partitioned on column a and writeId was 1 at the last rebuild:
  *
  * CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
- * SELECT a, b, sum(c) sumc FROM t1 GROUP BY b, a;
+ * SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a;
  *
  * 1. Query all rows from source tables since the last rebuild.
  * 2. Query all rows from MV which are in any of the partitions queried in 1.
  * 3. Take the union of rows from 1. and 2. and perform the same aggregations defined in the MV
  *
- * SELECT a, b, sum(sumc) FROM (
- *     SELECT a, b, sumc FROM mat1
- *     LEFT SEMI JOIN (SELECT a, b, sum(c) FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
- *     UNION ALL
- *     SELECT a, b, sum(c) sumc FROM t1 WHERE ROW__ID.writeId > 1 GROUP BY b, a
+ * SELECT a, b, sum(sumc), sum(countstar) counttotal FROM (
+ *   SELECT a, b, sumc, countstar FROM mat1
+ *   LEFT SEMI JOIN (SELECT a FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+ *   UNION ALL
+ *   SELECT a, b,
+ *     sum(CASE WHEN t1.ROW__IS__DELETED THEN -c ELSE c END) sumc,
+ *     sum(CASE WHEN t1.ROW__IS__DELETED THEN -1 ELSE 1 END) countstar
+ *   FROM t1('acid.fetch.deleted.rows'='true')
+ *   WHERE ROW__ID.writeId > 1
+ *   GROUP BY b, a
  * ) sub
- * GROUP BY b, a
+ * GROUP BY a, b
+ * HAVING counttotal > 0
+ * ORDER BY a, b;
+ *
  */
-public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
-  private static final Logger LOG = LoggerFactory.getLogger(HiveAggregatePartitionIncrementalRewritingRule.class);
+public class HiveAggregatePartitionInsertDeleteIncrementalRewritingRule extends RelOptRule {
+  private static final Logger LOG = LoggerFactory.getLogger(HiveAggregatePartitionInsertDeleteIncrementalRewritingRule.class);
 
-  public static final HiveAggregatePartitionIncrementalRewritingRule INSTANCE =
-          new HiveAggregatePartitionIncrementalRewritingRule();
+  public static final HiveAggregatePartitionInsertDeleteIncrementalRewritingRule INSTANCE =
+          new HiveAggregatePartitionInsertDeleteIncrementalRewritingRule();
 
-  private HiveAggregatePartitionIncrementalRewritingRule() {
-    super(operand(Aggregate.class, operand(Union.class, any())),
-            HiveRelFactories.HIVE_BUILDER, "HiveAggregatePartitionIncrementalRewritingRule");
+  private HiveAggregatePartitionInsertDeleteIncrementalRewritingRule() {
+    super(operand(Aggregate.class, operand(Union.class, operand(Aggregate.class, any()))),
+            HiveRelFactories.HIVE_BUILDER, "HiveAggregatePartitionInsertDeleteIncrementalRewritingRule");
   }
 
   @Override
@@ -83,13 +95,23 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
 
     final Aggregate aggregate = call.rel(0);
     final Union union = call.rel(1);
-    final RelNode queryBranch = union.getInput(0);
+    final Aggregate queryAgg = call.rel(2);
     final RelNode mvBranch = union.getInput(1);
+    RelBuilder relBuilder = call.builder();
 
     Set<Integer> partitionColumnIndexes = findPartitionColumnIndexes(mvBranch, rexBuilder);
     if (partitionColumnIndexes == null) {
       return;
     }
+
+    HiveAggregateInsertDeleteIncrementalRewritingRule.IncrementalComputePlanWithDeletedRows plan =
+            createJoinRightInput(queryAgg, call.builder());
+    if (plan == null) {
+      return;
+    }
+
+    RelNode queryBranch = plan.rightInput;
+    int countStarIdx = plan.getCountStarIndex();
 
     List<RexNode> joinConjs = new ArrayList<>();
     for (int partColIndex: partitionColumnIndexes) {
@@ -104,6 +126,10 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
 
     RexNode joinCond = RexUtil.composeConjunction(rexBuilder, joinConjs);
 
+    RexNode countStar = rexBuilder.makeInputRef(
+            aggregate.getRowType().getFieldList().get(countStarIdx).getType(), countStarIdx);
+    RexNode countStarGT0 = rexBuilder.makeCall(SqlStdOperatorTable.GREATER_THAN, countStar, relBuilder.literal(0));
+
     RelBuilder builder = call.builder();
     RelNode newNode = builder
             .push(mvBranch)
@@ -112,57 +138,8 @@ public class HiveAggregatePartitionIncrementalRewritingRule extends RelOptRule {
             .push(queryBranch)
             .union(union.all)
             .aggregate(builder.groupKey(aggregate.getGroupSet()), aggregate.getAggCallList())
+            .filter(countStarGT0)
             .build();
     call.transformTo(newNode);
-  }
-
-  /**
-   * Find Partition col indexes in mvBranch top operator row schema.
-   * mvBranch can be more complex than just a TS on the MV and the partition columns indexes in the top Operator's
-   * row schema may differ from the one in the TS row schema. Example:
-   * Project($2, $0, $1)
-   *   TableScan(table=materialized_view1, schema=a, b, part_col)
-   * @param mvBranch root of branch to scan
-   * @param rexBuilder rexBuilder instance to create InputRefs for column expression lineage query.
-   * @return set of partition column indexes in the given root row schema
-   * or null if not all the partition columns could be find.
-   */
-  static Set<Integer> findPartitionColumnIndexes(RelNode mvBranch, RexBuilder rexBuilder) {
-    RelMetadataQuery relMetadataQuery = RelMetadataQuery.instance();
-    int partitionColumnCount = -1;
-    Set<Integer> partitionColumnIndexes = new HashSet<>();
-    for (int i = 0; i < mvBranch.getRowType().getFieldList().size(); ++i) {
-      RelDataTypeField relDataTypeField = mvBranch.getRowType().getFieldList().get(i);
-      RexInputRef inputRef = rexBuilder.makeInputRef(relDataTypeField.getType(), i);
-
-      Set<RexNode> expressionLineage = relMetadataQuery.getExpressionLineage(mvBranch, inputRef);
-      if (expressionLineage == null || expressionLineage.size() != 1) {
-        continue;
-      }
-
-      Set<RexTableInputRef> tableInputRefs = findRexTableInputRefs(expressionLineage.iterator().next());
-      if (tableInputRefs.size() != 1) {
-        continue;
-      }
-
-      RexTableInputRef tableInputRef = tableInputRefs.iterator().next();
-      RelOptHiveTable relOptHiveTable = (RelOptHiveTable) tableInputRef.getTableRef().getTable();
-      if (!(relOptHiveTable.getHiveTableMD().isMaterializedView())) {
-        LOG.warn("{} is not a materialized view, bail out.", relOptHiveTable.getQualifiedName());
-        return null;
-      }
-
-      partitionColumnCount = relOptHiveTable.getPartColInfoMap().size();
-      if (relOptHiveTable.getPartColInfoMap().containsKey(tableInputRef.getIndex())) {
-        partitionColumnIndexes.add(i);
-      }
-    }
-
-    if (partitionColumnCount <= 0 || partitionColumnIndexes.size() != partitionColumnCount) {
-      LOG.debug("Could not find all partition column lineages, bail out.");
-      return null;
-    }
-
-    return partitionColumnIndexes;
   }
 }

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg.q
@@ -29,8 +29,15 @@ SELECT b, sum(sumc), a FROM (
 GROUP BY b, a
 ORDER BY a, b;
 
+
+SET hive.materializedview.rebuild.incremental.partition=false;
 EXPLAIN CBO
 ALTER MATERIALIZED VIEW mat1 REBUILD;
+
+SET hive.materializedview.rebuild.incremental.partition=true;
+EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+
 EXPLAIN
 ALTER MATERIALIZED VIEW mat1 REBUILD;
 ALTER MATERIALIZED VIEW mat1 REBUILD;

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_del.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_del.q
@@ -1,0 +1,41 @@
+set hive.support.concurrency=true;
+set hive.txn.manager=org.apache.hadoop.hive.ql.lockmgr.DbTxnManager;
+set hive.optimize.sort.dynamic.partition=true;
+--set hive.vectorized.execution.enabled=false;
+
+CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true');
+
+INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4), -- del
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100); -- del
+
+CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a;
+
+DELETE FROM t1 WHERE c = 4 OR c = 100;
+
+SELECT a, b, sum(sumc), sum(countstar) counttotal FROM (
+    SELECT a, b, sumc, countstar FROM mat1
+    LEFT SEMI JOIN (SELECT a, b, sum(c), count(*) FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT a, b, sum(CASE WHEN t1.ROW__IS__DELETED THEN -c ELSE c END) sumc, sum(CASE WHEN t1.ROW__IS__DELETED THEN -1 ELSE 1 END) countstar FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+HAVING counttotal > 0
+ORDER BY a, b;
+
+EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+ALTER MATERIALIZED VIEW mat1 REBUILD;
+
+SELECT a, b, sumc, countstar FROM mat1 ORDER BY a;
+
+DROP MATERIALIZED VIEW mat1;
+
+SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a;

--- a/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_del.q
+++ b/ql/src/test/queries/clientpositive/materialized_view_partitioned_create_rewrite_agg_del.q
@@ -11,7 +11,8 @@ INSERT INTO t1(a, b, c) VALUES
 (2, 1, 2),
 (1, 2, 10),
 (2, 2, 11),
-(1, 3, 100); -- del
+(1, 3, 100), -- del
+(3, 3, 100); -- del
 
 CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
 SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a;

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg.q.out
@@ -126,6 +126,36 @@ POSTHOOK: Output: default@mat1
 CBO PLAN:
 HiveProject(b=[$0], sumc=[$2], a=[$1])
   HiveAggregate(group=[{0, 1}], agg#0=[sum($2)])
+    HiveProject($f0=[$0], $f1=[$1], $f2=[$2])
+      HiveUnion(all=[true])
+        HiveProject(b=[$1], a=[$0], $f2=[$2])
+          HiveAggregate(group=[{0, 1}], agg#0=[sum($2)])
+            HiveFilter(condition=[<(1, $5.writeid)])
+              HiveTableScan(table=[[default, t1]], table:alias=[t1])
+        HiveProject(b=[$0], a=[$2], sumc=[$1])
+          HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+
+PREHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=__HIVE_DEFAULT_PARTITION__
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(b=[$0], sumc=[$2], a=[$1])
+  HiveAggregate(group=[{0, 1}], agg#0=[sum($2)])
     HiveProject(b=[$0], a=[$1], sumc=[$2])
       HiveUnion(all=[true])
         HiveProject(b=[$0], a=[$1], sumc=[$2])

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_del.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_del.q.out
@@ -1,0 +1,456 @@
+PREHOOK: query: CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@t1
+POSTHOOK: query: CREATE TABLE t1(a int, b int,c int) STORED AS ORC TBLPROPERTIES ('transactional' = 'true')
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@t1
+PREHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4), -- del
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@t1
+POSTHOOK: query: INSERT INTO t1(a, b, c) VALUES
+(1, 1, 1),
+(1, 1, 4), -- del
+(2, 1, 2),
+(1, 2, 10),
+(2, 2, 11),
+(1, 3, 100)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@t1
+POSTHOOK: Lineage: t1.a SCRIPT []
+POSTHOOK: Lineage: t1.b SCRIPT []
+POSTHOOK: Lineage: t1.c SCRIPT []
+PREHOOK: query: -- del
+
+CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a
+PREHOOK: type: CREATE_MATERIALIZED_VIEW
+PREHOOK: Input: default@t1
+PREHOOK: Output: database:default
+PREHOOK: Output: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: -- del
+
+CREATE MATERIALIZED VIEW mat1 PARTITIONED ON (a) STORED AS ORC TBLPROPERTIES ("transactional"="true", "transactional_properties"="insert_only") AS
+SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a
+POSTHOOK: type: CREATE_MATERIALIZED_VIEW
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1
+POSTHOOK: Output: default@mat1@a=2
+POSTHOOK: Lineage: mat1 PARTITION(a=1).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).countstar EXPRESSION [(t1)t1.null, ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2).countstar EXPRESSION [(t1)t1.null, ]
+POSTHOOK: Lineage: mat1 PARTITION(a=2).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: DELETE FROM t1 WHERE c = 4 OR c = 100
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@t1
+POSTHOOK: query: DELETE FROM t1 WHERE c = 4 OR c = 100
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@t1
+PREHOOK: query: SELECT a, b, sum(sumc), sum(countstar) counttotal FROM (
+    SELECT a, b, sumc, countstar FROM mat1
+    LEFT SEMI JOIN (SELECT a, b, sum(c), count(*) FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT a, b, sum(CASE WHEN t1.ROW__IS__DELETED THEN -c ELSE c END) sumc, sum(CASE WHEN t1.ROW__IS__DELETED THEN -1 ELSE 1 END) countstar FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+HAVING counttotal > 0
+ORDER BY a, b
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, b, sum(sumc), sum(countstar) counttotal FROM (
+    SELECT a, b, sumc, countstar FROM mat1
+    LEFT SEMI JOIN (SELECT a, b, sum(c), count(*) FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a) q ON (mat1.a <=> q.a)
+    UNION ALL
+    SELECT a, b, sum(CASE WHEN t1.ROW__IS__DELETED THEN -c ELSE c END) sumc, sum(CASE WHEN t1.ROW__IS__DELETED THEN -1 ELSE 1 END) countstar FROM t1('acid.fetch.deleted.rows'='true') WHERE ROW__ID.writeId > 1 GROUP BY b, a
+) sub
+GROUP BY a, b
+HAVING counttotal > 0
+ORDER BY a, b
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	1	1	1
+1	2	10	1
+PREHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN CBO
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+CBO PLAN:
+HiveProject(b=[$0], sumc=[$2], countstar=[COALESCE($3, 0:BIGINT)], a=[$1])
+  HiveFilter(condition=[>(COALESCE($3, 0:BIGINT), 0)])
+    HiveAggregate(group=[{0, 1}], agg#0=[sum($2)], agg#1=[sum($3)])
+      HiveProject(b=[$0], a=[$1], sumc=[$2], countstar=[$3])
+        HiveUnion(all=[true])
+          HiveProject(b=[$0], a=[$1], sumc=[$2], countstar=[$3])
+            HiveSemiJoin(condition=[IS NOT DISTINCT FROM($1, $5)], joinType=[semi])
+              HiveProject(b=[$0], a=[$3], sumc=[$1], countstar=[$2])
+                HiveTableScan(table=[[default, mat1]], table:alias=[default.mat1])
+              HiveProject(b=[$1], a=[$0])
+                HiveAggregate(group=[{0, 1}])
+                  HiveFilter(condition=[<(1, $5.writeid)])
+                    HiveTableScan(table=[[default, t1]], table:alias=[t1])
+          HiveProject(b=[$0], a=[$1], $f2=[$2], $f3=[$3])
+            HiveAggregate(group=[{0, 1}], agg#0=[SUM($2)], agg#1=[SUM($3)])
+              HiveProject(b=[$1], a=[$0], $f4=[CASE($6, *(-1, $2), $2)], $f5=[CASE($6, -1, 1)])
+                HiveFilter(condition=[<(1, $5.writeid)])
+                  HiveTableScan(table=[[default, t1]], table:alias=[t1])
+
+PREHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: EXPLAIN
+ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+STAGE DEPENDENCIES:
+  Stage-1 is a root stage
+  Stage-2 depends on stages: Stage-1
+  Stage-0 depends on stages: Stage-2
+  Stage-3 depends on stages: Stage-0
+  Stage-4 depends on stages: Stage-3
+
+STAGE PLANS:
+  Stage: Stage-1
+    Tez
+#### A masked pattern was here ####
+      Edges:
+        Reducer 2 <- Map 1 (SIMPLE_EDGE), Reducer 7 (SIMPLE_EDGE), Union 3 (CONTAINS)
+        Reducer 4 <- Union 3 (SIMPLE_EDGE)
+        Reducer 5 <- Reducer 4 (SIMPLE_EDGE)
+        Reducer 7 <- Map 6 (SIMPLE_EDGE)
+        Reducer 8 <- Map 6 (SIMPLE_EDGE), Union 3 (CONTAINS)
+#### A masked pattern was here ####
+      Vertices:
+        Map 1 
+            Map Operator Tree:
+                TableScan
+                  alias: default.mat1
+                  Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: b (type: int), a (type: int), sumc (type: bigint), countstar (type: bigint)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col1 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col1 (type: int)
+                      Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                      value expressions: _col0 (type: int), _col2 (type: bigint), _col3 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Map 6 
+            Map Operator Tree:
+                TableScan
+                  alias: t1
+                  filterExpr: (ROW__ID.writeid > 1L) (type: boolean)
+                  properties:
+                    acid.fetch.deleted.rows TRUE
+                  Statistics: Num rows: 4 Data size: 32 Basic stats: COMPLETE Column stats: COMPLETE
+                  Filter Operator
+                    predicate: (ROW__ID.writeid > 1L) (type: boolean)
+                    Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: a (type: int), b (type: int)
+                      outputColumnNames: a, b
+                      Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        keys: a (type: int), b (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1
+                        Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                          Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                    Select Operator
+                      expressions: b (type: int), a (type: int), CASE WHEN (ROW__IS__DELETED) THEN ((-1 * c)) ELSE (c) END (type: int), CASE WHEN (ROW__IS__DELETED) THEN (-1) ELSE (1) END (type: int)
+                      outputColumnNames: _col0, _col1, _col2, _col3
+                      Statistics: Num rows: 1 Data size: 12 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: sum(_col2), sum(_col3)
+                        keys: _col0 (type: int), _col1 (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3
+                        Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int), _col1 (type: int)
+                          null sort order: zz
+                          sort order: ++
+                          Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                          Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col2 (type: bigint), _col3 (type: bigint)
+            Execution mode: vectorized, llap
+            LLAP IO: may be used (ACID table)
+        Reducer 2 
+            Execution mode: llap
+            Reduce Operator Tree:
+              Merge Join Operator
+                condition map:
+                     Left Semi Join 0 to 1
+                keys:
+                  0 _col1 (type: int)
+                  1 _col0 (type: int)
+                nullSafes: [true]
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col2), sum(_col3)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint), _col3 (type: bigint)
+        Reducer 4 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), sum(VALUE._col1)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                Filter Operator
+                  predicate: (COALESCE(_col3,0L) > 0) (type: boolean)
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                  Select Operator
+                    expressions: _col0 (type: int), _col2 (type: bigint), COALESCE(_col3,0L) (type: bigint), _col1 (type: int)
+                    outputColumnNames: _col0, _col1, _col2, _col3
+                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                    File Output Operator
+                      compressed: false
+                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      table:
+                          input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+                          output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+                          serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+                          name: default.mat1
+                      Write Type: INSERT
+                    Select Operator
+                      expressions: _col0 (type: int), _col1 (type: bigint), _col2 (type: bigint), _col3 (type: int)
+                      outputColumnNames: b, sumc, countstar, a
+                      Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                      Group By Operator
+                        aggregations: min(b), max(b), count(1), count(b), compute_bit_vector_hll(b), min(sumc), max(sumc), count(sumc), compute_bit_vector_hll(sumc), min(countstar), max(countstar), count(countstar), compute_bit_vector_hll(countstar)
+                        keys: a (type: int)
+                        minReductionHashAggr: 0.4
+                        mode: hash
+                        outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
+                        Statistics: Num rows: 1 Data size: 508 Basic stats: COMPLETE Column stats: COMPLETE
+                        Reduce Output Operator
+                          key expressions: _col0 (type: int)
+                          null sort order: z
+                          sort order: +
+                          Map-reduce partition columns: _col0 (type: int)
+                          Statistics: Num rows: 1 Data size: 508 Basic stats: COMPLETE Column stats: COMPLETE
+                          value expressions: _col1 (type: int), _col2 (type: int), _col3 (type: bigint), _col4 (type: bigint), _col5 (type: binary), _col6 (type: bigint), _col7 (type: bigint), _col8 (type: bigint), _col9 (type: binary), _col10 (type: bigint), _col11 (type: bigint), _col12 (type: bigint), _col13 (type: binary)
+        Reducer 5 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: min(VALUE._col0), max(VALUE._col1), count(VALUE._col2), count(VALUE._col3), compute_bit_vector_hll(VALUE._col4), min(VALUE._col5), max(VALUE._col6), count(VALUE._col7), compute_bit_vector_hll(VALUE._col8), min(VALUE._col9), max(VALUE._col10), count(VALUE._col11), compute_bit_vector_hll(VALUE._col12)
+                keys: KEY._col0 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13
+                Statistics: Num rows: 1 Data size: 508 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: 'LONG' (type: string), UDFToLong(_col1) (type: bigint), UDFToLong(_col2) (type: bigint), (_col3 - _col4) (type: bigint), COALESCE(ndv_compute_bit_vector(_col5),0) (type: bigint), _col5 (type: binary), 'LONG' (type: string), _col6 (type: bigint), _col7 (type: bigint), (_col3 - _col8) (type: bigint), COALESCE(ndv_compute_bit_vector(_col9),0) (type: bigint), _col9 (type: binary), 'LONG' (type: string), _col10 (type: bigint), _col11 (type: bigint), (_col3 - _col12) (type: bigint), COALESCE(ndv_compute_bit_vector(_col13),0) (type: bigint), _col13 (type: binary), _col0 (type: int)
+                  outputColumnNames: _col0, _col1, _col2, _col3, _col4, _col5, _col6, _col7, _col8, _col9, _col10, _col11, _col12, _col13, _col14, _col15, _col16, _col17, _col18
+                  Statistics: Num rows: 1 Data size: 796 Basic stats: COMPLETE Column stats: COMPLETE
+                  File Output Operator
+                    compressed: false
+                    Statistics: Num rows: 1 Data size: 796 Basic stats: COMPLETE Column stats: COMPLETE
+                    table:
+                        input format: org.apache.hadoop.mapred.SequenceFileInputFormat
+                        output format: org.apache.hadoop.hive.ql.io.HiveSequenceFileOutputFormat
+                        serde: org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe
+        Reducer 7 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1
+                Statistics: Num rows: 1 Data size: 8 Basic stats: COMPLETE Column stats: COMPLETE
+                Select Operator
+                  expressions: _col0 (type: int)
+                  outputColumnNames: _col0
+                  Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                  Group By Operator
+                    keys: _col0 (type: int)
+                    minReductionHashAggr: 0.4
+                    mode: hash
+                    outputColumnNames: _col0
+                    Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+                    Reduce Output Operator
+                      key expressions: _col0 (type: int)
+                      null sort order: z
+                      sort order: +
+                      Map-reduce partition columns: _col0 (type: int)
+                      Statistics: Num rows: 1 Data size: 4 Basic stats: COMPLETE Column stats: COMPLETE
+        Reducer 8 
+            Execution mode: vectorized, llap
+            Reduce Operator Tree:
+              Group By Operator
+                aggregations: sum(VALUE._col0), sum(VALUE._col1)
+                keys: KEY._col0 (type: int), KEY._col1 (type: int)
+                mode: mergepartial
+                outputColumnNames: _col0, _col1, _col2, _col3
+                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
+                Group By Operator
+                  aggregations: sum(_col2), sum(_col3)
+                  keys: _col0 (type: int), _col1 (type: int)
+                  minReductionHashAggr: 0.4
+                  mode: hash
+                  outputColumnNames: _col0, _col1, _col2, _col3
+                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Reduce Output Operator
+                    key expressions: _col0 (type: int), _col1 (type: int)
+                    null sort order: zz
+                    sort order: ++
+                    Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
+                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    value expressions: _col2 (type: bigint), _col3 (type: bigint)
+        Union 3 
+            Vertex: Union 3
+
+  Stage: Stage-2
+    Dependency Collection
+
+  Stage: Stage-0
+    Move Operator
+      tables:
+          partition:
+            a 
+          replace: false
+          table:
+              input format: org.apache.hadoop.hive.ql.io.orc.OrcInputFormat
+              output format: org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat
+              serde: org.apache.hadoop.hive.ql.io.orc.OrcSerde
+              name: default.mat1
+          Write Type: INSERT
+          micromanaged table: true
+
+  Stage: Stage-3
+    Stats Work
+      Basic Stats Work:
+      Column Stats Desc:
+          Columns: b, sumc, countstar
+          Column Types: int, bigint, bigint
+          Table: default.mat1
+
+  Stage: Stage-4
+    Materialized View Update
+      name: default.mat1
+      update creation metadata: true
+
+PREHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@t1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
+POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@t1
+POSTHOOK: Output: default@mat1
+POSTHOOK: Output: default@mat1@a=1
+POSTHOOK: Lineage: mat1 PARTITION(a=1).b EXPRESSION [(mat1)default.mat1.FieldSchema(name:b, type:int, comment:null), (t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).countstar EXPRESSION [(mat1)default.mat1.FieldSchema(name:countstar, type:bigint, comment:null), (t1)t1.FieldSchema(name:ROW__IS__DELETED, type:boolean, comment:), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=1).sumc EXPRESSION [(mat1)default.mat1.FieldSchema(name:sumc, type:bigint, comment:null), (t1)t1.FieldSchema(name:ROW__IS__DELETED, type:boolean, comment:), (t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+PREHOOK: query: SELECT a, b, sumc, countstar FROM mat1 ORDER BY a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@mat1
+PREHOOK: Input: default@mat1@a=1
+PREHOOK: Input: default@mat1@a=2
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, b, sumc, countstar FROM mat1 ORDER BY a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@mat1
+POSTHOOK: Input: default@mat1@a=1
+POSTHOOK: Input: default@mat1@a=2
+#### A masked pattern was here ####
+1	1	1	1
+1	2	10	1
+2	1	2	1
+2	2	11	1
+PREHOOK: query: DROP MATERIALIZED VIEW mat1
+PREHOOK: type: DROP_MATERIALIZED_VIEW
+PREHOOK: Input: default@mat1
+PREHOOK: Output: default@mat1
+POSTHOOK: query: DROP MATERIALIZED VIEW mat1
+POSTHOOK: type: DROP_MATERIALIZED_VIEW
+POSTHOOK: Input: default@mat1
+POSTHOOK: Output: default@mat1
+PREHOOK: query: SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a
+PREHOOK: type: QUERY
+PREHOOK: Input: default@t1
+#### A masked pattern was here ####
+POSTHOOK: query: SELECT a, b, sum(c) sumc, count(*) countstar FROM t1 GROUP BY b, a
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@t1
+#### A masked pattern was here ####
+1	1	1	1
+1	2	10	1
+2	1	2	1
+2	2	11	1

--- a/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_del.q.out
+++ b/ql/src/test/results/clientpositive/llap/materialized_view_partitioned_create_rewrite_agg_del.q.out
@@ -12,7 +12,8 @@ PREHOOK: query: INSERT INTO t1(a, b, c) VALUES
 (2, 1, 2),
 (1, 2, 10),
 (2, 2, 11),
-(1, 3, 100)
+(1, 3, 100), -- del
+(3, 3, 100)
 PREHOOK: type: QUERY
 PREHOOK: Input: _dummy_database@_dummy_table
 PREHOOK: Output: default@t1
@@ -22,7 +23,8 @@ POSTHOOK: query: INSERT INTO t1(a, b, c) VALUES
 (2, 1, 2),
 (1, 2, 10),
 (2, 2, 11),
-(1, 3, 100)
+(1, 3, 100), -- del
+(3, 3, 100)
 POSTHOOK: type: QUERY
 POSTHOOK: Input: _dummy_database@_dummy_table
 POSTHOOK: Output: default@t1
@@ -49,12 +51,16 @@ POSTHOOK: Output: default@mat1
 POSTHOOK: Output: default@mat1
 POSTHOOK: Output: default@mat1@a=1
 POSTHOOK: Output: default@mat1@a=2
+POSTHOOK: Output: default@mat1@a=3
 POSTHOOK: Lineage: mat1 PARTITION(a=1).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
 POSTHOOK: Lineage: mat1 PARTITION(a=1).countstar EXPRESSION [(t1)t1.null, ]
 POSTHOOK: Lineage: mat1 PARTITION(a=1).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
 POSTHOOK: Lineage: mat1 PARTITION(a=2).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
 POSTHOOK: Lineage: mat1 PARTITION(a=2).countstar EXPRESSION [(t1)t1.null, ]
 POSTHOOK: Lineage: mat1 PARTITION(a=2).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=3).b SIMPLE [(t1)t1.FieldSchema(name:b, type:int, comment:null), ]
+POSTHOOK: Lineage: mat1 PARTITION(a=3).countstar EXPRESSION [(t1)t1.null, ]
+POSTHOOK: Lineage: mat1 PARTITION(a=3).sumc EXPRESSION [(t1)t1.FieldSchema(name:c, type:int, comment:null), ]
 PREHOOK: query: DELETE FROM t1 WHERE c = 4 OR c = 100
 PREHOOK: type: QUERY
 PREHOOK: Input: default@t1
@@ -76,6 +82,7 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@mat1@a=1
 PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=3
 PREHOOK: Input: default@t1
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT a, b, sum(sumc), sum(countstar) counttotal FROM (
@@ -91,6 +98,7 @@ POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@mat1@a=1
 POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=3
 POSTHOOK: Input: default@t1
 #### A masked pattern was here ####
 1	1	1	1
@@ -101,6 +109,7 @@ PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@mat1@a=1
 PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=3
 PREHOOK: Input: default@t1
 PREHOOK: Output: default@mat1
 POSTHOOK: query: EXPLAIN CBO
@@ -109,6 +118,7 @@ POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@mat1@a=1
 POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=3
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: default@mat1
 CBO PLAN:
@@ -137,6 +147,7 @@ PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@mat1@a=1
 PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=3
 PREHOOK: Input: default@t1
 PREHOOK: Output: default@mat1
 POSTHOOK: query: EXPLAIN
@@ -145,6 +156,7 @@ POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@mat1@a=1
 POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=3
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: default@mat1
 STAGE DEPENDENCIES:
@@ -170,17 +182,17 @@ STAGE PLANS:
             Map Operator Tree:
                 TableScan
                   alias: default.mat1
-                  Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 6 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
                   Select Operator
                     expressions: b (type: int), a (type: int), sumc (type: bigint), countstar (type: bigint)
                     outputColumnNames: _col0, _col1, _col2, _col3
-                    Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 6 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
                     Reduce Output Operator
                       key expressions: _col1 (type: int)
                       null sort order: z
                       sort order: +
                       Map-reduce partition columns: _col1 (type: int)
-                      Statistics: Num rows: 5 Data size: 120 Basic stats: COMPLETE Column stats: COMPLETE
+                      Statistics: Num rows: 6 Data size: 144 Basic stats: COMPLETE Column stats: COMPLETE
                       value expressions: _col0 (type: int), _col2 (type: bigint), _col3 (type: bigint)
             Execution mode: vectorized, llap
             LLAP IO: may be used (ACID table)
@@ -246,16 +258,16 @@ STAGE PLANS:
                 Group By Operator
                   aggregations: sum(_col2), sum(_col3)
                   keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.4
+                  minReductionHashAggr: 0.6666666
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int), _col1 (type: int)
                     null sort order: zz
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint), _col3 (type: bigint)
         Reducer 4 
             Execution mode: vectorized, llap
@@ -265,7 +277,7 @@ STAGE PLANS:
                 keys: KEY._col0 (type: int), KEY._col1 (type: int)
                 mode: mergepartial
                 outputColumnNames: _col0, _col1, _col2, _col3
-                Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                 Filter Operator
                   predicate: (COALESCE(_col3,0L) > 0) (type: boolean)
                   Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
@@ -356,16 +368,16 @@ STAGE PLANS:
                 Group By Operator
                   aggregations: sum(_col2), sum(_col3)
                   keys: _col0 (type: int), _col1 (type: int)
-                  minReductionHashAggr: 0.4
+                  minReductionHashAggr: 0.6666666
                   mode: hash
                   outputColumnNames: _col0, _col1, _col2, _col3
-                  Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                  Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                   Reduce Output Operator
                     key expressions: _col0 (type: int), _col1 (type: int)
                     null sort order: zz
                     sort order: ++
                     Map-reduce partition columns: _col0 (type: int), _col1 (type: int)
-                    Statistics: Num rows: 2 Data size: 48 Basic stats: COMPLETE Column stats: COMPLETE
+                    Statistics: Num rows: 1 Data size: 24 Basic stats: COMPLETE Column stats: COMPLETE
                     value expressions: _col2 (type: bigint), _col3 (type: bigint)
         Union 3 
             Vertex: Union 3
@@ -405,6 +417,7 @@ PREHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@mat1@a=1
 PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=3
 PREHOOK: Input: default@t1
 PREHOOK: Output: default@mat1
 POSTHOOK: query: ALTER MATERIALIZED VIEW mat1 REBUILD
@@ -412,6 +425,7 @@ POSTHOOK: type: ALTER_MATERIALIZED_VIEW_REBUILD
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@mat1@a=1
 POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=3
 POSTHOOK: Input: default@t1
 POSTHOOK: Output: default@mat1
 POSTHOOK: Output: default@mat1@a=1
@@ -423,17 +437,20 @@ PREHOOK: type: QUERY
 PREHOOK: Input: default@mat1
 PREHOOK: Input: default@mat1@a=1
 PREHOOK: Input: default@mat1@a=2
+PREHOOK: Input: default@mat1@a=3
 #### A masked pattern was here ####
 POSTHOOK: query: SELECT a, b, sumc, countstar FROM mat1 ORDER BY a
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@mat1
 POSTHOOK: Input: default@mat1@a=1
 POSTHOOK: Input: default@mat1@a=2
+POSTHOOK: Input: default@mat1@a=3
 #### A masked pattern was here ####
 1	1	1	1
 1	2	10	1
 2	1	2	1
 2	2	11	1
+3	3	100	1
 PREHOOK: query: DROP MATERIALIZED VIEW mat1
 PREHOOK: type: DROP_MATERIALIZED_VIEW
 PREHOOK: Input: default@mat1


### PR DESCRIPTION
### What changes were proposed in this pull request?
1. Check if source tables of an MV was compacted. If yes do an insert overwrite rebuild using the original MV definition plan since we can not determine if there were delete operations in the source tables since the last rebuild.
2. `applyPartitionIncrementalRebuildPlan` returns null if rewrite is not possible.
3. Introduce `HiveAggregatePartitionInsertDeleteIncrementalRewritingRule` to handle partition based rewrite of source tables has delete operation since last rebuild.
4. Extract common parts of `HiveAggregateInsertDeleteIncrementalRewritingRule` and `HiveAggregatePartitionIncrementalRewritingRule` and reuse them in the new `HiveAggregatePartitionInsertDeleteIncrementalRewritingRule`


### Why are the changes needed?
Extend existing Partiton based incremental MV rebuild to handle the case when any of the source tables has delete operation since the last MV rebuild. 

### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
```
mvn test -Dtest.output.overwrite -DskipSparkTests -Dtest=TestMiniLlapLocalCliDriver -Dqfile=materialized_view_create_rewrite.q,materialized_view_create_rewrite_2.q,materialized_view_create_rewrite_3.q,materialized_view_create_rewrite_4.q,materialized_view_create_rewrite_5.q,materialized_view_create_rewrite_6.q,materialized_view_partitioned_create_rewrite_agg.q,materialized_view_partitioned_create_rewrite_agg_2.q,materialized_view_partitioned_create_rewrite_agg_del.q -pl itests/qtest -Pitests
```

cc: @amansinha100