### PR TITLE
HIVE-25401: Insert overwrite a table which location is on other cluster fail in kerberos cluster

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -197,6 +197,7 @@ import org.apache.hadoop.mapred.Reporter;
 import org.apache.hadoop.mapred.SequenceFileInputFormat;
 import org.apache.hadoop.mapred.SequenceFileOutputFormat;
 import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.alias.CredentialProviderFactory;
@@ -4989,5 +4990,20 @@ public final class Utilities {
   public static boolean arePathsEqualOrWithin(Path p1, Path p2) {
     return ((p1.toString().toLowerCase().indexOf(p2.toString().toLowerCase()) > -1) ||
         (p2.toString().toLowerCase().indexOf(p1.toString().toLowerCase()) > -1)) ? true : false;
+  }
+
+  /**
+   * Convenience method to obtain delegation tokens
+   * corresponding to the paths passed for mapReduce job.
+   * @param job jonconf
+   * @param ps array of paths
+   */
+  public static void setToken(JobConf job, Path[] ps) {
+    try {
+      TokenCache.obtainTokensForNamenodes(job.getCredentials(),
+          ps, job);
+    } catch (IOException ex) {
+      LOG.error("Error in setToken ", ex);
+    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/Utilities.java
@@ -4998,12 +4998,8 @@ public final class Utilities {
    * @param job jonconf
    * @param ps array of paths
    */
-  public static void setToken(JobConf job, Path[] ps) {
-    try {
+  public static void setToken(JobConf job, Path[] ps) throws IOException {
       TokenCache.obtainTokensForNamenodes(job.getCredentials(),
           ps, job);
-    } catch (IOException ex) {
-      LOG.error("Error in setToken ", ex);
-    }
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/mr/ExecDriver.java
@@ -354,6 +354,8 @@ public class ExecDriver extends Task<MapredWork> implements Serializable, Hadoop
 
       Utilities.setMapRedWork(job, work, ctx.getMRTmpPath());
 
+      Utilities.setToken(job, ctx.getFsScratchDirs().values().toArray(new Path[0]));
+
       if (mWork.getSamplingType() > 0 && rWork != null && job.getNumReduceTasks() > 1) {
         try {
           handleSampling(ctx, mWork, job);


### PR DESCRIPTION

### What changes were proposed in this pull request?
obtaine delegation tokens for hive scratchDirs before hive submit mapreduce job.


### Why are the changes needed?
https://issues.apache.org/jira/browse/HIVE-25401


### Does this PR introduce _any_ user-facing change?
no

### How was this patch tested?
no test
