### PR TITLE
HIVE-25417 : Null bit vector is not handled while getting the stats for Postgres backend

### DIFF
--- a/ql/src/test/queries/clientpositive/nullBitVectorStats.q
+++ b/ql/src/test/queries/clientpositive/nullBitVectorStats.q
@@ -1,0 +1,210 @@
+set hive.strict.checks.type.safety=false;
+
+CREATE TABLE batch1_19671_fin(
+    pts char(15),
+    CoNameOrCIK char(60)
+);
+
+CREATE TABLE dimCompany(
+    sk_CompanyId bigint,
+    name char(60),
+    companyId bigint
+);
+
+CREATE TABLE  Financial (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+);
+
+CREATE TABLE  FinancialPart (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+)
+PARTITIONED BY (country string);
+
+-- This insert will add stats with null bit-vector as there is no records matching
+INSERT INTO FinancialPart partition (country='country1') (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name);
+
+desc formatted FinancialPart partition(country='country1') SK_CompanyID;
+
+-- This insert will try to merge the existing bit vector which is null
+INSERT INTO FinancialPart partition (country) values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE,
+   'country3'
+);
+
+desc formatted FinancialPart partition(country='country1') SK_CompanyID;
+desc formatted FinancialPart partition(country='country3') SK_CompanyID;
+
+-- This insert will add stats with null bit-vector as there is no records matching
+INSERT INTO Financial (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name);
+
+desc formatted Financial FI_QTR;
+
+-- This insert will try to merge the existing bit vector which is null
+INSERT INTO Financial values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+);
+
+desc formatted Financial FI_QTR;
+

