### PR TITLE
HIVE-25360

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/ExpressionToOrcSearchArgument.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/ExpressionToOrcSearchArgument.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.hive.common.type.HiveDecimal;
+import org.apache.hadoop.hive.ql.io.sarg.PredicateLeaf;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgument.TruthValue;
+import org.apache.hadoop.hive.ql.io.sarg.SearchArgumentFactory;
+import org.apache.hadoop.hive.serde2.io.HiveDecimalWritable;
+import org.apache.hive.iceberg.org.apache.orc.TypeDescription;
+import org.apache.iceberg.expressions.Bound;
+import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionVisitors;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Type.TypeID;
+
+/**
+ * Copy of ExpressionOrcSearchArgument from iceberg/orc module to provide java type compatibility between:
+ * org.apache.hadoop.hive.ql.io.sarg.SearchArgument and
+ * org.apache.hive.iceberg.org.apache.orc.storage.ql.io.sarg.SearchArgument
+ */
+class ExpressionToOrcSearchArgument extends ExpressionVisitors.BoundVisitor<ExpressionToOrcSearchArgument.Action> {
+
+  static SearchArgument convert(Expression expr, TypeDescription readSchema) {
+    Map<Integer, String> idToColumnName = ORCSchemaUtil.idToOrcName(ORCSchemaUtil.convert(readSchema));
+    SearchArgument.Builder builder = SearchArgumentFactory.newBuilder();
+    ExpressionVisitors.visit(expr, new ExpressionToOrcSearchArgument(builder, idToColumnName)).invoke();
+    return builder.build();
+  }
+
+  // Currently every predicate in ORC requires a PredicateLeaf.Type field which is not available for these Iceberg types
+  private static final Set<TypeID> UNSUPPORTED_TYPES = ImmutableSet.of(TypeID.BINARY, TypeID.FIXED, TypeID.UUID,
+      TypeID.STRUCT, TypeID.MAP, TypeID.LIST);
+
+  private SearchArgument.Builder builder;
+  private Map<Integer, String> idToColumnName;
+
+  private ExpressionToOrcSearchArgument(SearchArgument.Builder builder, Map<Integer, String> idToColumnName) {
+    this.builder = builder;
+    this.idToColumnName = idToColumnName;
+  }
+
+  @Override
+  public Action alwaysTrue() {
+    return () -> this.builder.literal(TruthValue.YES);
+  }
+
+  @Override
+  public Action alwaysFalse() {
+    return () -> this.builder.literal(TruthValue.NO);
+  }
+
+  @Override
+  public Action not(Action child) {
+    return () -> {
+      this.builder.startNot();
+      child.invoke();
+      this.builder.end();
+    };
+  }
+
+  @Override
+  public Action and(Action leftChild, Action rightChild) {
+    return () -> {
+      this.builder.startAnd();
+      leftChild.invoke();
+      rightChild.invoke();
+      this.builder.end();
+    };
+  }
+
+  @Override
+  public Action or(Action leftChild, Action rightChild) {
+    return () -> {
+      this.builder.startOr();
+      leftChild.invoke();
+      rightChild.invoke();
+      this.builder.end();
+    };
+  }
+
+  @Override
+  public <T> Action isNull(Bound<T> expr) {
+    return () -> this.builder.isNull(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()));
+  }
+
+  @Override
+  public <T> Action notNull(Bound<T> expr) {
+    return () -> this.builder.startNot().isNull(idToColumnName.get(expr.ref().fieldId()),
+        type(expr.ref().type())).end();
+  }
+
+  @Override
+  public <T> Action isNaN(Bound<T> expr) {
+    return () -> this.builder.equals(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literal(expr.ref().type(), getNaNForType(expr.ref().type())));
+  }
+
+  private Object getNaNForType(Type type) {
+    switch (type.typeId()) {
+      case FLOAT:
+        return Float.NaN;
+      case DOUBLE:
+        return Double.NaN;
+      default:
+        throw new IllegalArgumentException("Cannot get NaN value for type " + type.typeId());
+    }
+  }
+
+  @Override
+  public <T> Action notNaN(Bound<T> expr) {
+    return () -> {
+      this.builder.startOr();
+      isNull(expr).invoke();
+      this.builder.startNot();
+      isNaN(expr).invoke();
+      this.builder.end(); // end NOT
+      this.builder.end(); // end OR
+    };
+  }
+
+  @Override
+  public <T> Action lt(Bound<T> expr, Literal<T> lit) {
+    return () -> this.builder.lessThan(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literal(expr.ref().type(), lit.value()));
+  }
+
+  @Override
+  public <T> Action ltEq(Bound<T> expr, Literal<T> lit) {
+    return () -> this.builder.lessThanEquals(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literal(expr.ref().type(), lit.value()));
+  }
+
+  @Override
+  public <T> Action gt(Bound<T> expr, Literal<T> lit) {
+    // ORC SearchArguments do not have a greaterThan predicate, so we use not(lessThanOrEquals)
+    // e.g. x > 5 => not(x <= 5)
+    return () -> this.builder.startNot().lessThanEquals(idToColumnName.get(expr.ref().fieldId()),
+        type(expr.ref().type()), literal(expr.ref().type(), lit.value())).end();
+  }
+
+  @Override
+  public <T> Action gtEq(Bound<T> expr, Literal<T> lit) {
+    // ORC SearchArguments do not have a greaterThanOrEquals predicate, so we use not(lessThan)
+    // e.g. x >= 5 => not(x < 5)
+    return () -> this.builder.startNot().lessThan(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literal(expr.ref().type(), lit.value())).end();
+  }
+
+  @Override
+  public <T> Action eq(Bound<T> expr, Literal<T> lit) {
+    return () -> this.builder.equals(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literal(expr.ref().type(), lit.value()));
+  }
+
+  @Override
+  public <T> Action notEq(Bound<T> expr, Literal<T> lit) {
+    // NOTE: ORC uses SQL semantics for Search Arguments, so an expression like
+    // `col != 1` will exclude rows where col is NULL along with rows where col = 1
+    // In contrast, Iceberg's Expressions will keep rows with NULL values
+    // So the equivalent ORC Search Argument for an Iceberg Expression `col != x`
+    // is `col IS NULL OR col != x`
+    return () -> {
+      this.builder.startOr();
+      isNull(expr).invoke();
+      this.builder.startNot();
+      eq(expr, lit).invoke();
+      this.builder.end(); // end NOT
+      this.builder.end(); // end OR
+    };
+  }
+
+  @Override
+  public <T> Action in(Bound<T> expr, Set<T> literalSet) {
+    return () -> this.builder.in(idToColumnName.get(expr.ref().fieldId()), type(expr.ref().type()),
+        literalSet.stream().map(lit -> literal(expr.ref().type(), lit)).toArray(Object[]::new));
+  }
+
+  @Override
+  public <T> Action notIn(Bound<T> expr, Set<T> literalSet) {
+    // NOTE: ORC uses SQL semantics for Search Arguments, so an expression like
+    // `col NOT IN {1}` will exclude rows where col is NULL along with rows where col = 1
+    // In contrast, Iceberg's Expressions will keep rows with NULL values
+    // So the equivalent ORC Search Argument for an Iceberg Expression `col NOT IN {x}`
+    // is `col IS NULL OR col NOT IN {x}`
+    return () -> {
+      this.builder.startOr();
+      isNull(expr).invoke();
+      this.builder.startNot();
+      in(expr, literalSet).invoke();
+      this.builder.end(); // end NOT
+      this.builder.end(); // end OR
+    };
+  }
+
+  @Override
+  public <T> Action startsWith(Bound<T> expr, Literal<T> lit) {
+    // Cannot push down STARTS_WITH operator to ORC, so return TruthValue.YES_NO_NULL which signifies
+    // that this predicate cannot help with filtering
+    return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+  }
+
+  @Override
+  public <T> Action predicate(BoundPredicate<T> pred) {
+    if (UNSUPPORTED_TYPES.contains(pred.ref().type().typeId())) {
+      // Cannot push down predicates for types which cannot be represented in PredicateLeaf.Type, so return
+      // TruthValue.YES_NO_NULL which signifies that this predicate cannot help with filtering
+      return () -> this.builder.literal(TruthValue.YES_NO_NULL);
+    } else {
+      return super.predicate(pred);
+    }
+  }
+
+  @FunctionalInterface
+  interface Action {
+    void invoke();
+  }
+
+  private PredicateLeaf.Type type(Type icebergType) {
+    switch (icebergType.typeId()) {
+      case BOOLEAN:
+        return PredicateLeaf.Type.BOOLEAN;
+      case INTEGER:
+      case LONG:
+      case TIME:
+        return PredicateLeaf.Type.LONG;
+      case FLOAT:
+      case DOUBLE:
+        return PredicateLeaf.Type.FLOAT;
+      case DATE:
+        return PredicateLeaf.Type.DATE;
+      case TIMESTAMP:
+        return PredicateLeaf.Type.TIMESTAMP;
+      case STRING:
+        return PredicateLeaf.Type.STRING;
+      case DECIMAL:
+        return PredicateLeaf.Type.DECIMAL;
+      default:
+        throw new UnsupportedOperationException("Type " + icebergType + " not supported in ORC SearchArguments");
+    }
+  }
+
+  private <T> Object literal(Type icebergType, T icebergLiteral) {
+    switch (icebergType.typeId()) {
+      case BOOLEAN:
+      case LONG:
+      case TIME:
+      case DOUBLE:
+        return icebergLiteral;
+      case INTEGER:
+        return ((Integer) icebergLiteral).longValue();
+      case FLOAT:
+        return ((Float) icebergLiteral).doubleValue();
+      case STRING:
+        return icebergLiteral.toString();
+      case DATE:
+        return Date.valueOf(LocalDate.ofEpochDay((Integer) icebergLiteral));
+      case TIMESTAMP:
+        long microsFromEpoch = (Long) icebergLiteral;
+        return Timestamp.from(Instant.ofEpochSecond(Math.floorDiv(microsFromEpoch, 1_000_000),
+            Math.floorMod(microsFromEpoch, 1_000_000) * 1_000));
+      case DECIMAL:
+        return new HiveDecimalWritable(HiveDecimal.create((BigDecimal) icebergLiteral, false));
+      default:
+        throw new UnsupportedOperationException("Type " + icebergType + " not supported in ORC SearchArguments");
+    }
+  }
+}

