### PR TITLE
HIVE-25460: Add a check for advancing the write id for Alter table DDLs

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hive.metastore.api.LockType;
 import org.apache.hadoop.hive.metastore.api.TxnType;
 import org.apache.hadoop.hive.ql.ddl.DDLDesc.DDLDescWithWriteId;
 import org.apache.hadoop.hive.ql.ddl.table.AbstractAlterTableDesc;
+import org.apache.hadoop.hive.ql.ddl.table.create.CreateTableDesc;
 import org.apache.hadoop.hive.ql.ddl.table.partition.set.AlterTableSetPartitionSpecDesc;
 import org.apache.hadoop.hive.ql.ddl.table.storage.compact.AlterTableCompactDesc;
 import org.apache.hadoop.hive.ql.exec.AbstractFileMergeOperator;
@@ -331,7 +332,8 @@ class DriverTxnHandler {
           // If we don't want to advance write ID for certain DDLs, even for transactional tables,
           // they should be filtered here.
           if (acidDdlDesc instanceof AlterTableCompactDesc
-                  || acidDdlDesc instanceof AlterTableSetPartitionSpecDesc) {
+                  || acidDdlDesc instanceof AlterTableSetPartitionSpecDesc
+                    || acidDdlDesc instanceof CreateTableDesc) {
             return;
           }
           throw new IllegalStateException("should advance write id for a transactional table");

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -324,18 +324,21 @@ class DriverTxnHandler {
    * while serving metadata from HMS cache.
    * @param acidDdlDesc
    */
-  private void checkAdvancingWriteId(DDLDescWithWriteId acidDdlDesc){
-  Table table = driverContext.getPlan().getAcidAnalyzeTable().getTable();
-    if(table != null && AcidUtils.isTransactionalTable(table)) {
-      if(acidDdlDesc == null) {
-        // If we don't want to advance write ID for certain DDLs, even for transactional tables,
-        // they should be filtered here. 
-        if(acidDdlDesc instanceof AlterTableCompactDesc
-            || acidDdlDesc instanceof AlterTableSetPartitionSpecDesc ) {
-          return;
-        }
-        if( acidDdlDesc instanceof AbstractAlterTableDesc) {
-          throw new RuntimeException("should advance write id for Alter table DDL for a transactional table");
+  private void checkAdvancingWriteId(DDLDescWithWriteId acidDdlDesc) {
+    if (driverContext.getPlan()!=null
+            && driverContext.getPlan().getAcidAnalyzeTable()!=null) {
+      Table table = driverContext.getPlan().getAcidAnalyzeTable().getTable();
+      if (table!=null && AcidUtils.isTransactionalTable(table)) {
+        if (acidDdlDesc==null) {
+          // If we don't want to advance write ID for certain DDLs, even for transactional tables,
+          // they should be filtered here.
+          if (acidDdlDesc instanceof AlterTableCompactDesc
+                  || acidDdlDesc instanceof AlterTableSetPartitionSpecDesc) {
+            return;
+          }
+          if (acidDdlDesc instanceof AbstractAlterTableDesc) {
+            throw new RuntimeException("should advance write id for Alter table DDL for a transactional table");
+          }
         }
       }
     }

--- a/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/DriverTxnHandler.java
@@ -325,9 +325,11 @@ class DriverTxnHandler {
    * @param acidDdlDesc
    */
   private void checkAdvancingWriteId(DDLDescWithWriteId acidDdlDesc){
-    Table table = driverContext.getPlan().getAcidAnalyzeTable().getTable();
-    if(AcidUtils.isTransactionalTable(table)) {
+  Table table = driverContext.getPlan().getAcidAnalyzeTable().getTable();
+    if(table != null && AcidUtils.isTransactionalTable(table)) {
       if(acidDdlDesc == null) {
+        // If we don't want to advance write ID for certain DDLs, even for transactional tables,
+        // they should be filtered here. 
         if(acidDdlDesc instanceof AlterTableCompactDesc
             || acidDdlDesc instanceof AlterTableSetPartitionSpecDesc ) {
           return;


### PR DESCRIPTION


### What changes were proposed in this pull request?
Add a check for advancing the write id for Alter table DDLs

### Why are the changes needed?
To ensure we can provide strong consistency while serving metadata from HMS cache. 

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Current tests. 
