### PR TITLE
HIVE-25411 Don't parse zk path created by PrivilegeSynchronizer to ge…

### DIFF
--- a/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
@@ -148,6 +148,9 @@ class ZooKeeperHiveClientHelper {
       // Remove the znodes we've already tried from this list
       serverHosts.removeAll(connParams.getRejectedHostZnodePaths());
 
+      // Remove the znode used by PrivilegeSynchronizer (see HiveServer2#startPrivilegeSynchronizer)
+      serverHosts.remove("leader");
+
       LOG.debug("Servers in ZooKeeper after removing rejected: {}", serverHosts);
 
       return serverHosts;

--- a/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
+++ b/jdbc/src/java/org/apache/hive/jdbc/ZooKeeperHiveClientHelper.java
@@ -132,7 +132,7 @@ class ZooKeeperHiveClientHelper {
    * @return A list of HiveServer2 hosts
    * @throws ZooKeeperHiveClientException Failed to communicate to ZooKeeper
    */
-  private static List<String> getServerHosts(final JdbcConnectionParams connParams,
+  static List<String> getServerHosts(final JdbcConnectionParams connParams,
       final CuratorFramework zooKeeperClient) throws ZooKeeperHiveClientException {
     final String zookeeperNamespace = getZooKeeperNamespace(connParams);
     final String zkPath = ZKPaths.makePath(null, zookeeperNamespace);

--- a/jdbc/src/test/org/apache/hive/jdbc/TestZooKeeperHiveClientHelper.java
+++ b/jdbc/src/test/org/apache/hive/jdbc/TestZooKeeperHiveClientHelper.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hive.jdbc;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.api.GetChildrenBuilder;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class TestZooKeeperHiveClientHelper {
+
+  @Test
+  public void testGetServerHosts() throws Exception {
+    List<String> paths = Arrays.asList("good", "leader");
+    GetChildrenBuilder childrenBuilder = Mockito.mock(GetChildrenBuilder.class);
+    Mockito.when(childrenBuilder.forPath(Mockito.anyString())).thenReturn(new ArrayList<>(paths));
+    CuratorFramework zkClient = Mockito.mock(CuratorFramework.class);
+    Mockito.when(zkClient.getChildren()).thenReturn(childrenBuilder);
+    assertEquals(1, ZooKeeperHiveClientHelper.getServerHosts(new Utils.JdbcConnectionParams(), zkClient).size());
+  }
+}


### PR DESCRIPTION
…t HiveServer2 URI

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
The zk path `/{hive.server2.zookeeper.namespace}/leader` is used by PrivilegeSynchronizer so we should remove it from server hosts when parsing HiveServer2 URI.


### Why are the changes needed?
It breaks the HiveServer2 HA since it causes error when parsing the incorrect zk path.


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
see TestZooKeeperHiveClientHelper
