### PR TITLE
HIVE-25500: Switch back to alter_partition(s) in HMS client for Hive 2.3.x

### DIFF
--- a/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
+++ b/metastore/src/java/org/apache/hadoop/hive/metastore/HiveMetaStoreClient.java
@@ -1503,25 +1503,33 @@ public class HiveMetaStoreClient implements IMetaStoreClient {
   @Override
   public void alter_partition(String dbName, String tblName, Partition newPart)
       throws InvalidOperationException, MetaException, TException {
-    client.alter_partition_with_environment_context(dbName, tblName, newPart, null);
+    client.alter_partition(dbName, tblName, newPart);
   }
 
   @Override
   public void alter_partition(String dbName, String tblName, Partition newPart, EnvironmentContext environmentContext)
       throws InvalidOperationException, MetaException, TException {
-    client.alter_partition_with_environment_context(dbName, tblName, newPart, environmentContext);
+    if (environmentContext == null) {
+      client.alter_partition(dbName, tblName, newPart);
+    } else {
+      client.alter_partition_with_environment_context(dbName, tblName, newPart, environmentContext);
+    }
   }
 
   @Override
   public void alter_partitions(String dbName, String tblName, List<Partition> newParts)
       throws InvalidOperationException, MetaException, TException {
-    client.alter_partitions_with_environment_context(dbName, tblName, newParts, null);
+    client.alter_partitions(dbName, tblName, newParts);
   }
 
   @Override
   public void alter_partitions(String dbName, String tblName, List<Partition> newParts, EnvironmentContext environmentContext)
   throws InvalidOperationException, MetaException, TException {
-    client.alter_partitions_with_environment_context(dbName, tblName, newParts, environmentContext);
+    if (environmentContext == null) {
+      client.alter_partitions(dbName, tblName, newParts);
+    } else {
+      client.alter_partitions_with_environment_context(dbName, tblName, newParts, environmentContext);
+    }
 }
 
   @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?
Use `alter_partition`, `alter_partitions` when `EnvironmentContext` is null.

### Why are the changes needed?
[HIVE-12730](https://issues.apache.org/jira/browse/HIVE-12730) uses `alter_partition_with_environment_context` and `alter_partitions_with_environment_context` instead of `alter_partition` and `alter_partitions` when the `EnvironmentContext` is null.
This causes the client version to be greater than 2.1 to connect to server<2.1, and this error will occur.

```java
Caused by: org.apache.thrift.TApplicationException: Invalid method name: 'alter_partitions_with_environment_context'
	at org.apache.thrift.TServiceClient.receiveBase(TServiceClient.java:79)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.recv_alter_partitions_with_environment_context(ThriftHiveMetastore.java:2843)
	at org.apache.hadoop.hive.metastore.api.ThriftHiveMetastore$Client.alter_partitions_with_environment_context(ThriftHiveMetastore.java:2827)
	at org.apache.hadoop.hive.metastore.HiveMetaStoreClient.alter_partitions(HiveMetaStoreClient.java:1524)
```


### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
exist UT
