### PR TITLE
HIVE-24546: Avoid unwanted cloud storage call during dynamic partitio…

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -910,12 +910,12 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   }
 
   private void createDpDirCheckSrc(final Path dpStagingPath, final Path dpFinalPath) throws IOException {
-    if (!fs.exists(dpStagingPath) && !fs.exists(dpFinalPath)) {
-      fs.mkdirs(dpStagingPath);
-      // move task will create dp final path
-      if (reporter != null) {
-        reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
-      }
+    boolean dirCreated = fs.mkdirs(dpStagingPath);
+    if (!dirCreated && !fs.isDirectory(dpStagingPath)) {
+      throw new IOException("Failed to create dir " + dpStagingPath);
+    }
+    if (reporter != null && dirCreated) {
+      reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -910,21 +910,20 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   }
 
   private void createDpDirCheckSrc(final Path dpStagingPath, final Path dpFinalPath) throws IOException {
-    boolean dirCreated = fs.mkdirs(dpStagingPath);
-    if (!dirCreated && !fs.isDirectory(dpStagingPath)) {
-      throw new IOException("Failed to create dir " + dpStagingPath);
-    }
-    if (reporter != null && dirCreated) {
-      reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
+    if (!fs.exists(dpStagingPath) && !fs.exists(dpFinalPath)) {
+      fs.mkdirs(dpStagingPath);
+      // move task will create dp final path
+      if (reporter != null) {
+        reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
+      }
     }
   }
 
   private void createDpDir(final Path dpPath) throws IOException {
-    if (!fs.exists(dpPath)) {
-      fs.mkdirs(dpPath);
-      if (reporter != null) {
-        reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
-      }
+    boolean dirCreated = fs.mkdirs(dpPath);
+    LOG.debug("dpPath: {} created: {}", dpPath, dirCreated);
+    if (reporter != null) {
+      reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
     }
   }
 

--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/FileSinkOperator.java
@@ -922,7 +922,7 @@ public class FileSinkOperator extends TerminalOperator<FileSinkDesc> implements
   private void createDpDir(final Path dpPath) throws IOException {
     boolean dirCreated = fs.mkdirs(dpPath);
     LOG.debug("dpPath: {} created: {}", dpPath, dirCreated);
-    if (reporter != null) {
+    if (dirCreated && reporter != null) {
       reporter.incrCounter(counterGroup, Operator.HIVE_COUNTER_CREATED_DYNAMIC_PARTITIONS, 1);
     }
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
https://issues.apache.org/jira/browse/HIVE-24546
Fix FS usage

### Why are the changes needed?
Optimised FS usage for objectstores; especially during dynamic partition loads.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
small internal cluster.