### PR TITLE
HIVE-25423: Add new test driver to automatically launch and load external database (Same as PR#2559, squashed commit for test trigger)

### DIFF
--- a/data/scripts/derby/q_test_extDB_cleanup.derby.sql
+++ b/data/scripts/derby/q_test_extDB_cleanup.derby.sql
@@ -1,0 +1,3 @@
+drop table country;
+drop table stats;
+drop table city;

--- a/data/scripts/derby/q_test_extDB_init.derby.sql
+++ b/data/scripts/derby/q_test_extDB_init.derby.sql
@@ -1,0 +1,27 @@
+-- reference: https://medium.com/swlh/getting-started-with-apache-derby-9f6ca8dea873
+
+create table country (name char(30) not null unique);
+create table state (name char(30) not null unique,
+                    country_code int not null);
+create table city (name char(30) not null unique,
+                   state_code int not null);
+
+insert into country (name) values ('India');
+insert into country (name) values ('Russia');
+insert into country (name) values ('USA');
+
+insert into state (name,country_code) values ('Maharashtra',1);
+insert into state (name,country_code) values ('Madhya Pradesh',1);
+insert into state (name,country_code) values ('Moscow',3);
+insert into state (name,country_code) values ('Something',4);
+insert into state (name,country_code) values ('Florida',4);
+insert into state (name,country_code) values ('Texas',4);
+
+insert into city (name,state_code) values('Mumbai',1);
+insert into city (name,state_code) values('Pune',1);
+insert into city (name,state_code) values('Bhopal',2);
+insert into city (name,state_code) values('Indore',2);
+insert into city (name,state_code) values('Klin',3);
+insert into city (name,state_code) values('Los Angeles',5);
+insert into city (name,state_code) values('Plant City',5);
+insert into city (name,state_code) values('Arlington',6);

--- a/data/scripts/mysql/q_test_extDB_cleanup.mysql.sql
+++ b/data/scripts/mysql/q_test_extDB_cleanup.mysql.sql
@@ -1,0 +1,3 @@
+drop table if exists country;
+drop table if exists stats;
+drop table if exists city;

--- a/data/scripts/mysql/q_test_extDB_init.mysql.sql
+++ b/data/scripts/mysql/q_test_extDB_init.mysql.sql
@@ -1,0 +1,23 @@
+create table if not exists country (name varchar(255) not null);
+create table if not exists state (name varchar(255) not null, country_code int not null);
+create table if not exists city (name varchar(255) not null, state_code int not null);
+
+insert into country (name) values ('India');
+insert into country (name) values ('Russia');
+insert into country (name) values ('USA');
+
+insert into state (name,country_code) values ('Maharashtra',1);
+insert into state (name,country_code) values ('Madhya Pradesh',1);
+insert into state (name,country_code) values ('Moscow',3);
+insert into state (name,country_code) values ('Something',4);
+insert into state (name,country_code) values ('Florida',4);
+insert into state (name,country_code) values ('Texas',4);
+
+insert into city (name,state_code) values('Mumbai',1);
+insert into city (name,state_code) values('Pune',1);
+insert into city (name,state_code) values('Bhopal',2);
+insert into city (name,state_code) values('Indore',2);
+insert into city (name,state_code) values('Klin',3);
+insert into city (name,state_code) values('Los Angeles',5);
+insert into city (name,state_code) values('Plant City',5);
+insert into city (name,state_code) values('Arlington',6);

--- a/data/scripts/postgres/q_test_extDB_cleanup.postgres.sql
+++ b/data/scripts/postgres/q_test_extDB_cleanup.postgres.sql
@@ -1,0 +1,3 @@
+drop table if exists country;
+drop table if exists stats;
+drop table if exists city;

--- a/data/scripts/postgres/q_test_extDB_init.postgres.sql
+++ b/data/scripts/postgres/q_test_extDB_init.postgres.sql
@@ -1,0 +1,23 @@
+create table if not exists country (name varchar(80) not null);
+create table if not exists state (name varchar(80) not null, country_code int not null);
+create table if not exists city (name varchar(80) not null, state_code int not null);
+
+insert into country (name) values ('India');
+insert into country (name) values ('Russia');
+insert into country (name) values ('USA');
+
+insert into state (name,country_code) values ('Maharashtra',1);
+insert into state (name,country_code) values ('Madhya Pradesh',1);
+insert into state (name,country_code) values ('Moscow',3);
+insert into state (name,country_code) values ('Something',4);
+insert into state (name,country_code) values ('Florida',4);
+insert into state (name,country_code) values ('Texas',4);
+
+insert into city (name,state_code) values('Mumbai',1);
+insert into city (name,state_code) values('Pune',1);
+insert into city (name,state_code) values('Bhopal',2);
+insert into city (name,state_code) values('Indore',2);
+insert into city (name,state_code) values('Klin',3);
+insert into city (name,state_code) values('Los Angeles',5);
+insert into city (name,state_code) values('Plant City',5);
+insert into city (name,state_code) values('Arlington',6);

--- a/itests/qtest/pom.xml
+++ b/itests/qtest/pom.xml
@@ -478,6 +478,23 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>com.googlecode.maven-download-plugin</groupId>
+        <artifactId>download-maven-plugin</artifactId>
+        <version>1.3.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>http://downloads.mariadb.com/Connectors/java/connector-java-2.2.0/mariadb-java-client-2.2.0.jar</url>
+              <outputFileName>mariadb-java-client-2.2.0.jar</outputFileName>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>properties-maven-plugin</artifactId>
         <version>1.0-alpha-2</version>
@@ -576,6 +593,7 @@
             <additionalClasspathElement>${test.conf.dir}</additionalClasspathElement>
             <additionalClasspathElement>${basedir}/${hive.path.to.root}/conf</additionalClasspathElement>
             <additionalClasspathElement>${itest.jdbc.jars}</additionalClasspathElement>
+            <additionalClasspathElement>${project.build.directory}/mariadb-java-client-2.2.0.jar</additionalClasspathElement>
           </additionalClasspathElements>
         </configuration>
       </plugin>

--- a/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniLlapExtDBCliDriver.java
+++ b/itests/qtest/src/test/java/org/apache/hadoop/hive/cli/TestMiniLlapExtDBCliDriver.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.cli;
+
+import java.io.File;
+import java.util.List;
+
+import org.apache.hadoop.hive.cli.control.CliAdapter;
+import org.apache.hadoop.hive.cli.control.CliConfigs;
+import org.apache.hadoop.hive.cli.control.SplitSupport;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+public class TestMiniLlapExtDBCliDriver {
+
+    static CliAdapter adapter = new CliConfigs.MiniLlapExtDBCliConfig().getCliAdapter();
+
+    private static int N_SPLITS = 3;
+
+    @Parameters(name = "{0}")
+    public static List<Object[]> getParameters() throws Exception {
+        return SplitSupport.process(adapter.getParameters(), TestMiniLlapExtDBCliDriver.class, N_SPLITS);
+    }
+
+    @ClassRule
+    public static TestRule cliClassRule = adapter.buildClassRule();
+
+    @Rule
+    public TestRule cliTestRule = adapter.buildTestRule();
+
+    private String name;
+    private File qfile;
+
+    public TestMiniLlapExtDBCliDriver(String name, File qfile) {
+        this.name = name;
+        this.qfile = qfile;
+    }
+
+    @Test
+    public void testCliDriver() throws Exception {
+        adapter.runTest(name, qfile);
+    }
+
+}

--- a/itests/src/test/resources/testconfiguration.properties
+++ b/itests/src/test/resources/testconfiguration.properties
@@ -1247,3 +1247,8 @@ erasurecoding.only.query.files=\
   erasure_commands.q,\
   erasure_explain.q,\
   erasure_simple.q
+
+# tests that requires external database connection
+externalDB.llap.query.files=\
+  dataconnector.q,\
+  dataconnector_mysql.q

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCliConfig.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/AbstractCliConfig.java
@@ -36,6 +36,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.ql.QTestSystemProperties;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.MiniClusterType;
+import org.apache.hadoop.hive.ql.QTestExternalDB;
 import org.apache.hive.testutils.HiveTestEnvSetup;
 
 import com.google.common.base.Splitter;
@@ -60,6 +61,7 @@ public abstract class AbstractCliConfig {
   // these should have viable defaults
   private String cleanupScript;
   private String initScript;
+  private Set<QTestExternalDB> externalDBs = new LinkedHashSet<>();
   private String hiveConfDir;
   private MiniClusterType clusterType;
   private FsType fsType;
@@ -342,6 +344,9 @@ public abstract class AbstractCliConfig {
       this.initScript = initScript;
     }
   }
+  public Set<QTestExternalDB> getExternalDBs() { return externalDBs; }
+
+  protected void addExternalDB (QTestExternalDB externalDB) { this.externalDBs.add(externalDB); }
 
   public String getHiveConfDir() {
     return hiveConfDir;

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CliConfigs.java
@@ -24,6 +24,7 @@ import java.net.URL;
 import org.apache.hadoop.hive.ql.QTestMiniClusters;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.MiniClusterType;
 import org.apache.hadoop.hive.ql.parse.CoreParseNegative;
+import org.apache.hadoop.hive.ql.QTestExternalDB;
 
 public class CliConfigs {
 
@@ -225,12 +226,35 @@ public class CliConfigs {
         excludesFrom(testConfigProps, "spark.only.query.files");
         excludesFrom(testConfigProps, "localSpark.only.query.files");
         excludesFrom(testConfigProps, "miniSparkOnYarn.only.query.files");
+        excludesFrom(testConfigProps, "externalDB.llap.query.files");
 
         setResultsDir("ql/src/test/results/clientpositive/llap");
         setLogDir("itests/qtest/target/qfile-results/clientpositive");
 
         setInitScript("q_test_init.sql");
         setCleanupScript("q_test_cleanup.sql");
+
+        setHiveConfDir("data/conf/llap");
+        setClusterType(MiniClusterType.LLAP_LOCAL);
+      } catch (Exception e) {
+        throw new RuntimeException("can't construct cliconfig", e);
+      }
+    }
+  }
+
+  public static class MiniLlapExtDBCliConfig extends AbstractCliConfig {
+
+    public MiniLlapExtDBCliConfig() {
+      super(CoreCliDriver.class);
+      try {
+        setQueryDir("ql/src/test/queries/clientpositive");
+
+        includesFrom(testConfigProps, "externalDB.llap.query.files");
+
+        setResultsDir("ql/src/test/results/clientpositive/llap");
+        setLogDir("itests/qtest/target/qfile-results/clientpositive");
+
+        addExternalDB(QTestExternalDB.createDefaultExtDB("mysql"));
 
         setHiveConfDir("data/conf/llap");
         setClusterType(MiniClusterType.LLAP_LOCAL);

--- a/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/cli/control/CoreCliDriver.java
@@ -21,10 +21,13 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.File;
+import java.util.Set;
+import java.util.LinkedHashSet;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.conf.HiveConf.ConfVars;
+import org.apache.hadoop.hive.ql.QTestExternalDB;
 import org.apache.hadoop.hive.ql.QTestArguments;
 import org.apache.hadoop.hive.ql.QTestProcessExecResult;
 import org.apache.hadoop.hive.ql.QTestUtil;
@@ -62,6 +65,7 @@ public class CoreCliDriver extends CliAdapter {
     String hiveConfDir = cliConfig.getHiveConfDir();
     String initScript = cliConfig.getInitScript();
     String cleanupScript = cliConfig.getCleanupScript();
+    Set<QTestExternalDB> externalDBs = cliConfig.getExternalDBs();
 
     try {
       qt = new ElapsedTimeLoggingWrapper<QTestUtil>() {
@@ -75,6 +79,7 @@ public class CoreCliDriver extends CliAdapter {
                 .withConfDir(hiveConfDir)
                 .withInitScript(initScript)
                 .withCleanupScript(cleanupScript)
+                .withExternalDBs(externalDBs)
                 .withLlapIo(true)
                 .withFsType(cliConfig.getFsType())
                 .build());

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestArguments.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestArguments.java
@@ -18,6 +18,9 @@
 
 package org.apache.hadoop.hive.ql;
 
+import java.util.Set;
+import java.util.LinkedHashSet;
+import org.apache.hadoop.hive.ql.QTestExternalDB;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.FsType;
 import org.apache.hadoop.hive.ql.QTestMiniClusters.QTestSetup;
 
@@ -34,6 +37,7 @@ public final class QTestArguments {
   private String cleanupScript;
   private boolean withLlapIo;
   private FsType fsType;
+  private Set<QTestExternalDB> externalDBs = new LinkedHashSet<>();
   private QTestSetup qtestSetup;
 
   private QTestArguments() {
@@ -79,6 +83,10 @@ public final class QTestArguments {
     return initScript;
   }
 
+  private void setExternalDBs(Set<QTestExternalDB> externalDBs) { this.externalDBs = externalDBs; }
+
+  public Set<QTestExternalDB> getExternalDBs() { return this.externalDBs; }
+
   private void setCleanupScript(String cleanupScript) {
     this.cleanupScript = cleanupScript;
   }
@@ -122,6 +130,7 @@ public final class QTestArguments {
     private QTestMiniClusters.MiniClusterType clusterType;
     private String initScript;
     private String cleanupScript;
+    private Set<QTestExternalDB> externalDBs = new LinkedHashSet<>();
     private boolean withLlapIo;
     private FsType fsType;
     private QTestSetup qtestSetup;
@@ -163,6 +172,11 @@ public final class QTestArguments {
       return this;
     }
 
+    public QTestArgumentsBuilder withExternalDBs(Set<QTestExternalDB> externalDBs) {
+      this.externalDBs = externalDBs;
+      return this;
+    }
+
     public QTestArgumentsBuilder withLlapIo(boolean withLlapIo) {
       this.withLlapIo = withLlapIo;
       return this;
@@ -187,6 +201,9 @@ public final class QTestArguments {
       testArguments.setInitScript(initScript);
       testArguments.setCleanupScript(cleanupScript);
       testArguments.setWithLlapIo(withLlapIo);
+      
+      testArguments.setExternalDBs(
+              externalDBs != null ? externalDBs : new LinkedHashSet<>());
 
       testArguments.setFsType(
           fsType != null ? fsType : clusterType.getDefaultFsType());

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/QTestExternalDB.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hive.ql;
+
+import java.io.File;
+
+/**
+ * QTestExternalDB composite used as information holder for creating external databases of different types.
+ */
+public final class QTestExternalDB {
+
+    private String externalDBType;
+    private String externalDBInitScript;
+    private String externalDBCleanupScript;
+
+    public QTestExternalDB() { }
+
+    public static QTestExternalDB createDefaultExtDB(String externalDBType) {
+
+        QTestExternalDB externalDB = new QTestExternalDB();
+
+        externalDB.setExternalDBType(externalDBType);
+        externalDB.setExternalDBInitScript(String.format("q_test_extDB_init.%s.sql", externalDBType));
+        externalDB.setExternalDBCleanupScript(String.format("q_test_extDB_cleanup.%s.sql", externalDBType));
+
+        return externalDB;
+    }
+
+    public void setExternalDBType(String dbType) { this.externalDBType = dbType; }
+
+    public String getExternalDBType() { return externalDBType; }
+
+    public void setExternalDBInitScript(String InitScript) { this.externalDBInitScript = InitScript; }
+
+    public String getExternalDBInitScript() { return externalDBInitScript; }
+
+    public void setExternalDBCleanupScript(String cleanupScript) { this.externalDBCleanupScript = cleanupScript; }
+
+    public String getExternalDBCleanupScript() { return externalDBCleanupScript; }
+
+}

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/AbstractExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/AbstractExternalDB.java
@@ -1,0 +1,288 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.externalDB;
+
+import sqlline.SqlLine;
+
+import org.apache.commons.io.output.NullOutputStream;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileReader;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.IOException;
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+
+import org.apache.commons.lang3.StringUtils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * abstractExternalDB is incharge of connect to and populate externaal database for qtest
+ */
+public abstract class AbstractExternalDB {
+    protected static final Logger LOG = LoggerFactory.getLogger("AbstractExternalDB");
+
+    protected static final String userName = "qtestuser";
+    protected static final String password = "qtestpassword";
+    protected static final String dbName = "qtestDB";
+
+    public String externalDBType = "mysql"; // default: mysql
+    protected String url = "jdbc:mysql://localhost:3306/" + dbName; // default: mysql
+    protected String driver = "org.mariadb.jdbc.Driver"; // default: mysql
+    private static final int MAX_STARTUP_WAIT = 5 * 60 * 1000;
+
+    public static class ProcessResults {
+        final String stdout;
+        final String stderr;
+        final int rc;
+
+        public ProcessResults(String stdout, String stderr, int rc) {
+            this.stdout = stdout;
+            this.stderr = stderr;
+            this.rc = rc;
+        }
+    }
+
+    public static AbstractExternalDB initalizeExternalDB(String externalDBType) throws IOException {
+        AbstractExternalDB abstractExternalDB;
+        switch (externalDBType) {
+            case "mysql":
+                abstractExternalDB = new MySQLExternalDB();
+                break;
+            case "postgres":
+                abstractExternalDB = new PostgresExternalDB();
+                break;
+            default:
+                throw new IOException("unsupported external database type " + externalDBType);
+        }
+        return abstractExternalDB;
+    }
+
+    public AbstractExternalDB(String externalDBType) {
+        this.externalDBType = externalDBType;
+    }
+
+    protected String getDockerContainerName() {
+        return String.format("qtestExternalDB-%s", externalDBType);
+    }
+
+    private String[] buildRunCmd() {
+        List<String> cmd = new ArrayList<>(4 + getDockerAdditionalArgs().length);
+        cmd.add("docker");
+        cmd.add("run");
+        cmd.add("--rm");
+        cmd.add("--name");
+        cmd.add(getDockerContainerName());
+        cmd.addAll(Arrays.asList(getDockerAdditionalArgs()));
+        cmd.add(getDockerImageName());
+        return cmd.toArray(new String[cmd.size()]);
+    }
+
+    private String[] buildRmCmd() {
+        return buildArray(
+                "docker",
+                "rm",
+                "-f",
+                "-v",
+                getDockerContainerName()
+        );
+    }
+
+    private String[] buildLogCmd() {
+        return buildArray(
+                "docker",
+                "logs",
+                getDockerContainerName()
+        );
+    }
+
+
+    private ProcessResults runCmd(String[] cmd, long secondsToWait)
+            throws IOException, InterruptedException {
+        LOG.info("Going to run: " + StringUtils.join(cmd, " "));
+        Process proc = Runtime.getRuntime().exec(cmd);
+        if (!proc.waitFor(secondsToWait, TimeUnit.SECONDS)) {
+            throw new RuntimeException(
+                    "Process " + cmd[0] + " failed to run in " + secondsToWait + " seconds");
+        }
+        BufferedReader reader = new BufferedReader(new InputStreamReader(proc.getInputStream()));
+        final StringBuilder lines = new StringBuilder();
+        reader.lines().forEach(s -> lines.append(s).append('\n'));
+
+        reader = new BufferedReader(new InputStreamReader(proc.getErrorStream()));
+        final StringBuilder errLines = new StringBuilder();
+        reader.lines().forEach(s -> errLines.append(s).append('\n'));
+        return new ProcessResults(lines.toString(), errLines.toString(), proc.exitValue());
+    }
+
+    private int runCmdAndPrintStreams(String[] cmd, long secondsToWait)
+            throws InterruptedException, IOException {
+        ProcessResults results = runCmd(cmd, secondsToWait);
+        LOG.info("Stdout from proc: " + results.stdout);
+        LOG.info("Stderr from proc: " + results.stderr);
+        return results.rc;
+    }
+
+
+    public void launchDockerContainer() throws Exception { //runDockerContainer
+        runCmdAndPrintStreams(buildRmCmd(), 600);
+        if (runCmdAndPrintStreams(buildRunCmd(), 600) != 0) {
+            throw new RuntimeException("Unable to start docker container");
+        }
+        long startTime = System.currentTimeMillis();
+        ProcessResults pr;
+        do {
+            Thread.sleep(1000);
+            pr = runCmd(buildLogCmd(), 5);
+            if (pr.rc != 0) {
+                throw new RuntimeException("Failed to get docker logs");
+            }
+        } while (startTime + MAX_STARTUP_WAIT >= System.currentTimeMillis() && !isContainerReady(pr));
+        if (startTime + MAX_STARTUP_WAIT < System.currentTimeMillis()) {
+            throw new RuntimeException("Container failed to be ready in " + MAX_STARTUP_WAIT/1000 +
+                    " seconds");
+        }
+    }
+
+    public void cleanupDockerContainer() { // stopAndRmDockerContainer
+        try {
+            if (runCmdAndPrintStreams(buildRmCmd(), 600) != 0) {
+                LOG.info("Unable to remove docker container");
+                throw new RuntimeException("Unable to remove docker container");
+            }
+        } catch (InterruptedException | IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    public final String getContainerHostAddress() {
+        String hostAddress = System.getenv("HIVE_TEST_DOCKER_HOST");
+        if (hostAddress != null) {
+            return hostAddress;
+        } else {
+            return "localhost";
+        }
+    }
+
+    public abstract void setJdbcUrl(String hostAddress);
+
+    public abstract void setJdbcDriver();
+
+    public abstract String getDockerImageName();
+
+    public abstract String[] getDockerAdditionalArgs();
+
+    public abstract boolean isContainerReady(ProcessResults pr);
+
+    protected String[] buildArray(String... strs) {
+        return strs;
+    }
+
+    public Connection getConnectionToExternalDB() throws SQLException, ClassNotFoundException {
+        try {
+            LOG.info("external database connection URL:\t " + url);
+            LOG.info("JDBC Driver :\t " + driver);
+            LOG.info("external database connection User:\t " + userName);
+            LOG.info("external database connection Password:\t " + password);
+
+            // load required JDBC driver
+            Class.forName(driver);
+
+            // Connect using the JDBC URL and user/password
+            Connection conn = DriverManager.getConnection(url, userName, password);
+            return conn;
+        } catch (SQLException e) {
+            LOG.error("Failed to connect to external databse", e);
+            throw new SQLException(e);
+        } catch (ClassNotFoundException e) {
+            LOG.error("Unable to find driver class", e);
+            throw new ClassNotFoundException("Unable to find driver class");
+        }
+    }
+
+    public void testConnectionToExternalDB() throws SQLException, ClassNotFoundException {
+        Connection conn = getConnectionToExternalDB();
+        try {
+            conn.close();
+        } catch (SQLException e) {
+            LOG.error("Failed to close external database connection", e);
+        }
+    }
+
+    protected String[] SQLLineCmdBuild(String sqlScriptFile) throws IOException {
+        return new String[] {"-u", url,
+                            "-d", driver,
+                            "-n", userName,
+                            "-p", password,
+                            "--isolation=TRANSACTION_READ_COMMITTED",
+                            "-f", sqlScriptFile};
+
+    }
+
+    protected void execSql(String sqlScriptFile) throws IOException {
+        // run the script using SqlLine
+        SqlLine sqlLine = new SqlLine();
+        ByteArrayOutputStream outputForLog = null;
+        OutputStream out;
+        if (LOG.isDebugEnabled()) {
+            out = outputForLog = new ByteArrayOutputStream();
+        } else {
+            out = new NullOutputStream();
+        }
+        sqlLine.setOutputStream(new PrintStream(out));
+        System.setProperty("sqlline.silent", "true");
+
+        SqlLine.Status status = sqlLine.begin(SQLLineCmdBuild(sqlScriptFile), null, false);
+        if (LOG.isDebugEnabled() && outputForLog != null) {
+            LOG.debug("Received following output from Sqlline:");
+            LOG.debug(outputForLog.toString("UTF-8"));
+        }
+        if (status != SqlLine.Status.OK) {
+            throw new IOException("external database script failed, errorcode " + status);
+        }
+    }
+
+    public void execute(String script) throws IOException, SQLException, ClassNotFoundException {
+        testConnectionToExternalDB();
+        LOG.info("Starting external database initialization to " + this.externalDBType);
+
+        try {
+            LOG.info("Initialization script " + script);
+            execSql(script);
+            LOG.info("Initialization script completed in external database");
+
+        } catch (IOException e) {
+            throw new IOException("initialization in external database FAILED!");
+        }
+
+    }
+}

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MySQLExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/MySQLExternalDB.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.externalDB;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * MySQLExternalDB is a extension of abstractExternalDB
+ * Designed for MySQL external database connection
+ */
+public class MySQLExternalDB extends AbstractExternalDB {
+
+    public MySQLExternalDB() {
+        super("mysql");
+        setJdbcUrl(getContainerHostAddress());
+        setJdbcDriver();
+    }
+
+    public void setJdbcUrl(String hostAddress) {
+        this.url = "jdbc:mysql://" + hostAddress + ":3306/" + dbName;
+    }
+
+    public void setJdbcDriver() {
+        this.driver = "org.mariadb.jdbc.Driver";
+    }
+
+    public String getDockerImageName() { return "mariadb:5.5"; }
+
+    public String[] getDockerAdditionalArgs() {
+        return buildArray("-p", "3306:3306",
+                          "-e", "MYSQL_ROOT_PASSWORD=its-a-secret",
+                          "-e", "MYSQL_USER=" + userName,
+                          "-e", "MYSQL_PASSWORD=" + password,
+                          "-e", "MYSQL_DATABASE=" + dbName,
+                          "-d");
+    }
+
+    public boolean isContainerReady(ProcessResults pr) {
+        Pattern pat = Pattern.compile("ready for connections");
+        Matcher m = pat.matcher(pr.stderr);
+        return m.find() && m.find();
+    }
+}

--- a/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
+++ b/itests/util/src/main/java/org/apache/hadoop/hive/ql/externalDB/PostgresExternalDB.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hive.ql.externalDB;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+
+/**
+ * MySQLExternalDB is a extension of abstractExternalDB
+ * Designed for MySQL external database connection
+ */
+public class PostgresExternalDB extends AbstractExternalDB {
+
+    public PostgresExternalDB() {
+        super("postgres");
+        setJdbcUrl(getContainerHostAddress());
+        setJdbcDriver();
+    }
+
+    public void setJdbcUrl(String hostAddress) {
+        this.url = "jdbc:postgresql://" + hostAddress + ":5432/" + dbName;
+    }
+
+    public void setJdbcDriver() {
+        this.driver = "org.postgresql.Driver";
+    }
+
+    public String getDockerImageName() {
+        return "postgres:9.3";
+    }
+
+    public String[] getDockerAdditionalArgs() {
+        return buildArray("-p", "5432:5432", "-e", "POSTGRES_PASSWORD=its-a-secret", "-d");
+    }
+
+    public boolean isContainerReady(ProcessResults pr) {
+        if (pr.stdout.contains("PostgreSQL init process complete; ready for start up")) {
+            try (Socket socket = new Socket()) {
+                socket.connect(new InetSocketAddress(getContainerHostAddress(), 5432), 1000);
+                return true;
+            } catch (IOException e) {
+                LOG.info("cant connect to postgres; {}", e.getMessage());
+                return false;
+            }
+        }
+        return false;
+    }
+
+}

--- a/ql/src/test/queries/clientpositive/dataconnector_mysql.q
+++ b/ql/src/test/queries/clientpositive/dataconnector_mysql.q
@@ -1,0 +1,19 @@
+-- CREATE with comment
+CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="qtestuser",
+"hive.sql.dbcp.password"="qtestpassword");
+SHOW CONNECTORS;
+
+CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB");
+SHOW DATABASES;
+USE db_mysql;
+SHOW TABLES;
+
+-- clean up so it won't affect other tests
+DROP DATABASE db_mysql;
+DROP CONNECTOR mysql_qtest;
+

--- a/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
+++ b/ql/src/test/results/clientpositive/llap/dataconnector_mysql.q.out
@@ -1,0 +1,68 @@
+PREHOOK: query: CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="qtestuser",
+"hive.sql.dbcp.password"="qtestpassword")
+PREHOOK: type: CREATEDATACONNECTOR
+PREHOOK: Output: connector:mysql_qtest
+POSTHOOK: query: CREATE CONNECTOR mysql_qtest
+TYPE 'mysql'
+URL 'jdbc:mysql://localhost:3306/qtestDB'
+COMMENT 'test connector'
+WITH DCPROPERTIES (
+"hive.sql.dbcp.username"="qtestuser",
+"hive.sql.dbcp.password"="qtestpassword")
+POSTHOOK: type: CREATEDATACONNECTOR
+POSTHOOK: Output: connector:mysql_qtest
+PREHOOK: query: SHOW CONNECTORS
+PREHOOK: type: SHOWDATACONNECTORS
+POSTHOOK: query: SHOW CONNECTORS
+POSTHOOK: type: SHOWDATACONNECTORS
+mysql_qtest
+PREHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+PREHOOK: type: CREATEDATABASE
+PREHOOK: Input: connector:mysql_qtest
+PREHOOK: Output: database:db_mysql
+POSTHOOK: query: CREATE REMOTE DATABASE db_mysql USING mysql_qtest with DBPROPERTIES("connector.remoteDbName"="qtestDB")
+POSTHOOK: type: CREATEDATABASE
+POSTHOOK: Input: connector:mysql_qtest
+POSTHOOK: Output: database:db_mysql
+PREHOOK: query: SHOW DATABASES
+PREHOOK: type: SHOWDATABASES
+POSTHOOK: query: SHOW DATABASES
+POSTHOOK: type: SHOWDATABASES
+db_mysql
+default
+PREHOOK: query: USE db_mysql
+PREHOOK: type: SWITCHDATABASE
+PREHOOK: Input: database:db_mysql
+POSTHOOK: query: USE db_mysql
+POSTHOOK: type: SWITCHDATABASE
+POSTHOOK: Input: database:db_mysql
+PREHOOK: query: SHOW TABLES
+PREHOOK: type: SHOWTABLES
+PREHOOK: Input: database:db_mysql
+POSTHOOK: query: SHOW TABLES
+POSTHOOK: type: SHOWTABLES
+POSTHOOK: Input: database:db_mysql
+city
+country
+state
+PREHOOK: query: DROP DATABASE db_mysql
+PREHOOK: type: DROPDATABASE
+PREHOOK: Input: database:db_mysql
+PREHOOK: Output: database:db_mysql
+POSTHOOK: query: DROP DATABASE db_mysql
+POSTHOOK: type: DROPDATABASE
+POSTHOOK: Input: database:db_mysql
+POSTHOOK: Output: database:db_mysql
+PREHOOK: query: DROP CONNECTOR mysql_qtest
+PREHOOK: type: DROPDATACONNECTOR
+PREHOOK: Input: connector:mysql_qtest
+PREHOOK: Output: connector:mysql_qtest
+POSTHOOK: query: DROP CONNECTOR mysql_qtest
+POSTHOOK: type: DROPDATACONNECTOR
+POSTHOOK: Input: connector:mysql_qtest
+POSTHOOK: Output: connector:mysql_qtest

--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/dataconnector/jdbc/MySQLConnectorProvider.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class MySQLConnectorProvider extends AbstractJDBCConnectorProvider {
   private static Logger LOG = LoggerFactory.getLogger(MySQLConnectorProvider.class);
 
-  private static final String DRIVER_CLASS = "com.mysql.jdbc.Driver".intern();
+  private static final String DRIVER_CLASS = "org.mariadb.jdbc.Driver";
 
   public MySQLConnectorProvider(String dbName, DataConnector dataConn) {
     super(dbName, dataConn, DRIVER_CLASS);

--- a/testutils/ptest2/conf/deployed/master-mr2.properties
+++ b/testutils/ptest2/conf/deployed/master-mr2.properties
@@ -90,7 +90,7 @@ unitTests.module.hcatalog.core=hcatalog.core
 ut.hcatalog.core.batchSize=9
 
 
-qFileTests = clientPositive miniMr clientNegative miniMrNegative hbasePositive miniTez spark miniLlap miniLlapLocal encryptedCli miniSparkOnYarn
+qFileTests = clientPositive miniMr clientNegative miniMrNegative hbasePositive miniTez spark miniLlap miniLlapLocal miniLlapExtDB encryptedCli miniSparkOnYarn 
 qFileTests.propertyFiles.mainProperties = itests/src/test/resources/testconfiguration.properties
 
 qFileTest.clientPositive.driver = TestCliDriver
@@ -184,6 +184,13 @@ qFileTest.miniLlapLocal.batchSize = 30
 qFileTest.miniLlapLocal.queryFilesProperty = qfile
 qFileTest.miniLlapLocal.include = normal
 qFileTest.miniLlapLocal.groups.normal = mainProperties.${minillaplocal.query.files} mainProperties.${minillaplocal.shared.query.files}
+
+qFileTest.miniLlapExtDB.driver = TestMiniLlapExtDBCliDriver
+qFileTest.miniLlapExtDB.directory = ql/src/test/queries/clientpositive
+qFileTest.miniLlapExtDB.batchSize = 30
+qFileTest.miniLlapExtDB.queryFilesProperty = qfile
+qFileTest.miniLlapExtDB.include = normal
+qFileTest.miniLlapExtDB.groups.normal = mainProperties.${externalDB.llap.query.files}
 
 qFileTest.erasurecodingCli.driver = TestErasureCodingHDFSCliDriver
 qFileTest.erasurecodingCli.directory = ql/src/test/queries/clientpositive


### PR DESCRIPTION
[HIVE-25423](https://issues.apache.org/jira/browse/HIVE-25423): Add new test driver to automatically launch and load external database.

Add new test driver - **TestMiniLlapExtDBCliDriver** - which has the ability to automatically launch external database with custom SQL script(default init and cleanup script located at data/script/[databaseType]). Moved dataconnector.q test to test suite **externalDB.llap.query.files**

To run tests:
`mvn test -Dtest=TestMiniLlapExtDBCliDriver -Dqfile=xxxxxx.q`

Add new test dataconnector_mysql.q to benchmark the new test driver's loading ability, desired output located in dataconnector_mysql.q.out.

Currently this test driver only support mysql external database launching. Postgres and Derby support will land sequentially. 