### PR TITLE
HIVE-25420

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerWithEngine.java
@@ -421,8 +421,8 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testJoinTablesSupportedTypes() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if (type == Types.TimestampType.withZone() && isVectorized) {
-        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+      if ((type == Types.TimestampType.withZone() || type == Types.TimeType.get()) && isVectorized) {
+        // ORC/TIMESTAMP_INSTANT and time are not supported vectorized types for Hive
         continue;
       }
       // TODO: remove this filter when issue #1881 is resolved
@@ -448,8 +448,8 @@ public class TestHiveIcebergStorageHandlerWithEngine {
   public void testSelectDistinctFromTable() throws IOException {
     for (int i = 0; i < SUPPORTED_TYPES.size(); i++) {
       Type type = SUPPORTED_TYPES.get(i);
-      if (type == Types.TimestampType.withZone() && isVectorized) {
-        // ORC/TIMESTAMP_INSTANT is not a supported vectorized type for Hive
+      if ((type == Types.TimestampType.withZone() || type == Types.TimeType.get()) && isVectorized) {
+        // ORC/TIMESTAMP_INSTANT and time are not supported vectorized types for Hive
         continue;
       }
       // TODO: remove this filter when issue #1881 is resolved


### PR DESCRIPTION
Time is a valid type in Iceberg but not in Hive. In Hive it is represented as a string type column, while (at least if ORC is used as underlying file format) long type is written out to data files.

This requires translation two times: long@ORC -> LocalDate@Iceberg -> toString()@Hive and it works well for non vectorized reads, but when vectorization is turned on, we will get:

org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector cannot be cast to org.apache.hadoop.hive.ql.exec.vector.LongColumnVector 

Thus for now, time type is not supported with vectorization, and the relevant test cases should be ignored in such test configs.