### PR TITLE
HIVE-25384: Bump ORC to 1.6.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     <mariadb.version>2.5.0</mariadb.version>
     <postgres.version>42.2.14</postgres.version>
     <opencsv.version>2.3</opencsv.version>
-    <orc.version>1.6.8</orc.version>
+    <orc.version>1.6.9</orc.version>
     <mockito-core.version>3.4.4</mockito-core.version>
     <powermock.version>2.0.2</powermock.version>
     <mina.version>2.0.0-M5</mina.version>

--- a/standalone-metastore/pom.xml
+++ b/standalone-metastore/pom.xml
@@ -91,7 +91,7 @@
     <libthrift.version>0.14.1</libthrift.version>
     <log4j2.version>2.13.2</log4j2.version>
     <mockito-core.version>3.3.3</mockito-core.version>
-    <orc.version>1.6.8</orc.version>
+    <orc.version>1.6.9</orc.version>
     <!-- com.google repo will be used except on Aarch64 platform. -->
     <protobuf.group>com.google.protobuf</protobuf.group>
     <protobuf.version>2.6.1</protobuf.version>


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to bump ORC to 1.6.9.

### Why are the changes needed?

This will bring the latest bug fixes like ORC-804 .

### Does this PR introduce _any_ user-facing change?

No.

### How was this patch tested?

Pass the CIs.