### PR TITLE
HIVE-25386: hive-storage-api should not have guava compile dependency

### DIFF
--- a/storage-api/pom.xml
+++ b/storage-api/pom.xml
@@ -118,6 +118,7 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
+      <scope>test</scope>
     </dependency>
 
     <!-- test inter-project -->


### PR DESCRIPTION
### What changes were proposed in this pull request?

This PR aims to fix the recent regression of HIVE-24542 at `hive-storage-api` 2.8.0 release.

### Why are the changes needed?

HIVE-13906 removed the compile dependency on Guava at Apache Hive 2.2.0.
So, the downstream like Apache ORC can use it cleanly. We should recover this regression.

### Does this PR introduce _any_ user-facing change?

Yes, this is a bug fix for the dependency change.

### How was this patch tested?

Pass the CIs.