### PR TITLE
HIVE-25415: Disable auto-assign reviewer on forks

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   assign_reviewer:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'apache'
     steps:
     - uses: shufo/auto-assign-reviewer-by-files@v1.1.1
       with:


### PR DESCRIPTION
Only run of org is apache

Signed-off-by: Josh Soref <jsoref@users.noreply.github.com>

<!--
Thanks for sending a pull request!  Here are some tips for you:
  1. If this is your first time, please read our contributor guidelines: https://cwiki.apache.org/confluence/display/Hive/HowToContribute
  2. Ensure that you have created an issue on the Hive project JIRA: https://issues.apache.org/jira/projects/HIVE/summary
  3. Ensure you have added or run the appropriate tests for your PR: 
  4. If the PR is unfinished, add '[WIP]' in your PR title, e.g., '[WIP]HIVE-XXXXX:  Your PR title ...'.
  5. Be sure to keep the PR description updated to reflect all changes.
  6. Please write your PR title to summarize what this PR proposes.
  7. If possible, provide a concise example to reproduce the issue for a faster review.

-->

### What changes were proposed in this pull request?
<!--
Please clarify what changes you are proposing. The purpose of this section is to outline the changes and how this PR fixes the issue. 
If possible, please consider writing useful notes for better and faster reviews in your PR. See the examples below.
  1. If you refactor some codes with changing classes, showing the class hierarchy will help reviewers.
  2. If you fix some SQL features, you can provide some references of other DBMSes.
  3. If there is design documentation, please add the link.
  4. If there is a discussion in the mailing list, please add the link.
-->


### Why are the changes needed?

When I create a fork, and then create a PR in that fork, I get half of an error from the auto-assign workflow. Since it's really only configured to work in apache, it shouldn't run in my forks.

### Does this PR introduce _any_ user-facing change?
Forks by devs will have fewer workflows run

### How was this patch tested?
I set the default branch of my fork to this branch and then created a PR from another branch into the default branch. The auto assign workflow was skipped.

I then added an additional commit to the default branch that changed `apache` to the name of the owner of my fork, and pushed that to the fork. And then I closed and reopened the PR, the auto-assign workflow was run.