--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/orc/VectorizedReadUtils.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.iceberg.orc;
+
+import java.io.IOException;
+import org.apache.hadoop.hive.ql.io.sarg.ConvertAstToSearchArg;
+import org.apache.hadoop.hive.ql.plan.TableScanDesc;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hive.iceberg.org.apache.orc.Reader;
+import org.apache.hive.iceberg.org.apache.orc.TypeDescription;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.mapping.MappingUtil;
+
+/**
+ * Utilities that rely on Iceberg code from org.apache.iceberg.orc package.
+ */
+public class VectorizedReadUtils {
+
+  private VectorizedReadUtils() {
+
+  }
+
+  /**
+   * Adjusts the jobConf so that column reorders and renames that might have happened since this ORC file was written
+   * are properly mapped to the schema of the original file.
+   * @param inputFile - the original ORC file - this needs to be accessed to retrieve the original schema for mapping
+   * @param task - Iceberg task - required for
+   * @param job - JobConf instance to adjust
+   * @throws IOException - errors relating to accessing the ORC file
+   */
+  public static void handleIcebergProjection(InputFile inputFile, FileScanTask task, JobConf job)
+      throws IOException {
+    Reader orcFileReader = ORC.newFileReader(inputFile, job);
+
+    try {
+      // We need to map with the current (i.e. current Hive table columns) full schema (without projections),
+      // as OrcInputFormat will take care of the projections by the use of an include boolean array
+      Schema currentSchema = task.spec().schema();
+      TypeDescription fileSchema = orcFileReader.getSchema();
+
+      TypeDescription readOrcSchema;
+      if (ORCSchemaUtil.hasIds(fileSchema)) {
+        readOrcSchema = ORCSchemaUtil.buildOrcProjection(currentSchema, fileSchema);
+      } else {
+        TypeDescription typeWithIds =
+            ORCSchemaUtil.applyNameMapping(fileSchema, MappingUtil.create(currentSchema));
+        readOrcSchema = ORCSchemaUtil.buildOrcProjection(currentSchema, typeWithIds);
+      }
+
+      job.set(ColumnProjectionUtils.ICEBERG_ORC_SCHEMA_STRING, readOrcSchema.toString());
+
+      // Predicate pushdowns needs to be adjusted too in case of column renames, we let Iceberg generate this into job
+      if (task.residual() != null) {
+        Expression boundFilter = Binder.bind(currentSchema.asStruct(), task.residual(), false);
+
+        // Note the use of the unshaded version of this class here (required for SARG deseralization later)
+        org.apache.hadoop.hive.ql.io.sarg.SearchArgument sarg =
+            ExpressionToOrcSearchArgument.convert(boundFilter, readOrcSchema);
+        if (sarg != null) {
+          job.unset(TableScanDesc.FILTER_EXPR_CONF_STR);
+          job.unset(ConvertAstToSearchArg.SARG_PUSHDOWN);
+
+          job.set(ConvertAstToSearchArg.SARG_PUSHDOWN, ConvertAstToSearchArg.sargToKryo(sarg));
+        }
+      }
+    } finally {
+      orcFileReader.close();
+    }
+  }
+}

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/OrcInputFormat.java
@@ -585,7 +585,14 @@ public class OrcInputFormat implements InputFormat<NullWritable, OrcStruct>,
   }
 
   static String getNeededColumnNamesString(Configuration conf) {
-    return conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR);
+    String icebergOrcSchema = conf.get(ColumnProjectionUtils.ICEBERG_ORC_SCHEMA_STRING);
+
+    if (icebergOrcSchema != null) {
+      final String columnNameDelimiter = conf.get(serdeConstants.COLUMN_NAME_DELIMITER, String.valueOf(SerDeUtils.COMMA));
+      return String.join(columnNameDelimiter, TypeDescription.fromString(icebergOrcSchema).getFieldNames());
+    } else {
+      return conf.get(ColumnProjectionUtils.READ_COLUMN_NAMES_CONF_STR);
+    }
   }
 
   static String getSargColumnIDsString(Configuration conf) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/orc/VectorizedOrcInputFormat.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.ql.exec.vector.VectorizedSupport;
 import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.hadoop.hive.ql.io.InputFormatChecker;
 import org.apache.hadoop.hive.ql.io.SelfDescribingInputFormatInterface;
