### PR TITLE
HIVE-25014: Optimise ObjectStore::updateTableColumnStatistics

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -8860,10 +8860,10 @@ public class ObjectStore implements RawStore, Configurable {
       }
       Map<String, MTableColumnStatistics> oldStats = getPartitionColStats(table, colNames, colStats.getEngine());
 
+      MTable mTable = ensureGetMTable(catName, statsDesc.getDbName(), statsDesc.getTableName());
       for (ColumnStatisticsObj statsObj:statsObjs) {
-        // We have to get mtable again because DataNucleus.
         MTableColumnStatistics mStatsObj = StatObjectConverter.convertToMTableColumnStatistics(
-            ensureGetMTable(catName, statsDesc.getDbName(), statsDesc.getTableName()), statsDesc,
+            mTable, statsDesc,
             statsObj, colStats.getEngine());
         writeMTableColumnStatistics(table, mStatsObj, oldStats.get(statsObj.getColName()));
         // There is no need to add colname again, otherwise we will get duplicate colNames.

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -8874,7 +8874,7 @@ public class ObjectStore implements RawStore, Configurable {
       // No need to check again if it exists.
       String dbname = table.getDbName();
       String name = table.getTableName();
-      MTable oldt = getMTable(catName, dbname, name);
+      MTable oldt = mTable;
       Map<String, String> newParams = new HashMap<>(table.getParameters());
       StatsSetupConst.setColumnStatsState(newParams, colNames);
       boolean isTxn = TxnUtils.isTransactionalTable(oldt.getParameters());

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -8853,14 +8853,14 @@ public class ObjectStore implements RawStore, Configurable {
       // DataNucleus objects get detached all over the place for no (real) reason.
       // So let's not use them anywhere unless absolutely necessary.
       String catName = statsDesc.isSetCatName() ? statsDesc.getCatName() : getDefaultCatalog(conf);
-      Table table = ensureGetTable(catName, statsDesc.getDbName(), statsDesc.getTableName());
+      MTable mTable = ensureGetMTable(catName, statsDesc.getDbName(), statsDesc.getTableName());
+      Table table = convertToTable(mTable);
       List<String> colNames = new ArrayList<>();
       for (ColumnStatisticsObj statsObj : statsObjs) {
         colNames.add(statsObj.getColName());
       }
       Map<String, MTableColumnStatistics> oldStats = getPartitionColStats(table, colNames, colStats.getEngine());
 
-      MTable mTable = ensureGetMTable(catName, statsDesc.getDbName(), statsDesc.getTableName());
       for (ColumnStatisticsObj statsObj:statsObjs) {
         MTableColumnStatistics mStatsObj = StatObjectConverter.convertToMTableColumnStatistics(
             mTable, statsDesc,


### PR DESCRIPTION
### Why are the changes needed?
https://issues.apache.org/jira/browse/HIVE-25014

Table details were fetched multiple times within column stats updation. Depending on the width of the table, this was called multiple times. Datanuc* moves from persistent -> detached state on commit. https://www.datanucleus.org/products/accessplatform_4_2/jpa/object_lifecycle.html.
Since we commit at the end of all processing, fetching table details once is good enough.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
small internal cluster