### PR TITLE
HIVE-25449: datediff() gives wrong output when run in a tez task with some non-UTC timezone

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorUDFDateDiffScalarCol.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/exec/vector/expressions/VectorUDFDateDiffScalarCol.java
@@ -30,10 +30,9 @@ import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector.Pr
 import org.apache.hadoop.hive.serde2.typeinfo.PrimitiveTypeInfo;
 import org.apache.hadoop.io.Text;
 
+import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.util.Arrays;
 
 public class VectorUDFDateDiffScalarCol extends VectorExpression {
@@ -43,7 +42,6 @@ public class VectorUDFDateDiffScalarCol extends VectorExpression {
   private Timestamp timestampValue = null;
   private byte[] stringValue;
 
-  private transient final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
   private transient final Text text = new Text();
   private transient final Date date = new Date(0);
 
@@ -106,8 +104,9 @@ public class VectorUDFDateDiffScalarCol extends VectorExpression {
       case CHAR:
       case VARCHAR:
         try {
-          date.setTime(formatter.parse(new String(stringValue, "UTF-8")).getTime());
-          baseDate = DateWritableV2.dateToDays(date);
+          org.apache.hadoop.hive.common.type.Date hiveDate
+              = org.apache.hadoop.hive.common.type.Date.valueOf(new String(stringValue, StandardCharsets.UTF_8));
+          baseDate = hiveDate.toEpochDay();
           break;
         } catch (Exception e) {
           outputColVector.noNulls = false;
@@ -352,9 +351,10 @@ public class VectorUDFDateDiffScalarCol extends VectorExpression {
     BytesColumnVector bcv = (BytesColumnVector) columnVector;
     text.set(bcv.vector[i], bcv.start[i], bcv.length[i]);
     try {
-      date.setTime(formatter.parse(text.toString()).getTime());
-      output.vector[i] = baseDate - DateWritableV2.dateToDays(date);
-    } catch (ParseException e) {
+      org.apache.hadoop.hive.common.type.Date hiveDate
+          = org.apache.hadoop.hive.common.type.Date.valueOf(text.toString());
+      output.vector[i] = baseDate - hiveDate.toEpochDay();
+    } catch (IllegalArgumentException e) {
       output.vector[i] = 1;
       output.isNull[i] = true;
     }

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorGenericDateExpressions.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorGenericDateExpressions.java
@@ -643,6 +643,17 @@ public class TestVectorGenericDateExpressions {
     }
   }
 
+  @Test
+  public void testDateDiffColColWithTz() throws HiveException {
+    final TimeZone originalTz = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT+8"));
+      testDateDiffColCol();
+    } finally {
+      TimeZone.setDefault(originalTz);
+    }
+  }
+
   private void validateDateDiff(VectorizedRowBatch batch,
                                 LongColumnVector date1, LongColumnVector date2,
                                 PrimitiveCategory colType1, PrimitiveCategory colType2)

--- a/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorGenericDateExpressions.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/exec/vector/expressions/TestVectorGenericDateExpressions.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hive.ql.exec.vector.expressions;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.ColumnVector;
+import org.apache.hadoop.hive.ql.exec.vector.DateColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.LongColumnVector;
 import org.apache.hadoop.hive.ql.exec.vector.TestVectorizedRowBatch;
 import org.apache.hadoop.hive.ql.exec.vector.TimestampColumnVector;
@@ -38,6 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.sql.Date;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
@@ -578,6 +580,67 @@ public class TestVectorGenericDateExpressions {
     batch.cols[1] = new LongColumnVector(1);
     udf.evaluate(batch);
     Assert.assertEquals(batch.cols[1].isNull[0], true);
+  }
+
+  @Test
+  public void testDateDiffColScalarWithTz() throws HiveException {
+    final TimeZone originalTz = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT+8"));
+
+      // input column vector - 1st arg to datediff()
+      DateColumnVector dateColumnVector = new DateColumnVector(1);
+      dateColumnVector.fill(LocalDate.parse("2021-07-06").toEpochDay());
+
+      // scalar date string - 2nd arg to datediff()
+      byte[] scalarDateBytes = "2021-07-01".getBytes(utf8);
+
+
+      VectorExpression udf = new VectorUDFDateDiffColScalar(0, scalarDateBytes, 1);
+      udf.setInputTypeInfos(TypeInfoFactory.dateTypeInfo, TypeInfoFactory.stringTypeInfo);
+      udf.transientInit(hiveConf);
+
+      VectorizedRowBatch batch = new VectorizedRowBatch(2, 1);
+      batch.cols[0] = dateColumnVector;
+      // output container
+      LongColumnVector outputVector = new LongColumnVector(1);
+      batch.cols[1] = outputVector;
+      udf.evaluate(batch);
+      // ("2021-07-06" - "2021-07-01")
+      Assert.assertEquals(5, outputVector.vector[0]);
+    } finally {
+      TimeZone.setDefault(originalTz);
+    }
+  }
+
+  @Test
+  public void testDateDiffScalarColWithTz() throws HiveException {
+    final TimeZone originalTz = TimeZone.getDefault();
+    try {
+      TimeZone.setDefault(TimeZone.getTimeZone("GMT+8"));
+
+      // scalar date string - 1st arg to datediff()
+      byte[] scalarDateBytes = "2021-07-01".getBytes(utf8);
+
+      // input column vector - 2nd arg to datediff()
+      DateColumnVector dateColumnVector = new DateColumnVector(1);
+      dateColumnVector.fill(LocalDate.parse("2021-07-06").toEpochDay());
+
+      VectorExpression udf = new VectorUDFDateDiffScalarCol(scalarDateBytes, 0, 1);
+      udf.setInputTypeInfos(TypeInfoFactory.stringTypeInfo, TypeInfoFactory.dateTypeInfo);
+      udf.transientInit(hiveConf);
+
+      VectorizedRowBatch batch = new VectorizedRowBatch(2, 1);
+      batch.cols[0] = dateColumnVector;
+      // output container
+      LongColumnVector outputVector = new LongColumnVector(1);
+      batch.cols[1] = outputVector;
+      udf.evaluate(batch);
+      // ("2021-07-01" - "2021-07-06")
+      Assert.assertEquals(-5, outputVector.vector[0]);
+    } finally {
+      TimeZone.setDefault(originalTz);
+    }
   }
 
   private void validateDateDiff(VectorizedRowBatch batch,

--- a/ql/src/test/queries/clientpositive/udf_datediff_with_tz.q
+++ b/ql/src/test/queries/clientpositive/udf_datediff_with_tz.q
@@ -1,0 +1,15 @@
+--! qt:timezone:GMT+8
+
+--create test data
+create external table test_dt(id string, dt date);
+insert into test_dt values('11', '2021-07-06'), ('22', '2021-07-07');
+
+--test all the three variants of datediff() - (col,scalar), (scalar, col), (col, col)
+select datediff(dt1.dt, '2021-07-01') from test_dt dt1;
+select datediff(dt1.dt, '2021-07-01') from test_dt dt1 left join test_dt dt on dt1.id = dt.id;
+
+select datediff('2021-07-01', dt1.dt) from test_dt dt1;
+select datediff('2021-07-01', dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id;
+
+select datediff(dt1.dt, dt1.dt) from test_dt dt1;
+select datediff(dt1.dt, dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id;

--- a/ql/src/test/results/clientpositive/llap/udf_datediff_with_tz.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_datediff_with_tz.q.out
@@ -19,60 +19,60 @@ POSTHOOK: Lineage: test_dt.id SCRIPT []
 PREHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 5
 6
 PREHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 5
 6
 PREHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 -5
 -6
 PREHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 -5
 -6
 PREHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 0
 0
 PREHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 PREHOOK: type: QUERY
 PREHOOK: Input: default@test_dt
-PREHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 POSTHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
 POSTHOOK: type: QUERY
 POSTHOOK: Input: default@test_dt
-POSTHOOK: Output: hdfs://### HDFS PATH ###
+#### A masked pattern was here ####
 0
 0

--- a/ql/src/test/results/clientpositive/llap/udf_datediff_with_tz.q.out
+++ b/ql/src/test/results/clientpositive/llap/udf_datediff_with_tz.q.out
@@ -1,0 +1,78 @@
+PREHOOK: query: create external table test_dt(id string, dt date)
+PREHOOK: type: CREATETABLE
+PREHOOK: Output: database:default
+PREHOOK: Output: default@test_dt
+POSTHOOK: query: create external table test_dt(id string, dt date)
+POSTHOOK: type: CREATETABLE
+POSTHOOK: Output: database:default
+POSTHOOK: Output: default@test_dt
+PREHOOK: query: insert into test_dt values('11', '2021-07-06'), ('22', '2021-07-07')
+PREHOOK: type: QUERY
+PREHOOK: Input: _dummy_database@_dummy_table
+PREHOOK: Output: default@test_dt
+POSTHOOK: query: insert into test_dt values('11', '2021-07-06'), ('22', '2021-07-07')
+POSTHOOK: type: QUERY
+POSTHOOK: Input: _dummy_database@_dummy_table
+POSTHOOK: Output: default@test_dt
+POSTHOOK: Lineage: test_dt.dt SCRIPT []
+POSTHOOK: Lineage: test_dt.id SCRIPT []
+PREHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+5
+6
+PREHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff(dt1.dt, '2021-07-01') from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+5
+6
+PREHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+-5
+-6
+PREHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff('2021-07-01', dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+-5
+-6
+PREHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+0
+PREHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+PREHOOK: type: QUERY
+PREHOOK: Input: default@test_dt
+PREHOOK: Output: hdfs://### HDFS PATH ###
+POSTHOOK: query: select datediff(dt1.dt, dt1.dt) from test_dt dt1 left join test_dt dt on dt1.id = dt.id
+POSTHOOK: type: QUERY
+POSTHOOK: Input: default@test_dt
+POSTHOOK: Output: hdfs://### HDFS PATH ###
+0
+0


### PR DESCRIPTION
Please find the repro and detailed description here - https://issues.apache.org/jira/browse/HIVE-25449

### What changes were proposed in this pull request?
Removed usage of SimpleDateFormat which was using local timezone parsing scalar dates. 


### Why are the changes needed?
This fixes the bug described in the Jira and datediff() now gives correct values.

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
Manual testing and added two new unit tests - testDateDiffColScalarWithTz() and testDateDiffScalarColWithTz()
