### PR TITLE
HIVE-25433: DistCp job fails with yarn map compatibility mode issue.

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/DirCopyTask.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/repl/DirCopyTask.java
@@ -209,14 +209,13 @@ public class DirCopyTask extends Task<DirCopyWork> implements Serializable {
 
   private HiveConf getConf(HiveConf conf) {
     // if it is a db level path check for custom configurations.
+    HiveConf clonedConf = new HiveConf(conf);
     if (work.getTableName().startsWith("dbPath:")) {
-      HiveConf clonedConf = new HiveConf(conf);
       for (Map.Entry<String, String> entry : conf.getPropsWithPrefix(CUSTOM_PATH_CONFIG_PREFIX).entrySet()) {
         clonedConf.set(entry.getKey().replaceFirst(CUSTOM_PATH_CONFIG_PREFIX, ""), entry.getValue());
       }
-      return clonedConf;
     }
-    return conf;
+    return clonedConf;
   }
 
   private static Path reservedRawPath(URI uri) {

--- a/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
+++ b/shims/0.23/src/main/java/org/apache/hadoop/hive/shims/Hadoop23Shims.java
@@ -1203,8 +1203,8 @@ public class Hadoop23Shims extends HadoopShimsSecure {
     List<String> params = constructDistCpParams(srcPaths, dst, conf);
     DistCp distcp = null;
     try {
-      conf.setBoolean("mapred.mapper.new-api", true);
       distcp = new DistCp(conf, options);
+      distcp.getConf().setBoolean("mapred.mapper.new-api", true);
 
       // HIVE-13704 states that we should use run() instead of execute() due to a hadoop known issue
       // added by HADOOP-10459
@@ -1223,7 +1223,6 @@ public class Hadoop23Shims extends HadoopShimsSecure {
           conf.set(CONF_LABEL_DISTCP_JOB_ID, jobId);
         }
       }
-      conf.setBoolean("mapred.mapper.new-api", false);
     }
   }
 


### PR DESCRIPTION
Problem: Concurrency issues.
We were using same conf object across multiple threads. So, if one thread unsets 'mapred.mapper.new-api', this change would be reflected in other threads also and ultimately resulting in distcp job failure.  