### PR TITLE
HIVE-24742: Support router path or view fs path in Hive table location

### DIFF
--- a/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
+++ b/common/src/test/org/apache/hadoop/hive/common/TestFileUtils.java
@@ -30,11 +30,13 @@ import static org.mockito.Mockito.when;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.ContentSummary;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
@@ -263,5 +265,38 @@ public class TestFileUtils {
       Assert.assertTrue(e.getMessage().
               equalsIgnoreCase("Distcp is called with doAsUser and delete source set as true"));
     }
+  }
+
+  @Test
+  public void testEqualsFileSystem() throws IOException {
+    FileSystem mockFs1 = mock(FileSystem.class);
+    FileSystem mockFs2 = mock(FileSystem.class);
+    Path path1 = new Path("viewfs://ns/path1");
+    Path path2 = new Path("viewfs://ns/path2");
+
+    when(mockFs1.resolvePath(path1))
+            .thenReturn(new Path("hdfs://ns1/path1"));
+    when(mockFs2.resolvePath(path2))
+            .thenReturn(new Path("hdfs://ns1/path2"));
+
+    Assert.assertTrue(FileUtils.equalsFileSystem(mockFs1, path1, mockFs2, path2));
+
+    when(mockFs1.resolvePath(path1))
+            .thenReturn(new Path("hdfs://ns1/path1"));
+    when(mockFs2.resolvePath(path2))
+            .thenReturn(new Path("hdfs://ns2/path2"));
+
+    Assert.assertFalse(FileUtils.equalsFileSystem(mockFs1, path1, mockFs2, path2));
+
+    // Test local paths
+    path1 = new Path("file:/tmp/path1");
+    path2 = new Path("file:/tmp/path2");
+    FileSystem localFS = mock(FileSystem.class);
+    when(localFS.resolvePath(path1)).thenReturn(path1);
+    when(localFS.resolvePath(path2)).thenReturn(path2);
+
+    Assert.assertTrue(FileUtils.equalsFileSystem(localFS, path1, localFS, path2));
+
+
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/metadata/Hive.java
@@ -2475,7 +2475,7 @@ public class Hive {
            */
           FileSystem oldPartPathFS = oldPartPath.getFileSystem(getConf());
           FileSystem loadPathFS = loadPath.getFileSystem(getConf());
-          if (FileUtils.equalsFileSystem(oldPartPathFS,loadPathFS)) {
+          if (FileUtils.equalsFileSystem(oldPartPathFS, oldPartPath,loadPathFS, loadPath)) {
             newPartPath = oldPartPath;
           }
         }
@@ -4857,8 +4857,12 @@ private void constructOneLBLocationMap(FileStatus fSta,
   static private boolean needToCopy(final HiveConf conf, Path srcf, Path destf, FileSystem srcFs,
                                       FileSystem destFs, String configuredOwner, boolean isManaged) throws HiveException {
     //Check if different FileSystems
-    if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-      return true;
+    try {
+      if (!FileUtils.equalsFileSystem(srcFs, srcf, destFs, destf)) {
+        return true;
+      }
+    } catch(IOException e) {
+      throw new HiveException(e);
     }
 
     if (isManaged && !configuredOwner.isEmpty() && srcFs instanceof DistributedFileSystem) {

--- a/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigration.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/util/HiveStrictManagedMigration.java
@@ -663,7 +663,7 @@ public class HiveStrictManagedMigration {
           FileSystem curWhRootFs = targetPath.getFileSystem(conf);
           oldWhRootPath = oldWhRootFs.makeQualified(oldWhRootPath);
           targetPath = curWhRootFs.makeQualified(targetPath);
-          if (!FileUtils.equalsFileSystem(oldWhRootFs, curWhRootFs)) {
+          if (!FileUtils.equalsFileSystem(oldWhRootFs, oldWhRootPath, curWhRootFs, targetPath)) {
             LOG.info("oldWarehouseRoot {} has a different FS than the target path {}."
                 + " Disabling shouldModifyManagedTableLocation and shouldMoveExternal",
               runOptions.oldWarehouseRoot, currentPathString);

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveAlterHandler.java
@@ -265,10 +265,17 @@ public class HiveAlterHandler implements AlterHandler {
             // check that destination does not exist otherwise we will be
             // overwriting data
             // check that src and dest are on the same file system
-            if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-              throw new InvalidOperationException("table new location " + destPath
-                      + " is on a different file system than the old location "
-                      + srcPath + ". This operation is not supported");
+            try {
+              if (!FileUtils.equalsFileSystem(srcFs, srcPath, destFs, destPath)) {
+                throw new InvalidOperationException("table new location " + destPath
+                        + " is on a different file system than the old location "
+                        + srcPath + ". This operation is not supported");
+              }
+            } catch(IOException e) {
+              LOG.error("Failed to check if " + srcPath + "," + destPath
+                      + "are on same file system", e);
+              throw new InvalidOperationException("Alter Table operation for " + dbname + "." + name +
+                      " failed due to: '" + getSimpleMessage(e) +"'");
             }
 
             try {
@@ -655,10 +662,17 @@ public class HiveAlterHandler implements AlterHandler {
           srcFs = wh.getFs(srcPath);
           destFs = wh.getFs(destPath);
           // check that src and dest are on the same file system
-          if (!FileUtils.equalsFileSystem(srcFs, destFs)) {
-            throw new InvalidOperationException("New table location " + destPath
-              + " is on a different file system than the old location "
-              + srcPath + ". This operation is not supported.");
+          try {
+            if (!FileUtils.equalsFileSystem(srcFs, srcPath, destFs, destPath)) {
+              throw new InvalidOperationException("New table location " + destPath
+                      + " is on a different file system than the old location "
+                      + srcPath + ". This operation is not supported.");
+            }
+          } catch(IOException e) {
+            LOG.error("Failed to check if " + srcPath + "," + destPath
+                    + "are on same file system", e);
+            throw new InvalidOperationException("Alter partition operation for " + dbname + "." + name +
+                    " failed due to: '" + getSimpleMessage(e) +"'");
           }
 
           try {


### PR DESCRIPTION
What changes were proposed in this pull request?
Support router path or viewfs path in Hive table location by resolving the path to the physical cluster path and comparing them to determine if source or destination are on the same cluster.

Why are the changes needed?
HDFS router or viewfs is for file system federation and the path is not the physical path. Currently Hive uses the scheme and authority to check if the source and destination are on the same cluster and decides to rename the path or copy the data. That would cause issue for router or viewfs path since the physical paths could be on different clusters.

Does this PR introduce any user-facing change?
No

How was this patch tested?
New UT