### PR TITLE
HIVE-25443 : Arrow SerDe Cannot serialize/deserialize complex data types When there are more than 1024 values

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/ArrowColumnarBatchSerDe.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/ArrowColumnarBatchSerDe.java
@@ -210,9 +210,9 @@ public class ArrowColumnarBatchSerDe extends AbstractSerDe {
   static ListColumnVector toStructListVector(MapColumnVector mapVector) {
     final StructColumnVector structVector;
     final ListColumnVector structListVector;
-    structVector = new StructColumnVector();
+    structVector = new StructColumnVector(mapVector.childCount);
     structVector.fields = new ColumnVector[] {mapVector.keys, mapVector.values};
-    structListVector = new ListColumnVector();
+    structListVector = new ListColumnVector(mapVector.childCount, null);
     structListVector.child = structVector;
     structListVector.childCount = mapVector.childCount;
     structListVector.isRepeating = mapVector.isRepeating;

--- a/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Deserializer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/io/arrow/Deserializer.java
@@ -391,6 +391,7 @@ class Deserializer {
 
   private void readList(FieldVector arrowVector, ListColumnVector hiveVector, ListTypeInfo typeInfo) {
     final int size = arrowVector.getValueCount();
+    hiveVector.ensureSize(size, false);
     final ArrowBuf offsets = arrowVector.getOffsetBuffer();
     final int OFFSET_WIDTH = 4;
 
@@ -412,6 +413,7 @@ class Deserializer {
 
   private void readMap(FieldVector arrowVector, MapColumnVector hiveVector, MapTypeInfo typeInfo) {
     final int size = arrowVector.getValueCount();
+    hiveVector.ensureSize(size, false);
     final ListTypeInfo mapStructListTypeInfo = toStructListTypeInfo(typeInfo);
     final ListColumnVector mapStructListVector = toStructListVector(hiveVector);
     final StructColumnVector mapStructVector = (StructColumnVector) mapStructListVector.child;
@@ -430,6 +432,7 @@ class Deserializer {
 
   private void readStruct(FieldVector arrowVector, StructColumnVector hiveVector, StructTypeInfo typeInfo) {
     final int size = arrowVector.getValueCount();
+    hiveVector.ensureSize(size, false);
     final List<TypeInfo> fieldTypeInfos = typeInfo.getAllStructFieldTypeInfos();
     final int fieldSize = arrowVector.getChildrenFromFields().size();
     for (int i = 0; i < fieldSize; i++) {

--- a/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestArrowColumnarBatchSerDe.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/io/arrow/TestArrowColumnarBatchSerDe.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hive.ql.io.arrow;
 
+import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.HIVE_ARROW_BATCH_SIZE;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -157,6 +158,7 @@ public class TestArrowColumnarBatchSerDe {
   @Before
   public void setUp() {
     conf = new Configuration();
+    conf.setInt(HIVE_ARROW_BATCH_SIZE.varname, 1025);
   }
 
   private static ByteWritable byteW(int value) {
@@ -1024,4 +1026,45 @@ public class TestArrowColumnarBatchSerDe {
     initAndSerializeAndDeserialize(schema, toList(DECIMAL_ROWS));
   }
 
+  @Test
+  public void testListBooleanWithMoreThan1024Values() throws SerDeException {
+    String[][] schema = {
+            {"boolean_list", "array<boolean>"},
+    };
+
+    Object[][] rows = new Object[1025][1];
+    for (int i = 0; i < 1025; i++) {
+      rows[i][0] = new BooleanWritable(true);
+    }
+
+    initAndSerializeAndDeserialize(schema, toList(rows));
+  }
+
+  @Test
+  public void testStructBooleanWithMoreThan1024Values() throws SerDeException {
+    String[][] schema = {
+            {"boolean_struct", "struct<boolean1:boolean>"},
+    };
+
+    Object[][] rows = new Object[1025][1];
+    for (int i = 0; i < 1025; i++) {
+      rows[i][0] = new BooleanWritable(true);
+    }
+
+    initAndSerializeAndDeserialize(schema, toStruct(rows));
+  }
+
+  @Test
+  public void testMapIntergerWithMoreThan1024Values() throws SerDeException {
+    String[][] schema = {
+            {"int_map", "map<string,int>"},
+    };
+
+    Object[][] rows = new Object[1025][1];
+    for (int i = 0; i < 1025; i++) {
+      rows[i][0] = intW(i);
+    }
+
+    initAndSerializeAndDeserialize(schema, toMap(rows));
+  }
 }


### PR DESCRIPTION
…pes When there are more than 1024 values

<!--
Thanks for sending a pull request!  Here are some tips for you:

-->

### What changes were proposed in this pull request?
Instead of initializing the ColumnVector with default size which is 1024, Initialize it with the the size of record size required.

### Why are the changes needed?

Changes are needed to allow Arrow SerDe to Serialize/deserialize complex data types When there are more than 1024 values

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Unit test were added to confirm the behaviour