--- a/ql/src/test/results/clientpositive/llap/nullBitVectorStats.q.out
+++ b/ql/src/test/results/clientpositive/llap/nullBitVectorStats.q.out
@@ -1,0 +1,579 @@
+PREHOOK: query: CREATE TABLE batch1_19671_fin(
+    pts char(15),
+    CoNameOrCIK char(60)
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@batch1_19671_fin
+POSTHOOK: query: CREATE TABLE batch1_19671_fin(
+    pts char(15),
+    CoNameOrCIK char(60)
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@batch1_19671_fin
+PREHOOK: query: CREATE TABLE dimCompany(
+    sk_CompanyId bigint,
+    name char(60),
+    companyId bigint
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@dimCompany
+POSTHOOK: query: CREATE TABLE dimCompany(
+    sk_CompanyId bigint,
+    name char(60),
+    companyId bigint
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@dimCompany
+PREHOOK: query: CREATE TABLE  Financial (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@Financial
+POSTHOOK: query: CREATE TABLE  Financial (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@Financial
+PREHOOK: query: CREATE TABLE  FinancialPart (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+)
+PARTITIONED BY (country string)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@FinancialPart
+POSTHOOK: query: CREATE TABLE  FinancialPart (
+  SK_CompanyID BIGINT,
+  FI_YEAR NUMERIC(4) ,
+  FI_QTR char(10) ,
+  FI_QTR_START_DATE DATE,
+  cId        TINYINT,
+  cTimeStamp TIMESTAMP,
+  cDecimal   DECIMAL(38,18),
+  cDouble    DOUBLE,
+  cFloat     FLOAT,
+  cBigInt    BIGINT,
+  cInt       INT,
+  cSmallInt  SMALLINT,
+  cTinyint   TINYINT,
+  cBoolean   BOOLEAN
+)
+PARTITIONED BY (country string)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@FinancialPart
+WARNING: Comparing char(60) and bigint may result in loss of information.
+WARNING: Comparing char(60) and bigint may result in loss of information.
+PREHOOK: query: INSERT INTO FinancialPart partition (country='country1') (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@batch1_19671_fin
+PREHOOK: Input: default@dimcompany
+PREHOOK: Output: default@financialpart@country=country1
+POSTHOOK: query: INSERT INTO FinancialPart partition (country='country1') (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@batch1_19671_fin
+POSTHOOK: Input: default@dimcompany
+POSTHOOK: Output: default@financialpart@country=country1
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cbigint SIMPLE []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cboolean SIMPLE []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cdecimal SIMPLE []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cdouble SIMPLE []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cfloat EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cid EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).cint SIMPLE []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).csmallint EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).ctimestamp EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).ctinyint EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).fi_qtr EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).fi_qtr_start_date EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).fi_year EXPRESSION []
+POSTHOOK: Lineage: financialpart PARTITION(country=country1).sk_companyid EXPRESSION [(dimcompany)dimcompany.FieldSchema(name:sk_companyid, type:bigint, comment:null), ]
+PREHOOK: query: desc formatted FinancialPart partition(country='country1') SK_CompanyID
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@financialpart
+POSTHOOK: query: desc formatted FinancialPart partition(country='country1') SK_CompanyID
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@financialpart
+col_name            	SK_CompanyID        
+data_type           	bigint              
+min                 	                    
+max                 	                    
+num_nulls           	                    
+distinct_count      	                    
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	from deserializer   
+PREHOOK: query: INSERT INTO FinancialPart partition (country) values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE,
+   'country3'
+)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@financialpart
+POSTHOOK: query: INSERT INTO FinancialPart partition (country) values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE,
+   'country3'
+)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@financialpart
+POSTHOOK: Output: default@financialpart@country=country3
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cbigint SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cboolean SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cdecimal SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cdouble SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cfloat SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cid SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).cint SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).csmallint SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).ctimestamp SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).ctinyint SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).fi_qtr SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).fi_qtr_start_date SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).fi_year SCRIPT []
+POSTHOOK: Lineage: financialpart PARTITION(country=country3).sk_companyid SCRIPT []
+PREHOOK: query: desc formatted FinancialPart partition(country='country1') SK_CompanyID
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@financialpart
+POSTHOOK: query: desc formatted FinancialPart partition(country='country1') SK_CompanyID
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@financialpart
+col_name            	SK_CompanyID        
+data_type           	bigint              
+min                 	                    
+max                 	                    
+num_nulls           	                    
+distinct_count      	                    
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	from deserializer   
+PREHOOK: query: desc formatted FinancialPart partition(country='country3') SK_CompanyID
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@financialpart
+POSTHOOK: query: desc formatted FinancialPart partition(country='country3') SK_CompanyID
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@financialpart
+col_name            	SK_CompanyID        
+data_type           	bigint              
+min                 	1099511627778       
+max                 	1099511627778       
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	                    
+max_col_len         	                    
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+comment             	from deserializer   
+WARNING: Comparing char(60) and bigint may result in loss of information.
+WARNING: Comparing char(60) and bigint may result in loss of information.
+PREHOOK: query: INSERT INTO Financial (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name)
+PREHOOK: type: QUERY
+PREHOOK: Input: default@batch1_19671_fin
+PREHOOK: Input: default@dimcompany
+PREHOOK: Output: default@financial
+POSTHOOK: query: INSERT INTO Financial (
+  SK_CompanyID,
+  FI_YEAR,
+  FI_QTR,
+  FI_QTR_START_DATE,
+  cId,
+  cTimeStamp,
+  cDecimal,
+  cDouble,
+  cFloat,
+  cBigInt,
+  cInt,
+  cSmallInt,
+  cTinyint,
+  cBoolean
+)
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'third',
+   to_date('2021-11-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.CompanyID )
+UNION
+SELECT
+   DimCompany.SK_CompanyID,
+   2021,
+   'first',
+   to_date('2021-01-21'),
+   1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+FROM
+  batch1_19671_fin finwire_fin
+  JOIN DimCompany ON (
+    finwire_fin.CoNameOrCIK = DimCompany.Name)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@batch1_19671_fin
+POSTHOOK: Input: default@dimcompany
+POSTHOOK: Output: default@financial
+POSTHOOK: Lineage: financial.cbigint SIMPLE []
+POSTHOOK: Lineage: financial.cboolean SIMPLE []
+POSTHOOK: Lineage: financial.cdecimal SIMPLE []
+POSTHOOK: Lineage: financial.cdouble SIMPLE []
+POSTHOOK: Lineage: financial.cfloat EXPRESSION []
+POSTHOOK: Lineage: financial.cid EXPRESSION []
+POSTHOOK: Lineage: financial.cint SIMPLE []
+POSTHOOK: Lineage: financial.csmallint EXPRESSION []
+POSTHOOK: Lineage: financial.ctimestamp EXPRESSION []
+POSTHOOK: Lineage: financial.ctinyint EXPRESSION []
+POSTHOOK: Lineage: financial.fi_qtr EXPRESSION []
+POSTHOOK: Lineage: financial.fi_qtr_start_date EXPRESSION []
+POSTHOOK: Lineage: financial.fi_year EXPRESSION []
+POSTHOOK: Lineage: financial.sk_companyid EXPRESSION [(dimcompany)dimcompany.FieldSchema(name:sk_companyid, type:bigint, comment:null), ]
+PREHOOK: query: desc formatted Financial FI_QTR
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@financial
+POSTHOOK: query: desc formatted Financial FI_QTR
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@financial
+col_name            	FI_QTR              
+data_type           	char(10)            
+min                 	                    
+max                 	                    
+num_nulls           	0                   
+distinct_count      	0                   
+avg_col_len         	0.0                 
+max_col_len         	0                   
+num_trues           	                    
+num_falses          	                    
+bit_vector          	                    
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"cbigint\":\"true\",\"cboolean\":\"true\",\"cdecimal\":\"true\",\"cdouble\":\"true\",\"cfloat\":\"true\",\"cid\":\"true\",\"cint\":\"true\",\"csmallint\":\"true\",\"ctimestamp\":\"true\",\"ctinyint\":\"true\",\"fi_qtr\":\"true\",\"fi_qtr_start_date\":\"true\",\"fi_year\":\"true\",\"sk_companyid\":\"true\"}}
+PREHOOK: query: INSERT INTO Financial values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+)
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@financial
+POSTHOOK: query: INSERT INTO Financial values
+ (
+  1099511627778,
+  1967,
+  'second',
+  to_date('1967-04-01'),
+  1,
+   '2017-11-07 09:02:49.999999999',
+   12345678901234567890.123456789012345678,
+   1.79e308,
+   3.4e38,
+   1234567890123456789,
+   1234567890,
+   12345,
+   123,
+   TRUE
+)
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@financial
+POSTHOOK: Lineage: financial.cbigint SCRIPT []
+POSTHOOK: Lineage: financial.cboolean SCRIPT []
+POSTHOOK: Lineage: financial.cdecimal SCRIPT []
+POSTHOOK: Lineage: financial.cdouble SCRIPT []
+POSTHOOK: Lineage: financial.cfloat SCRIPT []
+POSTHOOK: Lineage: financial.cid SCRIPT []
+POSTHOOK: Lineage: financial.cint SCRIPT []
+POSTHOOK: Lineage: financial.csmallint SCRIPT []
+POSTHOOK: Lineage: financial.ctimestamp SCRIPT []
+POSTHOOK: Lineage: financial.ctinyint SCRIPT []
+POSTHOOK: Lineage: financial.fi_qtr SCRIPT []
+POSTHOOK: Lineage: financial.fi_qtr_start_date SCRIPT []
+POSTHOOK: Lineage: financial.fi_year SCRIPT []
+POSTHOOK: Lineage: financial.sk_companyid SCRIPT []
+PREHOOK: query: desc formatted Financial FI_QTR
+PREHOOK: type: DESCTABLE
+PREHOOK: Input: default@financial
+POSTHOOK: query: desc formatted Financial FI_QTR
+POSTHOOK: type: DESCTABLE
+POSTHOOK: Input: default@financial
+col_name            	FI_QTR              
+data_type           	char(10)            
+min                 	                    
+max                 	                    
+num_nulls           	0                   
+distinct_count      	1                   
+avg_col_len         	6.0                 
+max_col_len         	6                   
+num_trues           	                    
+num_falses          	                    
+bit_vector          	HL                  
+comment             	from deserializer   
+COLUMN_STATS_ACCURATE	{\"BASIC_STATS\":\"true\",\"COLUMN_STATS\":{\"cbigint\":\"true\",\"cboolean\":\"true\",\"cdecimal\":\"true\",\"cdouble\":\"true\",\"cfloat\":\"true\",\"cid\":\"true\",\"cint\":\"true\",\"csmallint\":\"true\",\"ctimestamp\":\"true\",\"ctinyint\":\"true\",\"fi_qtr\":\"true\",\"fi_qtr_start_date\":\"true\",\"fi_year\":\"true\",\"sk_companyid\":\"true\"}}

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/ObjectStore.java
@@ -9499,11 +9499,6 @@ public class ObjectStore implements RawStore, Configurable {
     if (oldStats != null) {
       StatObjectConverter.setFieldsIntoOldStats(mStatsObj, oldStats);
     } else {
-      if (sqlGenerator.getDbProduct().isPOSTGRES() && mStatsObj.getBitVector() == null) {
-        // workaround for DN bug in persisting nulls in pg bytea column
-        // instead set empty bit vector with header.
-        mStatsObj.setBitVector(new byte[] { 'H', 'L' });
-      }
       pm.makePersistent(mStatsObj);
     }
   }
@@ -9538,11 +9533,6 @@ public class ObjectStore implements RawStore, Configurable {
     if (oldStats != null) {
       StatObjectConverter.setFieldsIntoOldStats(mStatsObj, oldStats);
     } else {
-      if (sqlGenerator.getDbProduct().isPOSTGRES() && mStatsObj.getBitVector() == null) {
-        // workaround for DN bug in persisting nulls in pg bytea column
-        // instead set empty bit vector with header.
-        mStatsObj.setBitVector(new byte[] { 'H', 'L' });
-      }
       pm.makePersistent(mStatsObj);
     }
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/StatObjectConverter.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/StatObjectConverter.java
@@ -636,6 +636,16 @@ public class StatObjectConverter {
     return statsDesc;
   }
 
+  public static byte[] getBitVector(byte[] bytes) {
+    // workaround for DN bug in persisting nulls in pg bytea column
+    // instead set empty bit vector with header.
+    // https://issues.apache.org/jira/browse/HIVE-17836
+    if (bytes != null && bytes.length == 2 && bytes[0] == 'H' && bytes[1] == 'L') {
+      return null;
+    }
+    return bytes;
+  }
+
   // JAVA
   public static void fillColumnStatisticsData(String colType, ColumnStatisticsData data,
       Object llow, Object lhigh, Object dlow, Object dhigh, Object declow, Object dechigh,
@@ -654,7 +664,7 @@ public class StatObjectConverter {
       stringStats.setAvgColLen(MetastoreDirectSqlUtils.extractSqlDouble(avglen));
       stringStats.setMaxColLen(MetastoreDirectSqlUtils.extractSqlLong(maxlen));
       stringStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      stringStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      stringStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setStringStats(stringStats);
     } else if (colType.equals("binary")) {
       BinaryColumnStatsData binaryStats = new BinaryColumnStatsData();
@@ -673,7 +683,7 @@ public class StatObjectConverter {
         longStats.setLowValue(MetastoreDirectSqlUtils.extractSqlLong(llow));
       }
       longStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      longStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      longStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setLongStats(longStats);
     } else if (colType.equals("double") || colType.equals("float")) {
       DoubleColumnStatsDataInspector doubleStats = new DoubleColumnStatsDataInspector();
@@ -685,7 +695,7 @@ public class StatObjectConverter {
         doubleStats.setLowValue(MetastoreDirectSqlUtils.extractSqlDouble(dlow));
       }
       doubleStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      doubleStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      doubleStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setDoubleStats(doubleStats);
     } else if (colType.startsWith("decimal")) {
       DecimalColumnStatsDataInspector decimalStats = new DecimalColumnStatsDataInspector();
@@ -697,7 +707,7 @@ public class StatObjectConverter {
         decimalStats.setLowValue(DecimalUtils.createThriftDecimal((String)declow));
       }
       decimalStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      decimalStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      decimalStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setDecimalStats(decimalStats);
     } else if (colType.equals("date")) {
       DateColumnStatsDataInspector dateStats = new DateColumnStatsDataInspector();
@@ -709,7 +719,7 @@ public class StatObjectConverter {
         dateStats.setLowValue(new Date(MetastoreDirectSqlUtils.extractSqlLong(llow)));
       }
       dateStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      dateStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      dateStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setDateStats(dateStats);
     } else if (colType.equals("timestamp")) {
       TimestampColumnStatsDataInspector timestampStats = new TimestampColumnStatsDataInspector();
@@ -721,7 +731,7 @@ public class StatObjectConverter {
         timestampStats.setLowValue(new Timestamp(MetastoreDirectSqlUtils.extractSqlLong(llow)));
       }
       timestampStats.setNumDVs(MetastoreDirectSqlUtils.extractSqlLong(dist));
-      timestampStats.setBitVectors(MetastoreDirectSqlUtils.extractSqlBlob(bitVector));
+      timestampStats.setBitVectors(getBitVector(MetastoreDirectSqlUtils.extractSqlBlob(bitVector)));
       data.setTimestampStats(timestampStats);
     }
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartitionColumnStatistics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartitionColumnStatistics.java
@@ -50,7 +50,7 @@ public class MPartitionColumnStatistics {
   private String decimalHighValue;
   private Long numNulls;
   private Long numDVs;
-  private byte[] bitVector;
+  private byte[] bitVector = new byte[] { 'H', 'L' };
   private Double avgColLen;
   private Long maxColLen;
   private Long numTrues;
@@ -180,7 +180,7 @@ public class MPartitionColumnStatistics {
   public void setLongStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }
@@ -188,7 +188,7 @@ public class MPartitionColumnStatistics {
   public void setDoubleStats(Long numNulls, Long numNDVs, byte[] bitVector, Double lowValue, Double highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.doubleLowValue = lowValue;
     this.doubleHighValue = highValue;
   }
@@ -197,7 +197,7 @@ public class MPartitionColumnStatistics {
       Long numNulls, Long numNDVs, byte[] bitVector, String lowValue, String highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.decimalLowValue = lowValue;
     this.decimalHighValue = highValue;
   }
@@ -205,7 +205,7 @@ public class MPartitionColumnStatistics {
   public void setStringStats(Long numNulls, Long numNDVs, byte[] bitVector, Long maxColLen, Double avgColLen) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.maxColLen = maxColLen;
     this.avgColLen = avgColLen;
   }
@@ -219,7 +219,7 @@ public class MPartitionColumnStatistics {
   public void setDateStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }
@@ -227,7 +227,7 @@ public class MPartitionColumnStatistics {
   public void setTimestampStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartitionColumnStatistics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MPartitionColumnStatistics.java
@@ -281,11 +281,20 @@ public class MPartitionColumnStatistics {
   }
 
   public byte[] getBitVector() {
+    // workaround for DN bug in persisting nulls in pg bytea column
+    // instead set empty bit vector with header.
+    // https://issues.apache.org/jira/browse/HIVE-17836
+    if (bitVector != null && bitVector.length == 2 && bitVector[0] == 'H' && bitVector[1] == 'L') {
+      return null;
+    }
     return bitVector;
   }
 
   public void setBitVector(byte[] bitVector) {
-    this.bitVector = bitVector;
+    // workaround for DN bug in persisting nulls in pg bytea column
+    // instead set empty bit vector with header.
+    // https://issues.apache.org/jira/browse/HIVE-17836
+    this.bitVector = (bitVector == null ? new byte[] { 'H', 'L' } : bitVector);
   }
 
   public String getEngine() {

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MTableColumnStatistics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MTableColumnStatistics.java
@@ -48,7 +48,7 @@ public class MTableColumnStatistics {
   private String decimalHighValue;
   private Long numNulls;
   private Long numDVs;
-  private byte[] bitVector;
+  private byte[] bitVector = new byte[] { 'H', 'L' };
   private Double avgColLen;
   private Long maxColLen;
   private Long numTrues;
@@ -170,7 +170,7 @@ public class MTableColumnStatistics {
   public void setLongStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }
@@ -178,7 +178,7 @@ public class MTableColumnStatistics {
   public void setDoubleStats(Long numNulls, Long numNDVs, byte[] bitVector, Double lowValue, Double highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.doubleLowValue = lowValue;
     this.doubleHighValue = highValue;
   }
@@ -187,7 +187,7 @@ public class MTableColumnStatistics {
       Long numNulls, Long numNDVs, byte[] bitVector, String lowValue, String highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.decimalLowValue = lowValue;
     this.decimalHighValue = highValue;
   }
@@ -195,7 +195,7 @@ public class MTableColumnStatistics {
   public void setStringStats(Long numNulls, Long numNDVs, byte[] bitVector, Long maxColLen, Double avgColLen) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.maxColLen = maxColLen;
     this.avgColLen = avgColLen;
   }
@@ -209,7 +209,7 @@ public class MTableColumnStatistics {
   public void setDateStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }
@@ -217,7 +217,7 @@ public class MTableColumnStatistics {
   public void setTimestampStats(Long numNulls, Long numNDVs, byte[] bitVector, Long lowValue, Long highValue) {
     this.numNulls = numNulls;
     this.numDVs = numNDVs;
-    this.bitVector = bitVector;
+    setBitVector(bitVector);
     this.longLowValue = lowValue;
     this.longHighValue = highValue;
   }

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MTableColumnStatistics.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/model/MTableColumnStatistics.java
@@ -272,11 +272,20 @@ public class MTableColumnStatistics {
   }
 
   public byte[] getBitVector() {
+    // workaround for DN bug in persisting nulls in pg bytea column
+    // instead set empty bit vector with header.
+    // https://issues.apache.org/jira/browse/HIVE-17836
+    if (bitVector != null && bitVector.length == 2 && bitVector[0] == 'H' && bitVector[1] == 'L') {
+      return null;
+    }
     return bitVector;
   }
 
   public void setBitVector(byte[] bitVector) {
-    this.bitVector = bitVector;
+    // workaround for DN bug in persisting nulls in pg bytea column
+    // instead set empty bit vector with header.
+    // https://issues.apache.org/jira/browse/HIVE-17836
+    this.bitVector = (bitVector == null ? new byte[] { 'H', 'L' } : bitVector);
   }
 
   public String getEngine() {


### PR DESCRIPTION

### What changes were proposed in this pull request?
While getting the stats from the backend database, convert the bit vector column having magic value ("HL") with null bit vector.


### Why are the changes needed?
Causes exception while merging the stats in Postgres backend 


### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit tested 
