### PR TITLE
Advance write IDs for DDLs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecAnalyzer.java
@@ -63,6 +63,7 @@ public class AlterTableSetPartitionSpecAnalyzer extends AbstractAlterTableAnalyz
     }
 
     AlterTableSetPartitionSpecDesc desc = new AlterTableSetPartitionSpecDesc(tableName, partitionSpec);
+    setAcidDdlDesc(getTable(tableName), desc);
 
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
   }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/partition/set/AlterTableSetPartitionSpecDesc.java
@@ -36,6 +36,6 @@ public class AlterTableSetPartitionSpecDesc extends AbstractAlterTableDesc {
 
   @Override
   public boolean mayNeedWriteId() {
-    return false;
+    return true;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/serde/AlterTableUnsetSerdePropsAnalyzer.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/serde/AlterTableUnsetSerdePropsAnalyzer.java
@@ -47,6 +47,7 @@ public class AlterTableUnsetSerdePropsAnalyzer extends AbstractAlterTableAnalyze
 
     AlterTableUnsetSerdePropsDesc desc = new AlterTableUnsetSerdePropsDesc(tableName, partitionSpec, props);
     addInputsOutputsAlterTable(tableName, partitionSpec, desc, AlterTableType.SET_SERDE_PROPS, false);
+    setAcidDdlDesc(getTable(tableName), desc);
     rootTasks.add(TaskFactory.get(new DDLWork(getInputs(), getOutputs(), desc)));
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/serde/AlterTableUnsetSerdePropsDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/serde/AlterTableUnsetSerdePropsDesc.java
@@ -41,6 +41,6 @@ public class AlterTableUnsetSerdePropsDesc extends AbstractAlterTableDesc {
 
   @Override
   public boolean mayNeedWriteId() {
-    return false;
+    return true;
   }
 }

--- a/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/skewed/AlterTableSkewedByDesc.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/ddl/table/storage/skewed/AlterTableSkewedByDesc.java
@@ -70,6 +70,6 @@ public class AlterTableSkewedByDesc extends AbstractAlterTableDesc {
 
   @Override
   public boolean mayNeedWriteId() {
-    return false;
+    return true;
   }
 }

--- a/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
+++ b/ql/src/test/org/apache/hadoop/hive/ql/TestTxnCommands.java
@@ -524,12 +524,28 @@ public class TestTxnCommands extends TxnCommandsBaseForTests {
     // We should not advance the Write ID during compaction, since it affects the performance of
     // materialized views. So, below assertion ensures that we do not advance the write during compaction.
     runStatementOnDriver(String.format("ALTER TABLE %s PARTITION (ds='2013-04-05') COMPACT 'minor'", tableName));
-    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    validWriteIds = msClient.getValidWriteIds("default." + tableName).toString();
     Assert.assertEquals("default.alter_table:6:9223372036854775807::", validWriteIds);
 
     runStatementOnDriver(String.format("ALTER TABLE %s PARTITION (ds='2013-04-05') CONCATENATE", tableName));
-    validWriteIds  = msClient.getValidWriteIds("default." + tableName).toString();
+    validWriteIds = msClient.getValidWriteIds("default." + tableName).toString();
     Assert.assertEquals("default.alter_table:7:9223372036854775807::", validWriteIds);
+
+    runStatementOnDriver(String.format("ALTER TABLE %s SKEWED BY (a) ON (1,2)", tableName));
+    validWriteIds = msClient.getValidWriteIds(tableName).toString();
+    Assert.assertEquals("default.alter_table:8:9223372036854775807::", validWriteIds);
+
+    runStatementOnDriver(String.format("ALTER TABLE %s SET SKEWED LOCATION (1='hdfs://test:8020/abcd/1')", tableName));
+    validWriteIds = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.alter_table:9:9223372036854775807::", validWriteIds);
+
+    runStatementOnDriver(String.format("ALTER TABLE %s UNSET SERDEPROPERTIES ('field.delim')", tableName));
+    validWriteIds = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.alter_table:10:9223372036854775807::", validWriteIds);
+
+    runStatementOnDriver(String.format("ALTER TABLE %s SET PARTITION SPEC(years(ds))", tableName));
+    validWriteIds = msClient.getValidWriteIds("default." + tableName).toString();
+    Assert.assertEquals("default.alter_table:11:9223372036854775807::", validWriteIds);
 
   }
 


### PR DESCRIPTION


### Why are the changes needed?
Advance Write ID during "ALTER TABLE SKEWED BY, SET SKEWED LOCATION, SET PARTITION SPEC and UNSET SERDEPROPERTIES "

### Does this PR introduce _any_ user-facing change?
No


### How was this patch tested?
New unit tests added 
