### PR TITLE
Remove from deserializer comment from HMS schema in meta hook

### DIFF
--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergSchemaEvolution.java
@@ -171,11 +171,13 @@ public class TestHiveIcebergSchemaEvolution extends HiveIcebergStorageHandlerWit
         " FROM orders where fruit < 'o'and nick IS NOT NULL group by customer_first_name, nick");
     assertQueryResult(result, 1, "Natasha", "Black Widow", 250L, 7);
 
+    // check no columns got the "from deserializer" comment appended
+    List<FieldSchema> cols = shell.metastore().getTable("default", "orders").getSd().getCols();
+    Assert.assertTrue(cols.stream().allMatch(col -> col.getComment() == null));
+
     // Drop columns via REPLACE COLUMNS
-    shell.executeStatement("ALTER TABLE orders REPLACE COLUMNS (" +
-        "customer_last_name string COMMENT 'from deserializer', order_id int COMMENT 'from deserializer'," +
-        " quantity int, nick string COMMENT 'from deserializer'," +
-        " fruit string COMMENT 'from deserializer')");
+    shell.executeStatement("ALTER TABLE orders REPLACE COLUMNS (customer_last_name string, order_id int," +
+        " quantity int, nick string, fruit string)");
 
     result = shell.executeStatement("DESCRIBE orders");
     assertQueryResult(result, 5,

--- a/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
+++ b/iceberg/iceberg-handler/src/test/java/org/apache/iceberg/mr/hive/TestHiveIcebergStorageHandlerNoScan.java
@@ -1085,9 +1085,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
         new FieldSchema("family_name", "string", "This is family name"));
 
     Assert.assertEquals(expectedSchema, icebergSchema);
-    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
-      expectedSchema.stream().filter(fs -> fs.getComment() == null).forEach(fs -> fs.setComment("from deserializer"));
-    }
     Assert.assertEquals(expectedSchema, hmsSchema);
   }
 
@@ -1115,9 +1112,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
         new FieldSchema("last_name", "string", "This is last name"));
 
     Assert.assertEquals(expectedSchema, icebergSchema);
-    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
-      expectedSchema.stream().filter(fs -> fs.getComment() == null).forEach(fs -> fs.setComment("from deserializer"));
-    }
     Assert.assertEquals(expectedSchema, hmsSchema);
   }
 
@@ -1184,11 +1178,6 @@ public class TestHiveIcebergStorageHandlerNoScan {
         new FieldSchema("newstringcol", "string", "Column with description"));
 
     Assert.assertEquals(expectedSchema, icebergSchema);
-
-    if (testTableType != TestTables.TestTableType.HIVE_CATALOG) {
-      expectedSchema.get(0).setComment("from deserializer");
-    }
-
     Assert.assertEquals(expectedSchema, hmsSchema);
   }
 

--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreUtils.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreUtils.java
@@ -199,7 +199,7 @@ public class HiveMetaStoreUtils {
     return str_fields;
   }
 
-  private static final String FROM_SERIALIZER = "from deserializer";
+  public static final String FROM_SERIALIZER = "from deserializer";
   private static String determineFieldComment(String comment) {
     return (comment == null) ? FROM_SERIALIZER : comment;
   }


### PR DESCRIPTION
### What changes were proposed in this pull request?
For tables that get the schema from the serde instead of the HMS, alter table statements append a comment "from deserializer" to columns which previously had no comments. This is bad becay

### Why are the changes needed?


### Does this PR introduce _any_ user-facing change?


### How was this patch tested?
unit tests