### PR TITLE
HIVE-25375

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/parse/PartitionTransformSpec.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/parse/PartitionTransformSpec.java
@@ -22,7 +22,7 @@ import java.util.Optional;
 public class PartitionTransformSpec {
 
   public enum TransformType {
-    IDENTITY, YEAR, MONTH, DAY, HOUR, TRUNCATE, BUCKET
+    IDENTITY, YEAR, MONTH, DAY, HOUR, TRUNCATE, BUCKET, VOID
   }
 
   private String columnName;


### PR DESCRIPTION
Currently ALTER TABLE CHANGE COLUMN statement only updates the Iceberg-backed table's schema, but not it's partition spec. Updating the spec is required to allow subsequent partition spec changes (like set partition spec calls) to succeed.

Note: to do this in HiveIcebergMetaHook class we can't just create an updateSchema and an updatePartitionSpec object, do the modifications and commit both of them, as the last commit will fail due to invalid base. We might want to do this in two separate steps instead.