### PR TITLE
HIVE-25361: Allow Iceberg table update columns command

### DIFF
--- a/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
+++ b/iceberg/iceberg-handler/src/main/java/org/apache/iceberg/mr/hive/HiveIcebergMetaHook.java
@@ -85,7 +85,8 @@ public class HiveIcebergMetaHook implements HiveMetaHook {
       BaseMetastoreTableOperations.PREVIOUS_METADATA_LOCATION_PROP);
   static final EnumSet<AlterTableType> SUPPORTED_ALTER_OPS = EnumSet.of(
       AlterTableType.ADDCOLS, AlterTableType.REPLACE_COLUMNS, AlterTableType.RENAME_COLUMN,
-      AlterTableType.ADDPROPS, AlterTableType.DROPPROPS, AlterTableType.SETPARTITIONSPEC);
+      AlterTableType.ADDPROPS, AlterTableType.DROPPROPS, AlterTableType.SETPARTITIONSPEC,
+      AlterTableType.UPDATE_COLUMNS);
 
   private final Configuration conf;
   private Table icebergTable = null;

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -1464,6 +1464,10 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     // Add a new column (age long) to the Iceberg table.
     icebergTable.updateSchema().addColumn("age", Types.LongType.get()).commit();
+    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
+      // We need to update columns for non-Hive catalogs
+      shell.executeStatement("ALTER TABLE customers UPDATE COLUMNS");
+    }
 
     Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
         optional(2, "first_name", Types.StringType.get(), "This is first name"),
@@ -1527,6 +1531,10 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     // Add a new required column (age long) to the Iceberg table.
     icebergTable.updateSchema().allowIncompatibleChanges().addRequiredColumn("age", Types.LongType.get()).commit();
+    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
+      // We need to update columns for non-Hive catalogs
+      shell.executeStatement("ALTER TABLE customers UPDATE COLUMNS");
+    }
 
     Schema customerSchemaWithAge = new Schema(optional(1, "customer_id", Types.LongType.get()),
         optional(2, "first_name", Types.StringType.get(), "This is first name"),
@@ -1743,6 +1751,10 @@ public class TestHiveIcebergStorageHandlerWithEngine {
 
     // Rename the last_name column to family_name
     icebergTable.updateSchema().renameColumn("last_name", "family_name").commit();
+    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
+      // We need to update columns for non-Hive catalogs
+      shell.executeStatement("ALTER TABLE customers UPDATE COLUMNS");
+    }
 
     Schema schemaWithFamilyName = new Schema(optional(1, "customer_id", Types.LongType.get()),
         optional(2, "first_name", Types.StringType.get(), "This is first name"),


### PR DESCRIPTION
### What changes were proposed in this pull request?
Allows Iceberg table update columns command

### Why are the changes needed?
non-HiveCatalog based Iceberg tables need to be able to refresh the column list in the HMS DB

### Does this PR introduce _any_ user-facing change?
Allows Iceberg table update columns command

### How was this patch tested?
Added the command to the relevant unit tests