+import org.apache.hadoop.hive.serde2.ColumnProjectionUtils;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapred.FileInputFormat;
 import org.apache.hadoop.mapred.FileSplit;
@@ -76,8 +77,10 @@ public class VectorizedOrcInputFormat extends FileInputFormat<NullWritable, Vect
        * Do we have schema on read in the configuration variables?
        */
       int dataColumns = rbCtx.getDataColumnCount();
-      TypeDescription schema =
-          OrcInputFormat.getDesiredRowTypeDescr(conf, false, dataColumns);
+      String icebergOrcSchema = conf.get(ColumnProjectionUtils.ICEBERG_ORC_SCHEMA_STRING);
+      TypeDescription schema = icebergOrcSchema == null ?
+          OrcInputFormat.getDesiredRowTypeDescr(conf, false, dataColumns) :
+          TypeDescription.fromString(icebergOrcSchema);
       if (schema == null) {
         schema = file.getSchema();
         // Even if the user isn't doing schema evolution, cut the schema

--- a/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
+++ b/serde/src/java/org/apache/hadoop/hive/serde2/ColumnProjectionUtils.java
@@ -56,6 +56,7 @@ public final class ColumnProjectionUtils {
   private static final String READ_NESTED_COLUMN_PATH_CONF_STR_DEFAULT = "";
   private static final boolean READ_ALL_COLUMNS_DEFAULT = true;
   private static final Joiner CSV_JOINER = Joiner.on(",").skipNulls();
+  public static final String ICEBERG_ORC_SCHEMA_STRING = "hive.iceberg.orc.schema.string";
 
   /**
    * @deprecated for backwards compatibility with &lt;= 0.12, use setReadAllColumns


### PR DESCRIPTION
HIVE-25256 added support for Iceberg backed tables to support CHANGE COLUMN statement. These include type, name and order changes to the schema. Native ORC tables only support renames, but with the help of Iceberg as an intermediary table format layer, this can be achieved, and works well for non-vectorized reads already.

We should adjust the vectorized read path to support the same.

This change makes vectorized orc reads relies on Iceberg on finding out about column renames and reorders, so that the low level ORC vectorized reader can be appropriately configured.